### PR TITLE
docs(release): refresh v0.9.2 landing gates

### DIFF
--- a/docs/releases/v0.9.2-completion-ledger.md
+++ b/docs/releases/v0.9.2-completion-ledger.md
@@ -10,18 +10,34 @@
 
 | Boundary | Exact state |
 | --- | --- |
-| Integration worktree | `/Volumes/VIXinSSD/CW/worktrees/codewhale-v092-integration`, branch `codex/v092-integration-direct-main` |
-| Base | `origin/main` = `b49423631` (clean checkout at ledger creation) |
-| Candidate content head | `17f6ae848` (194 commits ahead of `origin/main`, 0 behind at this update). The 2026-07-27 overnight campaign integrated fifteen work streams as reviewed merges, each with its own PR on the integration branch (#4912–#4927) and post-merge verification: #4797 cost truth (nine-blocker repair), localization (7 new packs + web i18n + grapheme truncation), constitution lane (#3930/#4782/#3928/#3832-infra), #4411 auto-scope, tool-studio provenance, command-parity (#1888/#4022), Kimi K3 selection truth (live user report), StepFun setup stage (#4526), session control (#2934/#4397), visual slices (#4813/#4808/#4823/#4817/#4807), web-maturity (#3413), onboarding (#3409/#3927/#3937-step/#4227-skill), saved-Fleets + Router, provider-truth billing, and the #3897 incremental render + #4908 zh-Hans harvests. Cross-merge interaction fixes were committed with their own receipts (zh-Hans terminology restoration, cost-key/pack parity reconciliations with fresh translations, StepFun gate vs UNCLASSIFIED surfaces, classifier-election test alignment). Hosted-CI follow-ups are `1403dcca0` (test-target warning cleanup), `4822054d1` + `20351b242` (v0.9.2 public-surface truth and strict TypeScript narrowing), `501c0bf85` (scanner-safe adversarial fixtures), `54e38ec90` (MiniMax billing-test environment isolation), `310983284` (cross-process settings reader readiness on slower Windows startup), and final Claude-review repairs `71c70831c` / `280700704` / `fb6b1c6dc` / `17f6ae848` (Lane load error truth, duplicate catalog guard removal, cached Zen resolver, and SHA-256 fingerprint documentation). |
+| Authoritative release lane | protected `main` in `/Volumes/VIXinSSD/CW/codewhale` |
+| Current landed candidate | `origin/main` = `d2a5b2253e8d939eb74a1024d44babb6958200bb` (PR #4944 merge) |
+| Integration campaign | PR #4911 merged at `8fff533e6203193984c34552d837c47845e51f51`; focused PRs #4912–#4927 are represented in its landed history |
+| Final runtime follow-up | PR #4943 restored account-owned `/rc`; merged at `e3fbb6a915af0460dd12b03d88d92b295932ef8e` |
+| Final web follow-up | PR #4944 aligned the public landing with the CWC visual system; merged at `d2a5b2253e8d939eb74a1024d44babb6958200bb` |
 | Workspace version (`Cargo.toml`) | `0.9.2` — bumped at `0faa44a74` |
 | npm `npm/codewhale` | `0.9.2` — bumped at `0faa44a74` (`npm/deepseek-tui` 0.8.49 and `npm/runtime-sdk` 0.8.60 are separate legacy/SDK lines) |
 | Tag / Release | none for v0.9.2; no tag created, moved, or planned by this ledger |
 | Publication state | no crates/npm publish, no artifact upload, no web deploy |
 
-The local version bump is deliberately deferred until the release contents are
-stable; it is normal release preparation, not a publication action. Any receipt
-embedding `0.9.1 (<sha>)` describes the pre-bump candidate, not a released
-v0.9.2 build.
+## Final landing gate (current)
+
+This table is the release decision surface. The longer tables below retain
+historical engineering evidence but do not override this current state.
+
+| Gate | Status | Receipt |
+| --- | --- | --- |
+| Integration candidate | **PASS** | PR #4911 merged to `main` at `8fff533e6203193984c34552d837c47845e51f51`; focused PRs #4912–#4927 are landed in that history |
+| Full release verification | **PASS** | 11,215 tests passed on the integration candidate; exact CI clippy clean; version bump `0faa44a74`; the detailed receipts remain below |
+| ACP numeric request IDs | **PASS** | PR #4929 landed client-aware behavior: Avante numeric IDs are preserved and Zed numeric IDs retain the compatibility conversion |
+| Thinking expansion | **PASS** | PR #4928 merged and closed #4925 |
+| Web deploy workflow | **PASS (code path)** | #4907 is repaired; validation runs on push/PR and deployment remains manual-dispatch-only |
+| Real-session capture harness | **PASS (harness only)** | PR #4940 merged at `6acc5dd367547a12b31fccb473da30954ca35d72`; real human-operated capture remains #4906 |
+| Account-owned remote control | **PASS** | PR #4943 exact head passed hosted Ubuntu, Windows, and macOS; merged at `e3fbb6a915af0460dd12b03d88d92b295932ef8e` |
+| Public landing redesign | **PASS** | PR #4944 exact combined head `2d7b7590bda0f983d7d99541482c151b95dc5132`: web tests/lint/build, Claude, CodeQL, Buildkite, Windows (17m52s), and macOS including offline eval (20m42s) all passed; merged at `d2a5b2253e8d939eb74a1024d44babb6958200bb` |
+| Final dogfood binaries | **PASS** | `codew`, `codewhale`, and `codewhale-tui` all report `0.9.2 (2d7b7590bda0)`; receipt `backups/dogfood-installs/20260728T043937Z-2d7b7590bda0.txt` |
+| Milestone | **HUMAN-GATED** | #4906 is the only open v0.9.2 milestone issue: record and accept a real provider/local-Ollama session for the site and README |
+| Publication | **HUMAN-GATED** | no v0.9.2 tag, GitHub Release, crates/npm publication, artifact upload, web deploy, or customer communication has occurred |
 
 ## Approval rails (hard)
 
@@ -185,7 +201,7 @@ receipted audit on the landed SHA before the issue is closed), **deferred**
 | #3897 | must-land | **cherry-picked `89b73bdd1`; compile/test receipt pending** | The persistent rendered-prefix cache landed via cherry-pick of `f2358387c` from the md-incremental lane: `IncrementalMarkdownRenderCache` with resumable syntect highlighter state, `StreamingSourceReceipt` verified-append provenance (no quadratic byte compare), deterministic `MarkdownRenderWork` counters in production state, and differential exactness + linearity + invalidation tests. Known honest bound: the tail path still clones tail blocks, so unbounded open tables/paragraph tails are linear-in-common-case, not hard-bounded — the lane's uncommitted plain-tail/table follow-up does NOT compile (missing `IncrementalTableState.blocks` field) and was deliberately left out. Focused suite receipt on the candidate is still required before this row is PASS. |
 | #2342 | deferred product decision | not started | Click-to-preview needs a defined action and is not allowed to grow a decorative affordance without backend behavior. |
 | #998 | deferred product decision | not started | `hover_layer.rs` exists but remains unwired; do not surface it until its interaction contract is settled. |
-| #4906 | post-candidate media | not started | Record a real dogfood session for the site + README GIF after the candidate is stable; media does not gate runtime correctness. |
+| #4906 | post-candidate media | **human-gated; harness landed** | PR #4940 landed the executable capture harness. Record and accept one real provider/local-Ollama dogfood session for the site + README GIF; this is the only open v0.9.2 milestone issue and does not reopen runtime correctness. |
 | #4907 web CI | must-land | **candidate commit `990489c9b`; combined-candidate re-verified at `c46eb2936`** | Push/PR still validate; deploy is manual-dispatch-only at the exact SHA. Combined-candidate receipts: web suite 143/143 (21 files), ESLint clean, `tsc --noEmit` clean. |
 | #4904 mention review follow-ups | must-land | **candidate commits `9dd481072`, `9df3218fa`** | Preserved original authorship; PR checks were green before local integration. Re-verify on the combined candidate. |
 | #4808 visual-language baseline | must-land slice | **landed `2fe849f1d`; independently reviewed PASS after repair** | Pickers, Fleet/skills rows, hotbar, and workflow surfaces now share one selection marker/background vocabulary and compact action hints. The review blocked two false verbs (`cancel` where Esc only closes, `select` where feedback opens a browser); both were repaired before landing. Full release runtime QA passed 9/9 (1 ignored), exact CI clippy passed, and the four repaired blocker-size/selection tests passed 4/4. This is a baseline slice only: the remaining visual-program rows below stay active. |
@@ -201,10 +217,10 @@ receipted audit on the landed SHA before the issue is closed), **deferred**
 | Provider request truth | must-land (benchmark prerequisite) | confirmed gaps | GLM-5.2 must emit documented `reasoning_effort=high|max` in addition to thinking control, while GLM-5-Turbo must not receive invented granularity. MiniMax M3 must use `max_completion_tokens`. Kimi fixed-K3 `off` must fail or visibly normalize to `low`; Kimi membership catalog and subscription billing are stale. |
 | Context / tool-surface accounting | must-land (benchmark prerequisite) | confirmed gap | Active pressure and compaction omit serialized tool schemas even though the source map knows them; Standard and Full are currently behaviorally identical. Use one estimator with per-class byte/token estimates and stable tool hash, and either make the labels measurably distinct or collapse them. |
 | Notification app icon (#4847) | human-gated | **not fixed** | `display notification` runs through unbundled `/usr/bin/osascript`, so macOS attributes the banner to Script Editor. Requires a real signed `.app` bundle → signing/notarization, which is Hunter-gated. The separate OSC control-byte leak is fixed (#4905). |
-| Version bump + changelog band | release preparation | pending | Workspace and npm still `0.9.1`; bump locally after contents stabilize. |
+| Version bump + changelog band | release preparation | **done at `0faa44a74`** | Workspace, npm wrapper, lockfile, and changelog band are consistently `0.9.2`. |
 | Tag, GitHub Release, publication | human-gated | pending | |
-| Dogfood install of the release SHA | required local gate | pending | Run `scripts/release/install-dogfood.sh`; local dogfood installation is explicitly authorized by workspace guidance. |
-| Web deploy / CWC #123 | human-gated | pending, must not merge | |
+| Dogfood install of the release SHA | required local gate | **done** | Installed the exact combined runtime/web candidate `2d7b7590bda0`; all three binaries report `0.9.2 (2d7b7590bda0)`. Receipt: `backups/dogfood-installs/20260728T043937Z-2d7b7590bda0.txt`. |
+| Web deploy / CWC #123 | human-gated | **pending; code merged, deploy not run** | PR #4944 landed the CWC-aligned public design. Production remains unchanged until explicit deployment approval. |
 | Live-provider entitlement test (K3) | human-gated | pending | |
 | Manual multi-terminal QA (#3758) | split gate | **automated slice landed `14960d2c9`; physical-terminal matrix human-gated** | Provider-free terminal/key/modal matrix passed 19/19; release runtime QA passed 17/17 with one explicit 32-worker stress ignore; shortcut audit passed 15/15. Cell-by-cell record: `docs/releases/v0.9.2-terminal-matrix.md`; target `crates/tui/tests/terminal_matrix_qa.rs` plus harness additions (`modes.rs` control-stream ledger, `view_log.rs` view-stack trace reader). The matrix covers sizes, `TERM`/`COLORTERM` capability tiers, Unicode/ASCII fallback, bracketed/raw/multiline/CJK paste and IME-style commits, mouse/resize/focus, provider-free modal open/Esc lifecycle, terminal-mode restoration on every exit path, and exactly-once ordered queued follow-ups. Literal iTerm2, Terminal.app, WezTerm, SSH, tmux, ConPTY, listening, and visual observations remain `UNRUN`; provider-dependent modals remain a named automation gap. |
 | #4067 `@git`/`@diff` mentions | verify-and-close | closed by #4899 | Re-verify on the release SHA before the release notes claim it. |


### PR DESCRIPTION
No-Issue: release ledger reconciliation only; no product issue is being closed

## Summary
- replace the stale integration-lane identity with the current landed `main` candidate
- put the final release decision table at the top of the living ledger
- record the #4943/#4944 hosted CI and exact dogfood receipts
- make #4906 and publication/deployment the remaining human gates

## Verification
- `git diff --check`
- live GitHub reconciliation for PRs #4911, #4940, #4943, #4944 and the v0.9.2 milestone