### PR TITLE
fix(web): keep mobile navigation in view

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1792,15 +1792,16 @@ body:has(.product-home) .site-github-link {
 }
 
 @media (max-width: 520px) {
-  body:has(.product-home) .site-nav-inner {
+  .site-nav-inner {
     gap: 0.5rem;
   }
 
-  body:has(.product-home) .site-nav-actions {
+  .site-nav-actions {
+    min-width: 0;
     gap: 0.35rem;
   }
 
-  body:has(.product-home) .site-nav-actions select {
+  .site-nav-actions select {
     width: 8rem;
     min-width: 0;
   }

--- a/web/lib/blue-stage-contract.test.ts
+++ b/web/lib/blue-stage-contract.test.ts
@@ -44,4 +44,15 @@ describe("Blue Stage public-surface contract", () => {
     expect(CSS).toMatch(/\.portal-button-primary[\s\S]*background: var\(--indigo-deep\)/);
     expect(CSS).toMatch(/\.nav-link::after[\s\S]*background: var\(--indigo\)/);
   });
+
+  it("keeps the shared mobile navigation inside a 390px viewport", () => {
+    const mobile = CSS.split("@media (max-width: 520px)")[1];
+
+    expect(mobile).toMatch(/\.site-nav-inner\s*\{\s*gap:\s*0\.5rem/);
+    expect(mobile).toMatch(/\.site-nav-actions\s*\{[\s\S]*?min-width:\s*0/);
+    expect(mobile).toMatch(
+      /\.site-nav-actions select\s*\{[\s\S]*?width:\s*8rem;[\s\S]*?min-width:\s*0/,
+    );
+    expect(mobile).not.toMatch(/body:has\(\.product-home\) \.site-nav-actions select/);
+  });
 });


### PR DESCRIPTION
## Summary

- apply the existing compact homepage navigation sizing to every public route below 520px
- cap the locale selector at 8rem and allow the action group to shrink
- pin the mobile-fit contract in the shared visual token test

## Impact

At a 390px viewport, the install/docs header previously placed the menu button at x=373..409, 35px beyond the 374px content edge. The same header now ends exactly at x=374 with no document overflow, and the menu remains keyboard-labelled and interactive.

## Verification

- measured 390px before/after geometry in the in-app browser
- opened and closed the mobile menu; locale, navigation, and install actions remained available
- npm run prebuild
- npm run check:facts
- npm run check:docs
- npm test (224 passed)
- npm run lint
- npm run build (260 static pages)

No-Issue: focused responsive-layout defect found during the v0.9.2 maintainer visual audit; it does not close the broader site-maturity epic #3413.