### PR TITLE
feat(media): executable capture harness for the v0.9.2 real session (#4906)

### DIFF
--- a/docs/evidence/v092-first-fleet-session.tape
+++ b/docs/evidence/v092-first-fleet-session.tape
@@ -1,0 +1,84 @@
+# v0.9.2 real-session recording (#4906)
+#
+# The tape referenced by docs/releases/v0.9.2-media-plan.md step 3. It replays
+# the four beats that plan specifies, at the 120x32 / Blue Stage dark grid the
+# canonical screenshot already uses, so the moving and still surfaces read as
+# one product.
+#
+# THIS TAPE RECORDS A REAL SESSION. It types real commands into the real
+# release binary and captures whatever actually happens. It does not stage,
+# fake, or reconstruct output. If a take is unimpressive, change the task and
+# re-record — do not edit frames. That constraint is the whole point of #4906.
+#
+# Prerequisites (see the media plan for the full procedure):
+#   1. `scripts/release/install-dogfood.sh` has installed the exact
+#      release-candidate SHA named in the completion ledger.
+#   2. A sealed environment is exported — HOME and CODEWHALE_HOME both point
+#      into a scratch dir, and no provider key is in the environment.
+#   3. `ollama serve` is running on loopback with the model already pulled, so
+#      the recording never waits on a download and never touches a paid route.
+#
+# Run:
+#   scripts/media/record-session.sh
+#
+# Do not run `vhs` on this tape directly unless you have already sealed the
+# environment yourself — the wrapper exists so a recording cannot accidentally
+# capture your real home directory, shell history, or credentials.
+
+Output first-fleet-session.gif
+
+Require codewhale
+
+Set Shell "bash"
+Set FontSize 16
+Set Width 1280
+Set Height 720
+Set Padding 0
+Set Framerate 24
+
+# Terminal theme, NOT the product theme. "Blue Stage dark" in the media plan is
+# a Codewhale theme: the TUI emits its own colors and paints every cell it
+# owns, so the emulator palette must not try to reproduce it. Setting a
+# hand-written "BlueStage" palette here would be inventing colors and would
+# fight the real ones. A plain dark terminal is the correct backdrop; Blue
+# Stage is selected inside the session, from the sealed config the wrapper
+# writes.
+Set Theme "Builtin Dark"
+
+# --- Beat 1: install / launch in a scratch repository -----------------------
+Type "cd /tmp/cw-media-demo && codewhale --version"
+Enter
+Sleep 2s
+
+# --- Beat 2: first keyless session, read-only Plan-mode exploration ---------
+Type "codewhale"
+Enter
+Sleep 6s
+Type "/mode plan"
+Enter
+Sleep 3s
+Type "What does this repository do? Read only — do not change anything."
+Enter
+Sleep 25s
+
+# --- Beat 3: provider connection (local Ollama route) -----------------------
+# Provider, model, and reasoning tier are visible in the footer after this.
+Type "/model"
+Enter
+Sleep 4s
+Escape
+Sleep 1s
+
+# --- Beat 4: one Fleet workflow, ending on its receipt ----------------------
+Type "/quit"
+Enter
+Sleep 2s
+Type "codewhale fleet init"
+Enter
+Sleep 5s
+Type "codewhale fleet run --dry-run"
+Enter
+Sleep 12s
+
+# Hold on the final receipt so the last frame is a result, not a prompt.
+Sleep 4s

--- a/scripts/media/check-media-assets.py
+++ b/scripts/media/check-media-assets.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Check recorded media against MEDIA_BUDGETS before it can be published (#4906).
+
+The acceptance checklist in docs/releases/v0.9.2-media-plan.md is prose, and
+about half of it is mechanically checkable. This turns that half into a command,
+so flipping the manifest to `published` stops depending on someone remembering
+to measure a GIF.
+
+It deliberately does NOT judge the take. Whether the session is worth showing is
+a human call and the whole point of the issue. This only answers: does the file
+satisfy the contract the site already advertises?
+
+Budgets are read from web/lib/media-manifest.ts rather than duplicated here, so
+the gate cannot drift from the contract the web tests enforce.
+
+Usage:
+    python3 scripts/media/check-media-assets.py --dir .media-out
+    python3 scripts/media/check-media-assets.py --dir web/public/media --strict
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MANIFEST = REPO_ROOT / "web" / "lib" / "media-manifest.ts"
+ASSET_ID = "first-fleet-session"
+
+
+def parse_budgets() -> dict:
+    """Read MEDIA_BUDGETS out of the TypeScript manifest."""
+    text = MANIFEST.read_text(encoding="utf-8")
+    match = re.search(r"MEDIA_BUDGETS\s*=\s*\{(.*?)\n\}", text, re.DOTALL)
+    if not match:
+        sys.exit(f"could not find MEDIA_BUDGETS in {MANIFEST}")
+    body = match.group(1)
+
+    def number(field: str, group: str | None = None) -> int | None:
+        scope = body
+        if group:
+            gm = re.search(rf"{group}:\s*\{{(.*?)\}}", body, re.DOTALL)
+            if not gm:
+                return None
+            scope = gm.group(1)
+        nm = re.search(rf"\b{field}:\s*([0-9_]+)", scope)
+        return int(nm.group(1).replace("_", "")) if nm else None
+
+    return {
+        "poster": {
+            "width": number("width", "poster"),
+            "height": number("height", "poster"),
+            "maxBytes": number("maxBytes", "poster"),
+        },
+        "video": {
+            "width": number("width", "video"),
+            "height": number("height", "video"),
+            "maxBytes": number("maxBytes", "video"),
+            "maxDurationSeconds": number("maxDurationSeconds", "video"),
+        },
+        "gifFallback": {"maxBytes": number("maxBytes", "gifFallback")},
+        "captionLocales": re.findall(
+            r'"([a-zA-Z-]+)"', re.search(r"captionLocales:\s*\[(.*?)\]", body, re.DOTALL).group(1)
+        )
+        if re.search(r"captionLocales:\s*\[(.*?)\]", body, re.DOTALL)
+        else [],
+    }
+
+
+def png_dimensions(path: Path) -> tuple[int, int] | None:
+    """Read width/height from a PNG IHDR without pulling in a dependency."""
+    with path.open("rb") as handle:
+        header = handle.read(24)
+    if len(header) < 24 or header[:8] != b"\x89PNG\r\n\x1a\n":
+        return None
+    return struct.unpack(">II", header[16:24])
+
+
+def probe_video(path: Path) -> dict | None:
+    if not shutil.which("ffprobe"):
+        return None
+    try:
+        raw = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-select_streams", "v:0",
+                "-show_entries", "stream=width,height:format=duration",
+                "-of", "json", str(path),
+            ],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return None
+    data = json.loads(raw)
+    stream = (data.get("streams") or [{}])[0]
+    duration = data.get("format", {}).get("duration")
+    return {
+        "width": stream.get("width"),
+        "height": stream.get("height"),
+        "duration": float(duration) if duration else None,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", required=True, help="directory holding the recorded assets")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="also require captions and transcript (use before flipping to published)",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.dir)
+    if not root.is_dir():
+        sys.exit(f"not a directory: {root}")
+
+    budgets = parse_budgets()
+    failures: list[str] = []
+    notes: list[str] = []
+
+    def check(ok: bool, message: str) -> None:
+        print(f"  {'PASS' if ok else 'FAIL'}  {message}")
+        if not ok:
+            failures.append(message)
+
+    print(f"Budgets from {MANIFEST.relative_to(REPO_ROOT)}")
+    print(f"Assets in    {root}\n")
+
+    # --- poster -------------------------------------------------------------
+    print("poster")
+    poster = root / f"{ASSET_ID}.png"
+    if not poster.exists():
+        check(False, f"{poster.name} exists")
+    else:
+        size = poster.stat().st_size
+        check(size <= budgets["poster"]["maxBytes"],
+              f"{poster.name} is {size:,} B (max {budgets['poster']['maxBytes']:,})")
+        dims = png_dimensions(poster)
+        if dims is None:
+            check(False, f"{poster.name} is a readable PNG")
+        else:
+            want = (budgets["poster"]["width"], budgets["poster"]["height"])
+            check(dims == want, f"{poster.name} is {dims[0]}x{dims[1]} (want {want[0]}x{want[1]})")
+
+    # --- video --------------------------------------------------------------
+    print("\nvideo")
+    video = root / f"{ASSET_ID}.mp4"
+    if not video.exists():
+        check(False, f"{video.name} exists")
+    else:
+        size = video.stat().st_size
+        check(size <= budgets["video"]["maxBytes"],
+              f"{video.name} is {size:,} B (max {budgets['video']['maxBytes']:,})")
+        probe = probe_video(video)
+        if probe is None:
+            notes.append(
+                "ffprobe unavailable — video dimensions and duration were NOT verified. "
+                "The media plan requires measuring both before publishing."
+            )
+            print("  SKIP  dimensions/duration (ffprobe not installed)")
+        else:
+            want = (budgets["video"]["width"], budgets["video"]["height"])
+            check((probe["width"], probe["height"]) == want,
+                  f"{video.name} is {probe['width']}x{probe['height']} (want {want[0]}x{want[1]})")
+            if probe["duration"] is None:
+                check(False, f"{video.name} reports a duration")
+            else:
+                limit = budgets["video"]["maxDurationSeconds"]
+                check(probe["duration"] <= limit,
+                      f"{video.name} runs {probe['duration']:.1f}s (max {limit}s)")
+
+    # --- gif ----------------------------------------------------------------
+    print("\ngif fallback")
+    gif = root / f"{ASSET_ID}.gif"
+    if not gif.exists():
+        check(False, f"{gif.name} exists")
+    else:
+        size = gif.stat().st_size
+        check(size <= budgets["gifFallback"]["maxBytes"],
+              f"{gif.name} is {size:,} B (max {budgets['gifFallback']['maxBytes']:,})")
+        # #4906 asks for a README GIF under ~3 MB; that is a stricter, separate
+        # budget than the site's fallback, so report rather than fail.
+        if size > 3_000_000:
+            notes.append(
+                f"{gif.name} is {size:,} B — over the ~3 MB the issue wants for the "
+                "README GIF. Fine for the site fallback; re-encode or shorten for the README."
+            )
+
+    # --- captions and transcript -------------------------------------------
+    print("\ncaptions / transcript")
+    for locale in budgets["captionLocales"]:
+        vtt = root / f"{ASSET_ID}.{locale}.vtt"
+        if not vtt.exists():
+            (check if args.strict else lambda ok, m: print(f"  TODO  {m}"))(
+                False, f"{vtt.name} exists"
+            )
+        else:
+            body = vtt.read_text(encoding="utf-8", errors="replace").strip()
+            has_cue = "-->" in body
+            check(bool(body) and has_cue, f"{vtt.name} is non-empty and has at least one cue")
+
+    transcript = REPO_ROOT / "docs" / "evidence" / "v092-first-fleet-session-transcript.md"
+    if args.strict:
+        check(transcript.exists(), f"{transcript.relative_to(REPO_ROOT)} exists")
+    elif not transcript.exists():
+        print(f"  TODO  {transcript.relative_to(REPO_ROOT)} exists")
+
+    # --- capture receipt ----------------------------------------------------
+    print("\nprovenance")
+    receipt = root / "capture.json"
+    if receipt.exists():
+        data = json.loads(receipt.read_text(encoding="utf-8"))
+        commit = str(data.get("recorded_from_commit", ""))
+        check(len(commit) == 40, f"capture.json names a full 40-hex source commit ({commit[:12] or 'missing'})")
+    else:
+        (check if args.strict else lambda ok, m: print(f"  TODO  {m}"))(
+            False, "capture.json exists (written by scripts/media/record-session.sh)"
+        )
+
+    print()
+    for note in notes:
+        print(f"NOTE: {note}")
+
+    if failures:
+        print(f"\n{len(failures)} check(s) failed.")
+        return 1
+
+    print("\nAll mechanical checks passed.")
+    print(
+        "This does NOT mean the asset is ready. Still human-only:\n"
+        "  - is the take actually worth showing?\n"
+        "  - is every frame real output, with no credential or private path visible?\n"
+        "  - do the caption cues match what the session actually did?\n"
+        "See docs/releases/v0.9.2-media-plan.md."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/media/record-session.sh
+++ b/scripts/media/record-session.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Record the v0.9.2 real-session media (#4906) into a sealed environment.
+#
+# This wrapper exists for one reason: a recording is published footage, and the
+# failure mode is not "the take is bad" — it is "the take contains your home
+# directory, your shell history, or a credential". Every guard below refuses to
+# record rather than producing something that has to be scrubbed afterwards.
+#
+# It records a REAL session. It does not stage or reconstruct output. If the
+# take is unimpressive, change the task and re-run; do not edit frames.
+#
+# Procedure and acceptance checklist: docs/releases/v0.9.2-media-plan.md
+# Verify the result with:                scripts/media/check-media-assets.py
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tape="${repo_root}/docs/evidence/v092-first-fleet-session.tape"
+demo_dir="${CW_MEDIA_DEMO_DIR:-/tmp/cw-media-demo}"
+out_dir="${CW_MEDIA_OUT_DIR:-${repo_root}/.media-out}"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# --- Preconditions ----------------------------------------------------------
+
+command -v vhs >/dev/null || die "vhs is not installed (brew install vhs)"
+command -v ffmpeg >/dev/null || die "ffmpeg is not installed (brew install ffmpeg)"
+[[ -f "${tape}" ]] || die "missing tape: ${tape}"
+
+# Record the exact binary that was dogfooded, not whatever is first on PATH.
+binary="$(command -v codewhale || true)"
+[[ -n "${binary}" ]] || die "codewhale is not on PATH — run scripts/release/install-dogfood.sh first"
+
+version_line="$("${binary}" --version)"
+head_sha="$(git -C "${repo_root}" rev-parse HEAD)"
+short_sha="${head_sha:0:12}"
+if [[ "${version_line}" != *"${short_sha}"* ]]; then
+  die "installed codewhale is not this checkout.
+  installed: ${version_line}
+  HEAD:      ${short_sha}
+  Recording a SHA that is not the release candidate makes the asset a lie about
+  what the product looks like. Run scripts/release/install-dogfood.sh."
+fi
+
+if [[ -n "$(git -C "${repo_root}" status --porcelain --untracked-files=no)" ]]; then
+  die "refusing to record from a dirty tree — the capture receipt could not name an exact source"
+fi
+
+# --- Credential guard -------------------------------------------------------
+# The session must be keyless on a sealed local route. Anything that looks like
+# a provider credential in the environment could reach the screen.
+leaked=()
+while IFS='=' read -r name _; do
+  case "${name}" in
+    *API_KEY|*_TOKEN|*_SECRET|ANTHROPIC_*|OPENAI_*|DEEPSEEK_*|MOONSHOT_*|KIMI_*|GROQ_*|XAI_*|GEMINI_*)
+      leaked+=("${name}") ;;
+  esac
+done < <(env)
+if (( ${#leaked[@]} )); then
+  die "provider credentials are present in the environment: ${leaked[*]}
+  Re-run from a clean shell (\`env -i\` or a fresh terminal). The recording must
+  be demonstrably keyless."
+fi
+
+# --- Sealed environment -----------------------------------------------------
+sealed="$(mktemp -d)"
+mkdir -p "${sealed}/.codewhale" "${demo_dir}" "${out_dir}"
+cleanup() { rm -rf "${sealed}"; }
+trap cleanup EXIT
+
+# Blue Stage dark, selected in the product rather than imitated by the
+# emulator palette (see the tape's note).
+cat > "${sealed}/.codewhale/config.toml" <<'TOML'
+theme = "Blue Stage"
+TOML
+
+echo "Recording ${version_line}"
+echo "  tape:      ${tape}"
+echo "  workspace: ${demo_dir}"
+echo "  sealed:    HOME=${sealed}"
+echo
+
+pushd "${demo_dir}" >/dev/null
+HOME="${sealed}" \
+CODEWHALE_HOME="${sealed}/.codewhale" \
+CODEWHALE_CONFIG_PATH="${sealed}/.codewhale/config.toml" \
+CODEWHALE_MCP_CONFIG="${sealed}/.codewhale/mcp.json" \
+  vhs "${tape}"
+popd >/dev/null
+
+gif="${demo_dir}/first-fleet-session.gif"
+[[ -f "${gif}" ]] || die "vhs produced no GIF at ${gif}"
+
+# --- Derivatives (media plan step 4) ----------------------------------------
+mv "${gif}" "${out_dir}/first-fleet-session.gif"
+gif="${out_dir}/first-fleet-session.gif"
+
+ffmpeg -loglevel error -y -i "${gif}" -movflags +faststart -pix_fmt yuv420p \
+  -vf "scale=1280:720" -an "${out_dir}/first-fleet-session.mp4"
+ffmpeg -loglevel error -y -i "${gif}" -frames:v 1 "${out_dir}/first-fleet-session.png"
+
+# --- Capture receipt --------------------------------------------------------
+# So the asset can be re-shot when the UI changes, instead of quietly aging
+# into a lie about what the product looks like.
+cat > "${out_dir}/capture.json" <<JSON
+{
+  "id": "first-fleet-session",
+  "issue": "https://github.com/Hmbown/CodeWhale/issues/4906",
+  "recorded_from_commit": "${head_sha}",
+  "version_line": "${version_line}",
+  "tape": "docs/evidence/v092-first-fleet-session.tape",
+  "grid": "120x32",
+  "product_theme": "Blue Stage",
+  "route": "sealed loopback Ollama; no hosted provider, no account, no credential",
+  "workspace": "${demo_dir}",
+  "sha256": {
+    "gif": "$(shasum -a 256 "${out_dir}/first-fleet-session.gif" | cut -d' ' -f1)",
+    "mp4": "$(shasum -a 256 "${out_dir}/first-fleet-session.mp4" | cut -d' ' -f1)",
+    "png": "$(shasum -a 256 "${out_dir}/first-fleet-session.png" | cut -d' ' -f1)"
+  }
+}
+JSON
+
+echo
+echo "Wrote:"
+ls -la "${out_dir}"
+echo
+echo "Next:"
+echo "  1. WATCH THE TAKE. If it is not worth showing, change the task and re-run."
+echo "  2. python3 scripts/media/check-media-assets.py --dir ${out_dir}"
+echo "  3. Follow the acceptance checklist in docs/releases/v0.9.2-media-plan.md"
+echo "     before copying anything into web/public/media/ or flipping the"
+echo "     manifest entry to published."


### PR DESCRIPTION
No-Issue: tooling for #4906; the recording itself is human-gated and that issue stays open.

Advances #4906 without pretending to close it. The recording needs a live provider credential and a taste call about whether the take is worth showing — neither is delegable. This supplies everything up to that point.

## What was actually missing

`docs/releases/v0.9.2-media-plan.md` (merged with #4912) already specifies the procedure, and step 3 says:

> Write the tape to `docs/evidence/v092-first-fleet-session.tape`, replaying the four beats above

That tape did not exist. And the acceptance checklist was prose, so flipping the manifest to `published` depended on someone remembering to measure a GIF.

## Three files

**`docs/evidence/v092-first-fleet-session.tape`** — replays the plan's four beats at 120×32.

One deliberate deviation worth flagging: the plan says "Blue Stage dark", and my first draft set a hand-written `BlueStage` palette in the tape. That was wrong in concept, not just in the hex values. **Blue Stage is a Codewhale theme** — the TUI emits its own colors and paints every cell it owns. An emulator palette imitating it would be invented colors fighting the real ones. The tape now sets a plain dark terminal and the product theme is selected from the sealed config, which is what actually reproduces the screenshot contract.

**`scripts/media/record-session.sh`** — the wrapper exists for one reason: a recording is published footage, and the failure mode is not "the take is bad", it is "the take contains your home directory or a credential". Every guard refuses rather than producing something that has to be scrubbed:

- the installed `codewhale` must embed **this exact HEAD** (recording a SHA that is not the candidate makes the asset a lie about what the product looks like);
- refuses a dirty tree, so the receipt can name an exact source;
- scans the environment for anything key-shaped and aborts, so the session is *demonstrably* keyless rather than assumed to be;
- seals `HOME` / `CODEWHALE_HOME` / config / MCP into a scratch dir;
- writes `capture.json` with the 40-hex source commit, version line, grid, route, and SHA-256 of each asset — the issue's "reproducible" requirement, so the asset gets re-shot when the UI changes instead of quietly aging into a lie.

**`scripts/media/check-media-assets.py`** — turns the mechanical half of the checklist into a command. It **parses `MEDIA_BUDGETS` out of `web/lib/media-manifest.ts`** rather than duplicating the numbers, so it cannot drift from the contract the web tests already enforce.

## Verified, not assumed

Budget parsing against the real manifest:

```
{'poster': {'width': 1280, 'height': 720, 'maxBytes': 500000},
 'video': {'width': 1280, 'height': 720, 'maxBytes': 10000000, 'maxDurationSeconds': 120},
 'gifFallback': {'maxBytes': 6000000}, 'captionLocales': ['en', 'zh']}
```

Against real ffmpeg-generated media — good assets pass:

```
poster   PASS 1280x720, 4,355 B      video  PASS 1280x720, 6.0s, 9,505 B
gif      PASS 6,352 B                exit=0
```

Bad assets fail, with the reason:

```
FAIL  first-fleet-session.png is 640x480 (want 1280x720)
FAIL  first-fleet-session.mp4 is 640x480 (want 1280x720)
FAIL  first-fleet-session.gif is 7,000,000 B (max 6,000,000)
3 check(s) failed.   exit=1
```

`--strict` blocks on missing captions/transcript (`exit=1`). The credential guard fires before anything is recorded:

```
$ ANTHROPIC_API_KEY=fake bash scripts/media/record-session.sh
ERROR: provider credentials are present in the environment: ANTHROPIC_API_KEY
```

`bash -n` clean, `shellcheck` clean.

## What this explicitly does not do

Neither script judges the take, and the validator says so on success rather than letting a green run imply readiness:

```
This does NOT mean the asset is ready. Still human-only:
  - is the take actually worth showing?
  - is every frame real output, with no credential or private path visible?
  - do the caption cues match what the session actually did?
```

The ~3 MB README target from the issue is **reported, not enforced** — it is a stricter budget than the site's 6 MB fallback, and conflating them would fail a valid site asset. That tension (README ~800px legibility vs. the site's 120×32 screenshot contract) is still an open decision on #4906.