### PR TITLE
fix(v0.9.2): calm VS Code rendering and retry upstream 499

### DIFF
--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -969,6 +969,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn responses_stream_retries_upstream_499_before_streaming() {
+        let server = MockServer::start().await;
+        let attempts = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("POST"))
+            .and(path(CODEX_RESPONSES_PATH))
+            .respond_with(RetryThenSuccess {
+                attempts: Arc::clone(&attempts),
+                retry_status: 499,
+                retry_body: "upstream request cancelled",
+            })
+            .mount(&server)
+            .await;
+
+        let client = {
+            let _env_lock = crate::test_support::lock_test_env();
+            let _codex_token =
+                crate::test_support::EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "test-token");
+            let _legacy_codex_token =
+                crate::test_support::EnvVarGuard::remove("CODEX_ACCESS_TOKEN");
+            DeepSeekClient::new(&test_codex_config(&server)).unwrap()
+        };
+        let mut stream = client
+            .handle_responses_stream(
+                &client
+                    .prepare_outbound_request(minimal_responses_request(), true)
+                    .expect("responses request prepares"),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(event) = stream.next().await {
+                event.unwrap();
+            }
+        })
+        .await
+        .expect("Responses retry stream should finish after [DONE]");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
     async fn responses_stream_fails_fast_on_non_retryable_provider_error() {
         let server = MockServer::start().await;
         let attempts = Arc::new(AtomicUsize::new(0));

--- a/crates/tui/src/llm_client/mod.rs
+++ b/crates/tui/src/llm_client/mod.rs
@@ -413,7 +413,7 @@ impl LlmError {
     /// Constructs an `LlmError` from HTTP status code and response body.
     ///
     /// Performs heuristic classification based on:
-    /// - Status code (429 = rate limit, 401/403 = auth, 5xx = server error)
+    /// - Status code (429 = rate limit, 401/403 = auth, 499/5xx = transient upstream error)
     /// - Response body keywords (`context_length`, `content_policy`, safety, etc.)
     pub fn from_http_response(status: u16, body: &str) -> Self {
         match status {
@@ -472,7 +472,12 @@ impl LlmError {
                     }
                 }
             }
-            500..=599 => LlmError::ServerError {
+            // Several OpenAI-compatible gateways use nginx's non-standard
+            // 499 for an upstream request that was cancelled before response
+            // streaming began. At this boundary no response body stream has
+            // been exposed, so it is eligible for the same bounded retry
+            // policy as a 5xx gateway failure.
+            499..=599 => LlmError::ServerError {
                 status,
                 message: body.to_string(),
             },
@@ -781,7 +786,7 @@ impl From<serde_json::Error> for LlmError {
 /// - `exponential_base`: 2.0
 /// - `jitter`: true (adds randomness to prevent thundering herd)
 /// - `jitter_factor`: 0.1 (10% variation)
-/// - `retryable_status_codes`: [429, 500, 502, 503, 504]
+/// - `retryable_status_codes`: [429, 499, 500, 502, 503, 504]
 #[derive(Debug, Clone)]
 pub struct RetryConfig {
     /// Whether retry logic is enabled
@@ -831,7 +836,7 @@ impl Default for RetryConfig {
             jitter: true,
             jitter_factor: 0.1,
             respect_retry_after: true,
-            retryable_status_codes: vec![429, 500, 502, 503, 504],
+            retryable_status_codes: vec![429, 499, 500, 502, 503, 504],
             request_timeout: 120.0,
             total_timeout: 0.0, // No total timeout by default
         }
@@ -1253,6 +1258,7 @@ mod tests {
         let config = RetryConfig::default();
 
         assert!(config.is_retryable_status(429)); // Rate limit
+        assert!(config.is_retryable_status(499)); // Upstream request cancelled
         assert!(config.is_retryable_status(500)); // Internal server error
         assert!(config.is_retryable_status(502)); // Bad gateway
         assert!(config.is_retryable_status(503)); // Service unavailable
@@ -1315,6 +1321,10 @@ mod tests {
         assert!(matches!(err, LlmError::AuthenticationError(_)));
 
         // Server errors
+        let err = LlmError::from_http_response(499, "upstream request cancelled");
+        assert!(matches!(err, LlmError::ServerError { status: 499, .. }));
+        assert!(err.is_retryable());
+
         let err = LlmError::from_http_response(500, "internal server error");
         assert!(matches!(err, LlmError::ServerError { status: 500, .. }));
 

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -874,7 +874,9 @@ impl Settings {
         }
         // VS Code (TERM_PROGRAM=vscode, #1356), Ghostty (#1445), and a few
         // VTE terminals (#1470) produce visible flicker at 120 FPS. Cap their
-        // redraw rate without changing motion semantics or model text pacing.
+        // redraw rate. VS Code's xterm.js renderer also needs decorative
+        // motion disabled: the underwater chrome added substantially more
+        // independently moving cells than the original #1356 fix covered.
         // Ghostty may report
         // either TERM_PROGRAM=Ghostty/ghostty or TERM=xterm-ghostty.
         // Like NO_ANIMATIONS above, this unconditionally overrides any
@@ -892,6 +894,10 @@ impl Settings {
             || std::env::var_os("TERMINATOR_UUID").is_some_and(|v| !v.is_empty());
         if term_constrains_frame_rate || vte_env_constrains_frame_rate {
             self.constrained_frame_rate = true;
+        }
+        if term_program == "vscode" {
+            self.low_motion = true;
+            self.fancy_animations = false;
         }
 
         // Termius (TERM_PROGRAM=Termius) and SSH sessions exhibit the
@@ -3701,7 +3707,7 @@ mod tests {
     }
 
     #[test]
-    fn vscode_caps_redraws_without_disabling_motion_or_text_cadence() {
+    fn vscode_uses_calm_rendering_without_changing_text_cadence() {
         let _g = term_program_test_guard();
         let prev = std::env::var_os("TERM_PROGRAM");
         // SAFETY: serialised by the guard.
@@ -3711,8 +3717,11 @@ mod tests {
         let mut settings = animated_settings();
         assert!(!settings.low_motion, "default is animated");
         settings.apply_env_overrides();
-        assert!(!settings.low_motion);
-        assert!(settings.fancy_animations);
+        assert!(
+            settings.low_motion,
+            "TERM_PROGRAM=vscode must disable decorative motion"
+        );
+        assert!(!settings.fancy_animations);
         assert!(
             settings.constrained_frame_rate,
             "TERM_PROGRAM=vscode should cap redraws without changing animation semantics"


### PR DESCRIPTION
## Summary

- restore calm decorative rendering under `TERM_PROGRAM=vscode` while retaining the frame-rate cap and upstream text cadence
- classify pre-stream HTTP 499 responses as transient so the existing bounded exponential-backoff policy applies
- keep failures after response streaming begins outside the request retry path

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- exact CI `cargo clippy --workspace --all-features --locked -- ...`
- `vscode_uses_calm_rendering_without_changing_text_cadence`
- `test_llm_error_from_http_response`
- `responses_stream_retries_upstream_499_before_streaming` (provider-free loopback mock)

Closes #4950