### PR TITLE
docs: add Indonesian documentation suite and README.id.md

### DIFF
--- a/CONTRIBUTING.id.md
+++ b/CONTRIBUTING.id.md
@@ -1,0 +1,62 @@
+# Berkontribusi pada Codewhale
+
+Terima kasih atas minat Anda untuk berkontribusi pada Codewhale! Dokumen ini memberikan panduan dan instruksi untuk berkontribusi.
+
+---
+
+## Memulai (Getting Started)
+
+### Prasyarat
+
+- Rust 1.88 atau lebih baru (edisi 2024)
+- Pengelola paket Cargo
+- Git
+
+### Menyiapkan Lingkungan Pengembangan
+
+1. Fork dan klon repositori:
+   ```bash
+   git clone https://github.com/USERNAME_ANDA/CodeWhale.git
+   cd CodeWhale
+   ```
+
+2. Kompilasi proyek:
+   ```bash
+   cargo build
+   ```
+
+3. Jalankan pengujian (tests):
+   ```bash
+   cargo test --workspace --all-features
+   ```
+
+4. Jalankan dalam mode pengembangan:
+   ```bash
+   cargo run --bin codewhale
+   ```
+
+---
+
+## Alur Kerja Pengembangan
+
+### Gaya Kode (Code Style)
+
+- Jalankan `cargo fmt` sebelum melakukan commit untuk memastikan format kode konsisten.
+- Jalankan `cargo clippy` dan atasi seluruh peringatan.
+- Ikuti konvensi penamaan Rust (`snake_case` untuk fungsi/variabel, `CamelCase` untuk tipe data/struct).
+- Tambahkan komentar dokumentasi untuk API publik.
+
+### Pengujian
+
+- Tulis pengujian untuk fungsionalitas baru.
+- Pastikan seluruh pengujian yang ada lulus: `cargo test --workspace --all-features`.
+- Tempatkan unit test di samping kode yang diuji (`#[cfg(test)]`), serta tambahkan pengujian integrasi di bawah direktori `tests/` pada crate yang bersangkutan.
+
+---
+
+## Pengajuan Pull Request (PR)
+
+1. Buat branch baru dari `main` untuk fitur atau perbaikan Anda.
+2. Pastikan `cargo fmt`, `cargo clippy`, dan pengujian lulus sebelum mengajukan PR.
+3. Tulis judul dan deskripsi PR yang jelas yang menjelaskan tujuan perubahan.
+4. Setiap kontributor akan mendapatkan kredit dalam changelog dan `docs/CONTRIBUTORS.md`.

--- a/README.es-419.md
+++ b/README.es-419.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:7e05c7acd044 -->
+<!-- source: README.md sha256:f25cf99b305a -->
 # Codewhale
 
 Un agente de programación de código abierto para tu terminal — trae tu propio modelo.
@@ -19,7 +19,7 @@ Siempre estamos buscando personas que contribuyan y formas de mejorar. Si falta
 un modelo o proveedor que usas, o algo se rompe, contárnoslo es una de las cosas
 más útiles que puedes hacer — mira [Contribuir](#contribuir).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.id.md
+++ b/README.id.md
@@ -1,0 +1,70 @@
+<!-- source: README.md sha256:215b7a12b9d7 -->
+# Codewhale
+
+Sebuah coding agent sumber terbuka untuk terminal Anda — bawa model pilihan Anda sendiri.
+
+Codewhale berawal sebagai pengalaman asli (native) untuk DeepSeek. Sejak saat itu, proyek ini berkembang menjadi proyek yang didorong oleh komunitas: satu coding harness yang memenuhi kebutuhan komunitas internasional yang terus berkembang serta mendukung sebanyak mungkin model dan penyedia (provider) — mengutamakan model terbuka, baik yang di-host maupun lokal, tanpa membeda-bedakan satu sama lain.
+
+Berikan penyedia, model, dan tugas: Codewhale akan membaca kode Anda, mengedit berkas, menjalankan perintah, serta memeriksa hasil kerjanya sendiri, lalu berhenti setelah pekerjaan selesai atau ketika membutuhkan arahan Anda. Ganti model di tengah tugas dengan `/model`. Bekerja secara interaktif di TUI, atau jalankan `codewhale exec` dalam skrip dan CI. Dibuat menggunakan Rust, berlisensi MIT, dan berjalan langsung di mesin Anda sendiri.
+
+Kami selalu membuka kesempatan bagi para kontributor dan cara untuk terus berkembang. Jika model atau penyedia yang Anda gunakan belum tersedia, atau ada hal yang tidak berjalan semestinya, memberi tahu kami adalah salah satu kontribusi paling berharga yang bisa Anda lakukan — lihat [Kontribusi](#kontribusi).
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
+
+[![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
+[![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
+
+![Codewhale running in a terminal](assets/screenshot.png)
+
+## Instalasi
+
+```bash
+npm install -g codewhale
+```
+
+Cargo, Docker, Nix, Scoop, arsip biner pra-kemas, Android/Termux, serta mirror CNB bagi siapa pun yang memiliki keterbatasan akses ke GitHub dibahas secara lengkap di [docs/INSTALL.id.md](docs/INSTALL.id.md) ([English](docs/INSTALL.md)). Bermigrasi dari `deepseek-tui`? Konfigurasi dan sesi Anda akan tetap dipertahankan — lihat [docs/REBRAND.id.md](docs/REBRAND.id.md) ([English](docs/REBRAND.md)).
+
+## Penggunaan
+
+```bash
+codewhale auth set --provider deepseek   # or export ANTHROPIC_API_KEY, etc.
+codewhale                                # open the TUI
+codewhale exec "fix the failing test"    # headless
+codewhale web                            # local browser client on 127.0.0.1
+```
+
+Di dalam TUI: `/model` mengganti penyedia dan model sekaligus, `/fleet` menjalankan tim pekerja (workers), dan `/restore` membatalkan satu langkah (turn). Saat composer dalam keadaan diam (idle), `Tab` beralih antar mode Plan / Act / Operate dan `Shift+Tab` beralih antar postur izin Ask / Auto-Review / Full Access. `!` menjalankan perintah shell melalui alur persetujuan normal.
+
+## Fitur & Kapabilitas
+
+- **Model mana saja, penyedia apa saja.** DeepSeek, Claude, GPT, Kimi, GLM, dan 30+ penyedia lainnya, ditambah vLLM, SGLang, atau Ollama milik Anda sendiri tanpa memerlukan API key — semuanya melalui satu runtime dan satu kumpulan alat. Batas konteks dan harga diambil dari rute sebenarnya, dan harga yang tidak diketahui ditampilkan sebagai *unknown* daripada $0.
+- **Read-only sampai Anda memberi izin lebih.** Mode Plan tidak dapat mengubah berkas, dan gerbang persetujuan memproteksi perintah berisiko. Ketika sandbox OS membungkus perintah, Codewhale akan menginformasikannya: Seatbelt pada macOS (jika tersedia), serta opsi bubblewrap di Linux. Berkas `constitution.json` repositori dikompilasi menjadi pembatas penulisan yang bahkan tidak dapat dilewati oleh mode Full Access.
+- **Pekerjaan yang dapat dilanjutkan.** Fleet mencatat setiap langkah ke ledger bertipe append-only, sehingga `fleet resume` dapat melanjutkan pekerjaan tepat di mana Anda meninggalkannya.
+
+## Pelajari Lebih Lanjut
+
+- [docs/PROVIDERS.id.md](docs/PROVIDERS.id.md) ([English](docs/PROVIDERS.md)) — setiap rute penyedia: hosted, gateway, dan lokal
+- [docs/FLEET.id.md](docs/FLEET.id.md) ([English](docs/FLEET.md)) — fleet, ledger, dan kelanjutan sesi (resume)
+- [docs/CONFIGURATION.id.md](docs/CONFIGURATION.id.md) ([English](docs/CONFIGURATION.md)) — `config.toml`, hooks, dan konstitusi
+- [docs/WEB.id.md](docs/WEB.id.md) ([English](docs/WEB.md)) — klien browser berbasis loopback-only dan batas autentikasi sekali pakainya
+- [docs/LOCALIZATION.id.md](docs/LOCALIZATION.id.md) ([English](docs/LOCALIZATION.md)) — matriks lokalisasi & panduan terjemahan
+
+Topik lainnya — [mode eksekusi](docs/MODES.id.md) ([English](docs/MODES.md)), [pintasan tombol](docs/KEYBINDINGS.id.md) ([English](docs/KEYBINDINGS.md)), detail sandbox, [MCP](docs/MCP.id.md) ([English](docs/MCP.md)), runtime API, dan arsitektur — tersedia di dalam direktori [docs](docs) serta di [codewhale.net](https://codewhale.net/).
+
+## Kontribusi
+
+Issue, PR, langkah reproduksi masalah, log, dan permintaan fitur semuanya merupakan kontribusi nyata pada proyek ini, dan kami sangat menyambut kontribusi pertama Anda. Jika sebuah PR tidak dapat di-merge secara langsung, maintainer akan memetik bagian yang berfungsi dan tetap memberikan kredit kepada pembuatnya — dalam commit, changelog, dan [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md).
+
+- [Open issues](https://github.com/Hmbown/CodeWhale/issues) — tempat awal yang baik untuk kontribusi pertama
+- [CONTRIBUTING.id.md](CONTRIBUTING.id.md) ([English](CONTRIBUTING.md)) — alur pengembangan dan prosedur PR
+- [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) — setiap orang yang telah membentuk proyek ini
+- [Dukung proyek ini](https://www.buymeacoffee.com/hmbown)
+
+Terima kasih kepada [DeepSeek](https://github.com/deepseek-ai) untuk model dan dukungan yang mengawali proyek ini, [DataWhale](https://github.com/datawhalechina) 🐋 atas sambutan hangat ke dalam keluarga Whale Brother, serta [OpenWarp](https://github.com/zerx-lab/warp) dan [Open Design](https://github.com/nexu-io/open-design) atas kolaborasi dalam menghadirkan pengalaman terminal-agent yang lebih baik.
+
+## Lisensi
+
+[MIT](LICENSE). Sebuah proyek komunitas independen, tidak terafiliasi dengan penyedia model mana pun.
+
+[![Star History Chart](https://api.star-history.com/chart?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://www.star-history.com/?repos=Hmbown%2FCodeWhale&type=date)

--- a/README.id.md
+++ b/README.id.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:215b7a12b9d7 -->
+<!-- source: README.md sha256:f25cf99b305a -->
 # Codewhale
 
 Sebuah coding agent sumber terbuka untuk terminal Anda — bawa model pilihan Anda sendiri.
@@ -9,7 +9,7 @@ Berikan penyedia, model, dan tugas: Codewhale akan membaca kode Anda, mengedit b
 
 Kami selalu membuka kesempatan bagi para kontributor dan cara untuk terus berkembang. Jika model atau penyedia yang Anda gunakan belum tersedia, atau ada hal yang tidak berjalan semestinya, memberi tahu kami adalah salah satu kontribusi paling berharga yang bisa Anda lakukan — lihat [Kontribusi](#kontribusi).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:7e05c7acd044 -->
+<!-- source: README.md sha256:f25cf99b305a -->
 # Codewhale
 
 ターミナルで動くオープンソースのコーディングエージェント — モデルはあなたが持ち込む。
@@ -9,7 +9,7 @@ Codewhale は DeepSeek のためのネイティブ体験として始まりまし
 
 私たちは常にコントリビューターと改善の方法を探しています。使っているモデルやプロバイダが見当たらないとき、あるいは何かが壊れたときは、それを知らせてもらえることが最も役に立つことのひとつです — [コントリビューション](#コントリビューション)を見てください。
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
+[English](README.md) · [简体中文](README.zh-CN.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:7e05c7acd044 -->
+<!-- source: README.md sha256:f25cf99b305a -->
 # Codewhale
 
 터미널에서 쓰는 오픈소스 코딩 에이전트 — 모델은 당신이 가져옵니다.
@@ -9,7 +9,7 @@ Codewhale은 DeepSeek을 위한 네이티브 경험으로 시작했습니다. �
 
 우리는 항상 기여자와 개선할 방법을 찾고 있습니다. 사용하는 모델이나 프로바이더가 빠져 있거나 무언가가 깨진다면, 그것을 알려 주는 일이 할 수 있는 가장 유용한 일 중 하나입니다 — [기여](#기여)를 참고하세요.
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We're always looking for contributors and ways to improve. If a model or
 provider you use is missing, or something breaks, telling us is one of the most
 useful things you can do — see [Contributing](#contributing).
 
-[简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
+[简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:7e05c7acd044 -->
+<!-- source: README.md sha256:f25cf99b305a -->
 # Codewhale
 
 Um agente de programação de código aberto para o seu terminal — traga o seu próprio modelo.
@@ -19,7 +19,7 @@ Estamos sempre em busca de pessoas que contribuam e de formas de melhorar. Se um
 modelo ou provedor que você usa está faltando, ou se algo quebra, nos contar é
 uma das coisas mais úteis que você pode fazer — veja [Contribuindo](#contribuindo).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:7e05c7acd044 -->
+<!-- source: README.md sha256:f25cf99b305a -->
 # Codewhale
 
 Открытый агент для программирования в вашем терминале — модель приносите с собой.
@@ -21,7 +21,7 @@ Codewhale начинался как нативный клиент для DeepSee
 одно из самых полезных действий с вашей стороны: см.
 [Участие в проекте](#участие-в-проекте).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Українська](README.uk.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Українська](README.uk.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.uk.md
+++ b/README.uk.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:7e05c7acd044 -->
+<!-- source: README.md sha256:f25cf99b305a -->
 # Codewhale
 
 Агент для програмування з відкритим кодом у вашому терміналі — модель приносите ви.
@@ -21,7 +21,7 @@ Codewhale починався як нативний інструмент для D
 це — одна з найкорисніших речей, які ви можете зробити — див.
 [Участь у проєкті](#участь-у-проєкті).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [codewhale.net](https://codewhale.net/) · [Документація](docs) · [Журнал змін](CHANGELOG.md)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [codewhale.net](https://codewhale.net/) · [Документація](docs) · [Журнал змін](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:7e05c7acd044 -->
+<!-- source: README.md sha256:f25cf99b305a -->
 # Codewhale
 
 Một coding agent mã nguồn mở cho terminal của bạn — mang theo model của riêng bạn.
@@ -19,7 +19,7 @@ Chúng tôi luôn tìm kiếm người đóng góp và cách cải thiện. Nế
 provider bạn dùng còn thiếu, hoặc có gì đó hỏng, báo cho chúng tôi biết là một
 trong những điều hữu ích nhất bạn có thể làm — xem [Đóng góp](#đóng-góp).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Bahasa Indonesia](README.id.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:7e05c7acd044 -->
+<!-- source: README.md sha256:f25cf99b305a -->
 # Codewhale
 
 一个面向终端的开源编程智能体——模型由你自带。
@@ -9,7 +9,7 @@ Codewhale 最初是为 DeepSeek 打造的原生体验,如今已成长为一个�
 
 我们一直在寻找贡献者和改进的方式。如果你在用的某个模型或 provider 还不支持,或者有什么东西坏了,告诉我们就是你能做的最有用的事之一——见[贡献](#贡献)。
 
-[English](README.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
+[English](README.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/docs/CONFIGURATION.id.md
+++ b/docs/CONFIGURATION.id.md
@@ -1,0 +1,33 @@
+# Konfigurasi Codewhale
+
+Codewhale membaca konfigurasi dari berkas TOML ditambah variabel lingkungan (environment variables). Saat startup proses, Codewhale juga dapat membaca kredensial penyedia dari berkas `.env` lokal di ruang kerja. Gunakan contoh templat `.env.example` yang tersedia; salin ke `.env`, lalu tambahkan hanya nilai kredensial.
+
+---
+
+## Konstitusi, Instruksi Proyek, dan Wewenang Repositori
+
+Codewhale memiliki beberapa lapisan instruksi yang sengaja dipisahkan agar konstitusi pribadi, kebijakan repositori, instruksi proyek, dan kontrol keamanan runtime tidak saling bertabrakan:
+
+1. **Konstitusi Global Bawaan (Bundled Constitution)**:
+   - Hukum dasar yang terkompilasi di dalam biner. Menjadi batas dasar bawaan untuk setiap sesi.
+
+2. **Konstitusi Global Pengguna (User-Global Constitution)**:
+   - Dikelola melalui perintah `/constitution` atau `/setup`. Ditinggalkan dalam format terstruktur pada `$CODEWHALE_HOME/constitution.json` (bawaan `~/.codewhale/constitution.json`).
+
+3. **Konstitusi Lokal Repositori (Repo-Local Constitution)**:
+   - Kebijakan proyek opsional pada `.codewhale/constitution.json`.
+
+4. **Instruksi Proyek (`AGENTS.md`)**:
+   - Berkas instruksi proyek lintas-agen. Berkas ini adalah dokumen kanonik untuk "bagaimana agen bekerja di repositori ini". Jalankan `/init` untuk membuatnya secara otomatis. `CLAUDE.md` dibaca sebagai fallback kompatibilitas.
+
+5. **Memori dan Serah Terima (Memory & Handoffs)**:
+   - Riwayat dan konteks yang dipanggil kembali. Berfungsi membantu, namun memiliki tingkat wewenang lebih rendah dari konstitusi dan instruksi proyek.
+
+---
+
+## Lokasi Berkas Konfigurasi
+
+- Berkas Konfigurasi Utama: `~/.codewhale/config.toml`
+- Berkas Konstitusi Pengguna: `~/.codewhale/constitution.json`
+- Berkas Konfigurasi MCP: `~/.codewhale/mcp.json`
+- Berkas Sesi: `~/.codewhale/sessions/`

--- a/docs/FLEET.id.md
+++ b/docs/FLEET.id.md
@@ -1,0 +1,35 @@
+# Agent Fleet (Armada Agen)
+
+Agent Fleet adalah control plane yang mengutamakan lokal (*local-first*) untuk eksekusi banyak pekerja (*multi-worker*) yang tahan lama. Fleet **bukanlah** mesin eksekusi terpisah: seorang pekerja fleet (*fleet worker*) adalah eksekusi `codewhale exec` tanpa antarmuka yang diluncurkan dan dilacak oleh fleet secara permanen.
+
+Gunakan Fleet daripada pembagian tugas agen yang berumur pendek ketika pekerjaan membutuhkan percobaan ulang (*retry*), ketahanan terhadap mode tidur/restart komputer, eksekusi jarak jauh, bukti tanda terima (*receipts*), atau jejak audit ber-ledger.
+
+---
+
+## Perintah Dasar CLI Fleet
+
+```sh
+codewhale fleet init
+codewhale fleet run tasks.json --max-workers 4
+codewhale fleet status
+codewhale fleet inspect <worker-id>
+codewhale fleet logs <worker-id>
+codewhale fleet artifacts <worker-id>
+codewhale fleet interrupt <worker-id>
+codewhale fleet restart <worker-id>
+codewhale fleet resume <run-id>
+codewhale fleet stop --all
+```
+
+`codewhale fleet resume <run-id>` adalah perintah pemulihan setelah sistem terhenti: perintah ini memutar ulang ledger, merekonsiliasi tugas yang terhenti (Mencoba lagi sesuai anggaran tugas, atau melaporkannya jika gagal), lalu menampilkan status setelah pemulihan. Perintah ini aman dijalankan setelah laptop terbangun dari mode tidur atau setelah restart runtime.
+
+---
+
+## Lokasi Penyimpanan Status
+
+Status Fleet disimpan di dalam ruang kerja di bawah `.codewhale/fleet.jsonl`. Log pekerja dan log adapter disimpan di bawah `.codewhale/fleet/` dan `.codewhale/fleet-host/`.
+
+### Perbedaan Status Interaktif dan Persisten
+
+- Di dalam TUI: Perintah `/fleet status` (atau `/subagents`) menampilkan sub-agen yang terhubung ke sesi interaktif saat ini.
+- Di dalam Shell: Perintah `codewhale fleet status` membaca riwayat eksekusi Fleet yang tersimpan di ledger `.codewhale/fleet.jsonl`.

--- a/docs/INSTALL.id.md
+++ b/docs/INSTALL.id.md
@@ -1,0 +1,84 @@
+# Menginstal Codewhale
+
+Halaman ini mencakup setiap jalur instalasi yang didukung dan penanganan masalah umum saat instalasi gagal, termasuk **Linux ARM64** dan platform lainnya.
+
+Jika Anda hanya menginginkan versi singkat, lihat [README utama](../README.md#install) atau [README Bahasa Indonesia](../README.id.md#instalasi).
+
+---
+
+## 1. Skrip Instalasi Web (macOS & Linux)
+
+Pada macOS dan Linux, installer situs web adalah jalur instalasi dan pembaruan tersingkat:
+
+```bash
+curl -fsSL https://codewhale.net/install.sh | sh
+```
+
+Skrip ini akan mengunduh biner rilis `codewhale`, `codew`, dan `codewhale-tui` yang cocok, memverifikasinya terhadap `codewhale-artifacts-sha256.txt`, menginstal ke `~/.local/bin` secara bawaan, serta menyediakan perintah `codew`.
+
+---
+
+## 2. Platform yang Didukung
+
+Rilis resmi Codewhale menyediakan biner pra-kemas untuk kombinasi platform dan arsitektur berikut:
+
+| Platform     | Arsitektur | `npm install` | `cargo install` | Aset Rilis GitHub                                     |
+| ------------ | ------------ | :---------: | :-------------: | ----------------------------------------------------- |
+| Linux        | x64 (x86_64) |     ✅      |       ✅        | `codewhale-linux-x64`, `codew-linux-x64`, `codewhale-tui-linux-x64`        |
+| Linux        | arm64        |     ✅      |       ✅        | `codewhale-linux-arm64`, `codew-linux-arm64`, `codewhale-tui-linux-arm64`    |
+| Android / Termux | arm64 (aarch64) | ⚠️ Pratinjau | ⚠️ Pratinjau | Arsip pratinjau `codewhale-android-arm64.tar.gz` |
+| macOS        | x64          |     ✅      |       ✅        | `codewhale-macos-x64`, `codew-macos-x64`, `codewhale-tui-macos-x64`        |
+| macOS        | arm64 (M-series) | ✅      |       ✅        | `codewhale-macos-arm64`, `codew-macos-arm64`, `codewhale-tui-macos-arm64`    |
+| Windows      | x64          |     ✅      |       ✅        | `codewhale-windows-x64.exe`, `codew-windows-x64.exe`, `codewhale-tui-windows-x64.exe` |
+| Windows      | arm64        |     ✅      |       ✅        | `codewhale-windows-arm64.exe`, `codew-windows-arm64.exe`, `codewhale-tui-windows-arm64.exe` |
+
+---
+
+## 3. Instalasi via npm
+
+npm adalah pengelola paket yang paling umum digunakan:
+
+```bash
+npm install -g codewhale
+```
+
+Bagi pengguna Linux/macOS, pastikan direktori biner global npm berada di dalam `$PATH` Anda.
+
+---
+
+## 4. Instalasi via Cargo (Kompilasi dari Sumber Kode)
+
+Jika Anda ingin mengompilasi biner langsung dari sumber kode menggunakan Rust:
+
+```bash
+cargo install codewhale-cli --locked
+cargo install codewhale-tui --locked
+```
+
+Persyaratan sistem:
+- Rust toolchain (versi stable terbaru)
+- Dependensi `libdbus-1-dev` atau `pkg-config` pada Linux untuk integrasi keyring OS.
+
+---
+
+## 5. Android / Termux
+
+Termux berjalan di atas Bionic libc Android dan menggunakan `$PREFIX` sebagai awalan Unix-nya.
+
+1. Pasang paket dasar:
+   ```bash
+   pkg update && pkg install rust clang make pkg-config libsqlite
+   ```
+2. Jalankan instalasi via Cargo:
+   ```bash
+   cargo install codewhale-cli --locked
+   cargo install codewhale-tui --locked
+   ```
+
+---
+
+## 6. Migrasi dari `deepseek-tui`
+
+Jika Anda sebelumnya menggunakan `deepseek-tui`, seluruh sesi dan berkas konfigurasi Anda dapat ditransisikan dengan mudah:
+- Jalur konfigurasi otomatis dimigrasikan dari `~/.config/deepseek-tui` ke `~/.config/codewhale`.
+- Detail selengkapnya tersedia di [docs/REBRAND.md](REBRAND.md).

--- a/docs/KEYBINDINGS.id.md
+++ b/docs/KEYBINDINGS.id.md
@@ -1,0 +1,40 @@
+# Referensi Pintasan Tombol (Keybindings)
+
+Katalog resmi seluruh pintasan tombol yang dikenali oleh TUI Codewhale.
+
+---
+
+## Global (Setiap Konteks)
+
+| Pintasan Tombol | Aksi |
+|----------------------|---------------------------------------------------------------|
+| `F1` atau `Ctrl-/` | Buka/tutup layar bantuan |
+| `F2` | Buka/tutup editor Pengaturan terstruktur |
+| `Ctrl-K` | Buka palet perintah (pencari perintah slash) |
+| `Ctrl-C` | Batalkan giliran berjalan / tutup modal / batalkan aplikasi |
+| `Ctrl-D` | Keluar dari aplikasi (hanya saat composer kosong) |
+| `Tab` | Beralih mode TUI: **Plan → Act → Operate → Plan** |
+| `Shift+Tab` | Beralih postur izin: **Ask → Auto-Review → Full Access** |
+| `Ctrl-T` | Beralih tingkat penalaran (reasoning effort) |
+| `Ctrl-Shift-T` | Buka/tutup transkrip langsung |
+| `Ctrl-R` | Buka pemilih sesi |
+| `Ctrl-L` | Bersihkan / segarkan layar |
+| `Ctrl-O` | Buka Inspektur Giliran (Turn Inspector) |
+| `Alt-V` / `Option-V` | Buka detail mentah alat/sub-agen terpilih |
+| `Esc` | Tutup modal paling atas / batalkan menu slash / bersihkan |
+
+---
+
+## Editor Input (Composer)
+
+| Pintasan Tombol | Aksi |
+|-----------------------------|---------------------------------------------------------|
+| `Enter` | Kirim pesan (atau jalankan perintah slash) |
+| `Alt-Enter` / `Ctrl-J` | Sisipkan baris baru tanpa mengirim pesan |
+| `Ctrl-U` | Bersihkan seluruh draf pesan |
+| `Ctrl-Z` | Pulihkan draf yang dibersihkan (saat composer kosong) |
+| `Ctrl-W` | Hapus satu kata di belakang kursor |
+| `Ctrl-A` / `Home` | Pindah ke awal baris |
+| `Ctrl-E` / `End` | Pindah ke akhir baris |
+| `↑` / `↓` | Navigasikan riwayat prompt |
+| `Ctrl-S` | Simpan draf saat ini (`/stash pop` untuk memulihkan) |

--- a/docs/LOCALIZATION.id.md
+++ b/docs/LOCALIZATION.id.md
@@ -1,0 +1,62 @@
+# Matriks Lokalisasi (Localization Matrix)
+
+Dokumen pelacakan kanonik untuk setiap bahasa yang didukung, sedang dibangun, direncanakan, atau ditunda oleh Codewhale.
+
+> **Catatan Cakupan (2026-07-12):** Matriks ini mencakup tiga permukaan utama — paket bahasa TUI (`crates/tui/locales/`), README terjemahan (root repositori), dan situs web (`web/`). Ketiganya rilis pada ritme yang berbeda, sehingga suatu bahasa bisa berstatus **shipped** di satu permukaan dan **planned** di permukaan lain.
+
+---
+
+## Keterangan Status
+
+| Status | Arti |
+|--------|------|
+| **shipped** | Aktif di codewhale.net dan/atau diterbitkan sebagai README mandiri / paket TUI |
+| **partial** | Rilis tetapi belum mencakup seluruh bagian; dalam proses pengisian |
+| **planned** | Diprioritaskan secara eksplisit untuk gelombang rilis berikutnya |
+| **deferred** | Diakui tetapi belum dijadwalkan; memerlukan pengujian tata letak, dukungan jembatan, atau kontributor komunitas |
+
+---
+
+## Paket Bahasa TUI
+
+Paket TUI di bawah `crates/tui/locales/` adalah permukaan terjemahan terbesar di repositori. `en.json` adalah acuan utama; sebuah paket dianggap **lengkap** (complete) jika memiliki paritas kunci persis dengannya, yang ditegakkan oleh `scripts/check-tui-locale-parity.py` (CI) dan pengujian paritas di `crates/tui/src/localization.rs`.
+
+| Bahasa | Berkas | Kunci vs `en.json` (1134) | Status | Catatan |
+|--------|------|--------------------------|--------|-------|
+| Bahasa Inggris | `en.json` | 1134/1134 | **shipped** | Paket acuan utama. |
+| Bahasa Indonesia | `id.json` | 1134/1134 | **shipped** | Lengkap (100% paritas kunci). |
+| Bahasa Jepang | `ja.json` | 1134/1134 | **shipped** | Lengkap. |
+| Bahasa Mandarin Sederhana | `zh-Hans.json` | 1134/1134 | **shipped** | Lengkap. |
+| Bahasa Mandarin Tradisional | `zh-Hant.json` | 480/1134 | **partial** | Hanya inti pengaturan; kunci yang hilang menggunakan fallback Bahasa Inggris. |
+| Bahasa Portugis Brasil | `pt-BR.json` | 1134/1134 | **shipped** | Lengkap. |
+| Bahasa Spanyol Amerika Latin | `es-419.json` | 1134/1134 | **shipped** | Lengkap. |
+| Bahasa Vietnam | `vi.json` | 1134/1134 | **shipped** | Lengkap. |
+| Bahasa Korea | `ko.json` | 1134/1134 | **shipped** | Lengkap. |
+
+---
+
+## README Terjemahan
+
+| Bahasa | Berkas | Status | Catatan |
+|--------|------|--------|---------|
+| Bahasa Inggris | `README.md` | **shipped** | Sumber utama kanonik |
+| Bahasa Indonesia | `README.id.md` | **shipped** | Ditinjau per rilis (#4789) |
+| Bahasa Mandarin Sederhana | `README.zh-CN.md` | **shipped** | Ditinjau per rilis |
+| Bahasa Jepang | `README.ja-JP.md` | **shipped** | Ditinjau per rilis |
+| Bahasa Vietnam | `README.vi.md` | **shipped** | Ditinjau per rilis |
+| Bahasa Korea | `README.ko-KR.md` | **shipped** | Ditinjau per rilis |
+| Bahasa Spanyol | `README.es-419.md` | **shipped** | Ditinjau per rilis |
+| Bahasa Portugis Brasil | `README.pt-BR.md` | **shipped** | Ditinjau per rilis |
+
+---
+
+## Cara Menambahkan Paket Bahasa Baru
+
+1. **Paket TUI**:
+   - Buat berkas `crates/tui/locales/<tag>.json` berisi seluruh kunci di `en.json`.
+   - Tambahkan varian `Locale` pada `crates/tui/src/localization.rs` dan daftarkan di `config_ui.rs`.
+   - Jalankan `python3 scripts/check-tui-locale-parity.py` dan `cargo test -p codewhale-tui localization`.
+
+2. **README**:
+   - Terjemahkan `README.md` menjadi `README.<tag>.md`.
+   - Perbarui stempel sumber sha256 dan jalankan `python3 scripts/check-readme-translations.py`.

--- a/docs/MCP.id.md
+++ b/docs/MCP.id.md
@@ -1,0 +1,34 @@
+# Integrasi MCP (Server Alat Eksternal)
+
+Codewhale dapat memuat alat tambahan melalui **MCP (Model Context Protocol)**. Server MCP dapat berupa proses stdio lokal yang dijalankan oleh TUI, atau server jarak jauh berbasis URL yang menggunakan Streamable HTTP dengan fallback SSE.
+
+---
+
+## Konfigurasi Server MCP
+
+Konfigurasi server MCP disimpan di dalam `mcp.json` (baik di `$CODEWHALE_HOME/mcp.json` untuk global atau `.codewhale/mcp.json` untuk proyek).
+
+Contoh konfigurasi `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/allowed/dir"]
+    },
+    "git": {
+      "command": "uvx",
+      "args": ["mcp-server-git", "--repository", "."]
+    }
+  }
+}
+```
+
+---
+
+## Perintah CLI & TUI untuk MCP
+
+- `/mcp` — Kelola server dan alat MCP dari dalam TUI.
+- `codewhale mcp init` — Inisialisasi templat konfigurasi `mcp.json`.
+- `codewhale doctor` — Periksa kesehatan dan kesiapan server MCP yang terkonfigurasi.

--- a/docs/MODES.id.md
+++ b/docs/MODES.id.md
@@ -1,0 +1,39 @@
+# Mode dan Postur Izin (Modes and Permission Postures)
+
+Codewhale memiliki tiga konsep yang saling berhubungan:
+
+- **Mode TUI**: jenis interaksi yang terlihat (Plan / Act / Operate).
+- **Postur Izin**: seberapa ketat antarmuka meminta persetujuan sebelum mengeksekusi alat.
+- **Lapisan Alur Kerja (Workflow Overlay)**: orkestrasi berjangka panjang opsional yang dapat berjalan di atas mode TUI mana pun ketika tugas membutuhkan banyak pekerja terkoordinasi.
+
+---
+
+## Mode TUI
+
+Tekan `Tab` saat composer dalam keadaan diam untuk beralih antar mode: **Plan → Act → Operate → Plan**.
+Tekan `Shift+Tab` untuk beralih postur izin (**Ask → Auto-Review → Full Access**).
+Tekan `Ctrl+T` untuk beralih tingkat penalaran (reasoning effort).
+Jalankan `/mode` untuk membuka pemilih mode, atau beralih secara langsung dengan `/mode act`, `/mode plan`, atau `/mode operate`.
+
+### 1. Plan (Perencanaan)
+- Mengutamakan perancangan dan analisis sebelum eksekusi.
+- Alat investigasi baca-saja (*read-only*) tetap tersedia; eksekusi shell dan pengeditan berkas dinonaktifkan.
+
+### 2. Act (Eksekusi / Agen)
+- Penggunaan alat multi-langkah.
+- Perintah `Bash` dan pengeditan berkas dilindungi oleh gerbang persetujuan secara bawaan.
+
+### 3. Operate (Armada / Orkestrasi)
+- Mode konduktor multi-tugas.
+- Menugaskan pekerja di latar belakang (*background workers*) sebagai cara utama untuk menangani tugas-tugas besar atau independen secara paralel.
+
+---
+
+## Ketersediaan Alat Berdasarkan Mode
+
+| Keluarga Alat | Plan | Act | Operate |
+|:---|:---:|:---:|:---:|
+| Alat baca berkas, pencarian, dan diagnostik | Ya | Ya | Ya |
+| Alat penulisan berkas dan penambalan | Tidak | Ya | Ya |
+| Perintah `Bash` | Tidak | Memerlukan persetujuan | Sama dengan Act |
+| Akses di luar root ruang kerja | Jalur terpercaya saja | Jalur terpercaya / mode trust | Sama dengan Act |

--- a/docs/PROVIDERS.id.md
+++ b/docs/PROVIDERS.id.md
@@ -1,0 +1,44 @@
+# Registri Penyedia (Provider Registry)
+
+Registri ini menjelaskan perilaku penyedia (provider) yang terhubung ke dalam basis kode Codewhale saat ini. Registri ini sengaja dibuat konservatif: entri yang dirilis terbatas pada ID penyedia, kunci konfigurasi, jalur autentikasi, URL dasar, resolusi model, dan metadata kapabilitas yang sudah dikelola oleh sistem.
+
+DeepSeek tetap menjadi penyedia bawaan (default), tetapi setiap entri dalam `ProviderKind::ALL` dan `PROVIDER_REGISTRY` adalah rute penyedia yang dapat dipilih sebagai warga kelas satu. Rute ter-host, endpoint generik kompatibel-OpenAI, rute OpenAI Codex/ChatGPT, Anthropic native, dan runtime lokal semuanya menjalankan harness terminal yang sama terhadap penyedia/model/URL dasar terpilih.
+
+---
+
+## Pemilihan Penyedia (Provider Selection)
+
+ID penyedia kanonik yang didukung meliputi:
+
+`deepseek`, `deepseek-anthropic`, `nvidia-nim`, `openai`, `atlascloud`, `wanjie-ark`, `volcengine`, `openrouter`, `xiaomi-mimo`, `novita`, `fireworks`, `siliconflow`, `arcee`, `siliconflow-CN`, `moonshot`, `sglang`, `vllm`, `ollama`, `huggingface`, `together`, `qianfan`, `openai-codex`, `anthropic`, `openmodel`, `zai`, `stepfun`, `minimax`, `deepinfra`, `sakana`, `longcat`, `opencode-go`, `meta`, `telecomjs`, dan `xai`.
+
+Gunakan salah satu cara berikut untuk memilih penyedia:
+
+- CLI: `codewhale --provider <id>`
+- TUI: `/provider <id>` atau melalui pemilih penyedia (provider picker)
+- Variabel Lingkungan: `CODEWHALE_PROVIDER=<id>` (atau alias lama `DEEPSEEK_PROVIDER=<id>`)
+- Konfigurasi (`config.toml`): `provider = "<id>"`
+
+---
+
+## Ringkasan Rute Utama
+
+1. **DeepSeek (`deepseek`)**:
+   - URL Dasar: `https://api.deepseek.com`
+   - Model bawaan: `deepseek-chat` / `deepseek-coder`
+   - Autentikasi: `DEEPSEEK_API_KEY` (Bearer auth)
+
+2. **OpenAI (`openai`)**:
+   - URL Dasar: `https://api.openai.com/v1`
+   - Model bawaan: `gpt-4o`, `gpt-4o-mini`, `o1`, `o3-mini`
+   - Autentikasi: `OPENAI_API_KEY`
+
+3. **Anthropic (`anthropic`)**:
+   - URL Dasar: `https://api.anthropic.com`
+   - Model bawaan: `claude-3-5-sonnet-latest`, `claude-3-5-haiku-latest`
+   - Autentikasi: `ANTHROPIC_API_KEY` (`x-api-key`)
+
+4. **Runtime Lokal (`vllm`, `ollama`, `sglang`)**:
+   - Ollama bawaan: `http://127.0.0.1:11434/v1`
+   - vLLM / SGLang bawaan: `http://127.0.0.1:8000/v1`
+   - Tidak memerlukan API key untuk eksekusi lokal.

--- a/docs/REBRAND.id.md
+++ b/docs/REBRAND.id.md
@@ -1,0 +1,48 @@
+# Rebrand: DeepSeek TUI → Codewhale
+
+Mulai dari versi **v0.8.41**, proyek ini dirilis dengan nama baru: `codewhale`.
+
+Dokumen ini menjelaskan apa saja yang berubah, apa yang tetap sama, dan cara melakukan migrasi. Seluruh integrasi penyedia (provider) DeepSeek tidak mengalami perubahan — hanya nama merek CLI / TUI lokal yang diperbarui.
+
+---
+
+## Ringkasan Migrasi
+
+```bash
+# 1. Hapus instalasi paket atau biner lama.
+npm uninstall -g deepseek-tui      # atau:
+cargo uninstall deepseek-tui-cli 2>/dev/null || true
+cargo uninstall deepseek-tui 2>/dev/null || true
+
+# 2. Pasang dengan nama baru.
+npm install -g codewhale            # atau:
+cargo install codewhale-cli --locked
+cargo install codewhale-tui --locked
+
+# 3. Jalankan perintah baru.
+codewhale doctor
+codewhale
+```
+
+Berkas dan direktori Anda yang ada seperti `~/.deepseek/config.toml`, `~/.deepseek/sessions/`, `~/.deepseek/skills/`, `~/.deepseek/tasks/`, dan `~/.deepseek/mcp.json` **tidak akan dihapus**. Instalasi baru Codewhale mengutamakan `~/.codewhale/`, sementara direktori lama `~/.deepseek/` tetap dibaca sebagai fallback selama masa transisi. Variabel lingkungan `DEEPSEEK_*` tetap berfungsi sebagaimana mestinya.
+
+---
+
+## Apa Saja yang Berubah Nama
+
+| Komponen | Sebelum | Sesudah |
+|---|---|---|
+| Biner CLI Dispatcher | `deepseek` | `codewhale` |
+| Biner TUI Runtime | `deepseek-tui` | `codewhale-tui` |
+| Paket Wrapper npm | `deepseek-tui` | `codewhale` |
+| Crate Crates.io | `deepseek-tui-cli` / `deepseek-tui` | `codewhale-cli` / `codewhale-tui` |
+| Aset Rilis | `deepseek-<platform>` / `deepseek-tui-<platform>` | `codewhale-<platform>` / `codew-<platform>` / `codewhale-tui-<platform>` |
+| Manifest Checksum | `deepseek-artifacts-sha256.txt` | `codewhale-artifacts-sha256.txt` |
+
+---
+
+## Apa yang TIDAK Berubah
+
+Semua hal yang berkaitan dengan API penyedia DeepSeek tetap berjalan persis seperti sebelumnya:
+- **Variabel Lingkungan**: `DEEPSEEK_API_KEY`, `DEEPSEEK_BASE_URL`, `DEEPSEEK_MODEL`, `DEEPSEEK_PROVIDER`, `DEEPSEEK_PROFILE`, `DEEPSEEK_YOLO`, dll. tetap didukung sepenuhnya.
+- **Konfigurasi Penyedia**: Pengaturan rute `[providers.deepseek]` pada `config.toml` tetap valid.

--- a/docs/WEB.id.md
+++ b/docs/WEB.id.md
@@ -1,0 +1,27 @@
+# Klien Peramban Lokal (Local Browser Client)
+
+Perintah `codewhale web` membuka klien peramban (*browser client*) bawaan Codewhale melalui Runtime API kanonik. Klien ini merupakan permukaan lokal: server selalu terikat pada `127.0.0.1`, tidak dapat diikat ke alamat LAN, dan tidak dapat berjalan tanpa autentikasi Runtime.
+
+---
+
+## Cara Menjalankan
+
+Dari ruang kerja yang ingin Anda kelola dengan Codewhale, jalankan:
+
+```bash
+codewhale web
+```
+
+Alamat bawaan adalah `http://127.0.0.1:7878`. Untuk menghindari bentrokan port lokal, pilih port loopback lain:
+
+```bash
+codewhale web --port 8788
+```
+
+Codewhale akan mengaktifkan Runtime API, menyajikan klien bawaan yang tersemat di dalam biner, dan meminta sistem operasi untuk membuka URL di peramban bawaan Anda. Hentikan proses dengan `Ctrl+C`.
+
+---
+
+## Batas Autentikasi & Keamanan
+
+URL peluncuran peramban berisi kredensial bootstrap sekali pakai (*one-time bootstrap capability*) yang berumur pendek dan acak. Nilai ini tidak pernah menyimpan token penyedia atau kunci API ke dalam penyimpanan peramban (browser storage).


### PR DESCRIPTION
## Summary
Adds a comprehensive Indonesian documentation suite (`README.id.md`, `CONTRIBUTING.id.md`, and `docs/*.id.md`) to complement the shipped Indonesian TUI locale pack (`crates/tui/locales/id.json`).

## Changes Included
- `README.md` & `README.*.md`: Added `[Bahasa Indonesia](README.id.md)` link to language switcher header line.
- `README.id.md`: Main repository README translated to Indonesian, synced with `README.md` (`sha256:f25cf99b305a`).
- `CONTRIBUTING.id.md`: Contribution & PR guidelines.
- `docs/*.id.md`: Comprehensive guides for `INSTALL`, `PROVIDERS`, `FLEET`, `CONFIGURATION`, `WEB`, `MODES`, `KEYBINDINGS`, `MCP`, `REBRAND`, and `LOCALIZATION`.

## Verification
- `python3 scripts/check-readme-translations.py` -> PASS
- `bash scripts/check-readme-locales.sh` -> PASS
- `python3 scripts/check-tui-locale-parity.py` -> PASS
- `cargo test -p codewhale-tui localization` -> PASS

Closes #4789
