### PR TITLE
fix(tui): preserve reasoning effort with auto routing

### DIFF
--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -1529,14 +1529,15 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             // Support "/model auto" — auto-select model based on request complexity
             if value.trim().eq_ignore_ascii_case("auto") {
                 app.set_model_selection("auto".to_string());
-                app.reasoning_effort = ReasoningEffort::Auto;
-                app.last_effective_reasoning_effort = None;
                 app.update_model_compaction_budget();
                 app.session.last_prompt_tokens = None;
                 app.session.last_completion_tokens = None;
                 app.session.last_output_throughput = None;
                 return CommandResult::with_message_and_action(
-                    "model = auto (auto-select model and thinking per turn)".to_string(),
+                    format!(
+                        "model = auto (auto-select model per turn; thinking = {})",
+                        app.reasoning_effort_display_label()
+                    ),
                     AppAction::UpdateCompaction(app.compaction_config()),
                 );
             }
@@ -2131,10 +2132,6 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             ) && let Some(ref model) = settings.default_model
             {
                 app.set_model_selection(model.clone());
-                if app.auto_model {
-                    app.reasoning_effort = ReasoningEffort::Auto;
-                    app.last_effective_reasoning_effort = None;
-                }
                 app.update_model_compaction_budget();
                 app.session.last_prompt_tokens = None;
                 app.session.last_completion_tokens = None;
@@ -2143,16 +2140,23 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             }
         }
         "reasoning_effort" | "effort" => {
-            app.reasoning_effort = if app.auto_model {
-                ReasoningEffort::Auto
-            } else {
-                settings
-                    .reasoning_effort
-                    .as_deref()
-                    .map_or_else(ReasoningEffort::default, |value| {
+            app.reasoning_effort = settings.reasoning_effort.as_deref().map_or_else(
+                || {
+                    if app.auto_model {
+                        ReasoningEffort::Auto
+                    } else {
+                        ReasoningEffort::default()
+                    }
+                },
+                |value| {
+                    if app.auto_model {
+                        ReasoningEffort::from_setting(value)
+                    } else {
                         ReasoningEffort::from_setting_for_provider(value, app.api_provider)
-                    })
-            };
+                    }
+                },
+            );
+            app.reasoning_effort_explicit = settings.reasoning_effort.is_some();
             app.last_effective_reasoning_effort = None;
             app.update_model_compaction_budget();
             action = Some(AppAction::UpdateCompaction(app.compaction_config()));
@@ -3259,7 +3263,7 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
     }
 
     #[test]
-    fn config_model_auto_enables_auto_thinking() {
+    fn config_model_auto_preserves_explicit_thinking() {
         let mut app = create_test_app();
         app.reasoning_effort = ReasoningEffort::Off;
 
@@ -3268,9 +3272,33 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
         assert!(result.message.is_some());
         assert!(app.auto_model);
         assert_eq!(app.model, "auto");
-        assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
+        assert_eq!(app.reasoning_effort, ReasoningEffort::Off);
+        assert!(
+            result
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("thinking = off"))
+        );
         assert!(app.last_effective_model.is_none());
         assert!(app.last_effective_reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn config_reasoning_effort_applies_while_model_routing_is_auto() {
+        let mut app = create_test_app();
+        app.set_model_selection("auto".to_string());
+        app.reasoning_effort = ReasoningEffort::Auto;
+        app.reasoning_effort_explicit = false;
+
+        let result = set_config_value(&mut app, "reasoning_effort", "low", false);
+
+        assert!(!result.is_error);
+        assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
+        assert!(app.reasoning_effort_explicit);
+        assert!(matches!(
+            result.action,
+            Some(AppAction::UpdateCompaction(_))
+        ));
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -3266,6 +3266,7 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
     fn config_model_auto_preserves_explicit_thinking() {
         let mut app = create_test_app();
         app.reasoning_effort = ReasoningEffort::Off;
+        app.reasoning_effort_explicit = true;
 
         let result = config_command(&mut app, Some("model auto"));
 
@@ -3281,6 +3282,26 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
         );
         assert!(app.last_effective_model.is_none());
         assert!(app.last_effective_reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn config_model_auto_releases_implicit_fixed_model_thinking() {
+        let mut app = create_test_app();
+        app.reasoning_effort = ReasoningEffort::Max;
+        app.reasoning_effort_explicit = false;
+
+        let result = config_command(&mut app, Some("model auto"));
+
+        assert!(result.message.is_some());
+        assert!(app.auto_model);
+        assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
+        assert!(!app.reasoning_effort_explicit);
+        assert!(
+            result
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("thinking = auto"))
+        );
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -2140,7 +2140,11 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             }
         }
         "reasoning_effort" | "effort" => {
-            app.reasoning_effort = settings.reasoning_effort.as_deref().map_or_else(
+            app.reasoning_effort_preference = settings
+                .reasoning_effort
+                .as_deref()
+                .map(ReasoningEffort::from_setting);
+            app.reasoning_effort = app.reasoning_effort_preference.map_or_else(
                 || {
                     if app.auto_model {
                         ReasoningEffort::Auto
@@ -2148,15 +2152,14 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
                         ReasoningEffort::default()
                     }
                 },
-                |value| {
+                |requested| {
                     if app.auto_model {
-                        ReasoningEffort::from_setting(value)
+                        requested
                     } else {
-                        ReasoningEffort::from_setting_for_provider(value, app.api_provider)
+                        requested.normalize_for_provider(app.api_provider)
                     }
                 },
             );
-            app.reasoning_effort_explicit = settings.reasoning_effort.is_some();
             app.last_effective_reasoning_effort = None;
             app.update_model_compaction_budget();
             action = Some(AppAction::UpdateCompaction(app.compaction_config()));
@@ -3266,7 +3269,7 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
     fn config_model_auto_preserves_explicit_thinking() {
         let mut app = create_test_app();
         app.reasoning_effort = ReasoningEffort::Off;
-        app.reasoning_effort_explicit = true;
+        app.reasoning_effort_preference = Some(ReasoningEffort::Off);
 
         let result = config_command(&mut app, Some("model auto"));
 
@@ -3288,14 +3291,14 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
     fn config_model_auto_releases_implicit_fixed_model_thinking() {
         let mut app = create_test_app();
         app.reasoning_effort = ReasoningEffort::Max;
-        app.reasoning_effort_explicit = false;
+        app.reasoning_effort_preference = None;
 
         let result = config_command(&mut app, Some("model auto"));
 
         assert!(result.message.is_some());
         assert!(app.auto_model);
         assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
-        assert!(!app.reasoning_effort_explicit);
+        assert_eq!(app.reasoning_effort_preference, None);
         assert!(
             result
                 .message
@@ -3309,13 +3312,13 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
         let mut app = create_test_app();
         app.set_model_selection("auto".to_string());
         app.reasoning_effort = ReasoningEffort::Auto;
-        app.reasoning_effort_explicit = false;
+        app.reasoning_effort_preference = None;
 
         let result = set_config_value(&mut app, "reasoning_effort", "low", false);
 
         assert!(!result.is_error);
         assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
-        assert!(app.reasoning_effort_explicit);
+        assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Low));
         assert!(matches!(
             result.action,
             Some(AppAction::UpdateCompaction(_))
@@ -3380,6 +3383,7 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
         let result = set_config_value(&mut app, "reasoning_effort", "off", false);
 
         assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
+        assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Off));
         assert_eq!(
             result.message.as_deref(),
             Some("reasoning_effort = low (session only, add --save to persist)")

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -2160,7 +2160,7 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
                     }
                 },
             );
-            app.last_effective_reasoning_effort = None;
+            app.invalidate_route_receipts_for_reasoning_change();
             app.update_model_compaction_budget();
             action = Some(AppAction::UpdateCompaction(app.compaction_config()));
         }

--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -8,7 +8,9 @@ use crate::config::{
     normalize_custom_model_id, normalize_model_name_for_provider,
 };
 use crate::localization::{Locale, MessageId, tr};
-use crate::tui::app::{App, AppAction, AppMode, ReasoningEffort};
+#[cfg(test)]
+use crate::tui::app::ReasoningEffort;
+use crate::tui::app::{App, AppAction, AppMode};
 use crate::tui::views::{HelpView, ModalKind, SubAgentsView, subagent_view_agents};
 
 use super::CommandResult;
@@ -238,11 +240,7 @@ pub fn model(app: &mut App, model_name: Option<&str>) -> CommandResult {
         if name.trim().eq_ignore_ascii_case("auto") {
             let old_model = app.model_display_label();
             let model_changed = !app.auto_model || app.model != "auto";
-            app.auto_model = true;
-            app.model = "auto".to_string();
-            app.last_effective_model = None;
-            app.reasoning_effort = ReasoningEffort::Auto;
-            app.last_effective_reasoning_effort = None;
+            app.set_model_selection("auto".to_string());
             app.active_route_limits = app.context_window_override_limits();
             app.update_model_compaction_budget();
             if model_changed {
@@ -1354,6 +1352,7 @@ mod tests {
         let _settings = SettingsPathGuard::new();
         let mut app = create_test_app();
         app.reasoning_effort = ReasoningEffort::Off;
+        app.reasoning_effort_preference = None;
 
         let result = model(&mut app, Some("auto"));
 
@@ -1363,6 +1362,24 @@ mod tests {
         assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
         assert!(app.last_effective_model.is_none());
         assert!(app.last_effective_reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn test_model_auto_preserves_raw_explicit_thinking() {
+        let _settings = SettingsPathGuard::new();
+        let mut app = create_test_app();
+        app.api_provider = ApiProvider::OpenaiCodex;
+        app.auto_model = false;
+        app.reasoning_effort = ReasoningEffort::Low;
+        app.reasoning_effort_preference = Some(ReasoningEffort::Off);
+
+        let result = model(&mut app, Some("auto"));
+
+        assert!(result.message.is_some());
+        assert!(app.auto_model);
+        assert_eq!(app.model, "auto");
+        assert_eq!(app.reasoning_effort, ReasoningEffort::Off);
+        assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Off));
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/core/provider.rs
+++ b/crates/tui/src/commands/groups/core/provider.rs
@@ -652,7 +652,7 @@ mod tests {
                             crate::config::DEEPSEEK_ALIAS_REPLACEMENT
                         );
                         app.reasoning_effort = crate::tui::app::ReasoningEffort::Max;
-                        app.reasoning_effort_explicit = false;
+                        app.reasoning_effort_preference = None;
                         app.apply_provider_switch_reasoning_effort(
                             provider,
                             official_base_url,
@@ -705,7 +705,7 @@ mod tests {
             "deepseek-reasoner"
         );
         app.reasoning_effort = crate::tui::app::ReasoningEffort::Max;
-        app.reasoning_effort_explicit = false;
+        app.reasoning_effort_preference = None;
         app.apply_provider_switch_reasoning_effort(
             provider,
             "https://models.example/v1",
@@ -717,7 +717,7 @@ mod tests {
             "custom endpoint owns alias semantics"
         );
 
-        app.reasoning_effort_explicit = true;
+        app.reasoning_effort_preference = Some(crate::tui::app::ReasoningEffort::Max);
         app.apply_provider_switch_reasoning_effort(
             provider,
             crate::config::DEFAULT_DEEPSEEK_BASE_URL,

--- a/crates/tui/src/commands/groups/debug/cache.rs
+++ b/crates/tui/src/commands/groups/debug/cache.rs
@@ -48,16 +48,18 @@ fn format_cache_inspect(app: &mut App, verbose: bool, json_mode: bool) -> String
         return "cache inspect: --json and --verbose cannot be combined".to_string();
     }
 
-    let replay_base_url = app
-        .session
-        .last_base_url
-        .as_deref()
-        .unwrap_or(&app.active_route_base_url);
+    let Some(target) = app.cache_replay_target() else {
+        return "cache inspect: Auto has no concrete route yet; send a turn first".to_string();
+    };
+    let Some(replay_base_url) = target.base_url.as_deref() else {
+        return "cache inspect: the restored Auto route has no captured endpoint; send a turn first"
+            .to_string();
+    };
     let reasoning_effort = app
-        .reasoning_effort_api_value_for_replay(replay_base_url)
+        .reasoning_effort_api_value_for_replay(target.provider, replay_base_url, &target.model)
         .map(str::to_string);
     let request = MessageRequest {
-        model: app.model.clone(),
+        model: target.model.clone(),
         messages: app.api_messages.clone(),
         max_tokens: 0,
         system: app.system_prompt.clone(),
@@ -73,9 +75,9 @@ fn format_cache_inspect(app: &mut App, verbose: bool, json_mode: bool) -> String
     let inspection = inspect_prompt_for_request(&request);
     let previous = app.session.last_cache_inspection.as_ref();
     let current_warmup_key = CacheWarmupKey::from_inspection(
-        &format!("{:?}", app.api_provider),
-        &app.model,
-        app.session.last_base_url.as_deref().unwrap_or_default(),
+        &target.provider_identity,
+        &target.model,
+        replay_base_url,
         &inspection,
     );
     let warmup_status =

--- a/crates/tui/src/commands/groups/debug/cache.rs
+++ b/crates/tui/src/commands/groups/debug/cache.rs
@@ -48,16 +48,14 @@ fn format_cache_inspect(app: &mut App, verbose: bool, json_mode: bool) -> String
         return "cache inspect: --json and --verbose cannot be combined".to_string();
     }
 
-    let reasoning_effort = if app.reasoning_effort == crate::tui::app::ReasoningEffort::Auto {
-        app.last_effective_reasoning_effort
-            .and_then(crate::tui::app::EffectiveReasoningEffort::tier)
-            .and_then(|effort| effort.api_value_for_provider(app.api_provider))
-            .map(str::to_string)
-    } else {
-        app.reasoning_effort
-            .api_value_for_provider(app.api_provider)
-            .map(str::to_string)
-    };
+    let replay_base_url = app
+        .session
+        .last_base_url
+        .as_deref()
+        .unwrap_or(&app.active_route_base_url);
+    let reasoning_effort = app
+        .reasoning_effort_api_value_for_replay(replay_base_url)
+        .map(str::to_string);
     let request = MessageRequest {
         model: app.model.clone(),
         messages: app.api_messages.clone(),

--- a/crates/tui/src/commands/groups/debug/cache.rs
+++ b/crates/tui/src/commands/groups/debug/cache.rs
@@ -50,6 +50,7 @@ fn format_cache_inspect(app: &mut App, verbose: bool, json_mode: bool) -> String
 
     let reasoning_effort = if app.reasoning_effort == crate::tui::app::ReasoningEffort::Auto {
         app.last_effective_reasoning_effort
+            .and_then(crate::tui::app::EffectiveReasoningEffort::tier)
             .and_then(|effort| effort.api_value_for_provider(app.api_provider))
             .map(str::to_string)
     } else {

--- a/crates/tui/src/commands/groups/debug/tests.rs
+++ b/crates/tui/src/commands/groups/debug/tests.rs
@@ -560,6 +560,50 @@ fn cache_inspect_json_reports_tool_catalog_hash_and_layer_sizes() {
     assert!(tool_layer["token_estimate"].as_u64().unwrap() > 0);
 }
 
+#[test]
+fn cache_inspect_json_keys_auto_replay_to_the_last_concrete_route() {
+    let mut app = create_test_app();
+    app.model = "auto".to_string();
+    app.auto_model = true;
+    app.reasoning_effort = crate::tui::app::ReasoningEffort::Off;
+    app.last_effective_provider = Some(crate::config::ApiProvider::OpenaiCodex);
+    app.last_effective_provider_identity =
+        Some(crate::config::ApiProvider::OpenaiCodex.as_str().to_string());
+    app.last_effective_model = Some(crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string());
+    app.session.last_base_url = Some(crate::config::DEFAULT_OPENAI_CODEX_BASE_URL.to_string());
+    app.push_turn_cache_record(TurnCacheRecord {
+        provider: Some(crate::config::ApiProvider::OpenaiCodex),
+        provider_identity: Some(crate::config::ApiProvider::OpenaiCodex.as_str().to_string()),
+        model: Some(crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string()),
+        auto_model: true,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_hit_tokens: None,
+        cache_miss_tokens: None,
+        cache_write_tokens: None,
+        reasoning_tokens: None,
+        cost_audit: None,
+        reasoning_replay_tokens: None,
+        recorded_at: Instant::now(),
+    });
+
+    let message = cache(&mut app, Some("inspect --json"))
+        .message
+        .expect("inspect json output");
+    let parsed: serde_json::Value = serde_json::from_str(&message).expect("valid json");
+    let key = &parsed["current_warmup_key"];
+
+    assert_eq!(
+        key["provider"],
+        crate::config::ApiProvider::OpenaiCodex.as_str()
+    );
+    assert_eq!(key["model"], crate::config::DEFAULT_OPENAI_CODEX_MODEL);
+    assert_eq!(
+        key["base_url"],
+        crate::config::DEFAULT_OPENAI_CODEX_BASE_URL
+    );
+}
+
 fn warmup_key(model: &str, static_hash: &str) -> CacheWarmupKey {
     CacheWarmupKey {
         provider: "Deepseek".to_string(),

--- a/crates/tui/src/commands/groups/session/session.rs
+++ b/crates/tui/src/commands/groups/session/session.rs
@@ -538,6 +538,8 @@ mod tests {
         app.last_effective_provider_identity = Some("zai".to_string());
         app.last_effective_model = Some(crate::config::ZAI_GLM_5_TURBO_MODEL.to_string());
         app.last_auto_route_receipt = Some(receipt.clone());
+        app.last_effective_reasoning_effort =
+            Some(crate::tui::app::EffectiveReasoningEffort::ThinkingEnabledGranularityUnavailable);
 
         let result = save(&mut app, Some(save_path.to_str().unwrap()));
 
@@ -549,6 +551,10 @@ mod tests {
         assert_eq!(route.provider_identity, "zai");
         assert_eq!(route.model, crate::config::ZAI_GLM_5_TURBO_MODEL);
         assert_eq!(route.receipt, receipt);
+        assert_eq!(
+            route.effective_reasoning_effort,
+            Some(crate::work_graph::ReasoningEffortTier::ThinkingEnabledGranularityUnavailable)
+        );
     }
 
     #[test]
@@ -1044,7 +1050,9 @@ mod tests {
         let mut saved_app = create_test_app_with_tmpdir(&tmpdir);
         saved_app.set_model_selection("auto".to_string());
         saved_app.last_effective_model = Some("deepseek-v4-flash".to_string());
-        saved_app.last_effective_reasoning_effort = Some(ReasoningEffort::Low);
+        saved_app.last_effective_reasoning_effort = Some(
+            crate::tui::app::EffectiveReasoningEffort::Tier(ReasoningEffort::Low),
+        );
         let save_path = tmpdir.path().join("auto_model.json");
         save(&mut saved_app, Some(save_path.to_str().unwrap()));
 

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -417,9 +417,14 @@ pub fn parse_mode(arg: Option<&str>) -> Result<ConfigUiMode, String> {
 
 pub fn build_document(app: &App, config: &Config) -> Result<ConfigUiDocument> {
     let settings = Settings::load_persisted().unwrap_or_default();
-    let reasoning_effort = config
-        .reasoning_effort()
-        .map(ReasoningEffortValue::from_setting)
+    let reasoning_effort = app
+        .reasoning_effort_preference
+        .map(Into::into)
+        .or_else(|| {
+            config
+                .reasoning_effort()
+                .map(ReasoningEffortValue::from_setting)
+        })
         .unwrap_or_else(|| app.reasoning_effort.into());
     let default_model = settings.default_model.clone();
     let status_items = app.status_items.iter().copied().map(Into::into).collect();
@@ -904,12 +909,19 @@ fn reload_runtime_config(app: &mut App, config: &mut Config) -> Result<()> {
     }
     .map_err(anyhow::Error::msg)?;
     app.set_provider_identity_record(identity);
-    app.reasoning_effort =
-        ReasoningEffort::from_setting(reloaded.reasoning_effort().unwrap_or_else(|| {
-            app.reasoning_effort
-                .as_setting_for_provider(app.api_provider)
-        }))
-        .normalize_for_provider(app.api_provider);
+    let requested = reloaded
+        .reasoning_effort()
+        .map(ReasoningEffort::from_setting)
+        .or(app.reasoning_effort_preference)
+        .unwrap_or(app.reasoning_effort);
+    if reloaded.reasoning_effort().is_some() {
+        app.reasoning_effort_preference = Some(requested);
+    }
+    app.reasoning_effort = if app.auto_model {
+        requested
+    } else {
+        requested.normalize_for_provider(app.api_provider)
+    };
     app.last_effective_reasoning_effort = None;
     app.update_model_compaction_budget();
     app.mcp_config_path = reloaded.mcp_config_path();
@@ -936,19 +948,24 @@ fn apply_reasoning_effort(
     value: ReasoningEffortValue,
     persist: bool,
 ) -> Result<()> {
-    let effort: ReasoningEffort =
-        ReasoningEffort::from(value).normalize_for_provider(app.api_provider);
-    app.reasoning_effort = effort;
+    let requested = ReasoningEffort::from(value);
+    let effective = if app.auto_model {
+        requested
+    } else {
+        requested.normalize_for_provider(app.api_provider)
+    };
+    app.reasoning_effort = effective;
+    app.reasoning_effort_preference = Some(requested);
     app.last_effective_reasoning_effort = None;
     app.update_model_compaction_budget();
     if persist {
         crate::config_persistence::persist_root_string_key(
             app.config_path.as_deref(),
             "reasoning_effort",
-            effort.as_setting_for_provider(app.api_provider),
+            requested.as_setting(),
         )?;
     }
-    config.reasoning_effort = Some(effort.as_setting_for_provider(app.api_provider).to_string());
+    config.reasoning_effort = Some(requested.as_setting().to_string());
     Ok(())
 }
 
@@ -1468,6 +1485,7 @@ mod tests {
         app.api_provider = ApiProvider::Deepseek;
         app.model_ids_passthrough = false;
         app.active_route_limits = None;
+        app.reasoning_effort_preference = None;
         app.update_model_compaction_budget();
         app
     }
@@ -1486,6 +1504,34 @@ mod tests {
         // rewrite that product setting into an assumed Suggest default.
         assert_eq!(doc.runtime.approval_mode, app.approval_mode.into());
         assert_eq!(doc.config.reasoning_effort, ReasoningEffortValue::Max);
+    }
+
+    #[test]
+    fn build_document_uses_raw_reasoning_preference() {
+        let mut app = app();
+        app.api_provider = ApiProvider::OpenaiCodex;
+        app.reasoning_effort = ReasoningEffort::Low;
+        app.reasoning_effort_preference = Some(ReasoningEffort::Off);
+
+        let doc = build_document(&app, &Config::default()).expect("document");
+
+        assert_eq!(doc.config.reasoning_effort, ReasoningEffortValue::Off);
+    }
+
+    #[test]
+    fn config_ui_reasoning_keeps_raw_preference_for_fixed_route() {
+        let mut app = app();
+        app.api_provider = ApiProvider::OpenaiCodex;
+        app.reasoning_effort = ReasoningEffort::High;
+        app.reasoning_effort_preference = None;
+        let mut config = Config::default();
+
+        apply_reasoning_effort(&mut app, &mut config, ReasoningEffortValue::Off, false)
+            .expect("apply reasoning");
+
+        assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
+        assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Off));
+        assert_eq!(config.reasoning_effort.as_deref(), Some("off"));
     }
 
     #[test]

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -922,7 +922,7 @@ fn reload_runtime_config(app: &mut App, config: &mut Config) -> Result<()> {
     } else {
         requested.normalize_for_provider(app.api_provider)
     };
-    app.last_effective_reasoning_effort = None;
+    app.invalidate_route_receipts_for_reasoning_change();
     app.update_model_compaction_budget();
     app.mcp_config_path = reloaded.mcp_config_path();
     app.skills_dir = reloaded.skills_dir();
@@ -956,7 +956,7 @@ fn apply_reasoning_effort(
     };
     app.reasoning_effort = effective;
     app.reasoning_effort_preference = Some(requested);
-    app.last_effective_reasoning_effort = None;
+    app.invalidate_route_receipts_for_reasoning_change();
     app.update_model_compaction_budget();
     if persist {
         crate::config_persistence::persist_root_string_key(

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -964,6 +964,13 @@ fn apply_reasoning_effort(
             "reasoning_effort",
             requested.as_setting(),
         )?;
+        // App startup gives settings.toml precedence over config.toml. Keep
+        // the schema-driven TUI/web editor aligned with the picker so an older
+        // saved startup value cannot silently undo this persisted choice on
+        // the next launch.
+        app.startup_defaults.apply_blocking(
+            crate::tui::startup_defaults::StartupDefaults::reasoning_effort(requested.as_setting()),
+        )?;
     }
     config.reasoning_effort = Some(requested.as_setting().to_string());
     Ok(())
@@ -1532,6 +1539,53 @@ mod tests {
         assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
         assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Off));
         assert_eq!(config.reasoning_effort.as_deref(), Some("off"));
+    }
+
+    #[test]
+    fn persisted_config_ui_reasoning_updates_the_startup_precedence_layer() {
+        let _lock = lock_test_env();
+        let temp_root = tempfile::tempdir().expect("isolated Codewhale home");
+        let codewhale_home = temp_root.path().join(".codewhale");
+        fs::create_dir_all(&codewhale_home).expect("settings dir");
+        fs::write(
+            codewhale_home.join("settings.toml"),
+            "default_model = \"auto\"\nreasoning_effort = \"max\"\n",
+        )
+        .expect("seed settings");
+        let config_path = temp_root.path().join("config.toml");
+        fs::write(&config_path, "reasoning_effort = \"max\"\n").expect("seed config");
+        let _home = EnvVarGuard::set("CODEWHALE_HOME", &codewhale_home);
+
+        let mut app = app();
+        app.config_path = Some(config_path.clone());
+        let mut config = Config::load(Some(config_path.clone()), None).expect("load config");
+
+        apply_reasoning_effort(&mut app, &mut config, ReasoningEffortValue::Low, true)
+            .expect("persist reasoning");
+
+        assert_eq!(
+            Settings::load_persisted()
+                .expect("reload settings")
+                .reasoning_effort
+                .as_deref(),
+            Some("low")
+        );
+        let persisted_config =
+            Config::load(Some(config_path), None).expect("reload persisted config");
+        let restored = App::new(
+            TuiOptions {
+                use_alt_screen: false,
+                start_in_agent_mode: true,
+                ..crate::test_support::test_tui_options(PathBuf::from("."))
+            },
+            &persisted_config,
+        );
+        assert!(restored.auto_model);
+        assert_eq!(restored.reasoning_effort, ReasoningEffort::Low);
+        assert_eq!(
+            restored.reasoning_effort_preference,
+            Some(ReasoningEffort::Low)
+        );
     }
 
     #[test]

--- a/crates/tui/src/core/engine/preview.rs
+++ b/crates/tui/src/core/engine/preview.rs
@@ -112,7 +112,8 @@ pub struct PreviewNextTurn {
     /// Normalized reasoning-effort api value from the planner, exactly as it
     /// would be sent.
     pub reasoning_effort: Option<String>,
-    /// True when auto reasoning (or auto model routing) picked that tier.
+    /// True when the user selected auto reasoning and the planner picked that
+    /// tier.
     pub reasoning_effort_auto: bool,
     /// How the auto router chose this route, when auto routing ran.
     pub auto_route_source: Option<String>,
@@ -2653,7 +2654,7 @@ mod tests {
         let planned_base_url = planned.route.candidate.endpoint().base_url.clone();
         assert!(
             planned.auto_controls_reasoning,
-            "auto model routing also drives the reasoning tier"
+            "the helper requests auto reasoning for its auto-model fixture"
         );
 
         let manifest = engine

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1577,6 +1577,7 @@ async fn run_async_main(
                     .filter(|value| !value.is_empty())
                 {
                     config.reasoning_effort = normalize_cli_reasoning_effort(reasoning_arg)?;
+                    config.reasoning_effort_inferred_from_legacy_alias = false;
                 }
                 let prompt = join_prompt_parts(&args.prompt);
                 let resume_session_id = resolve_exec_resume_session_id(&args, &workspace)?;
@@ -7001,8 +7002,26 @@ fn effective_config_profile(cli: &Cli) -> Option<String> {
 fn load_config_from_cli_with_effective_profile(cli: &Cli) -> Result<(Config, Option<String>)> {
     let profile = effective_config_profile(cli);
     let mut config = Config::load(cli.config.clone(), profile.as_deref())?;
+    if let Ok(settings) = crate::settings::Settings::load_persisted() {
+        apply_saved_reasoning_preference(&mut config, &settings);
+    }
     cli.feature_toggles.apply(&mut config)?;
     Ok((config, profile))
+}
+
+/// Apply the same reasoning-preference precedence as interactive `App`
+/// construction to non-TUI runtimes.
+///
+/// `/model` and the config editor persist this preference in `settings.toml`.
+/// Exec, review, workflow, ACP, and runtime-thread launches all begin with a
+/// `Config`, so copying the saved value here keeps those entry points from
+/// silently falling back to a route classifier or an older config.toml value.
+fn apply_saved_reasoning_preference(config: &mut Config, settings: &crate::settings::Settings) {
+    let Some(reasoning_effort) = settings.reasoning_effort.as_ref() else {
+        return;
+    };
+    config.reasoning_effort = Some(reasoning_effort.clone());
+    config.reasoning_effort_inferred_from_legacy_alias = false;
 }
 
 fn read_api_key_from_stdin() -> Result<String> {
@@ -9111,6 +9130,11 @@ struct CliAutoRoute {
     provider: crate::config::ApiProvider,
     model: String,
     reasoning_effort: Option<crate::tui::app::ReasoningEffort>,
+    /// Whether the runtime should continue resolving reasoning per prompt.
+    ///
+    /// This is independent from `auto_model`: an Auto model can carry a fixed
+    /// saved effort, while a fixed Fleet model can still request Auto effort.
+    auto_controls_reasoning: bool,
     auto_model: bool,
 }
 
@@ -9136,23 +9160,6 @@ fn cli_reasoning_effort_value_for_prompt(
         effort
     };
     cli_reasoning_effort_value(config, model, resolved)
-}
-
-/// Whether a CLI launch is an Auto *reasoning* request.
-///
-/// Auto reasoning and Auto model are independent decisions. A Fleet worker
-/// subprocess launches with `--model <exact> --reasoning-effort auto`: the
-/// model is pinned (so `auto_model` is false) while the reasoning tier is
-/// still Auto. Reading the flag off `auto_model` alone therefore mislabels
-/// exactly the launch shape the exact-Fleet path uses.
-const fn cli_reasoning_is_auto(
-    reasoning_effort: Option<crate::tui::app::ReasoningEffort>,
-    auto_model: bool,
-) -> bool {
-    matches!(
-        reasoning_effort,
-        Some(crate::tui::app::ReasoningEffort::Auto)
-    ) || auto_model
 }
 
 fn normalize_cli_reasoning_effort(value: &str) -> Result<Option<String>> {
@@ -9193,19 +9200,31 @@ async fn resolve_cli_auto_route(
         let selection =
             model_routing::resolve_auto_route_with_inventory(config, prompt, "", "auto", "auto")
                 .await?;
+        let preference = config
+            .reasoning_effort()
+            .filter(|_| config.reasoning_effort_is_explicit())
+            .map(crate::tui::app::ReasoningEffort::from_setting);
+        let (reasoning_effort, auto_controls_reasoning) =
+            model_routing::resolve_auto_model_reasoning(preference, selection.reasoning_effort);
         Ok(CliAutoRoute {
             provider: selection.provider,
             model: selection.model,
-            reasoning_effort: selection.reasoning_effort,
+            reasoning_effort,
+            auto_controls_reasoning,
             auto_model: true,
         })
     } else {
         if let Some(selection) = model_routing::resolve_explicit_route_with_inventory(config, model)
         {
+            let auto_controls_reasoning = matches!(
+                selection.reasoning_effort,
+                Some(crate::tui::app::ReasoningEffort::Auto)
+            );
             return Ok(CliAutoRoute {
                 provider: selection.provider,
                 model: selection.model,
                 reasoning_effort: selection.reasoning_effort,
+                auto_controls_reasoning,
                 auto_model: false,
             });
         }
@@ -9231,12 +9250,17 @@ async fn resolve_cli_auto_route(
         // call, which (for example) prevented vllm + Qwen3 users from
         // disabling thinking via `reasoning_effort = "off"` and caused
         // 30+ second SSE idle timeouts on trivial prompts.
+        let reasoning_effort = config
+            .reasoning_effort()
+            .map(crate::tui::app::ReasoningEffort::from_setting);
         Ok(CliAutoRoute {
             provider: config.api_provider(),
             model: model.to_string(),
-            reasoning_effort: config
-                .reasoning_effort()
-                .map(crate::tui::app::ReasoningEffort::from_setting),
+            auto_controls_reasoning: matches!(
+                reasoning_effort,
+                Some(crate::tui::app::ReasoningEffort::Auto)
+            ),
+            reasoning_effort,
             auto_model: false,
         })
     }
@@ -9249,12 +9273,17 @@ async fn resolve_cli_exec_route(
     force_configured_route: bool,
 ) -> Result<CliAutoRoute> {
     if force_configured_route && !model.trim().eq_ignore_ascii_case("auto") {
+        let reasoning_effort = config
+            .reasoning_effort()
+            .map(crate::tui::app::ReasoningEffort::from_setting);
         return Ok(CliAutoRoute {
             provider: config.api_provider(),
             model: model.to_string(),
-            reasoning_effort: config
-                .reasoning_effort()
-                .map(crate::tui::app::ReasoningEffort::from_setting),
+            auto_controls_reasoning: matches!(
+                reasoning_effort,
+                Some(crate::tui::app::ReasoningEffort::Auto)
+            ),
+            reasoning_effort,
             auto_model: false,
         });
     }
@@ -9951,7 +9980,7 @@ async fn build_direct_workflow_tool(
     // raw AND non-auto: the runtime carried the literal string `"auto"` while
     // nothing was allowed to resolve it. Auto is a reasoning decision, not a
     // model decision — it does not require `--model auto`.
-    let reasoning_effort_auto = cli_reasoning_is_auto(route.reasoning_effort, route.auto_model);
+    let reasoning_effort_auto = route.auto_controls_reasoning;
     let reasoning_effort = route
         .reasoning_effort
         .and_then(|effort| cli_reasoning_effort_value(config, &route.model, effort));
@@ -10439,7 +10468,7 @@ async fn run_exec_agent(
     // here, so deriving the auto flag from it left this path both raw and
     // non-auto: the literal string `"auto"` travelled to the engine while the
     // receipt claimed no Auto was in play.
-    let reasoning_effort_auto = cli_reasoning_is_auto(route.reasoning_effort, auto_model);
+    let reasoning_effort_auto = route.auto_controls_reasoning;
     // Resolve Auto against this run's prompt at the CLI boundary, exactly like
     // `run_one_shot`/`run_one_shot_json` and the interactive launch path do,
     // so the tier the engine (and the receipt below) sees is concrete.
@@ -13005,6 +13034,7 @@ mod terminal_mode_tests {
             provider: crate::config::ApiProvider::Vllm,
             model: "offline-test-model".to_string(),
             reasoning_effort: None,
+            auto_controls_reasoning: false,
             auto_model: false,
         };
         let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
@@ -13215,6 +13245,37 @@ mod terminal_mode_tests {
         assert!(message.contains("/setup"));
     }
 
+    #[tokio::test]
+    async fn cli_auto_model_honors_a_fixed_reasoning_preference() {
+        let config = Config {
+            provider: Some("vllm".to_string()),
+            reasoning_effort: Some("low".to_string()),
+            providers: Some(crate::config::ProvidersConfig {
+                vllm: crate::config::ProviderConfig {
+                    base_url: Some("http://127.0.0.1:18190/v1".to_string()),
+                    model: Some("local-auto-model".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let route = resolve_cli_auto_route(&config, "auto", "debug a failing test")
+            .await
+            .expect("Auto model route");
+
+        assert!(route.auto_model);
+        assert_eq!(
+            route.reasoning_effort,
+            Some(crate::tui::app::ReasoningEffort::Low)
+        );
+        assert!(
+            !route.auto_controls_reasoning,
+            "a fixed saved tier must not be replaced per prompt"
+        );
+    }
+
     #[test]
     fn cli_route_execution_config_stamps_routed_model_into_provider_slot() {
         let mut providers = crate::config::ProvidersConfig::default();
@@ -13228,6 +13289,7 @@ mod terminal_mode_tests {
             provider: crate::config::ApiProvider::Deepseek,
             model: "deepseek-v4-flash".to_string(),
             reasoning_effort: None,
+            auto_controls_reasoning: true,
             auto_model: true,
         };
 
@@ -13258,6 +13320,7 @@ mod terminal_mode_tests {
             provider: crate::config::ApiProvider::Custom,
             model: "routed-legacy-model".to_string(),
             reasoning_effort: None,
+            auto_controls_reasoning: false,
             auto_model: false,
         };
 
@@ -13823,24 +13886,47 @@ mod terminal_mode_tests {
         );
     }
 
-    /// The exact shape a Fleet worker subprocess launches with:
-    /// `codewhale exec --model <exact> --reasoning-effort auto`. The model is
-    /// pinned, so `auto_model` is false — but the run is still an Auto
-    /// *reasoning* request and must be labelled and resolved as one.
     #[test]
-    fn a_fixed_model_exec_with_reasoning_auto_is_still_an_auto_reasoning_run() {
+    fn cli_route_tracks_auto_reasoning_independently_from_auto_model() {
         use crate::tui::app::ReasoningEffort;
 
-        assert!(
-            cli_reasoning_is_auto(Some(ReasoningEffort::Auto), false),
-            "--model <exact> --reasoning-effort auto is an Auto reasoning run"
-        );
-        assert!(
-            cli_reasoning_is_auto(None, true),
-            "an Auto model route keeps its historic Auto labelling"
-        );
-        assert!(!cli_reasoning_is_auto(Some(ReasoningEffort::High), false));
-        assert!(!cli_reasoning_is_auto(None, false));
+        let fixed_model_auto_reasoning = CliAutoRoute {
+            provider: crate::config::ApiProvider::Deepseek,
+            model: crate::config::DEFAULT_TEXT_MODEL.to_string(),
+            reasoning_effort: Some(ReasoningEffort::Auto),
+            auto_controls_reasoning: true,
+            auto_model: false,
+        };
+        let auto_model_fixed_reasoning = CliAutoRoute {
+            provider: crate::config::ApiProvider::OpenaiCodex,
+            model: crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string(),
+            reasoning_effort: Some(ReasoningEffort::High),
+            auto_controls_reasoning: false,
+            auto_model: true,
+        };
+
+        assert!(fixed_model_auto_reasoning.auto_controls_reasoning);
+        assert!(!fixed_model_auto_reasoning.auto_model);
+        assert!(!auto_model_fixed_reasoning.auto_controls_reasoning);
+        assert!(auto_model_fixed_reasoning.auto_model);
+    }
+
+    #[test]
+    fn saved_reasoning_preference_overrides_config_for_non_tui_runtimes() {
+        let mut config = Config {
+            reasoning_effort: Some("max".to_string()),
+            reasoning_effort_inferred_from_legacy_alias: true,
+            ..Default::default()
+        };
+        let settings = crate::settings::Settings {
+            reasoning_effort: Some("low".to_string()),
+            ..Default::default()
+        };
+
+        apply_saved_reasoning_preference(&mut config, &settings);
+
+        assert_eq!(config.reasoning_effort(), Some("low"));
+        assert!(config.reasoning_effort_is_explicit());
     }
 
     /// `run_exec_agent` must hand the engine a concrete tier, never the literal

--- a/crates/tui/src/model_routing.rs
+++ b/crates/tui/src/model_routing.rs
@@ -532,6 +532,28 @@ pub(crate) fn normalize_auto_route_effort_for_provider(
     }
 }
 
+/// Select the reasoning request that accompanies an Auto-model route.
+///
+/// Model routing and reasoning routing are independent. An explicit fixed
+/// preference wins over the classifier's suggestion; an absent preference or
+/// explicit `Auto` keeps reasoning under per-prompt control.
+#[must_use]
+pub(crate) fn resolve_auto_model_reasoning(
+    preference: Option<ReasoningEffort>,
+    routed: Option<ReasoningEffort>,
+) -> (Option<ReasoningEffort>, bool) {
+    match preference {
+        Some(
+            effort @ (ReasoningEffort::Off
+            | ReasoningEffort::Low
+            | ReasoningEffort::Medium
+            | ReasoningEffort::High
+            | ReasoningEffort::Max),
+        ) => (Some(effort), false),
+        None | Some(ReasoningEffort::Auto) => (routed, true),
+    }
+}
+
 /// Route-aware equivalent of [`normalize_auto_route_effort_for_provider`].
 /// The inventory knows the selected provider/model, and the route resolver
 /// supplies the endpoint needed to distinguish Kimi Code's official bare-K3
@@ -1170,6 +1192,22 @@ fn truncate_for_auto_router(text: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn auto_model_reasoning_keeps_model_and_thinking_choices_independent() {
+        assert_eq!(
+            resolve_auto_model_reasoning(Some(ReasoningEffort::Low), Some(ReasoningEffort::Max)),
+            (Some(ReasoningEffort::Low), false)
+        );
+        assert_eq!(
+            resolve_auto_model_reasoning(Some(ReasoningEffort::Auto), Some(ReasoningEffort::Max)),
+            (Some(ReasoningEffort::Max), true)
+        );
+        assert_eq!(
+            resolve_auto_model_reasoning(None, Some(ReasoningEffort::High)),
+            (Some(ReasoningEffort::High), true)
+        );
+    }
 
     #[test]
     fn auto_model_heuristic_chinese_keywords_route_to_pro() {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -4806,7 +4806,11 @@ impl RuntimeThreadManager {
         let mut thread_config = cfg_snapshot.clone();
         thread_config.scope_to_provider_identity(&identity);
         let verbosity = thread_config.verbosity.clone();
-        let (route, reasoning_effort) = if auto_model {
+        let reasoning_preference = thread_config
+            .reasoning_effort()
+            .filter(|_| thread_config.reasoning_effort_is_explicit())
+            .map(crate::tui::app::ReasoningEffort::from_setting);
+        let (route, reasoning_effort, auto_controls_reasoning) = if auto_model {
             let selection = crate::model_routing::resolve_auto_route_with_inventory(
                 &thread_config,
                 &prompt,
@@ -4820,7 +4824,12 @@ impl RuntimeThreadManager {
                 selection.provider,
                 Some(&selection.model),
             )?;
-            let reasoning_effort = selection.reasoning_effort.map(|effort| {
+            let (selected_reasoning, auto_controls_reasoning) =
+                crate::model_routing::resolve_auto_model_reasoning(
+                    reasoning_preference,
+                    selection.reasoning_effort,
+                );
+            let reasoning_effort = selected_reasoning.map(|effort| {
                 effort
                     .normalize_for_route(
                         route.identity.provider,
@@ -4830,7 +4839,7 @@ impl RuntimeThreadManager {
                     .as_setting()
                     .to_string()
             });
-            (route, reasoning_effort)
+            (route, reasoning_effort, auto_controls_reasoning)
         } else {
             (
                 resolve_runtime_thread_route_for_identity(
@@ -4839,6 +4848,7 @@ impl RuntimeThreadManager {
                     Some(&requested_model),
                 )?,
                 None,
+                false,
             )
         };
         let route = if client_preflight_required {
@@ -4925,7 +4935,7 @@ impl RuntimeThreadManager {
             goal_token_budget: None,
             goal_status: crate::tools::goal::GoalStatus::Active,
             reasoning_effort,
-            reasoning_effort_auto: auto_model,
+            reasoning_effort_auto: auto_controls_reasoning,
             auto_model,
             allow_shell,
             trust_mode,

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -14,6 +14,7 @@ use crate::tools::plan::PlanSnapshot;
 use crate::tools::todo::TodoListSnapshot;
 use crate::tui::file_mention::ContextReference;
 use crate::utils::write_atomic;
+use crate::work_graph::ReasoningEffortTier;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -455,6 +456,11 @@ pub(crate) struct SavedAutoRouteReceipt {
     pub(crate) provider_identity: String,
     pub(crate) model: String,
     pub(crate) receipt: AutoRouteReceipt,
+    /// Canonical effective reasoning receipt for the selected route, including
+    /// routes where a concrete tier cannot be proven. Optional so older
+    /// sessions remain loadable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) effective_reasoning_effort: Option<ReasoningEffortTier>,
 }
 
 /// A saved session containing full conversation history

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2455,7 +2455,7 @@ impl App {
         }
     }
 
-    /// Cycle reasoning-effort through the active provider's distinct tiers.
+    /// Cycle reasoning-effort through the active route's distinct tiers.
     ///
     /// Typed for the same reason as [`Self::select_mode`]: a bool could not tell
     /// the hotbar whether the turn lock refused the action or the provider
@@ -2473,14 +2473,19 @@ impl App {
         }
     }
 
-    /// Advance reasoning effort to the next tier for the active provider and
+    /// Advance reasoning effort to the next tier for the active route and
     /// surface the change: set a status message and refresh the compaction
-    /// budget. Shared by the Ctrl+T shortcut (`cycle_effort`) and the hotbar
+    /// budget. Auto routing retains the full provider-neutral vocabulary until
+    /// dispatch; a concrete provider uses its distinct supported tiers. Shared
+    /// by the Ctrl+T shortcut (`cycle_effort`) and the hotbar
     /// `reasoning.cycle` action so the two paths cannot drift.
     pub(crate) fn apply_reasoning_effort_cycle(&mut self) {
-        let requested = self
-            .reasoning_effort
-            .cycle_next_for_provider(self.api_provider);
+        let requested = if self.auto_model {
+            self.reasoning_effort.cycle_next_for_auto_model()
+        } else {
+            self.reasoning_effort
+                .cycle_next_for_provider(self.api_provider)
+        };
         let effective = self.effective_reasoning_effort_for_active_route(requested);
         let route_truth = self.active_reasoning_route_truth();
         let provider_kind = route_truth.map_or(self.api_provider, |(provider, _, _, _)| provider);

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -67,12 +67,12 @@ pub(crate) use composer::{
     MAX_SUBMITTED_INPUT_CHARS, next_grapheme_boundary, prev_grapheme_boundary,
 };
 pub use status::{StatusToast, StatusToastLevel};
-pub(crate) use types::EffectiveReasoningEffort;
 pub use types::{
     ApiKeyError, AppAction, AppMode, ComposerDensity, InitialInput, McpUiAction, QueuedMessage,
     ReasoningEffort, SettingSelection, ShellJobAction, SubmitDisposition, TaskPanelEntry,
     TaskPanelEntryKind, ToolCollapseMode, ToolDetailRecord, TranscriptSpacing, TuiOptions, VimMode,
 };
+pub(crate) use types::{CacheReplayTarget, EffectiveReasoningEffort};
 
 // === Types ===
 
@@ -4905,12 +4905,112 @@ impl App {
         Self::reasoning_effort_resolution_label(requested, effective, self.api_provider)
     }
 
+    /// Return the concrete provider/model route whose current prompt may be
+    /// inspected or replayed.
+    ///
+    /// For a fixed selection, the active route is authoritative. For Auto,
+    /// `self.model` is only the selector sentinel, so the latest completed
+    /// turn supplies provider/model/endpoint truth. A restored Auto session
+    /// retains provider/model but not a raw endpoint; warmup may re-resolve
+    /// that route from live config, while inspect fails honestly until a new
+    /// turn captures the endpoint.
+    #[must_use]
+    pub(crate) fn cache_replay_target(&self) -> Option<CacheReplayTarget> {
+        if !self.auto_model {
+            let model = self.model.trim();
+            if model.is_empty() || model.eq_ignore_ascii_case("auto") {
+                return None;
+            }
+            let base_url = (!self.active_route_base_url.trim().is_empty())
+                .then(|| self.active_route_base_url.clone());
+            return Some(CacheReplayTarget {
+                provider: self.api_provider,
+                provider_identity: self.provider_identity_for_persistence().to_string(),
+                provider_id: self.provider_id_for_persistence().map(str::to_string),
+                model: model.to_string(),
+                base_url,
+            });
+        }
+
+        let provider = self.last_effective_provider?;
+        let model = self.last_effective_model.as_deref()?.trim();
+        if model.is_empty() || model.eq_ignore_ascii_case("auto") {
+            return None;
+        }
+        let provider_identity = self
+            .last_effective_provider_identity
+            .as_deref()
+            .map(str::trim)
+            .filter(|identity| !identity.is_empty())
+            .map(str::to_string)
+            .or_else(|| (provider != ApiProvider::Custom).then(|| provider.as_str().to_string()))?;
+        let provider_id = if provider != ApiProvider::Custom {
+            Some(provider.as_str().to_string())
+        } else if !provider_identity.eq_ignore_ascii_case(ApiProvider::Custom.as_str()) {
+            Some(provider_identity.clone())
+        } else if self.api_provider == ApiProvider::Custom
+            && self
+                .provider_identity_for_persistence()
+                .eq_ignore_ascii_case(&provider_identity)
+        {
+            self.provider_id_for_persistence().map(str::to_string)
+        } else {
+            None
+        };
+
+        let latest_matches_route = self
+            .session
+            .turn_cache_history
+            .back()
+            .is_some_and(|record| {
+                record.auto_model
+                    && record.provider == Some(provider)
+                    && record
+                        .model
+                        .as_deref()
+                        .is_some_and(|record_model| record_model.eq_ignore_ascii_case(model))
+                    && record
+                        .provider_identity
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|identity| !identity.is_empty())
+                        .map_or(provider != ApiProvider::Custom, |identity| {
+                            identity == provider_identity
+                        })
+            });
+        let warmup_base_url = self
+            .session
+            .last_warmup_key
+            .as_ref()
+            .filter(|key| {
+                key.provider == provider_identity
+                    && key.model.eq_ignore_ascii_case(model)
+                    && !key.base_url.trim().is_empty()
+            })
+            .map(|key| key.base_url.clone());
+        let base_url = latest_matches_route
+            .then(|| self.session.last_base_url.clone())
+            .flatten()
+            .or(warmup_base_url)
+            .filter(|base_url| !base_url.trim().is_empty());
+
+        Some(CacheReplayTarget {
+            provider,
+            provider_identity,
+            provider_id,
+            model: model.to_string(),
+            base_url,
+        })
+    }
+
     /// Provider-facing effort used when replaying the current prompt for cache
-    /// inspection or warmup.
+    /// inspection or warmup on one exact route.
     #[must_use]
     pub(crate) fn reasoning_effort_api_value_for_replay(
         &self,
+        provider: ApiProvider,
         base_url: &str,
+        model: &str,
     ) -> Option<&'static str> {
         let requested = if self.reasoning_effort == ReasoningEffort::Auto {
             self.last_effective_reasoning_effort?
@@ -4918,7 +5018,7 @@ impl App {
         } else {
             self.reasoning_effort
         };
-        requested.api_value_for_route(self.api_provider, base_url, &self.model)
+        requested.api_value_for_route(provider, base_url, model)
     }
 
     pub fn compaction_config(&self) -> CompactionConfig {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1213,8 +1213,8 @@ pub struct App {
     /// Whether the current effort came from an explicit user setting rather
     /// than compatibility inference from a retiring model alias.
     pub(crate) reasoning_effort_explicit: bool,
-    /// Last concrete thinking tier chosen while `reasoning_effort` is auto.
-    pub last_effective_reasoning_effort: Option<ReasoningEffort>,
+    /// Last effective thinking receipt for the most recently accepted route.
+    pub(crate) last_effective_reasoning_effort: Option<EffectiveReasoningEffort>,
     pub workspace: PathBuf,
     /// Off-event-loop worker for durable Lane control writes. `/lane interrupt`
     /// submits here instead of tearing down a Runtime on the composer thread
@@ -4579,10 +4579,14 @@ impl App {
         self.last_auto_route_receipt = None;
         self.pending_auto_route_receipt = None;
         self.last_effective_reasoning_effort = None;
-        // Auto model routing is independent from the requested reasoning
-        // tier. Keep that preference intact so session restore and model
-        // changes cannot silently replace a persisted fixed tier with Auto.
-        if !auto_model {
+        // Auto model routing is independent from an explicitly requested
+        // reasoning tier. An implicit fixed-model default is route-local,
+        // though, so entering Auto must hand reasoning back to the router.
+        if auto_model {
+            if !self.reasoning_effort_explicit {
+                self.reasoning_effort = ReasoningEffort::Auto;
+            }
+        } else {
             self.reasoning_effort = self
                 .reasoning_effort
                 .normalize_for_provider(self.api_provider);
@@ -4630,6 +4634,7 @@ impl App {
             provider_identity,
             model: model.clone(),
             receipt: receipt.clone(),
+            effective_reasoning_effort: self.last_effective_reasoning_effort.map(Into::into),
         })
     }
 
@@ -4766,8 +4771,20 @@ impl App {
             .as_ref()
             .and_then(|turn| turn.route.as_ref())
             .is_some_and(|route| route.receipt.is_some());
+        if self.auto_model
+            && !auto_route_has_receipt
+            && self.last_auto_route_receipt.is_some()
+            && let Some(effective) = self.last_effective_reasoning_effort
+        {
+            // Once a concrete Auto route has been accepted, its normalized
+            // tier remains the display authority until the model or requested
+            // effort changes. The configured classifier route is not evidence
+            // of what the completed turn received.
+            return effective;
+        }
         let effective = if requested == ReasoningEffort::Auto {
             self.last_effective_reasoning_effort
+                .and_then(EffectiveReasoningEffort::tier)
                 .unwrap_or(ReasoningEffort::Auto)
         } else if self.auto_model && !auto_route_has_receipt {
             // The configured provider is only the classifier's starting

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1207,12 +1207,14 @@ pub struct App {
     /// Pending provider transition for transactional rollback when the next
     /// auth failure indicates the new provider cannot be used.
     pub pending_provider_switch: Option<PendingProviderSwitch>,
-    /// Current reasoning-effort tier for DeepSeek thinking mode.
-    /// Cycled via Shift+Tab; initialized from config at startup.
+    /// Current live reasoning-effort selection. Route changes may normalize
+    /// this value; the raw user choice remains in
+    /// [`Self::reasoning_effort_preference`].
     pub reasoning_effort: ReasoningEffort,
-    /// Whether the current effort came from an explicit user setting rather
-    /// than compatibility inference from a retiring model alias.
-    pub(crate) reasoning_effort_explicit: bool,
+    /// Raw explicit user preference, before any fixed provider/model route
+    /// normalizes it. `None` means the current live tier is an implicit route
+    /// default or compatibility inference and must not constrain Auto routing.
+    pub(crate) reasoning_effort_preference: Option<ReasoningEffort>,
     /// Last effective thinking receipt for the most recently accepted route.
     pub(crate) last_effective_reasoning_effort: Option<EffectiveReasoningEffort>,
     pub workspace: PathBuf,
@@ -2514,23 +2516,14 @@ impl App {
             return;
         }
         self.reasoning_effort = requested;
-        self.reasoning_effort_explicit = true;
+        self.reasoning_effort_preference = Some(requested);
         self.last_effective_reasoning_effort = None;
         // Same persistence owner as the model/effort pickers, so Ctrl+T and the
         // hotbar `reasoning.cycle` action restore on restart exactly like a
         // picker selection does. Only the *requested* tier is persisted — the
         // effective tier is a per-turn route fact, not a user preference.
-        let persisted_effort = if self.auto_model {
-            requested.as_setting()
-        } else {
-            requested.as_setting_for_route(
-                self.api_provider,
-                &self.active_route_base_url,
-                &self.model,
-            )
-        };
         self.startup_defaults.spawn(
-            crate::tui::startup_defaults::StartupDefaults::reasoning_effort(persisted_effort),
+            crate::tui::startup_defaults::StartupDefaults::reasoning_effort(requested.as_setting()),
         );
         self.update_model_compaction_budget();
         self.status_message = Some(format!(
@@ -4584,17 +4577,18 @@ impl App {
         self.last_auto_route_receipt = None;
         self.pending_auto_route_receipt = None;
         self.last_effective_reasoning_effort = None;
-        // Auto model routing is independent from an explicitly requested
-        // reasoning tier. An implicit fixed-model default is route-local,
-        // though, so entering Auto must hand reasoning back to the router.
+        // Auto model routing is independent from an explicitly requested raw
+        // reasoning tier. Never reuse the route-normalized live value here:
+        // fixed DeepSeek can collapse low→high and Codex off→low.
         if auto_model {
-            if !self.reasoning_effort_explicit {
-                self.reasoning_effort = ReasoningEffort::Auto;
-            }
-        } else {
             self.reasoning_effort = self
-                .reasoning_effort
-                .normalize_for_provider(self.api_provider);
+                .reasoning_effort_preference
+                .unwrap_or(ReasoningEffort::Auto);
+        } else {
+            let requested = self
+                .reasoning_effort_preference
+                .unwrap_or(self.reasoning_effort);
+            self.reasoning_effort = requested.normalize_for_provider(self.api_provider);
         }
     }
 
@@ -4694,9 +4688,8 @@ impl App {
         let inferred = model_override.and_then(|model| {
             crate::config::legacy_deepseek_alias_effort_for_route(provider, base_url, model)
         });
-        self.reasoning_effort = if self.reasoning_effort_explicit {
-            self.reasoning_effort
-                .normalize_for_route(provider, base_url, wire_model)
+        self.reasoning_effort = if let Some(requested) = self.reasoning_effort_preference {
+            requested.normalize_for_route(provider, base_url, wire_model)
         } else if let Some(effort) = inferred {
             ReasoningEffort::from_setting(effort)
                 .normalize_for_route(provider, base_url, wire_model)

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2057,6 +2057,24 @@ impl App {
         self.last_pinned_prefix_hash = None;
     }
 
+    /// Invalidate facts that were accepted under the previous reasoning
+    /// request.
+    ///
+    /// A fixed model keeps the same concrete route when its reasoning tier
+    /// changes, so only its effective-reasoning receipt becomes stale. Under
+    /// Auto, reasoning is one of the classifier inputs; the previous concrete
+    /// provider/model route therefore cannot be replayed or displayed as the
+    /// route for the new request.
+    pub(crate) fn invalidate_route_receipts_for_reasoning_change(&mut self) {
+        self.last_effective_reasoning_effort = None;
+        if self.auto_model {
+            self.last_effective_model = None;
+            self.last_effective_provider = None;
+            self.last_effective_provider_identity = None;
+            self.last_auto_route_receipt = None;
+        }
+    }
+
     pub fn tr(&self, id: MessageId) -> Cow<'static, str> {
         tr(self.ui_locale, id)
     }
@@ -2517,7 +2535,7 @@ impl App {
         }
         self.reasoning_effort = requested;
         self.reasoning_effort_preference = Some(requested);
-        self.last_effective_reasoning_effort = None;
+        self.invalidate_route_receipts_for_reasoning_change();
         // Same persistence owner as the model/effort pickers, so Ctrl+T and the
         // hotbar `reasoning.cycle` action restore on restart exactly like a
         // picker selection does. Only the *requested* tier is persisted — the
@@ -4697,7 +4715,7 @@ impl App {
             self.reasoning_effort
                 .normalize_for_route(provider, base_url, wire_model)
         };
-        self.last_effective_reasoning_effort = None;
+        self.invalidate_route_receipts_for_reasoning_change();
     }
 
     pub fn effective_model_for_budget(&self) -> &str {
@@ -4772,6 +4790,7 @@ impl App {
         if self.auto_model
             && !auto_route_has_receipt
             && self.last_auto_route_receipt.is_some()
+            && requested == self.reasoning_effort
             && let Some(effective) = self.last_effective_reasoning_effort
         {
             // Once a concrete Auto route has been accepted, its normalized
@@ -4780,7 +4799,8 @@ impl App {
             // of what the completed turn received.
             return effective;
         }
-        if requested == ReasoningEffort::Auto
+        if requested == self.reasoning_effort
+            && requested == ReasoningEffort::Auto
             && let Some(effective) = self.last_effective_reasoning_effort
         {
             // The accepted route receipt is already the strongest available

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -4780,10 +4780,16 @@ impl App {
             // of what the completed turn received.
             return effective;
         }
+        if requested == ReasoningEffort::Auto
+            && let Some(effective) = self.last_effective_reasoning_effort
+        {
+            // The accepted route receipt is already the strongest available
+            // truth. Preserve enabled-but-untiered and unavailable states
+            // instead of forcing them through the tier-only projection.
+            return effective;
+        }
         let effective = if requested == ReasoningEffort::Auto {
-            self.last_effective_reasoning_effort
-                .and_then(EffectiveReasoningEffort::tier)
-                .unwrap_or(ReasoningEffort::Auto)
+            ReasoningEffort::Auto
         } else if self.auto_model && !auto_route_has_receipt {
             // The configured provider is only the classifier's starting
             // point, not the route that will receive the request.
@@ -4897,6 +4903,22 @@ impl App {
         let requested = self.reasoning_effort;
         let effective = self.effective_reasoning_effort_for_active_route(requested);
         Self::reasoning_effort_resolution_label(requested, effective, self.api_provider)
+    }
+
+    /// Provider-facing effort used when replaying the current prompt for cache
+    /// inspection or warmup.
+    #[must_use]
+    pub(crate) fn reasoning_effort_api_value_for_replay(
+        &self,
+        base_url: &str,
+    ) -> Option<&'static str> {
+        let requested = if self.reasoning_effort == ReasoningEffort::Auto {
+            self.last_effective_reasoning_effort?
+                .request_tier_for_replay()?
+        } else {
+            self.reasoning_effort
+        };
+        requested.api_value_for_route(self.api_provider, base_url, &self.model)
     }
 
     pub fn compaction_config(&self) -> CompactionConfig {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2515,11 +2515,15 @@ impl App {
         // hotbar `reasoning.cycle` action restore on restart exactly like a
         // picker selection does. Only the *requested* tier is persisted — the
         // effective tier is a per-turn route fact, not a user preference.
-        let persisted_effort = requested.as_setting_for_route(
-            self.api_provider,
-            &self.active_route_base_url,
-            &self.model,
-        );
+        let persisted_effort = if self.auto_model {
+            requested.as_setting()
+        } else {
+            requested.as_setting_for_route(
+                self.api_provider,
+                &self.active_route_base_url,
+                &self.model,
+            )
+        };
         self.startup_defaults.spawn(
             crate::tui::startup_defaults::StartupDefaults::reasoning_effort(persisted_effort),
         );
@@ -4575,9 +4579,10 @@ impl App {
         self.last_auto_route_receipt = None;
         self.pending_auto_route_receipt = None;
         self.last_effective_reasoning_effort = None;
-        if auto_model {
-            self.reasoning_effort = ReasoningEffort::Auto;
-        } else {
+        // Auto model routing is independent from the requested reasoning
+        // tier. Keep that preference intact so session restore and model
+        // changes cannot silently replace a persisted fixed tier with Auto.
+        if !auto_model {
             self.reasoning_effort = self
                 .reasoning_effort
                 .normalize_for_provider(self.api_provider);
@@ -4755,9 +4760,21 @@ impl App {
         &self,
         requested: ReasoningEffort,
     ) -> EffectiveReasoningEffort {
-        let effective = if self.auto_model || requested == ReasoningEffort::Auto {
+        let route_truth = self.active_reasoning_route_truth();
+        let auto_route_has_receipt = self
+            .active_turn
+            .as_ref()
+            .and_then(|turn| turn.route.as_ref())
+            .is_some_and(|route| route.receipt.is_some());
+        let effective = if requested == ReasoningEffort::Auto {
             self.last_effective_reasoning_effort
                 .unwrap_or(ReasoningEffort::Auto)
+        } else if self.auto_model && !auto_route_has_receipt {
+            // The configured provider is only the classifier's starting
+            // point, not the route that will receive the request.
+            requested
+        } else if let Some((provider, _, base_url, model)) = route_truth {
+            requested.normalize_for_route(provider, base_url, model)
         } else {
             requested.normalize_for_route(
                 self.api_provider,
@@ -4769,7 +4786,6 @@ impl App {
         // Prefer the immutable installed-client receipt while a turn is live.
         // If it is unavailable, only use the configured route when no pending
         // or active foreign route could make that identity stale.
-        let route_truth = self.active_reasoning_route_truth();
         if let Some((provider, _, base_url, model)) = route_truth {
             if let Some(constrained) = crate::work_graph::constrained_effective_reasoning_for_route(
                 requested.into(),
@@ -4863,11 +4879,7 @@ impl App {
     }
 
     pub fn reasoning_effort_display_label(&self) -> String {
-        let requested = if self.auto_model {
-            ReasoningEffort::Auto
-        } else {
-            self.reasoning_effort
-        };
+        let requested = self.reasoning_effort;
         let effective = self.effective_reasoning_effort_for_active_route(requested);
         Self::reasoning_effort_resolution_label(requested, effective, self.api_provider)
     }

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -336,6 +336,9 @@ impl App {
             .reasoning_effort
             .as_deref()
             .or_else(|| config.reasoning_effort());
+        let reasoning_effort_preference = configured_reasoning_effort
+            .filter(|_| reasoning_effort_explicit)
+            .map(ReasoningEffort::from_setting);
         let threshold_model = if auto_model {
             DEFAULT_TEXT_MODEL
         } else {
@@ -634,7 +637,7 @@ impl App {
             active_context_window_override,
             pending_provider_switch: None,
             reasoning_effort,
-            reasoning_effort_explicit,
+            reasoning_effort_preference,
             last_effective_reasoning_effort: None,
             workspace,
             // #4022: the worker thread is spawned lazily on first submit, so

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -356,22 +356,29 @@ impl App {
                 active_route_limits,
             )
         };
-        let mut reasoning_effort = configured_reasoning_effort.map_or_else(
-            || {
-                if auto_model {
-                    ReasoningEffort::Auto
-                } else {
-                    ReasoningEffort::default()
-                }
-            },
-            |setting| {
-                if auto_model {
-                    ReasoningEffort::from_setting(setting)
-                } else {
-                    ReasoningEffort::from_setting_for_provider(setting, provider)
-                }
-            },
-        );
+        let mut reasoning_effort = if auto_model && !reasoning_effort_explicit {
+            // A retired fixed-model alias can infer a compatibility effort in
+            // Config. That is route metadata, not an explicit user preference,
+            // so it must not silently constrain unresolved auto routing.
+            ReasoningEffort::Auto
+        } else {
+            configured_reasoning_effort.map_or_else(
+                || {
+                    if auto_model {
+                        ReasoningEffort::Auto
+                    } else {
+                        ReasoningEffort::default()
+                    }
+                },
+                |setting| {
+                    if auto_model {
+                        ReasoningEffort::from_setting(setting)
+                    } else {
+                        ReasoningEffort::from_setting_for_provider(setting, provider)
+                    }
+                },
+            )
+        };
         if !auto_model
             && !reasoning_effort_explicit
             && let Some(effort) = crate::config::legacy_deepseek_alias_effort_for_route(

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -356,13 +356,22 @@ impl App {
                 active_route_limits,
             )
         };
-        let mut reasoning_effort = if auto_model {
-            ReasoningEffort::Auto
-        } else {
-            configured_reasoning_effort.map_or_else(ReasoningEffort::default, |s| {
-                ReasoningEffort::from_setting_for_provider(s, provider)
-            })
-        };
+        let mut reasoning_effort = configured_reasoning_effort.map_or_else(
+            || {
+                if auto_model {
+                    ReasoningEffort::Auto
+                } else {
+                    ReasoningEffort::default()
+                }
+            },
+            |setting| {
+                if auto_model {
+                    ReasoningEffort::from_setting(setting)
+                } else {
+                    ReasoningEffort::from_setting_for_provider(setting, provider)
+                }
+            },
+        );
         if !auto_model
             && !reasoning_effort_explicit
             && let Some(effort) = crate::config::legacy_deepseek_alias_effort_for_route(

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -325,7 +325,7 @@ fn cycle_effort_updates_effort_status_and_compaction() {
     app.cycle_effort();
 
     assert_eq!(app.reasoning_effort, ReasoningEffort::High);
-    assert!(app.reasoning_effort_explicit);
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::High));
     assert_eq!(
         app.status_message.as_deref(),
         Some("Reasoning effort: high"),
@@ -1017,10 +1017,12 @@ fn set_model_selection_normalizes_codex_fixed_model_effort() {
     let mut app = App::new(test_options(false), &Config::default());
     app.api_provider = ApiProvider::OpenaiCodex;
     app.reasoning_effort = ReasoningEffort::Off;
+    app.reasoning_effort_preference = Some(ReasoningEffort::Off);
 
     app.set_model_selection("gpt-5.5-codex".to_string());
 
     assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Off));
     assert!(!app.auto_model);
     assert_eq!(app.reasoning_effort_display_label(), "low");
 }
@@ -1029,21 +1031,41 @@ fn set_model_selection_normalizes_codex_fixed_model_effort() {
 fn auto_model_selection_preserves_only_explicit_reasoning_effort() {
     let mut app = App::new(test_options(false), &Config::default());
     app.reasoning_effort = ReasoningEffort::Max;
-    app.reasoning_effort_explicit = false;
+    app.reasoning_effort_preference = None;
 
     app.set_model_selection("auto".to_string());
 
     assert!(app.auto_model);
     assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
-    assert!(!app.reasoning_effort_explicit);
+    assert_eq!(app.reasoning_effort_preference, None);
 
-    app.set_model_selection("deepseek-v4-pro".to_string());
-    app.reasoning_effort = ReasoningEffort::Low;
-    app.reasoning_effort_explicit = true;
-    app.set_model_selection("auto".to_string());
+    for (provider, requested, normalized) in [
+        (
+            ApiProvider::Deepseek,
+            ReasoningEffort::Low,
+            ReasoningEffort::High,
+        ),
+        (
+            ApiProvider::OpenaiCodex,
+            ReasoningEffort::Off,
+            ReasoningEffort::Low,
+        ),
+    ] {
+        app.api_provider = provider;
+        app.auto_model = false;
+        app.model = "fixed-model".to_string();
+        app.reasoning_effort = normalized;
+        app.reasoning_effort_preference = Some(requested);
 
-    assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
-    assert!(app.reasoning_effort_explicit);
+        app.set_model_selection("auto".to_string());
+
+        assert_eq!(app.reasoning_effort, requested, "{provider:?}");
+        assert_eq!(
+            app.reasoning_effort_preference,
+            Some(requested),
+            "{provider:?}"
+        );
+    }
 }
 
 #[test]
@@ -1080,6 +1102,11 @@ fn app_new_normalizes_saved_codex_reasoning_effort() {
 
         assert_eq!(app.api_provider, ApiProvider::OpenaiCodex);
         assert_eq!(app.reasoning_effort, expected, "raw setting {raw}");
+        assert_eq!(
+            app.reasoning_effort_preference,
+            Some(ReasoningEffort::from_setting(raw)),
+            "raw setting {raw}"
+        );
         assert_eq!(app.reasoning_effort_display_label(), display);
     }
 }
@@ -5735,6 +5762,35 @@ async fn rapid_thinking_selections_persist_the_last_one() {
             .as_deref(),
         Some(expected),
         "the tier the session ended on must be the tier on disk"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fixed_route_thinking_cycle_persists_raw_preference() {
+    let _lock = lock_test_env();
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let _env = sealed_settings_home(tmp.path());
+    let _writes = crate::tui::startup_defaults::allow_writes_in_tests();
+
+    let mut app = App::new(test_options(false), &Config::default());
+    app.api_provider = ApiProvider::Moonshot;
+    app.auto_model = false;
+    app.active_route_base_url = crate::config::DEFAULT_MOONSHOT_BASE_URL.to_string();
+    app.model = crate::config::MOONSHOT_KIMI_K3_MODEL.to_string();
+    app.reasoning_effort = ReasoningEffort::Max;
+
+    app.apply_reasoning_effort_cycle();
+    app.startup_defaults.flush();
+
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Off);
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Off));
+    assert_eq!(
+        Settings::load()
+            .expect("reload")
+            .reasoning_effort
+            .as_deref(),
+        Some("off"),
+        "the always-thinking route may execute Low, but the raw Off preference must survive restart"
     );
 }
 

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -428,6 +428,73 @@ fn cache_replay_target_uses_the_last_completed_auto_route() {
 }
 
 #[test]
+fn auto_reasoning_change_invalidates_the_previous_route_and_receipt() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.api_provider = ApiProvider::Deepseek;
+    app.model = "auto".to_string();
+    app.auto_model = true;
+    app.reasoning_effort = ReasoningEffort::Low;
+    app.reasoning_effort_preference = Some(ReasoningEffort::Low);
+    app.last_effective_provider = Some(ApiProvider::OpenaiCodex);
+    app.last_effective_provider_identity = Some(ApiProvider::OpenaiCodex.as_str().to_string());
+    app.last_effective_model = Some(crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string());
+    app.last_auto_route_receipt = Some(crate::model_routing::AutoRouteReceipt {
+        tier: crate::model_routing::AutoRouteTier::Strong,
+        pair: crate::model_routing::AutoRoutePair {
+            strong: crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string(),
+            fast: None,
+        },
+        scope: crate::model_routing::AutoRouteScope::ResolvedProvider,
+        data_path: crate::model_routing::AutoRouteDataPath::LocalHeuristic,
+        reason: crate::model_routing::AutoRouteReason::LocalHeuristic(
+            crate::model_routing::AutoRouteHeuristicReason::ComplexRequest,
+        ),
+    });
+    app.last_effective_reasoning_effort =
+        Some(EffectiveReasoningEffort::Tier(ReasoningEffort::Max));
+
+    assert!(
+        app.cache_replay_target().is_some(),
+        "the completed route is replayable before its classifier input changes"
+    );
+
+    app.cycle_effort();
+
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Medium);
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("Reasoning effort: med"),
+        "the change must describe the new unresolved request, not the old Codex receipt"
+    );
+    assert_eq!(app.last_effective_reasoning_effort, None);
+    assert_eq!(app.last_effective_provider, None);
+    assert_eq!(app.last_effective_provider_identity, None);
+    assert_eq!(app.last_effective_model, None);
+    assert_eq!(app.last_auto_route_receipt, None);
+    assert!(
+        app.cache_replay_target().is_none(),
+        "cache replay must wait for a route accepted under the new reasoning request"
+    );
+
+    let work = app
+        .work_state_snapshot()
+        .expect("Work snapshot")
+        .expect("effort activity creates graph state");
+    let crate::work_graph::WorkActivityEvent::ReasoningEffortChanged { effective, .. } = work
+        .graph
+        .expect("Work Graph")
+        .activities
+        .last()
+        .cloned()
+        .expect("effort activity");
+    assert_eq!(
+        effective,
+        crate::work_graph::ReasoningEffortTier::Medium,
+        "the activity receipt must not reuse the previous turn's effective tier"
+    );
+}
+
+#[test]
 fn mode_and_thinking_are_locked_while_a_turn_is_running() {
     // #2982: while a turn is in flight, user-initiated mode/thinking changes
     // are refused with a concise message instead of shifting the surface the

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -271,7 +271,8 @@ fn reasoning_effort_display_label_uses_codex_xhigh() {
     assert_eq!(app.reasoning_effort_display_label(), "xhigh");
 
     app.reasoning_effort = ReasoningEffort::Auto;
-    app.last_effective_reasoning_effort = Some(ReasoningEffort::Max);
+    app.last_effective_reasoning_effort =
+        Some(EffectiveReasoningEffort::Tier(ReasoningEffort::Max));
     assert_eq!(app.reasoning_effort_display_label(), "auto: xhigh");
 }
 
@@ -1022,6 +1023,27 @@ fn set_model_selection_normalizes_codex_fixed_model_effort() {
     assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
     assert!(!app.auto_model);
     assert_eq!(app.reasoning_effort_display_label(), "low");
+}
+
+#[test]
+fn auto_model_selection_preserves_only_explicit_reasoning_effort() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.reasoning_effort = ReasoningEffort::Max;
+    app.reasoning_effort_explicit = false;
+
+    app.set_model_selection("auto".to_string());
+
+    assert!(app.auto_model);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
+    assert!(!app.reasoning_effort_explicit);
+
+    app.set_model_selection("deepseek-v4-pro".to_string());
+    app.reasoning_effort = ReasoningEffort::Low;
+    app.reasoning_effort_explicit = true;
+    app.set_model_selection("auto".to_string());
+
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
+    assert!(app.reasoning_effort_explicit);
 }
 
 #[test]

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -277,6 +277,52 @@ fn reasoning_effort_display_label_uses_codex_xhigh() {
 }
 
 #[test]
+fn fixed_auto_reasoning_label_preserves_untiered_effective_receipt() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.api_provider = ApiProvider::Zai;
+    app.auto_model = false;
+    app.model = crate::config::ZAI_GLM_5_TURBO_MODEL.to_string();
+    app.active_route_base_url = crate::config::DEFAULT_ZAI_BASE_URL.to_string();
+    app.reasoning_effort = ReasoningEffort::Auto;
+    app.last_effective_reasoning_effort =
+        Some(EffectiveReasoningEffort::ThinkingEnabledGranularityUnavailable);
+
+    assert_eq!(
+        app.reasoning_effort_display_label(),
+        "auto→thinking enabled; granularity unavailable"
+    );
+}
+
+#[test]
+fn cache_replay_keeps_untiered_reasoning_enabled() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.api_provider = ApiProvider::Zai;
+    app.auto_model = false;
+    app.model = crate::config::ZAI_GLM_5_TURBO_MODEL.to_string();
+    app.reasoning_effort = ReasoningEffort::Auto;
+    app.last_effective_reasoning_effort =
+        Some(EffectiveReasoningEffort::ThinkingEnabledGranularityUnavailable);
+
+    assert_eq!(
+        app.reasoning_effort_api_value_for_replay(crate::config::DEFAULT_ZAI_BASE_URL),
+        Some("high")
+    );
+
+    app.api_provider = ApiProvider::Minimax;
+    app.model = crate::config::DEFAULT_MINIMAX_MODEL.to_string();
+    assert_eq!(
+        app.reasoning_effort_api_value_for_replay(crate::config::DEFAULT_MINIMAX_BASE_URL),
+        Some("high")
+    );
+
+    app.last_effective_reasoning_effort = Some(EffectiveReasoningEffort::Unavailable);
+    assert_eq!(
+        app.reasoning_effort_api_value_for_replay(crate::config::DEFAULT_ZAI_BASE_URL),
+        None
+    );
+}
+
+#[test]
 fn mode_and_thinking_are_locked_while_a_turn_is_running() {
     // #2982: while a turn is in flight, user-initiated mode/thinking changes
     // are refused with a concise message instead of shifting the surface the

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -304,21 +304,126 @@ fn cache_replay_keeps_untiered_reasoning_enabled() {
         Some(EffectiveReasoningEffort::ThinkingEnabledGranularityUnavailable);
 
     assert_eq!(
-        app.reasoning_effort_api_value_for_replay(crate::config::DEFAULT_ZAI_BASE_URL),
+        app.reasoning_effort_api_value_for_replay(
+            ApiProvider::Zai,
+            crate::config::DEFAULT_ZAI_BASE_URL,
+            crate::config::ZAI_GLM_5_TURBO_MODEL,
+        ),
         Some("high")
     );
 
     app.api_provider = ApiProvider::Minimax;
     app.model = crate::config::DEFAULT_MINIMAX_MODEL.to_string();
     assert_eq!(
-        app.reasoning_effort_api_value_for_replay(crate::config::DEFAULT_MINIMAX_BASE_URL),
+        app.reasoning_effort_api_value_for_replay(
+            ApiProvider::Minimax,
+            crate::config::DEFAULT_MINIMAX_BASE_URL,
+            crate::config::DEFAULT_MINIMAX_MODEL,
+        ),
         Some("high")
     );
 
     app.last_effective_reasoning_effort = Some(EffectiveReasoningEffort::Unavailable);
     assert_eq!(
-        app.reasoning_effort_api_value_for_replay(crate::config::DEFAULT_ZAI_BASE_URL),
+        app.reasoning_effort_api_value_for_replay(
+            ApiProvider::Zai,
+            crate::config::DEFAULT_ZAI_BASE_URL,
+            crate::config::ZAI_GLM_5_TURBO_MODEL,
+        ),
         None
+    );
+}
+
+#[test]
+fn cache_replay_normalizes_reasoning_against_the_concrete_auto_route() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.api_provider = ApiProvider::Deepseek;
+    app.model = "auto".to_string();
+    app.auto_model = true;
+
+    app.reasoning_effort = ReasoningEffort::Off;
+    assert_eq!(
+        app.reasoning_effort_api_value_for_replay(
+            ApiProvider::OpenaiCodex,
+            crate::config::DEFAULT_OPENAI_CODEX_BASE_URL,
+            crate::config::DEFAULT_OPENAI_CODEX_MODEL,
+        ),
+        Some("low"),
+        "Codex must apply its Off-to-Low floor even when DeepSeek is configured"
+    );
+
+    app.reasoning_effort = ReasoningEffort::Medium;
+    assert_eq!(
+        app.reasoning_effort_api_value_for_replay(
+            ApiProvider::Moonshot,
+            crate::config::DEFAULT_KIMI_CODE_BASE_URL,
+            crate::config::KIMI_CODE_K3_MODEL,
+        ),
+        Some("medium"),
+        "Kimi Code K3 must retain its exact-route Medium tier"
+    );
+}
+
+#[test]
+fn cache_replay_target_uses_the_last_completed_auto_route() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.model = "auto".to_string();
+    app.auto_model = true;
+    app.last_effective_provider = Some(ApiProvider::OpenaiCodex);
+    app.last_effective_provider_identity = Some(ApiProvider::OpenaiCodex.as_str().to_string());
+    app.last_effective_model = Some(crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string());
+    app.session.last_base_url = Some(crate::config::DEFAULT_OPENAI_CODEX_BASE_URL.to_string());
+    app.push_turn_cache_record(TurnCacheRecord {
+        provider: Some(ApiProvider::OpenaiCodex),
+        provider_identity: Some(ApiProvider::OpenaiCodex.as_str().to_string()),
+        model: Some(crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string()),
+        auto_model: true,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_hit_tokens: None,
+        cache_miss_tokens: None,
+        cache_write_tokens: None,
+        reasoning_tokens: None,
+        cost_audit: None,
+        reasoning_replay_tokens: None,
+        recorded_at: std::time::Instant::now(),
+    });
+
+    let target = app
+        .cache_replay_target()
+        .expect("completed Auto route must be replayable");
+
+    assert_eq!(target.provider, ApiProvider::OpenaiCodex);
+    assert_eq!(target.provider_identity, ApiProvider::OpenaiCodex.as_str());
+    assert_eq!(
+        target.provider_id.as_deref(),
+        Some(ApiProvider::OpenaiCodex.as_str())
+    );
+    assert_eq!(target.model, crate::config::DEFAULT_OPENAI_CODEX_MODEL);
+    assert_eq!(
+        target.base_url.as_deref(),
+        Some(crate::config::DEFAULT_OPENAI_CODEX_BASE_URL)
+    );
+
+    // A restored Auto session has no turn ring or raw endpoint. Once warmup
+    // safely re-resolves that route, its exact key becomes sufficient
+    // endpoint evidence for a following inspect.
+    app.session.turn_cache_history.clear();
+    app.session.last_base_url = None;
+    app.session.last_warmup_key = Some(CacheWarmupKey {
+        provider: ApiProvider::OpenaiCodex.as_str().to_string(),
+        model: crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string(),
+        base_url: crate::config::DEFAULT_OPENAI_CODEX_BASE_URL.to_string(),
+        static_prefix_hash: "static".to_string(),
+        tool_catalog_hash: "tools".to_string(),
+        project_pack_hash: "project".to_string(),
+        skills_hash: "skills".to_string(),
+    });
+    assert_eq!(
+        app.cache_replay_target()
+            .and_then(|target| target.base_url)
+            .as_deref(),
+        Some(crate::config::DEFAULT_OPENAI_CODEX_BASE_URL)
     );
 }
 

--- a/crates/tui/src/tui/app/types.rs
+++ b/crates/tui/src/tui/app/types.rs
@@ -58,13 +58,15 @@ pub enum AppMode {
 
 /// Reasoning-effort tier, mirrored across DeepSeek and Codex effort pickers.
 ///
-/// The config file accepts all five string values for forward-compat with
+/// The config file accepts all six string values for forward-compat with
 /// providers that expose the full spectrum; DeepSeek currently collapses
 /// `Low`/`Medium` → `high`. OpenAI Codex normalizes inherited DeepSeek-only
 /// `Off` to `Low` and displays/sends `Max` as `xhigh` at the provider
 /// boundary. The default keyboard cycler walks the three DeepSeek-distinct
 /// tiers: `Off` → `High` → `Max` → `Off`; provider-aware callers should use
-/// [`ReasoningEffort::cycle_next_for_provider`].
+/// [`ReasoningEffort::cycle_next_for_provider`]. Auto routing has no concrete
+/// provider yet, so [`ReasoningEffort::cycle_next_for_auto_model`] retains the
+/// full provider-neutral preference vocabulary until dispatch.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ReasoningEffort {
     Off,
@@ -342,6 +344,20 @@ impl ReasoningEffort {
             Self::High => Self::Max,
             Self::Max => Self::Low,
             Self::Off | Self::Auto => Self::Low,
+        }
+    }
+
+    /// Cycle the unresolved auto-model preference without applying any
+    /// provider's normalization rules prematurely.
+    #[must_use]
+    pub fn cycle_next_for_auto_model(self) -> Self {
+        match self {
+            Self::Auto => Self::Off,
+            Self::Off => Self::Low,
+            Self::Low => Self::Medium,
+            Self::Medium => Self::High,
+            Self::High => Self::Max,
+            Self::Max => Self::Auto,
         }
     }
 }

--- a/crates/tui/src/tui/app/types.rs
+++ b/crates/tui/src/tui/app/types.rs
@@ -91,6 +91,23 @@ pub(crate) enum EffectiveReasoningEffort {
     Unavailable,
 }
 
+/// Exact provider/model route whose prompt can be inspected or replayed.
+///
+/// Auto-model sessions keep `model == "auto"` as the user's selection, so
+/// cache operations must carry the last concrete route separately. The base
+/// URL is absent after restoring an older session because saved Auto receipts
+/// intentionally do not persist raw endpoints.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CacheReplayTarget {
+    pub(crate) provider: ApiProvider,
+    pub(crate) provider_identity: String,
+    /// Additive exact provider id used by persisted-route resolution.
+    /// `None` is meaningful for the legacy root-level `custom` route.
+    pub(crate) provider_id: Option<String>,
+    pub(crate) model: String,
+    pub(crate) base_url: Option<String>,
+}
+
 impl EffectiveReasoningEffort {
     /// Reconstruct a safe request tier for cache replay and inspection.
     ///

--- a/crates/tui/src/tui/app/types.rs
+++ b/crates/tui/src/tui/app/types.rs
@@ -89,6 +89,16 @@ pub(crate) enum EffectiveReasoningEffort {
     Unavailable,
 }
 
+impl EffectiveReasoningEffort {
+    #[must_use]
+    pub(crate) const fn tier(self) -> Option<ReasoningEffort> {
+        match self {
+            Self::Tier(tier) => Some(tier),
+            Self::ThinkingEnabledGranularityUnavailable | Self::Unavailable => None,
+        }
+    }
+}
+
 impl From<EffectiveReasoningEffort> for crate::work_graph::ReasoningEffortTier {
     fn from(value: EffectiveReasoningEffort) -> Self {
         match value {

--- a/crates/tui/src/tui/app/types.rs
+++ b/crates/tui/src/tui/app/types.rs
@@ -92,11 +92,17 @@ pub(crate) enum EffectiveReasoningEffort {
 }
 
 impl EffectiveReasoningEffort {
+    /// Reconstruct a safe request tier for cache replay and inspection.
+    ///
+    /// Routes with an enabled-but-untiered receipt collapse every non-Off
+    /// request to the same wire toggle, so High is the canonical value that
+    /// keeps reasoning enabled without claiming a granular effective tier.
     #[must_use]
-    pub(crate) const fn tier(self) -> Option<ReasoningEffort> {
+    pub(crate) const fn request_tier_for_replay(self) -> Option<ReasoningEffort> {
         match self {
             Self::Tier(tier) => Some(tier),
-            Self::ThinkingEnabledGranularityUnavailable | Self::Unavailable => None,
+            Self::ThinkingEnabledGranularityUnavailable => Some(ReasoningEffort::High),
+            Self::Unavailable => None,
         }
     }
 }

--- a/crates/tui/src/tui/hotbar/actions.rs
+++ b/crates/tui/src/tui/hotbar/actions.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 
 use crate::commands::{self, CommandInfo, CommandResult};
 use crate::config::{ApiProvider, Config};
@@ -983,25 +983,12 @@ impl HotbarAction for AppHotbarAction {
             AppHotbarKind::SessionCompact => app.is_compacting,
             AppHotbarKind::Mode(mode) => app.mode == mode,
             AppHotbarKind::ReasoningCycle => {
-                !app.auto_model && app.reasoning_effort != crate::tui::app::ReasoningEffort::Off
+                app.reasoning_effort != crate::tui::app::ReasoningEffort::Off
             }
             AppHotbarKind::SidebarToggle => app.sidebar_focus != SidebarFocus::Hidden,
             AppHotbarKind::FileTreeToggle => app.file_tree.is_some(),
             AppHotbarKind::PaletteOpen => false,
             AppHotbarKind::TrustToggle => app.trust_mode,
-        }
-    }
-
-    fn disabled_reason(&self, app: &App) -> Option<String> {
-        match self.kind {
-            AppHotbarKind::ReasoningCycle if app.auto_model => Some(
-                tr(
-                    app.ui_locale,
-                    MessageId::HotbarActionReasoningCycleAutoDisabled,
-                )
-                .into_owned(),
-            ),
-            _ => None,
         }
     }
 
@@ -1034,9 +1021,6 @@ impl HotbarAction for AppHotbarAction {
                 }
             }
             AppHotbarKind::ReasoningCycle => {
-                if app.auto_model {
-                    bail!("Reasoning effort is controlled by auto model routing.");
-                }
                 if app.cycle_effort().changed_live_state() {
                     Ok(HotbarDispatch::AppAction(AppAction::UpdateCompaction(
                         app.compaction_config(),
@@ -1869,7 +1853,7 @@ mod tests {
     }
 
     #[test]
-    fn app_action_metadata_exposes_dynamic_disabled_reason() {
+    fn reasoning_action_remains_available_for_auto_model_routing() {
         let registry = HotbarActionRegistry::with_builtins();
         let reasoning = registry.get("reasoning.cycle").expect("reasoning action");
         let mut app = test_app();
@@ -1881,10 +1865,7 @@ mod tests {
         assert!(reasoning.disabled_reason(&app).is_none());
 
         app.auto_model = true;
-        assert_eq!(
-            reasoning.disabled_reason(&app).as_deref(),
-            Some("Reasoning effort is controlled by auto model routing.")
-        );
+        assert!(reasoning.disabled_reason(&app).is_none());
     }
 
     #[test]
@@ -1908,7 +1889,7 @@ mod tests {
     }
 
     #[test]
-    fn hotbar_recommendations_exclude_disabled_actions() {
+    fn hotbar_recommendations_keep_reasoning_for_auto_model() {
         let mut app = test_app();
         app.auto_model = true;
 
@@ -1916,7 +1897,7 @@ mod tests {
             recommend_hotbar_actions(&app, HotbarRecommendationOptions::for_setup_wizard());
 
         assert!(
-            !recommendations
+            recommendations
                 .iter()
                 .any(|entry| entry.metadata.id == "reasoning.cycle")
         );
@@ -2481,8 +2462,14 @@ mod tests {
         );
 
         app.auto_model = true;
-        assert!(!reasoning.is_active(&app));
-        assert!(reasoning.dispatch(&mut app).is_err());
+        assert!(reasoning.is_active(&app));
+        assert!(matches!(
+            reasoning
+                .dispatch(&mut app)
+                .expect("dispatch reasoning under auto model"),
+            HotbarDispatch::AppAction(AppAction::UpdateCompaction(_))
+        ));
+        assert_eq!(app.reasoning_effort, ReasoningEffort::Max);
     }
 
     #[test]

--- a/crates/tui/src/tui/hotbar/setup.rs
+++ b/crates/tui/src/tui/hotbar/setup.rs
@@ -1315,9 +1315,14 @@ mod tests {
 
     #[test]
     fn disabled_actions_are_visible_but_not_assignable() {
-        let mut app = test_app();
-        app.auto_model = true;
+        let app = test_app();
         let mut view = HotbarSetupView::new(&app, &Config::default());
+        let reasoning = view
+            .actions
+            .iter_mut()
+            .find(|row| row.metadata.id == "reasoning.cycle")
+            .expect("reasoning action");
+        reasoning.disabled_reason = Some("disabled by test policy".to_string());
 
         assert!(view.select_slot(2));
         assert!(view.select_action_by_id("reasoning.cycle"));

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -180,7 +180,11 @@ pub struct ModelPickerView {
     /// instead of being misclassified as "unchanged".
     previous_model: String,
     initial_provider: ApiProvider,
+    /// Raw preference before the active route normalizes unsupported tiers.
     initial_effort: ReasoningEffort,
+    /// Working raw preference. Model-row navigation only changes how this is
+    /// projected into the visible route-specific effort rows.
+    selected_effort_request: ReasoningEffort,
     active_accepts_custom_model_ids: bool,
     query: String,
     /// Working selection (separate from the initial values so we can offer a
@@ -283,7 +287,9 @@ impl ModelPickerView {
         }
         let selected_model_idx = selected_model_idx.unwrap_or(0);
 
-        let initial_effort = app.reasoning_effort;
+        let initial_effort = app
+            .reasoning_effort_preference
+            .unwrap_or(app.reasoning_effort);
         let effort_rows = picker_efforts_for_route(
             app.api_provider,
             &config.deepseek_base_url(),
@@ -314,6 +320,7 @@ impl ModelPickerView {
             previous_model,
             initial_provider: app.api_provider,
             initial_effort,
+            selected_effort_request: initial_effort,
             active_accepts_custom_model_ids: app.accepts_custom_model_ids(),
             query: String::new(),
             selected_model_idx,
@@ -355,9 +362,8 @@ impl ModelPickerView {
                 .iter()
                 .position(|row| row.id == remembered_id);
             if let Some(position) = position {
-                let effort = self.resolved_effort();
                 self.selected_model_idx = position;
-                self.select_effort_for_current_model(effort);
+                self.select_effort_for_current_model();
             }
         }
         self.clamp_model_selection();
@@ -605,20 +611,24 @@ impl ModelPickerView {
     }
 
     fn update_query(&mut self, next: String) {
-        let effort = self.resolved_effort();
         self.query = next;
         self.selected_model_idx = 0;
         self.clamp_model_selection();
-        self.select_effort_for_current_model(effort);
+        self.select_effort_for_current_model();
     }
 
-    fn select_effort_for_current_model(&mut self, effort: ReasoningEffort) {
+    fn select_effort_for_current_model(&mut self) {
         let provider = self.resolved_provider().unwrap_or(self.initial_provider);
         let model = self.resolved_model();
         let model_is_auto = model.trim().eq_ignore_ascii_case("auto");
         let base_url = self.resolved_base_url_for_provider(provider, &model);
-        let normalized =
-            normalize_picker_effort(effort, provider, &base_url, &model, model_is_auto);
+        let normalized = normalize_picker_effort(
+            self.selected_effort_request,
+            provider,
+            &base_url,
+            &model,
+            model_is_auto,
+        );
         self.selected_effort_idx =
             picker_efforts_for_route(provider, &base_url, &model, model_is_auto)
                 .iter()
@@ -632,15 +642,15 @@ impl ModelPickerView {
         match self.focus {
             Pane::Model => {
                 if self.selected_model_idx > 0 {
-                    let effort = self.resolved_effort();
                     self.selected_model_idx -= 1;
-                    self.select_effort_for_current_model(effort);
+                    self.select_effort_for_current_model();
                     return true;
                 }
             }
             Pane::Effort => {
                 if self.selected_effort_idx > 0 {
                     self.selected_effort_idx -= 1;
+                    self.selected_effort_request = self.resolved_effort();
                     return true;
                 }
             }
@@ -653,9 +663,8 @@ impl ModelPickerView {
             Pane::Model => {
                 let max = self.model_row_count().saturating_sub(1);
                 if self.selected_model_idx < max {
-                    let effort = self.resolved_effort();
                     self.selected_model_idx += 1;
-                    self.select_effort_for_current_model(effort);
+                    self.select_effort_for_current_model();
                     return true;
                 }
             }
@@ -663,6 +672,7 @@ impl ModelPickerView {
                 let max = self.current_efforts().len().saturating_sub(1);
                 if self.selected_effort_idx < max {
                     self.selected_effort_idx += 1;
+                    self.selected_effort_request = self.resolved_effort();
                     return true;
                 }
             }
@@ -679,10 +689,9 @@ impl ModelPickerView {
 
     fn toggle_view(&mut self) {
         self.view = self.view.next();
-        let effort = self.resolved_effort();
         self.selected_model_idx = 0;
         self.clamp_model_selection();
-        self.select_effort_for_current_model(effort);
+        self.select_effort_for_current_model();
     }
 
     fn build_event(&self) -> ViewEvent {
@@ -694,7 +703,7 @@ impl ModelPickerView {
             model: self.resolved_model(),
             provider,
             provider_id,
-            effort: self.resolved_effort(),
+            effort: self.selected_effort_request,
             previous_model: self.previous_model.clone(),
             previous_effort: self.initial_effort,
         }
@@ -1913,23 +1922,25 @@ impl ModalView for ModelPickerView {
             KeyCode::Home => {
                 match self.focus {
                     Pane::Model => {
-                        let effort = self.resolved_effort();
                         self.selected_model_idx = 0;
-                        self.select_effort_for_current_model(effort);
+                        self.select_effort_for_current_model();
                     }
-                    Pane::Effort => self.selected_effort_idx = 0,
+                    Pane::Effort => {
+                        self.selected_effort_idx = 0;
+                        self.selected_effort_request = self.resolved_effort();
+                    }
                 }
                 ViewAction::None
             }
             KeyCode::End => {
                 match self.focus {
                     Pane::Model => {
-                        let effort = self.resolved_effort();
                         self.selected_model_idx = self.model_row_count().saturating_sub(1);
-                        self.select_effort_for_current_model(effort);
+                        self.select_effort_for_current_model();
                     }
                     Pane::Effort => {
                         self.selected_effort_idx = self.current_efforts().len().saturating_sub(1);
+                        self.selected_effort_request = self.resolved_effort();
                     }
                 }
                 ViewAction::None
@@ -1984,13 +1995,13 @@ impl ModalView for ModelPickerView {
                 self.focus = pane;
                 match pane {
                     Pane::Model => {
-                        let effort = self.resolved_effort();
                         self.selected_model_idx = idx.min(self.model_row_count().saturating_sub(1));
-                        self.select_effort_for_current_model(effort);
+                        self.select_effort_for_current_model();
                     }
                     Pane::Effort => {
                         self.selected_effort_idx =
                             idx.min(self.current_efforts().len().saturating_sub(1));
+                        self.selected_effort_request = self.resolved_effort();
                     }
                 }
                 self.last_mouse_selected = Some((pane, idx));
@@ -3307,12 +3318,48 @@ mod tests {
         app.model = "auto".to_string();
         app.auto_model = true;
         app.reasoning_effort = ReasoningEffort::Low;
+        app.reasoning_effort_preference = Some(ReasoningEffort::Low);
 
         let view = ModelPickerView::new(&app, &config);
 
         assert_eq!(view.resolved_model(), "auto");
         assert_eq!(view.resolved_effort(), ReasoningEffort::Low);
         assert_eq!(view.current_efforts(), AUTO_MODEL_PICKER_EFFORTS);
+    }
+
+    #[test]
+    fn picker_model_navigation_preserves_raw_effort_request() {
+        let (mut app, config, _lock) = create_test_app();
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app.model = "deepseek-v4-pro".to_string();
+        app.auto_model = false;
+        app.reasoning_effort = ReasoningEffort::High;
+        app.reasoning_effort_preference = Some(ReasoningEffort::Low);
+
+        let mut view = ModelPickerView::new(&app, &config);
+        assert_eq!(view.initial_effort, ReasoningEffort::Low);
+        assert_eq!(
+            view.resolved_effort(),
+            ReasoningEffort::High,
+            "the fixed route still previews its normalized tier"
+        );
+
+        view.selected_model_idx = view
+            .visible_model_rows()
+            .iter()
+            .position(|row| row.id == "auto")
+            .expect("Auto row");
+        view.select_effort_for_current_model();
+
+        assert_eq!(view.resolved_effort(), ReasoningEffort::Low);
+        assert!(matches!(
+            view.build_event(),
+            ViewEvent::ModelPickerApplied {
+                effort: ReasoningEffort::Low,
+                previous_effort: ReasoningEffort::Low,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -180,7 +180,9 @@ pub struct ModelPickerView {
     /// instead of being misclassified as "unchanged".
     previous_model: String,
     initial_provider: ApiProvider,
-    /// Raw preference before the active route normalizes unsupported tiers.
+    /// Raw preference before the picker opened. An absent explicit preference
+    /// is represented by Auto so applying a visible fixed-route tier is still
+    /// recognized as an intentional picker choice.
     initial_effort: ReasoningEffort,
     /// Working raw preference. Model-row navigation only changes how this is
     /// projected into the visible route-specific effort rows.
@@ -289,6 +291,9 @@ impl ModelPickerView {
 
         let initial_effort = app
             .reasoning_effort_preference
+            .unwrap_or(ReasoningEffort::Auto);
+        let selected_effort_request = app
+            .reasoning_effort_preference
             .unwrap_or(app.reasoning_effort);
         let effort_rows = picker_efforts_for_route(
             app.api_provider,
@@ -297,7 +302,7 @@ impl ModelPickerView {
             app.auto_model,
         );
         let normalized = normalize_picker_effort(
-            initial_effort,
+            selected_effort_request,
             app.api_provider,
             &config.deepseek_base_url(),
             &initial_model,
@@ -320,7 +325,7 @@ impl ModelPickerView {
             previous_model,
             initial_provider: app.api_provider,
             initial_effort,
-            selected_effort_request: initial_effort,
+            selected_effort_request,
             active_accepts_custom_model_ids: app.accepts_custom_model_ids(),
             query: String::new(),
             selected_model_idx,
@@ -3363,6 +3368,35 @@ mod tests {
     }
 
     #[test]
+    fn picker_auto_row_commits_visible_implicit_effort() {
+        let (mut app, config, _lock) = create_test_app();
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app.model = "deepseek-v4-pro".to_string();
+        app.auto_model = false;
+        app.reasoning_effort = ReasoningEffort::High;
+        app.reasoning_effort_preference = None;
+
+        let mut view = ModelPickerView::new(&app, &config);
+        assert_eq!(view.initial_effort, ReasoningEffort::Auto);
+        view.selected_model_idx = view
+            .visible_model_rows()
+            .iter()
+            .position(|row| row.id == "auto")
+            .expect("Auto row");
+        view.select_effort_for_current_model();
+
+        assert_eq!(view.resolved_effort(), ReasoningEffort::High);
+        assert!(matches!(
+            view.build_event(),
+            ViewEvent::ModelPickerApplied {
+                effort: ReasoningEffort::High,
+                previous_effort: ReasoningEffort::Auto,
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn picker_normalizes_low_medium_to_high() {
         let (mut app, config, _lock) = create_test_app();
         app.reasoning_effort = ReasoningEffort::Medium;
@@ -4409,6 +4443,7 @@ mod tests {
         let (mut app, mut config, _lock) = create_test_app();
         config.api_key = Some("deepseek-picker-test-key".to_string());
         app.reasoning_effort = ReasoningEffort::High;
+        app.reasoning_effort_preference = Some(ReasoningEffort::High);
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;
         app.enable_provider_model("deepseek", "deepseek-v4-flash");

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -72,7 +72,16 @@ const CODEX_PICKER_EFFORTS: &[ReasoningEffort] = &[
     ReasoningEffort::High,
     ReasoningEffort::Max,
 ];
-const AUTO_MODEL_PICKER_EFFORTS: &[ReasoningEffort] = &[ReasoningEffort::Auto];
+/// Auto model routing has no concrete provider dialect yet, so retain the
+/// complete preference vocabulary and defer normalization to dispatch.
+const AUTO_MODEL_PICKER_EFFORTS: &[ReasoningEffort] = &[
+    ReasoningEffort::Auto,
+    ReasoningEffort::Off,
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+    ReasoningEffort::Max,
+];
 
 /// `/model` catalog views (#4115).
 ///
@@ -500,9 +509,6 @@ impl ModelPickerView {
     }
 
     fn resolved_effort(&self) -> ReasoningEffort {
-        if self.resolved_model().trim().eq_ignore_ascii_case("auto") {
-            return ReasoningEffort::Auto;
-        }
         let efforts = self.current_efforts();
         efforts[self
             .selected_effort_idx
@@ -2266,11 +2272,12 @@ fn normalize_picker_effort(
     wire_model: &str,
     model_is_auto: bool,
 ) -> ReasoningEffort {
-    if model_is_auto {
-        return ReasoningEffort::Auto;
-    }
-    let normalized = effort.normalize_for_route(provider, base_url, wire_model);
-    let efforts = picker_efforts_for_route(provider, base_url, wire_model, false);
+    let normalized = if model_is_auto {
+        effort
+    } else {
+        effort.normalize_for_route(provider, base_url, wire_model)
+    };
+    let efforts = picker_efforts_for_route(provider, base_url, wire_model, model_is_auto);
     if efforts.contains(&normalized) {
         return normalized;
     }
@@ -2307,10 +2314,7 @@ fn default_picker_effort_idx(
     wire_model: &str,
     model_is_auto: bool,
 ) -> usize {
-    if model_is_auto {
-        return 0;
-    }
-    let efforts = picker_efforts_for_route(provider, base_url, wire_model, false);
+    let efforts = picker_efforts_for_route(provider, base_url, wire_model, model_is_auto);
     let default_effort = default_picker_effort(provider, &efforts);
     efforts
         .iter()
@@ -3298,16 +3302,17 @@ mod tests {
     }
 
     #[test]
-    fn picker_auto_model_forces_auto_effort_on_apply() {
+    fn picker_auto_model_preserves_explicit_effort_on_apply() {
         let (mut app, config, _lock) = create_test_app();
         app.model = "auto".to_string();
         app.auto_model = true;
-        app.reasoning_effort = ReasoningEffort::Off;
+        app.reasoning_effort = ReasoningEffort::Low;
 
         let view = ModelPickerView::new(&app, &config);
 
         assert_eq!(view.resolved_model(), "auto");
-        assert_eq!(view.resolved_effort(), ReasoningEffort::Auto);
+        assert_eq!(view.resolved_effort(), ReasoningEffort::Low);
+        assert_eq!(view.current_efforts(), AUTO_MODEL_PICKER_EFFORTS);
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7578,16 +7578,6 @@ fn handle_reasoning_effort_key(app: &mut App, key: &event::KeyEvent) -> bool {
     {
         return false;
     }
-    if app.auto_model {
-        // The auto router picks a tier per turn, so a Ctrl+T here would persist
-        // a startup default the session then ignores. Refuse, and say why.
-        let message = app
-            .tr(crate::localization::MessageId::ThinkingControlledByAutoRouting)
-            .into_owned();
-        app.status_message = Some(message);
-        app.needs_redraw = true;
-        return true;
-    }
     let _ = app.cycle_effort();
     true
 }
@@ -10760,9 +10750,6 @@ async fn apply_model_picker_choice(
         target_provider.as_str().to_string()
     };
     let model_is_auto = model.trim().eq_ignore_ascii_case("auto");
-    if model_is_auto {
-        effort = ReasoningEffort::Auto;
-    }
     if target_provider != app.api_provider
         || target_identity != app.provider_identity_for_persistence()
     {
@@ -10842,6 +10829,7 @@ async fn apply_model_picker_choice(
         effort = effort.normalize_for_route(app.api_provider, &route_base_url, &resolved_model);
     }
     let effort_changed = effort != previous_effort;
+    let live_effort_changed = effort != app.reasoning_effort;
 
     if model_changed {
         app.set_model_selection(resolved_model.clone());
@@ -10851,10 +10839,12 @@ async fn apply_model_picker_choice(
         app.enable_provider_model(&provider_identity, &resolved_model);
         app.clear_model_scoped_telemetry();
     }
-    if effort_changed {
+    if live_effort_changed {
         app.reasoning_effort = effort;
-        app.reasoning_effort_explicit = true;
         app.last_effective_reasoning_effort = None;
+    }
+    if effort_changed {
+        app.reasoning_effort_explicit = true;
     }
     if model_changed || effort_changed {
         app.update_model_compaction_budget();
@@ -10874,16 +10864,17 @@ async fn apply_model_picker_choice(
     ) {
         update = update.with_default_model(resolved_model.as_str());
     }
+    let persisted_effort = if model_is_auto {
+        effort.as_setting()
+    } else {
+        effort.as_setting_for_route(app.api_provider, &route_base_url, &resolved_model)
+    };
     update = update
         .with_provider_model(
             app.provider_identity_for_persistence(),
             resolved_model.as_str(),
         )
-        .with_reasoning_effort(effort.as_setting_for_route(
-            app.api_provider,
-            &route_base_url,
-            &resolved_model,
-        ));
+        .with_reasoning_effort(persisted_effort);
     // Applied synchronously: the setup receipt below is only honest if we know
     // the write landed. Going through the app-owned writer means any queued
     // mode/thinking selection the user made first is applied first, so this
@@ -10965,7 +10956,10 @@ async fn apply_picker_effort_choice(
     {
         return;
     }
-    effort = effort.normalize_for_route(app.api_provider, &app.active_route_base_url, &app.model);
+    if !app.auto_model {
+        effort =
+            effort.normalize_for_route(app.api_provider, &app.active_route_base_url, &app.model);
+    }
     let changed = effort != previous_effort;
 
     if changed {
@@ -10975,16 +10969,15 @@ async fn apply_picker_effort_choice(
         app.update_model_compaction_budget();
     }
 
+    let persisted_effort = if app.auto_model {
+        effort.as_setting()
+    } else {
+        effort.as_setting_for_route(app.api_provider, &app.active_route_base_url, &app.model)
+    };
     let persist_warning = app
         .startup_defaults
         .apply_blocking(
-            crate::tui::startup_defaults::StartupDefaults::reasoning_effort(
-                effort.as_setting_for_route(
-                    app.api_provider,
-                    &app.active_route_base_url,
-                    &app.model,
-                ),
-            ),
+            crate::tui::startup_defaults::StartupDefaults::reasoning_effort(persisted_effort),
         )
         .err()
         .map(|err| format!(" (not persisted: {err})"));
@@ -16611,7 +16604,14 @@ fn apply_loaded_session(
     app.sync_context_references_from_session(&session.context_references, &message_to_cell);
     app.mark_history_updated();
     app.viewport.transcript_selection.clear();
+    let requested_reasoning_effort = app.reasoning_effort;
     restore_loaded_session_provider(app, config, provider_identity);
+    if session.metadata.model.trim().eq_ignore_ascii_case("auto") {
+        // Session records do not own a reasoning preference. Provider restore
+        // must not normalize the global requested tier before an auto route
+        // has selected its concrete provider/model.
+        app.reasoning_effort = requested_reasoning_effort;
+    }
     app.set_model_selection(session.metadata.model.clone());
     if app.auto_model
         && let Some(saved) = session.last_auto_route.as_ref()
@@ -16624,6 +16624,13 @@ fn apply_loaded_session(
         app.last_auto_route_receipt = Some(saved.receipt.clone());
     }
     resolve_loaded_session_route(app, config);
+    if !app.auto_model {
+        app.reasoning_effort = app.reasoning_effort.normalize_for_route(
+            app.api_provider,
+            &app.active_route_base_url,
+            &app.model,
+        );
+    }
     app.provider_models.insert(
         app.provider_identity_for_persistence().to_string(),
         app.model_selection_for_persistence(),
@@ -16780,9 +16787,13 @@ fn restore_loaded_session_provider(app: &mut App, config: &mut Config, identity:
         .filter(|chain| chain.providers().len() > 1);
     app.last_fallback_reason = None;
     app.model_ids_passthrough = config.model_ids_pass_through();
-    app.reasoning_effort =
-        app.reasoning_effort
-            .normalize_for_route(provider, &config.deepseek_base_url(), &app.model);
+    if !app.auto_model {
+        app.reasoning_effort = app.reasoning_effort.normalize_for_route(
+            provider,
+            &config.deepseek_base_url(),
+            &app.model,
+        );
+    }
     app.set_active_context_window_override(config.context_window_for_provider_config(provider));
     app.active_route_limits = app.context_window_override_limits();
     app.active_route_base_url = config.deepseek_base_url();

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7824,16 +7824,9 @@ async fn fetch_available_models(config: &Config) -> Result<Vec<String>> {
 async fn run_cache_warmup(app: &App, config: &Config) -> Result<(Usage, String, PromptInspection)> {
     let client = DeepSeekClient::new(config)?;
     let base_url = client.base_url().to_string();
-    let reasoning_effort = if app.reasoning_effort == ReasoningEffort::Auto {
-        app.last_effective_reasoning_effort
-            .and_then(EffectiveReasoningEffort::tier)
-            .and_then(|effort| effort.api_value_for_route(app.api_provider, &base_url, &app.model))
-            .map(str::to_string)
-    } else {
-        app.reasoning_effort
-            .api_value_for_route(app.api_provider, &base_url, &app.model)
-            .map(str::to_string)
-    };
+    let reasoning_effort = app
+        .reasoning_effort_api_value_for_replay(&base_url)
+        .map(str::to_string);
     let request = MessageRequest {
         model: app.model.clone(),
         messages: app.api_messages.clone(),

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -138,9 +138,9 @@ use super::key_actions;
 
 use super::app::{
     ActiveTurnMetadata, AgentCurrentActivity, AgentCurrentActivityStatus, App, AppAction, AppMode,
-    HuntVerdict, OnboardingState, PendingProviderSwitch, QueuedMessage, ReasoningEffort,
-    SidebarFocus, StatusToast, StatusToastLevel, SubmitDisposition, TaskPanelEntry,
-    TaskPanelEntryKind, ToolEvidence, TuiOptions, bound_agent_activity_text,
+    EffectiveReasoningEffort, HuntVerdict, OnboardingState, PendingProviderSwitch, QueuedMessage,
+    ReasoningEffort, SidebarFocus, StatusToast, StatusToastLevel, SubmitDisposition,
+    TaskPanelEntry, TaskPanelEntryKind, ToolEvidence, TuiOptions, bound_agent_activity_text,
     looks_like_slash_command_input, shell_command_from_bang_input,
 };
 use super::approval::{
@@ -7826,6 +7826,7 @@ async fn run_cache_warmup(app: &App, config: &Config) -> Result<(Usage, String, 
     let base_url = client.base_url().to_string();
     let reasoning_effort = if app.reasoning_effort == ReasoningEffort::Auto {
         app.last_effective_reasoning_effort
+            .and_then(EffectiveReasoningEffort::tier)
             .and_then(|effort| effort.api_value_for_route(app.api_provider, &base_url, &app.model))
             .map(str::to_string)
     } else {
@@ -9813,8 +9814,24 @@ struct UserDispatchOutcome {
     effective_model: String,
     effective_provider_identity: String,
     effective_provider_label: String,
-    selected_reasoning_effort: Option<ReasoningEffort>,
+    effective_reasoning_effort: EffectiveReasoningEffort,
     auto_selection: Option<crate::model_routing::AutoRouteSelection>,
+}
+
+fn reasoning_effort_receipt_for_route(
+    tier: ReasoningEffort,
+    provider: ApiProvider,
+    endpoint_identity: &str,
+    model: &str,
+) -> EffectiveReasoningEffort {
+    crate::work_graph::constrained_effective_reasoning_for_route(
+        tier.into(),
+        provider,
+        endpoint_identity,
+        model,
+    )
+    .map(Into::into)
+    .unwrap_or(EffectiveReasoningEffort::Tier(tier))
 }
 
 #[cfg(test)]
@@ -10121,9 +10138,16 @@ async fn run_prepared_dispatch(
     recovery: DispatchRecovery,
 ) -> Result<()> {
     // Unit tests that intentionally omit the production completion mailbox
-    // apply the result inline. Production always enters through
-    // `start_user_dispatch`, which reserves a mailbox permit first.
-    let apply = spawned_dispatch_inner(prepare, recovery, engine_handle.clone()).await;
+    // apply the result inline. Run the owned async phase as a task just like
+    // production does so its large future is polled from a clean executor
+    // stack instead of nesting under the test helper's call chain.
+    let apply = tokio::spawn(spawned_dispatch_inner(
+        prepare,
+        recovery,
+        engine_handle.clone(),
+    ))
+    .await
+    .map_err(|err| anyhow::anyhow!("dispatch task was lost: {err}"))?;
     apply(app, engine_handle, config)
 }
 
@@ -10181,6 +10205,19 @@ async fn spawned_dispatch_inner(
         auto_selection,
         routing_source: _,
     } = planned;
+    let effective_reasoning_tier = selected_reasoning_effort
+        .unwrap_or(prepare.reasoning_effort)
+        .normalize_for_route(
+            effective_provider,
+            &turn_route.candidate.endpoint().base_url,
+            &turn_route.model,
+        );
+    let effective_reasoning_receipt = reasoning_effort_receipt_for_route(
+        effective_reasoning_tier,
+        effective_provider,
+        &turn_route.candidate.endpoint().base_url,
+        &turn_route.model,
+    );
 
     if let Err(err) = engine_handle
         .send(Op::SendMessage {
@@ -10219,7 +10256,7 @@ async fn spawned_dispatch_inner(
             effective_model,
             effective_provider_identity,
             effective_provider_label,
-            selected_reasoning_effort,
+            effective_reasoning_effort: effective_reasoning_receipt,
             auto_selection,
         },
     )
@@ -10257,7 +10294,7 @@ fn build_dispatch_success_closure(
             );
             app.scroll_to_bottom();
 
-            app.last_effective_reasoning_effort = outcome.selected_reasoning_effort;
+            app.last_effective_reasoning_effort = Some(outcome.effective_reasoning_effort);
             if prepare.auto_model {
                 app.last_effective_model = Some(outcome.effective_model.clone());
                 app.last_effective_provider = Some(outcome.effective_provider);
@@ -10750,6 +10787,7 @@ async fn apply_model_picker_choice(
         target_provider.as_str().to_string()
     };
     let model_is_auto = model.trim().eq_ignore_ascii_case("auto");
+    let preserve_auto_effort = app.reasoning_effort_explicit || effort != previous_effort;
     if target_provider != app.api_provider
         || target_identity != app.provider_identity_for_persistence()
     {
@@ -10839,7 +10877,7 @@ async fn apply_model_picker_choice(
         app.enable_provider_model(&provider_identity, &resolved_model);
         app.clear_model_scoped_telemetry();
     }
-    if live_effort_changed {
+    if live_effort_changed && (!model_is_auto || preserve_auto_effort) {
         app.reasoning_effort = effort;
         app.last_effective_reasoning_effort = None;
     }
@@ -10864,17 +10902,18 @@ async fn apply_model_picker_choice(
     ) {
         update = update.with_default_model(resolved_model.as_str());
     }
-    let persisted_effort = if model_is_auto {
-        effort.as_setting()
-    } else {
-        effort.as_setting_for_route(app.api_provider, &route_base_url, &resolved_model)
-    };
-    update = update
-        .with_provider_model(
-            app.provider_identity_for_persistence(),
-            resolved_model.as_str(),
-        )
-        .with_reasoning_effort(persisted_effort);
+    update = update.with_provider_model(
+        app.provider_identity_for_persistence(),
+        resolved_model.as_str(),
+    );
+    if !model_is_auto || preserve_auto_effort {
+        let persisted_effort = if model_is_auto {
+            app.reasoning_effort.as_setting()
+        } else {
+            effort.as_setting_for_route(app.api_provider, &route_base_url, &resolved_model)
+        };
+        update = update.with_reasoning_effort(persisted_effort);
+    }
     // Applied synchronously: the setup receipt below is only honest if we know
     // the write landed. Going through the app-owned writer means any queued
     // mode/thinking selection the user made first is applied first, so this
@@ -10900,10 +10939,11 @@ async fn apply_model_picker_choice(
         resolved_model.clone()
     };
     let previous_effort_summary = previous_effort.display_label_for_provider(app.api_provider);
-    let effort_summary = if effort == ReasoningEffort::Auto {
+    let applied_effort = app.reasoning_effort;
+    let effort_summary = if applied_effort == ReasoningEffort::Auto {
         "auto (per-turn thinking)".to_string()
     } else {
-        effort
+        applied_effort
             .display_label_for_provider(app.api_provider)
             .to_string()
     };
@@ -16604,13 +16644,16 @@ fn apply_loaded_session(
     app.sync_context_references_from_session(&session.context_references, &message_to_cell);
     app.mark_history_updated();
     app.viewport.transcript_selection.clear();
-    let requested_reasoning_effort = app.reasoning_effort;
+    let requested_reasoning_effort = app
+        .reasoning_effort_explicit
+        .then_some(app.reasoning_effort);
     restore_loaded_session_provider(app, config, provider_identity);
     if session.metadata.model.trim().eq_ignore_ascii_case("auto") {
         // Session records do not own a reasoning preference. Provider restore
-        // must not normalize the global requested tier before an auto route
-        // has selected its concrete provider/model.
-        app.reasoning_effort = requested_reasoning_effort;
+        // must not normalize an explicit global requested tier before an auto
+        // route has selected its concrete provider/model. An implicit
+        // fixed-route default returns to per-turn Auto reasoning.
+        app.reasoning_effort = requested_reasoning_effort.unwrap_or(ReasoningEffort::Auto);
     }
     app.set_model_selection(session.metadata.model.clone());
     if app.auto_model
@@ -16622,6 +16665,7 @@ fn apply_loaded_session(
         app.last_effective_provider_identity = Some(saved.provider_identity.clone());
         app.last_effective_model = Some(saved.model.clone());
         app.last_auto_route_receipt = Some(saved.receipt.clone());
+        app.last_effective_reasoning_effort = saved.effective_reasoning_effort.map(Into::into);
     }
     resolve_loaded_session_route(app, config);
     if !app.auto_model {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7821,14 +7821,63 @@ async fn fetch_available_models(config: &Config) -> Result<Vec<String>> {
     Ok(ids)
 }
 
-async fn run_cache_warmup(app: &App, config: &Config) -> Result<(Usage, String, PromptInspection)> {
-    let client = DeepSeekClient::new(config)?;
-    let base_url = client.base_url().to_string();
+#[derive(Debug)]
+struct CacheWarmupOutcome {
+    usage: Usage,
+    provider_identity: String,
+    model: String,
+    base_url: String,
+    inspection: PromptInspection,
+}
+
+fn resolve_cache_replay_route(
+    app: &App,
+    config: &Config,
+) -> Result<crate::route_runtime::ResolvedRuntimeRoute> {
+    let target = app.cache_replay_target().ok_or_else(|| {
+        anyhow::anyhow!("Auto has no concrete route yet; send a turn before warming its cache")
+    })?;
+    let identity = config
+        .resolve_persisted_provider_identity(
+            Some(target.provider.as_str()),
+            target.provider_id.as_deref(),
+        )
+        .map_err(anyhow::Error::msg)?;
+    if identity.provider != target.provider || identity.key != target.provider_identity {
+        anyhow::bail!(
+            "saved cache route identity `{}` now resolves as {}/{} instead of {}/{}; send a new turn before warming",
+            target.provider_identity,
+            identity.provider.as_str(),
+            identity.key,
+            target.provider.as_str(),
+            target.provider_identity
+        );
+    }
+    let route = resolve_runtime_route_for_identity(config, &identity, Some(&target.model))
+        .map_err(anyhow::Error::msg)?;
+    if let Some(previous_base_url) = target.base_url.as_deref() {
+        let previous_endpoint = crate::route_receipt::endpoint_identity(previous_base_url);
+        let current_endpoint =
+            crate::route_receipt::endpoint_identity(&route.candidate.endpoint().base_url);
+        if previous_endpoint != current_endpoint {
+            anyhow::bail!(
+                "the cache route endpoint changed since the last turn; send a new turn before warming"
+            );
+        }
+    }
+    Ok(route)
+}
+
+async fn run_cache_warmup(app: &App, config: &Config) -> Result<CacheWarmupOutcome> {
+    let route = resolve_cache_replay_route(app, config)?
+        .validate()
+        .map_err(anyhow::Error::msg)?;
+    let base_url = route.client.base_url().to_string();
     let reasoning_effort = app
-        .reasoning_effort_api_value_for_replay(&base_url)
+        .reasoning_effort_api_value_for_replay(route.identity.provider, &base_url, &route.model)
         .map(str::to_string);
     let request = MessageRequest {
-        model: app.model.clone(),
+        model: route.model.clone(),
         messages: app.api_messages.clone(),
         max_tokens: 1024,
         system: app.system_prompt.clone(),
@@ -7844,8 +7893,15 @@ async fn run_cache_warmup(app: &App, config: &Config) -> Result<(Usage, String, 
     let warmup = build_cache_warmup_request(&request);
     let inspection = inspect_prompt_for_request(&warmup);
     let response =
-        tokio::time::timeout(Duration::from_secs(45), client.create_message(warmup)).await??;
-    Ok((response.usage, base_url, inspection))
+        tokio::time::timeout(Duration::from_secs(45), route.client.create_message(warmup))
+            .await??;
+    Ok(CacheWarmupOutcome {
+        usage: response.usage,
+        provider_identity: route.identity.key,
+        model: route.model,
+        base_url,
+        inspection,
+    })
 }
 
 /// One-shot "draft my constitution" call against the user's first configured
@@ -11915,15 +11971,15 @@ async fn apply_command_result(
             AppAction::CacheWarmup => {
                 app.status_message = Some("Warming prompt cache...".to_string());
                 match run_cache_warmup(app, config).await {
-                    Ok((usage, base_url, inspection)) => {
-                        app.session.last_base_url = Some(base_url.clone());
+                    Ok(outcome) => {
+                        app.session.last_base_url = Some(outcome.base_url.clone());
                         app.session.last_warmup_key = Some(CacheWarmupKey::from_inspection(
-                            &format!("{:?}", app.api_provider),
-                            &app.model,
-                            &base_url,
-                            &inspection,
+                            &outcome.provider_identity,
+                            &outcome.model,
+                            &outcome.base_url,
+                            &outcome.inspection,
                         ));
-                        let mut message = format_helpers::cache_warmup_result(&usage);
+                        let mut message = format_helpers::cache_warmup_result(&outcome.usage);
                         if let Some(key) = app.session.last_warmup_key.as_ref() {
                             message.push_str(&format!("\nWarmup key: {}", key.hash_short()));
                         }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -10937,7 +10937,7 @@ async fn apply_model_picker_choice(
         app.reasoning_effort = ReasoningEffort::Auto;
     }
     if live_effort_changed || preference_changed {
-        app.last_effective_reasoning_effort = None;
+        app.invalidate_route_receipts_for_reasoning_change();
     }
     if model_changed || live_effort_changed || preference_changed {
         app.update_model_compaction_budget();
@@ -11063,7 +11063,7 @@ async fn apply_picker_effort_choice(
         app.reasoning_effort_preference = Some(effort);
     }
     if selection_changed {
-        app.last_effective_reasoning_effort = None;
+        app.invalidate_route_receipts_for_reasoning_change();
         app.update_model_compaction_budget();
     }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -10771,7 +10771,7 @@ async fn apply_model_picker_choice(
     model: String,
     target_provider: Option<ApiProvider>,
     target_provider_id: Option<String>,
-    mut effort: crate::tui::app::ReasoningEffort,
+    effort: crate::tui::app::ReasoningEffort,
     previous_model: String,
     previous_effort: crate::tui::app::ReasoningEffort,
 ) {
@@ -10787,7 +10787,8 @@ async fn apply_model_picker_choice(
         target_provider.as_str().to_string()
     };
     let model_is_auto = model.trim().eq_ignore_ascii_case("auto");
-    let preserve_auto_effort = app.reasoning_effort_explicit || effort != previous_effort;
+    let preserve_auto_effort =
+        app.reasoning_effort_preference.is_some() || effort != previous_effort;
     if target_provider != app.api_provider
         || target_identity != app.provider_identity_for_persistence()
     {
@@ -10806,11 +10807,6 @@ async fn apply_model_picker_choice(
             return;
         }
         if !model_is_auto {
-            effort = effort.normalize_for_route(
-                app.api_provider,
-                &app.active_route_base_url,
-                &app.model,
-            );
             apply_picker_effort_choice(app, engine_handle, effort, previous_effort).await;
             return;
         }
@@ -10863,11 +10859,12 @@ async fn apply_model_picker_choice(
         };
     }
 
-    if !model_is_auto {
-        effort = effort.normalize_for_route(app.api_provider, &route_base_url, &resolved_model);
-    }
+    let effective_effort = if model_is_auto {
+        effort
+    } else {
+        effort.normalize_for_route(app.api_provider, &route_base_url, &resolved_model)
+    };
     let effort_changed = effort != previous_effort;
-    let live_effort_changed = effort != app.reasoning_effort;
 
     if model_changed {
         app.set_model_selection(resolved_model.clone());
@@ -10877,14 +10874,23 @@ async fn apply_model_picker_choice(
         app.enable_provider_model(&provider_identity, &resolved_model);
         app.clear_model_scoped_telemetry();
     }
-    if live_effort_changed && (!model_is_auto || preserve_auto_effort) {
-        app.reasoning_effort = effort;
+    let preference_changed = if model_is_auto && !preserve_auto_effort {
+        app.reasoning_effort_preference.take().is_some()
+    } else {
+        let changed = app.reasoning_effort_preference != Some(effort);
+        app.reasoning_effort_preference = Some(effort);
+        changed
+    };
+    let live_effort_changed = effective_effort != app.reasoning_effort;
+    if !model_is_auto || preserve_auto_effort {
+        app.reasoning_effort = effective_effort;
+    } else {
+        app.reasoning_effort = ReasoningEffort::Auto;
+    }
+    if live_effort_changed || preference_changed {
         app.last_effective_reasoning_effort = None;
     }
-    if effort_changed {
-        app.reasoning_effort_explicit = true;
-    }
-    if model_changed || effort_changed {
+    if model_changed || live_effort_changed || preference_changed {
         app.update_model_compaction_budget();
     }
 
@@ -10907,12 +10913,10 @@ async fn apply_model_picker_choice(
         resolved_model.as_str(),
     );
     if !model_is_auto || preserve_auto_effort {
-        let persisted_effort = if model_is_auto {
-            app.reasoning_effort.as_setting()
-        } else {
-            effort.as_setting_for_route(app.api_provider, &route_base_url, &resolved_model)
-        };
-        update = update.with_reasoning_effort(persisted_effort);
+        // Settings own the raw global preference. Route normalization belongs
+        // to the concrete live request and must not erase a tier before the
+        // user returns to Auto routing.
+        update = update.with_reasoning_effort(effort.as_setting());
     }
     // Applied synchronously: the setup receipt below is only honest if we know
     // the write landed. Going through the app-owned writer means any queued
@@ -10989,40 +10993,40 @@ async fn apply_model_picker_choice(
 async fn apply_picker_effort_choice(
     app: &mut App,
     engine_handle: &EngineHandle,
-    mut effort: ReasoningEffort,
+    effort: ReasoningEffort,
     previous_effort: ReasoningEffort,
 ) {
     if app.reject_setting_change_while_busy(crate::localization::MessageId::SettingSubjectThinking)
     {
         return;
     }
-    if !app.auto_model {
-        effort =
-            effort.normalize_for_route(app.api_provider, &app.active_route_base_url, &app.model);
-    }
-    let changed = effort != previous_effort;
+    let effective_effort = if app.auto_model {
+        effort
+    } else {
+        effort.normalize_for_route(app.api_provider, &app.active_route_base_url, &app.model)
+    };
+    let live_changed = effective_effort != app.reasoning_effort;
+    let preference_changed = app.reasoning_effort_preference != Some(effort);
+    let selection_changed = effort != previous_effort || live_changed;
 
-    if changed {
-        app.reasoning_effort = effort;
-        app.reasoning_effort_explicit = true;
+    if live_changed || preference_changed {
+        app.reasoning_effort = effective_effort;
+        app.reasoning_effort_preference = Some(effort);
+    }
+    if selection_changed {
         app.last_effective_reasoning_effort = None;
         app.update_model_compaction_budget();
     }
 
-    let persisted_effort = if app.auto_model {
-        effort.as_setting()
-    } else {
-        effort.as_setting_for_route(app.api_provider, &app.active_route_base_url, &app.model)
-    };
     let persist_warning = app
         .startup_defaults
         .apply_blocking(
-            crate::tui::startup_defaults::StartupDefaults::reasoning_effort(persisted_effort),
+            crate::tui::startup_defaults::StartupDefaults::reasoning_effort(effort.as_setting()),
         )
         .err()
         .map(|err| format!(" (not persisted: {err})"));
 
-    if changed {
+    if live_changed {
         apply_model_and_compaction_update(
             engine_handle,
             app.compaction_config(),
@@ -11033,7 +11037,7 @@ async fn apply_picker_effort_choice(
     }
 
     let persisted = persist_warning.is_none();
-    let mut summary = if changed {
+    let mut summary = if selection_changed {
         format!(
             "Thinking: {} → {} · model {}",
             previous_effort.display_label_for_provider(app.api_provider),
@@ -11177,8 +11181,8 @@ async fn switch_provider(
         .filter(|chain| chain.providers().len() > 1);
     app.last_fallback_reason = None;
     app.model_ids_passthrough = config.model_ids_pass_through();
-    app.apply_provider_switch_reasoning_effort(target, &new_base_url, model_override.as_deref());
     app.set_model_selection(new_model.clone());
+    app.apply_provider_switch_reasoning_effort(target, &new_base_url, model_override.as_deref());
     app.set_active_context_window_override(config.context_window_for_provider_config(target));
     app.set_active_route_resolution(new_base_url.clone(), route_limits, context_window_source);
     if model_override.is_some() {
@@ -11340,10 +11344,8 @@ async fn apply_provider_fallback_switch(
     let new_endpoint = display_base_url_host(&new_base_url);
     let cache_scope_changed = previous_provider != target || previous_model != new_model;
     app.model_ids_passthrough = config.model_ids_pass_through();
-    app.reasoning_effort =
-        app.reasoning_effort
-            .normalize_for_route(target, &new_base_url, &new_model);
     app.set_model_selection(new_model.clone());
+    app.apply_provider_switch_reasoning_effort(target, &new_base_url, None);
     app.set_active_context_window_override(config.context_window_for_provider_config(target));
     app.set_active_route_resolution(
         new_base_url.clone(),
@@ -11993,7 +11995,12 @@ async fn apply_command_result(
                 } else {
                     app.model.clone()
                 };
-                let previous_effort = app.reasoning_effort;
+                // Hotbar route actions do not carry an effort choice. Preserve
+                // the raw global preference instead of feeding a fixed
+                // route's normalized live tier back through the picker path.
+                let previous_effort = app
+                    .reasoning_effort_preference
+                    .unwrap_or(app.reasoning_effort);
                 apply_model_picker_choice(
                     app,
                     engine_handle,
@@ -16644,17 +16651,10 @@ fn apply_loaded_session(
     app.sync_context_references_from_session(&session.context_references, &message_to_cell);
     app.mark_history_updated();
     app.viewport.transcript_selection.clear();
-    let requested_reasoning_effort = app
-        .reasoning_effort_explicit
-        .then_some(app.reasoning_effort);
     restore_loaded_session_provider(app, config, provider_identity);
-    if session.metadata.model.trim().eq_ignore_ascii_case("auto") {
-        // Session records do not own a reasoning preference. Provider restore
-        // must not normalize an explicit global requested tier before an auto
-        // route has selected its concrete provider/model. An implicit
-        // fixed-route default returns to per-turn Auto reasoning.
-        app.reasoning_effort = requested_reasoning_effort.unwrap_or(ReasoningEffort::Auto);
-    }
+    // Session records do not own a reasoning preference. `set_model_selection`
+    // restores the raw explicit global preference for Auto (or releases an
+    // implicit fixed-route default) instead of reusing normalized live state.
     app.set_model_selection(session.metadata.model.clone());
     if app.auto_model
         && let Some(saved) = session.last_auto_route.as_ref()
@@ -16669,11 +16669,11 @@ fn apply_loaded_session(
     }
     resolve_loaded_session_route(app, config);
     if !app.auto_model {
-        app.reasoning_effort = app.reasoning_effort.normalize_for_route(
-            app.api_provider,
-            &app.active_route_base_url,
-            &app.model,
-        );
+        let requested = app
+            .reasoning_effort_preference
+            .unwrap_or(app.reasoning_effort);
+        app.reasoning_effort =
+            requested.normalize_for_route(app.api_provider, &app.active_route_base_url, &app.model);
     }
     app.provider_models.insert(
         app.provider_identity_for_persistence().to_string(),
@@ -16832,11 +16832,11 @@ fn restore_loaded_session_provider(app: &mut App, config: &mut Config, identity:
     app.last_fallback_reason = None;
     app.model_ids_passthrough = config.model_ids_pass_through();
     if !app.auto_model {
-        app.reasoning_effort = app.reasoning_effort.normalize_for_route(
-            provider,
-            &config.deepseek_base_url(),
-            &app.model,
-        );
+        let requested = app
+            .reasoning_effort_preference
+            .unwrap_or(app.reasoning_effort);
+        app.reasoning_effort =
+            requested.normalize_for_route(provider, &config.deepseek_base_url(), &app.model);
     }
     app.set_active_context_window_override(config.context_window_for_provider_config(provider));
     app.active_route_limits = app.context_window_override_limits();

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5970,6 +5970,8 @@ async fn auto_dispatch_keeps_last_and_pending_receipts_aligned() {
     let _zai = crate::test_support::EnvVarGuard::set("ZAI_API_KEY", "zai-test-key");
     let mut app = create_test_app();
     app.set_provider_identity(ApiProvider::Zai, "zai");
+    app.reasoning_effort = ReasoningEffort::Low;
+    app.reasoning_effort_explicit = true;
     app.set_model_selection("auto".to_string());
     let config = Config {
         provider: Some("zai".to_string()),
@@ -6002,6 +6004,15 @@ async fn auto_dispatch_keeps_last_and_pending_receipts_aligned() {
             .as_ref()
             .map(|receipt| receipt.tier),
         Some(crate::model_routing::AutoRouteTier::Fast)
+    );
+    assert_eq!(
+        app.last_effective_reasoning_effort,
+        Some(EffectiveReasoningEffort::ThinkingEnabledGranularityUnavailable),
+        "the post-turn receipt must retain exact route capability constraints"
+    );
+    assert_eq!(
+        app.reasoning_effort_display_label(),
+        "low→thinking enabled; granularity unavailable"
     );
 }
 
@@ -14827,8 +14838,10 @@ fn apply_loaded_session_restores_auto_model_mode() {
     let mut app = create_test_app();
     app.set_model_selection("deepseek-v4-pro".to_string());
     app.reasoning_effort = ReasoningEffort::Low;
+    app.reasoning_effort_explicit = true;
     app.last_effective_model = Some("deepseek-v4-flash".to_string());
-    app.last_effective_reasoning_effort = Some(ReasoningEffort::Low);
+    app.last_effective_reasoning_effort =
+        Some(EffectiveReasoningEffort::Tier(ReasoningEffort::Low));
     let mut session = saved_session_with_messages(vec![
         text_message("user", "hello"),
         text_message("assistant", "hi"),
@@ -14849,6 +14862,25 @@ fn apply_loaded_session_restores_auto_model_mode() {
     assert_eq!(app.last_effective_reasoning_effort, None);
     assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
     assert_eq!(app.effective_model_for_budget(), DEFAULT_TEXT_MODEL);
+}
+
+#[test]
+fn apply_loaded_auto_session_releases_implicit_fixed_model_thinking() {
+    let mut app = create_test_app();
+    app.set_model_selection("deepseek-v4-pro".to_string());
+    app.reasoning_effort = ReasoningEffort::Max;
+    app.reasoning_effort_explicit = false;
+    let mut session = saved_session_with_messages(vec![
+        text_message("user", "hello"),
+        text_message("assistant", "hi"),
+    ]);
+    session.metadata.model = "auto".to_string();
+
+    apply_loaded_session(&mut app, &mut Config::default(), &session).expect("restore auto session");
+
+    assert!(app.auto_model);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
+    assert!(!app.reasoning_effort_explicit);
 }
 
 #[test]
@@ -14874,11 +14906,28 @@ fn auto_route_receipt_survives_session_snapshot_and_restore() {
     app.last_effective_provider_identity = Some("zai".to_string());
     app.last_effective_model = Some(crate::config::ZAI_GLM_5_2_MODEL.to_string());
     app.last_auto_route_receipt = Some(receipt.clone());
+    app.last_effective_reasoning_effort =
+        Some(EffectiveReasoningEffort::Tier(ReasoningEffort::High));
     app.api_messages
         .push(text_message("user", "inspect this route"));
 
     let snapshot = build_session_snapshot(&mut app, &manager).expect("session snapshot");
     let serialized = serde_json::to_string(&snapshot).expect("serialize session");
+    let mut legacy_json: serde_json::Value =
+        serde_json::from_str(&serialized).expect("parse session json");
+    legacy_json["last_auto_route"]
+        .as_object_mut()
+        .expect("Auto route object")
+        .remove("effective_reasoning_effort");
+    let legacy: SavedSession =
+        serde_json::from_value(legacy_json).expect("deserialize legacy Auto route");
+    assert_eq!(
+        legacy
+            .last_auto_route
+            .as_ref()
+            .and_then(|route| route.effective_reasoning_effort),
+        None
+    );
     let persisted: SavedSession = serde_json::from_str(&serialized).expect("deserialize session");
     let saved = persisted
         .last_auto_route
@@ -14888,6 +14937,10 @@ fn auto_route_receipt_survives_session_snapshot_and_restore() {
     assert_eq!(saved.provider_identity, "zai");
     assert_eq!(saved.model, crate::config::ZAI_GLM_5_2_MODEL);
     assert_eq!(saved.receipt, receipt);
+    assert_eq!(
+        saved.effective_reasoning_effort,
+        Some(crate::work_graph::ReasoningEffortTier::High)
+    );
 
     let mut restored_app = create_test_app();
     apply_loaded_session(&mut restored_app, &mut Config::default(), &persisted)
@@ -14904,6 +14957,11 @@ fn auto_route_receipt_survives_session_snapshot_and_restore() {
         Some(crate::config::ZAI_GLM_5_2_MODEL)
     );
     assert_eq!(restored_app.last_auto_route_receipt, Some(receipt));
+    assert_eq!(
+        restored_app.last_effective_reasoning_effort,
+        Some(EffectiveReasoningEffort::Tier(ReasoningEffort::High))
+    );
+    assert_eq!(restored_app.reasoning_effort_display_label(), "auto: high");
 }
 
 #[test]
@@ -15058,6 +15116,44 @@ async fn model_picker_persists_model_and_reasoning_effort() {
     assert!(provider_model_result.contains("auth=key saved · not checked"));
     assert!(provider_model_result.contains("health=attemptable"));
     assert!(!provider_model_result.contains("test-key"));
+}
+
+#[tokio::test]
+async fn model_picker_auto_releases_implicit_fixed_model_thinking() {
+    let _guard = SettingsHomeGuard::new();
+    let mut app = create_test_app();
+    app.set_model_selection("deepseek-v4-pro".to_string());
+    app.reasoning_effort = ReasoningEffort::Max;
+    app.reasoning_effort_explicit = false;
+    let mut engine = mock_engine_handle();
+    let mut config = Config {
+        api_key: Some("test-key".to_string()),
+        ..Default::default()
+    };
+
+    apply_model_picker_choice(
+        &mut app,
+        &mut engine.handle,
+        &mut config,
+        "auto".to_string(),
+        None,
+        None,
+        ReasoningEffort::Max,
+        "deepseek-v4-pro".to_string(),
+        ReasoningEffort::Max,
+    )
+    .await;
+
+    assert!(app.auto_model);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
+    assert!(!app.reasoning_effort_explicit);
+    assert_eq!(
+        crate::settings::Settings::load()
+            .expect("load settings")
+            .reasoning_effort
+            .as_deref(),
+        None
+    );
 }
 
 #[tokio::test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -197,7 +197,7 @@ fn ctrl_t_key_event_reaches_reasoning_effort_cycle() {
 }
 
 #[test]
-fn ctrl_t_does_not_persist_an_ignored_tier_under_auto_model() {
+fn ctrl_t_cycles_reasoning_effort_under_auto_model() {
     let mut app = create_test_app();
     app.auto_model = true;
     app.reasoning_effort = ReasoningEffort::Auto;
@@ -206,11 +206,11 @@ fn ctrl_t_does_not_persist_an_ignored_tier_under_auto_model() {
         &mut app,
         &KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
     ));
-    assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Off);
     assert!(
         app.status_message
             .as_deref()
-            .is_some_and(|message| message.contains("automatic model routing"))
+            .is_some_and(|message| message.contains("Reasoning effort: off"))
     );
 }
 
@@ -8335,7 +8335,7 @@ fn hotbar_dispatches_route_switch_slot() {
 }
 
 #[test]
-fn hotbar_bound_disabled_action_reports_reason_without_dispatching() {
+fn hotbar_bound_reasoning_action_updates_auto_model_preference() {
     let mut app = create_test_app();
     app.onboarding = OnboardingState::None;
     app.auto_model = true;
@@ -8350,16 +8350,15 @@ fn hotbar_bound_disabled_action_reports_reason_without_dispatching() {
         ..Config::default()
     };
 
-    assert_eq!(
-        dispatch_hotbar_slot(&mut app, &config, 1).expect("disabled slot dispatch"),
-        Some(HotbarDispatch::Handled)
-    );
-    assert_eq!(app.reasoning_effort, ReasoningEffort::Off);
-    assert_eq!(
-        app.status_message.as_deref(),
-        Some(
-            "Hotbar slot 1 action is not available: Reasoning effort is controlled by auto model routing."
-        )
+    assert!(matches!(
+        dispatch_hotbar_slot(&mut app, &config, 1).expect("reasoning slot dispatch"),
+        Some(HotbarDispatch::AppAction(AppAction::UpdateCompaction(_)))
+    ));
+    assert_eq!(app.reasoning_effort, ReasoningEffort::High);
+    assert!(
+        app.status_message
+            .as_deref()
+            .is_some_and(|message| message.contains("Reasoning effort: high"))
     );
     assert!(app.needs_redraw);
 }
@@ -14806,6 +14805,7 @@ fn session_restore_rebuilds_fresh_codex_route_limits() {
 fn apply_loaded_session_restores_concrete_model_mode() {
     let mut app = create_test_app();
     app.set_model_selection("auto".to_string());
+    app.reasoning_effort = ReasoningEffort::Low;
     let mut session = saved_session_with_messages(vec![
         text_message("user", "hello"),
         text_message("assistant", "hi"),
@@ -14819,13 +14819,14 @@ fn apply_loaded_session_restores_concrete_model_mode() {
     assert!(!app.auto_model);
     assert_eq!(app.model, "deepseek-v4-flash");
     assert_eq!(app.model_selection_for_persistence(), "deepseek-v4-flash");
+    assert_eq!(app.reasoning_effort, ReasoningEffort::High);
 }
 
 #[test]
 fn apply_loaded_session_restores_auto_model_mode() {
     let mut app = create_test_app();
     app.set_model_selection("deepseek-v4-pro".to_string());
-    app.reasoning_effort = ReasoningEffort::High;
+    app.reasoning_effort = ReasoningEffort::Low;
     app.last_effective_model = Some("deepseek-v4-flash".to_string());
     app.last_effective_reasoning_effort = Some(ReasoningEffort::Low);
     let mut session = saved_session_with_messages(vec![
@@ -14846,7 +14847,7 @@ fn apply_loaded_session_restores_auto_model_mode() {
     assert_eq!(app.last_effective_provider_identity, None);
     assert_eq!(app.last_auto_route_receipt, None);
     assert_eq!(app.last_effective_reasoning_effort, None);
-    assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
     assert_eq!(app.effective_model_for_budget(), DEFAULT_TEXT_MODEL);
 }
 
@@ -14952,6 +14953,55 @@ fn app_new_restores_saved_model_and_reasoning_effort() {
     assert_eq!(app.reasoning_effort, ReasoningEffort::High);
 }
 
+#[test]
+fn app_new_restores_saved_reasoning_effort_for_auto_model() {
+    let _guard = ConfigPathEnvGuard::new();
+    let settings = crate::settings::Settings {
+        default_model: Some("auto".to_string()),
+        reasoning_effort: Some("low".to_string()),
+        ..Default::default()
+    };
+    settings.save().expect("save settings");
+
+    let options = TuiOptions {
+        model: "deepseek-v4-pro".to_string(),
+        start_in_agent_mode: true,
+        skip_onboarding: false,
+        ..crate::test_support::test_tui_options(PathBuf::from("."))
+    };
+
+    let app = App::new(options, &Config::default());
+
+    assert!(app.auto_model);
+    assert_eq!(app.model, "auto");
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
+    assert_eq!(app.reasoning_effort_display_label(), "low");
+}
+
+#[test]
+fn app_new_auto_model_without_saved_reasoning_keeps_auto_default() {
+    let _guard = ConfigPathEnvGuard::new();
+    let settings = crate::settings::Settings {
+        default_model: Some("auto".to_string()),
+        reasoning_effort: None,
+        ..Default::default()
+    };
+    settings.save().expect("save settings");
+
+    let options = TuiOptions {
+        model: "deepseek-v4-pro".to_string(),
+        start_in_agent_mode: true,
+        skip_onboarding: false,
+        ..crate::test_support::test_tui_options(PathBuf::from("."))
+    };
+
+    let app = App::new(options, &Config::default());
+
+    assert!(app.auto_model);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
+    assert_eq!(app.reasoning_effort_display_label(), "auto");
+}
+
 #[tokio::test]
 async fn model_picker_persists_model_and_reasoning_effort() {
     let _guard = SettingsHomeGuard::new();
@@ -15008,6 +15058,36 @@ async fn model_picker_persists_model_and_reasoning_effort() {
     assert!(provider_model_result.contains("auth=key saved · not checked"));
     assert!(provider_model_result.contains("health=attemptable"));
     assert!(!provider_model_result.contains("test-key"));
+}
+
+#[tokio::test]
+async fn auto_model_effort_picker_persists_unresolved_tier_verbatim() {
+    let _guard = SettingsHomeGuard::new();
+    let mut app = create_test_app();
+    app.set_model_selection("auto".to_string());
+    app.reasoning_effort = ReasoningEffort::Auto;
+    app.reasoning_effort_explicit = false;
+    let engine = mock_engine_handle();
+
+    apply_picker_effort_choice(
+        &mut app,
+        &engine.handle,
+        ReasoningEffort::Low,
+        ReasoningEffort::Auto,
+    )
+    .await;
+
+    assert!(app.auto_model);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
+    assert!(app.reasoning_effort_explicit);
+    assert_eq!(
+        crate::settings::Settings::load()
+            .expect("load settings")
+            .reasoning_effort
+            .as_deref(),
+        Some("low"),
+        "an unresolved auto route must not pre-normalize Low to DeepSeek High"
+    );
 }
 
 /// Re-picking the already-live model is a real, completed provider/model
@@ -15158,6 +15238,8 @@ async fn model_picker_auto_switches_exact_named_custom_route_transactionally() {
     let mut app = create_test_app();
     app.set_provider_identity(ApiProvider::Custom, "custom-a");
     app.set_model_selection("model-a".to_string());
+    app.reasoning_effort = ReasoningEffort::Low;
+    app.reasoning_effort_explicit = true;
     let previous_effort = app.reasoning_effort;
     let mut custom = HashMap::new();
     for (name, base_url, model) in [
@@ -15192,7 +15274,7 @@ async fn model_picker_auto_switches_exact_named_custom_route_transactionally() {
         "auto".to_string(),
         None,
         Some("custom-b".to_string()),
-        ReasoningEffort::Auto,
+        ReasoningEffort::Low,
         "model-a".to_string(),
         previous_effort,
     )
@@ -15202,8 +15284,16 @@ async fn model_picker_auto_switches_exact_named_custom_route_transactionally() {
     assert_eq!(app.provider_identity_for_persistence(), "custom-b");
     assert!(app.auto_model);
     assert_eq!(app.model_selection_for_persistence(), "auto");
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
     assert_eq!(config.provider.as_deref(), Some("custom-b"));
     assert_eq!(config.deepseek_base_url(), "http://127.0.0.1:18182/v1");
+    assert_eq!(
+        crate::settings::Settings::load()
+            .expect("load settings")
+            .reasoning_effort
+            .as_deref(),
+        Some("low")
+    );
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -199,19 +199,27 @@ fn ctrl_t_key_event_reaches_reasoning_effort_cycle() {
 #[test]
 fn ctrl_t_cycles_reasoning_effort_under_auto_model() {
     let mut app = create_test_app();
+    app.api_provider = ApiProvider::Deepseek;
     app.auto_model = true;
     app.reasoning_effort = ReasoningEffort::Auto;
 
-    assert!(handle_reasoning_effort_key(
-        &mut app,
-        &KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
-    ));
-    assert_eq!(app.reasoning_effort, ReasoningEffort::Off);
-    assert!(
-        app.status_message
-            .as_deref()
-            .is_some_and(|message| message.contains("Reasoning effort: off"))
-    );
+    for expected in [
+        ReasoningEffort::Off,
+        ReasoningEffort::Low,
+        ReasoningEffort::Medium,
+        ReasoningEffort::High,
+        ReasoningEffort::Max,
+        ReasoningEffort::Auto,
+    ] {
+        assert!(handle_reasoning_effort_key(
+            &mut app,
+            &KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+        ));
+        assert_eq!(app.reasoning_effort, expected);
+        assert!(app.status_message.as_deref().is_some_and(|message| {
+            message.contains(&format!("Reasoning effort: {}", expected.short_label()))
+        }));
+    }
 }
 
 #[test]
@@ -8365,11 +8373,11 @@ fn hotbar_bound_reasoning_action_updates_auto_model_preference() {
         dispatch_hotbar_slot(&mut app, &config, 1).expect("reasoning slot dispatch"),
         Some(HotbarDispatch::AppAction(AppAction::UpdateCompaction(_)))
     ));
-    assert_eq!(app.reasoning_effort, ReasoningEffort::High);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
     assert!(
         app.status_message
             .as_deref()
-            .is_some_and(|message| message.contains("Reasoning effort: high"))
+            .is_some_and(|message| message.contains("Reasoning effort: low"))
     );
     assert!(app.needs_redraw);
 }
@@ -15037,6 +15045,34 @@ fn app_new_restores_saved_reasoning_effort_for_auto_model() {
 }
 
 #[test]
+fn app_new_auto_model_preserves_explicit_config_reasoning() {
+    let _guard = ConfigPathEnvGuard::new();
+    let settings = crate::settings::Settings {
+        default_model: Some("auto".to_string()),
+        reasoning_effort: None,
+        ..Default::default()
+    };
+    settings.save().expect("save settings");
+
+    let options = TuiOptions {
+        model: "deepseek-v4-pro".to_string(),
+        start_in_agent_mode: true,
+        skip_onboarding: false,
+        ..crate::test_support::test_tui_options(PathBuf::from("."))
+    };
+    let config = Config {
+        reasoning_effort: Some("medium".to_string()),
+        ..Config::default()
+    };
+
+    let app = App::new(options, &config);
+
+    assert!(app.auto_model);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Medium);
+    assert!(app.reasoning_effort_explicit);
+}
+
+#[test]
 fn app_new_auto_model_without_saved_reasoning_keeps_auto_default() {
     let _guard = ConfigPathEnvGuard::new();
     let settings = crate::settings::Settings {
@@ -15058,6 +15094,36 @@ fn app_new_auto_model_without_saved_reasoning_keeps_auto_default() {
     assert!(app.auto_model);
     assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
     assert_eq!(app.reasoning_effort_display_label(), "auto");
+}
+
+#[test]
+fn app_new_auto_model_ignores_reasoning_inferred_from_legacy_alias() {
+    let _guard = ConfigPathEnvGuard::new();
+    let settings = crate::settings::Settings {
+        default_model: Some("auto".to_string()),
+        reasoning_effort: None,
+        ..Default::default()
+    };
+    settings.save().expect("save settings");
+
+    let options = TuiOptions {
+        model: "deepseek-v4-pro".to_string(),
+        start_in_agent_mode: true,
+        skip_onboarding: false,
+        ..crate::test_support::test_tui_options(PathBuf::from("."))
+    };
+    let config = Config {
+        reasoning_effort: Some("high".to_string()),
+        reasoning_effort_inferred_from_legacy_alias: true,
+        migrated_deepseek_model_alias: Some("deepseek-reasoner".to_string()),
+        ..Config::default()
+    };
+
+    let app = App::new(options, &config);
+
+    assert!(app.auto_model);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
+    assert!(!app.reasoning_effort_explicit);
 }
 
 #[tokio::test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5877,6 +5877,7 @@ async fn provider_switch_to_openai_codex_normalizes_deepseek_off_effort() {
     app.api_provider = ApiProvider::Deepseek;
     app.model = DEFAULT_TEXT_MODEL.to_string();
     app.reasoning_effort = ReasoningEffort::Off;
+    app.reasoning_effort_preference = Some(ReasoningEffort::Off);
     let mut engine = mock_engine_handle();
     let mut config = Config {
         provider: Some("deepseek".to_string()),
@@ -5903,6 +5904,7 @@ async fn provider_switch_to_openai_codex_normalizes_deepseek_off_effort() {
     assert_eq!(app.api_provider, ApiProvider::OpenaiCodex);
     assert_eq!(app.model, crate::config::DEFAULT_OPENAI_CODEX_MODEL);
     assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Off));
     assert_eq!(app.reasoning_effort_display_label(), "low");
 }
 
@@ -5979,7 +5981,7 @@ async fn auto_dispatch_keeps_last_and_pending_receipts_aligned() {
     let mut app = create_test_app();
     app.set_provider_identity(ApiProvider::Zai, "zai");
     app.reasoning_effort = ReasoningEffort::Low;
-    app.reasoning_effort_explicit = true;
+    app.reasoning_effort_preference = Some(ReasoningEffort::Low);
     app.set_model_selection("auto".to_string());
     let config = Config {
         provider: Some("zai".to_string()),
@@ -14825,6 +14827,7 @@ fn apply_loaded_session_restores_concrete_model_mode() {
     let mut app = create_test_app();
     app.set_model_selection("auto".to_string());
     app.reasoning_effort = ReasoningEffort::Low;
+    app.reasoning_effort_preference = Some(ReasoningEffort::Low);
     let mut session = saved_session_with_messages(vec![
         text_message("user", "hello"),
         text_message("assistant", "hi"),
@@ -14839,14 +14842,17 @@ fn apply_loaded_session_restores_concrete_model_mode() {
     assert_eq!(app.model, "deepseek-v4-flash");
     assert_eq!(app.model_selection_for_persistence(), "deepseek-v4-flash");
     assert_eq!(app.reasoning_effort, ReasoningEffort::High);
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Low));
 }
 
 #[test]
 fn apply_loaded_session_restores_auto_model_mode() {
     let mut app = create_test_app();
     app.set_model_selection("deepseek-v4-pro".to_string());
-    app.reasoning_effort = ReasoningEffort::Low;
-    app.reasoning_effort_explicit = true;
+    // Simulate a raw `low` preference already collapsed by the fixed
+    // DeepSeek route. Loading Auto must restore `low`, not snapshot `high`.
+    app.reasoning_effort = ReasoningEffort::High;
+    app.reasoning_effort_preference = Some(ReasoningEffort::Low);
     app.last_effective_model = Some("deepseek-v4-flash".to_string());
     app.last_effective_reasoning_effort =
         Some(EffectiveReasoningEffort::Tier(ReasoningEffort::Low));
@@ -14869,6 +14875,7 @@ fn apply_loaded_session_restores_auto_model_mode() {
     assert_eq!(app.last_auto_route_receipt, None);
     assert_eq!(app.last_effective_reasoning_effort, None);
     assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Low));
     assert_eq!(app.effective_model_for_budget(), DEFAULT_TEXT_MODEL);
 }
 
@@ -14877,7 +14884,7 @@ fn apply_loaded_auto_session_releases_implicit_fixed_model_thinking() {
     let mut app = create_test_app();
     app.set_model_selection("deepseek-v4-pro".to_string());
     app.reasoning_effort = ReasoningEffort::Max;
-    app.reasoning_effort_explicit = false;
+    app.reasoning_effort_preference = None;
     let mut session = saved_session_with_messages(vec![
         text_message("user", "hello"),
         text_message("assistant", "hi"),
@@ -14888,7 +14895,7 @@ fn apply_loaded_auto_session_releases_implicit_fixed_model_thinking() {
 
     assert!(app.auto_model);
     assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
-    assert!(!app.reasoning_effort_explicit);
+    assert_eq!(app.reasoning_effort_preference, None);
 }
 
 #[test]
@@ -15069,7 +15076,10 @@ fn app_new_auto_model_preserves_explicit_config_reasoning() {
 
     assert!(app.auto_model);
     assert_eq!(app.reasoning_effort, ReasoningEffort::Medium);
-    assert!(app.reasoning_effort_explicit);
+    assert_eq!(
+        app.reasoning_effort_preference,
+        Some(ReasoningEffort::Medium)
+    );
 }
 
 #[test]
@@ -15123,7 +15133,7 @@ fn app_new_auto_model_ignores_reasoning_inferred_from_legacy_alias() {
 
     assert!(app.auto_model);
     assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
-    assert!(!app.reasoning_effort_explicit);
+    assert_eq!(app.reasoning_effort_preference, None);
 }
 
 #[tokio::test]
@@ -15190,7 +15200,7 @@ async fn model_picker_auto_releases_implicit_fixed_model_thinking() {
     let mut app = create_test_app();
     app.set_model_selection("deepseek-v4-pro".to_string());
     app.reasoning_effort = ReasoningEffort::Max;
-    app.reasoning_effort_explicit = false;
+    app.reasoning_effort_preference = None;
     let mut engine = mock_engine_handle();
     let mut config = Config {
         api_key: Some("test-key".to_string()),
@@ -15212,7 +15222,7 @@ async fn model_picker_auto_releases_implicit_fixed_model_thinking() {
 
     assert!(app.auto_model);
     assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
-    assert!(!app.reasoning_effort_explicit);
+    assert_eq!(app.reasoning_effort_preference, None);
     assert_eq!(
         crate::settings::Settings::load()
             .expect("load settings")
@@ -15223,12 +15233,51 @@ async fn model_picker_auto_releases_implicit_fixed_model_thinking() {
 }
 
 #[tokio::test]
+async fn model_picker_auto_restores_raw_preference_after_fixed_normalization() {
+    let _guard = SettingsHomeGuard::new();
+    let mut app = create_test_app();
+    app.api_provider = ApiProvider::Deepseek;
+    app.set_model_selection("deepseek-v4-pro".to_string());
+    app.reasoning_effort = ReasoningEffort::High;
+    app.reasoning_effort_preference = Some(ReasoningEffort::Low);
+    let mut engine = mock_engine_handle();
+    let mut config = Config {
+        api_key: Some("test-key".to_string()),
+        ..Default::default()
+    };
+
+    apply_model_picker_choice(
+        &mut app,
+        &mut engine.handle,
+        &mut config,
+        "auto".to_string(),
+        None,
+        None,
+        ReasoningEffort::Low,
+        "deepseek-v4-pro".to_string(),
+        ReasoningEffort::Low,
+    )
+    .await;
+
+    assert!(app.auto_model);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Low));
+    assert_eq!(
+        crate::settings::Settings::load()
+            .expect("load settings")
+            .reasoning_effort
+            .as_deref(),
+        Some("low")
+    );
+}
+
+#[tokio::test]
 async fn auto_model_effort_picker_persists_unresolved_tier_verbatim() {
     let _guard = SettingsHomeGuard::new();
     let mut app = create_test_app();
     app.set_model_selection("auto".to_string());
     app.reasoning_effort = ReasoningEffort::Auto;
-    app.reasoning_effort_explicit = false;
+    app.reasoning_effort_preference = None;
     let engine = mock_engine_handle();
 
     apply_picker_effort_choice(
@@ -15241,7 +15290,7 @@ async fn auto_model_effort_picker_persists_unresolved_tier_verbatim() {
 
     assert!(app.auto_model);
     assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
-    assert!(app.reasoning_effort_explicit);
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Low));
     assert_eq!(
         crate::settings::Settings::load()
             .expect("load settings")
@@ -15332,6 +15381,7 @@ async fn reselecting_live_thinking_only_persists_startup_default() {
             .as_deref(),
         Some("high")
     );
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::High));
     assert!(
         app.status_message
             .as_deref()
@@ -15401,7 +15451,7 @@ async fn model_picker_auto_switches_exact_named_custom_route_transactionally() {
     app.set_provider_identity(ApiProvider::Custom, "custom-a");
     app.set_model_selection("model-a".to_string());
     app.reasoning_effort = ReasoningEffort::Low;
-    app.reasoning_effort_explicit = true;
+    app.reasoning_effort_preference = Some(ReasoningEffort::Low);
     let previous_effort = app.reasoning_effort;
     let mut custom = HashMap::new();
     for (name, base_url, model) in [

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2831,6 +2831,89 @@ fn create_test_app() -> App {
 }
 
 #[test]
+fn cache_warmup_resolves_the_last_concrete_auto_route() {
+    let config = Config {
+        provider: Some("deepseek".to_string()),
+        providers: Some(ProvidersConfig {
+            vllm: ProviderConfig {
+                base_url: Some("http://127.0.0.1:18191/v1".to_string()),
+                model: Some("auto-cache-model".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let mut app = create_test_app();
+    app.model = "auto".to_string();
+    app.auto_model = true;
+    app.last_effective_provider = Some(ApiProvider::Vllm);
+    app.last_effective_provider_identity = Some(ApiProvider::Vllm.as_str().to_string());
+    app.last_effective_model = Some("auto-cache-model".to_string());
+
+    let route = resolve_cache_replay_route(&app, &config).expect("last Auto route should resolve");
+
+    assert_eq!(route.identity.provider, ApiProvider::Vllm);
+    assert_eq!(route.identity.key, ApiProvider::Vllm.as_str());
+    assert_eq!(route.model, "auto-cache-model");
+    assert_eq!(
+        route.candidate.endpoint().base_url,
+        "http://127.0.0.1:18191/v1"
+    );
+
+    app.last_effective_provider_identity = Some(ApiProvider::Openrouter.as_str().to_string());
+    let error = resolve_cache_replay_route(&app, &config)
+        .expect_err("a mismatched persisted identity must fail closed");
+    assert!(
+        error.to_string().contains("route identity"),
+        "unexpected error: {error:#}"
+    );
+}
+
+#[test]
+fn cache_warmup_rejects_an_auto_route_whose_endpoint_changed() {
+    let config = Config {
+        provider: Some("deepseek".to_string()),
+        providers: Some(ProvidersConfig {
+            vllm: ProviderConfig {
+                base_url: Some("http://127.0.0.1:18192/v1".to_string()),
+                model: Some("auto-cache-model".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let mut app = create_test_app();
+    app.model = "auto".to_string();
+    app.auto_model = true;
+    app.last_effective_provider = Some(ApiProvider::Vllm);
+    app.last_effective_provider_identity = Some(ApiProvider::Vllm.as_str().to_string());
+    app.last_effective_model = Some("auto-cache-model".to_string());
+    app.session.last_base_url = Some("http://127.0.0.1:18191/v1".to_string());
+    app.push_turn_cache_record(crate::tui::app::TurnCacheRecord {
+        provider: Some(ApiProvider::Vllm),
+        provider_identity: Some(ApiProvider::Vllm.as_str().to_string()),
+        model: Some("auto-cache-model".to_string()),
+        auto_model: true,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_hit_tokens: None,
+        cache_miss_tokens: None,
+        cache_write_tokens: None,
+        reasoning_tokens: None,
+        cost_audit: None,
+        reasoning_replay_tokens: None,
+        recorded_at: Instant::now(),
+    });
+
+    let error = resolve_cache_replay_route(&app, &config)
+        .expect_err("changed endpoint must invalidate cache replay");
+
+    assert!(error.to_string().contains("endpoint changed"), "{error:#}");
+}
+
+#[test]
 fn hotbar_setup_save_persists_bindings_to_config_path() {
     let tmp = TempDir::new().expect("config tempdir");
     let config_path = tmp.path().join("config.toml");

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -15195,7 +15195,7 @@ async fn model_picker_persists_model_and_reasoning_effort() {
 }
 
 #[tokio::test]
-async fn model_picker_auto_releases_implicit_fixed_model_thinking() {
+async fn model_picker_auto_commits_visible_implicit_fixed_model_thinking() {
     let _guard = SettingsHomeGuard::new();
     let mut app = create_test_app();
     app.set_model_selection("deepseek-v4-pro".to_string());
@@ -15216,19 +15216,19 @@ async fn model_picker_auto_releases_implicit_fixed_model_thinking() {
         None,
         ReasoningEffort::Max,
         "deepseek-v4-pro".to_string(),
-        ReasoningEffort::Max,
+        ReasoningEffort::Auto,
     )
     .await;
 
     assert!(app.auto_model);
-    assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
-    assert_eq!(app.reasoning_effort_preference, None);
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Max);
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Max));
     assert_eq!(
         crate::settings::Settings::load()
             .expect("load settings")
             .reasoning_effort
             .as_deref(),
-        None
+        Some("max")
     );
 }
 

--- a/crates/tui/src/turn_route_plan.rs
+++ b/crates/tui/src/turn_route_plan.rs
@@ -96,6 +96,18 @@ impl TurnRoutingSource {
     }
 }
 
+fn reasoning_effort_for_route_selection(
+    auto_model: bool,
+    provider: ApiProvider,
+    effort: ReasoningEffort,
+) -> &'static str {
+    if auto_model {
+        effort.as_setting()
+    } else {
+        effort.as_setting_for_provider(provider)
+    }
+}
+
 /// Resolve the route for one turn.
 ///
 /// This is *the* route planner (#1004). `spawned_dispatch_inner` calls it to
@@ -121,9 +133,11 @@ pub(crate) async fn plan_turn_route(
                 request.auto_router_context,
                 request.mode.as_setting(),
                 if request.auto_model { "auto" } else { "fixed" },
-                request
-                    .reasoning_effort
-                    .as_setting_for_provider(request.api_provider),
+                reasoning_effort_for_route_selection(
+                    request.auto_model,
+                    request.api_provider,
+                    request.reasoning_effort,
+                ),
                 request.allow_auto_router_response_cache,
             )
             .await
@@ -203,8 +217,11 @@ pub(crate) async fn plan_turn_route(
         ..Default::default()
     };
 
-    let auto_controls_reasoning =
-        request.auto_model || request.reasoning_effort == ReasoningEffort::Auto;
+    // Model selection and reasoning selection are independent. A fixed
+    // reasoning preference survives auto model routing and is normalized
+    // against the concrete route below; only an explicit `auto` delegates the
+    // tier to the classifier/heuristic.
+    let auto_controls_reasoning = request.reasoning_effort == ReasoningEffort::Auto;
     let selected_reasoning_effort = if auto_controls_reasoning {
         Some(
             auto_selection
@@ -246,4 +263,75 @@ pub(crate) async fn plan_turn_route(
         auto_selection,
         routing_source,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DEFAULT_TEXT_MODEL;
+
+    fn deepseek_identity() -> ProviderIdentity {
+        ProviderIdentity {
+            provider: ApiProvider::Deepseek,
+            key: ApiProvider::Deepseek.as_str().to_string(),
+            exact_id: None,
+        }
+    }
+
+    #[test]
+    fn auto_model_route_selection_keeps_raw_reasoning_preference() {
+        assert_eq!(
+            reasoning_effort_for_route_selection(
+                true,
+                ApiProvider::OpenaiCodex,
+                ReasoningEffort::Off,
+            ),
+            "off"
+        );
+        assert_eq!(
+            reasoning_effort_for_route_selection(
+                false,
+                ApiProvider::OpenaiCodex,
+                ReasoningEffort::Off,
+            ),
+            "low"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_model_route_respects_fixed_reasoning_preference() {
+        let config = Config::default();
+        let identity = deepseek_identity();
+
+        let planned = plan_turn_route(TurnRoutePlanRequest {
+            route_config: &config,
+            app_route_identity: &identity,
+            api_provider: ApiProvider::Deepseek,
+            app_model: DEFAULT_TEXT_MODEL,
+            auto_model: true,
+            reasoning_effort: ReasoningEffort::Low,
+            mode: AppMode::Agent,
+            content: "explain this function",
+            display_text: "explain this function",
+            auto_router_context: "",
+            should_auto_resolve: false,
+            allow_auto_router_response_cache: false,
+            preflight_required: false,
+            auto_compact_user_configured: false,
+            auto_compact: true,
+            auto_compact_threshold_percent: 80.0,
+        })
+        .await
+        .expect("plan auto-model turn");
+
+        assert_eq!(
+            planned.routing_source,
+            TurnRoutingSource::AutoLocalHeuristic
+        );
+        assert!(!planned.auto_controls_reasoning);
+        assert_eq!(planned.selected_reasoning_effort, None);
+        // DeepSeek collapses low to high, but only after the concrete route is
+        // known; the App keeps the unresolved preference as Low.
+        assert_eq!(planned.effective_reasoning_effort.as_deref(), Some("high"));
+    }
 }


### PR DESCRIPTION
## Summary

- keep automatic model routing independent from the persisted reasoning-effort preference
- preserve the raw requested tier through startup, model/provider changes, session restore, config, picker, Ctrl+T, Hotbar, CLI, workflow, ACP, and runtime-thread flows
- normalize reasoning only after the concrete provider/model/endpoint route is known
- replay cache inspection and warmup on the last concrete Auto route, rejecting exact-identity or endpoint drift
- add regression coverage for persistence, cross-provider selection, session restore, non-TUI runtimes, cache replay, UI controls, and wire-level route planning

Fixes #4941

## Verification

- cargo fmt --all -- --check
- cargo check -p codewhale-tui --bin codewhale-tui --locked
- reasoning_effort: 43 passed
- auto_model: 27 passed
- model_picker: 99 passed
- config_ui: 16 passed
- cache: 276 passed
- terminal_mode_tests: 88 passed
- runtime_threads: 123 passed; one unrelated timing test passed three consecutive isolation runs
- codewhale-cli all-features serial run: 156 passed
- workspace all-features clippy passed with the CI allowlist plus Rust 1.95 allowances for three pre-existing lint classes
- full TUI all-features run: 9,207 passed, 4 ignored; the sole failure is the pre-existing Windows Job Object kill-on-close test, which also fails in isolation and is unchanged from upstream/main
- full workspace parallel run reached nine Windows temp-file sharing failures in codewhale-cli; the same 156-test crate passes serially

## Self-review

Verified that persisted reasoning remains an unresolved user preference until route selection, model Auto and reasoning Auto have separate authority flags, explicit CLI overrides still win, cache replay never substitutes the configured provider/model for the last Auto route, named custom identities fail closed, endpoint drift refuses warmup, and no unrelated worktree changes are included.