### PR TITLE
ci(release): configure candidate Rust toolchain

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           node-version: 20
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable 2026-07-18
+        with:
+          toolchain: stable
       - name: Match dispatch to the requested commit
         id: source
         shell: bash


### PR DESCRIPTION
Fix the v0.9.2 release-candidate workflow setup failure by passing the required `toolchain: stable` input to the pinned Rust toolchain action.

Verification:
- `node .github/scripts/release-workflows.test.js`
- observed failing run: https://github.com/Hmbown/CodeWhale/actions/runs/30443216361

Fixes #4941.