### PR TITLE
docs: repair strict rustdoc links

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2201,10 +2201,10 @@ impl ConfigToml {
 
     /// The unquoted contents of an extras key that holds a TOML string.
     ///
-    /// [`Config::get_value`] renders extras through `toml::Value::to_string`,
+    /// [`ConfigToml::get_value`] renders extras through `toml::Value::to_string`,
     /// which re-applies TOML quoting — and switches to a single-quoted literal
     /// string whenever the payload contains a `"`. A JSON blob written with
-    /// [`Config::set_value`] therefore comes back as `'[{"a":1}]'` and no
+    /// [`ConfigToml::set_value`] therefore comes back as `'[{"a":1}]'` and no
     /// longer parses as JSON (#4727). Callers that stored structured text want
     /// the payload, not its TOML rendering.
     #[must_use]

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -781,7 +781,7 @@ fn first_token(command: &str) -> String {
 ///
 /// Case is preserved on case-sensitive filesystems and folded on
 /// case-insensitive ones, matching what the host actually considers the same
-/// file. See [`platform_paths_are_case_insensitive`].
+/// file. See `platform_paths_are_case_insensitive`.
 pub fn normalize_workspace_relative_path(value: &str, workspace_root: &str) -> Option<String> {
     normalize_workspace_relative_path_with_case(
         value,

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -217,7 +217,7 @@ impl McpManager {
     /// Register an MCP server with its config, tool filter, and client implementation.
     ///
     /// Fails when the server's name collides with an already-registered server
-    /// after [`sanitize_component`] folding. Qualified tool names are built
+    /// after `sanitize_component` folding. Qualified tool names are built
     /// from the sanitized name, so `my-server`, `my_server`, and `My.Server`
     /// all produce `mcp__my_server__*`: registering two of them would let
     /// either server answer a qualified name meant for the other. Re-registering

--- a/crates/mcp/src/stdio_client.rs
+++ b/crates/mcp/src/stdio_client.rs
@@ -79,7 +79,7 @@ impl ChildProcessMcpClient {
     ///
     /// Returns `Err` — never a degraded-but-usable client — when the command
     /// cannot be executed, exits immediately, or does not answer `initialize`
-    /// within [`HANDSHAKE_TIMEOUT`].
+    /// within `HANDSHAKE_TIMEOUT`.
     pub fn spawn(config: &McpServerConfig) -> Result<Self> {
         Self::spawn_with_timeouts(config, HANDSHAKE_TIMEOUT, REQUEST_TIMEOUT)
     }

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -2079,10 +2079,10 @@ impl DeepSeekClient {
     /// Best-effort background refresh of the active provider's own `/v1/models`
     /// catalog, merging results into the provider lake (#3385).
     ///
-    /// Unlike [`models_dev_live::spawn_background_refresh`] (which fetches the
+    /// Unlike `models_dev_live::spawn_background_refresh` (which fetches the
     /// cross-provider Models.dev catalog), this calls the provider's own
     /// `/v1/models` endpoint and merges the results into the existing live
-    /// snapshot via [`provider_lake::merge_live_offerings`], preserving rows
+    /// snapshot via `provider_lake::merge_live_offerings`, preserving rows
     /// from other sources.
     ///
     /// Currently activated for providers whose model list is not covered by the

--- a/crates/tui/src/client/prepared.rs
+++ b/crates/tui/src/client/prepared.rs
@@ -4,7 +4,7 @@
 //! Every **primary agent turn** — `LlmClient::create_message` and
 //! `create_message_stream`, in Chat Completions, Anthropic Messages, and
 //! OpenAI Responses alike — reaches the wire through
-//! [`DeepSeekClient::prepare_outbound_request`], which returns a
+//! [`crate::client::DeepSeekClient::prepare_outbound_request`], which returns a
 //! [`PreparedOutboundRequest`]. The transports send it; the preview command
 //! describes it. Because there is exactly one builder, a preview cannot
 //! report a request different from the one a turn would send.

--- a/crates/tui/src/cost_status.rs
+++ b/crates/tui/src/cost_status.rs
@@ -8,7 +8,8 @@
 //! cost by however many tokens those background calls consumed.
 //!
 //! Mirrors the [`crate::retry_status`] pattern: background callers
-//! call [`report`] after each `client.create_message`, the TUI
+//! call [`crate::cost_status::report_effective_route`] after each
+//! `client.create_message`, the TUI
 //! render loop calls [`drain`] every frame, and any drained amount
 //! gets folded into `App::accrue_subagent_cost_estimate`.
 //!

--- a/crates/tui/src/route_billing.rs
+++ b/crates/tui/src/route_billing.rs
@@ -224,7 +224,7 @@ pub enum RouteProduct {
 /// membership quota.
 ///
 /// This is the pre-dispatch answer — for a turn that already ran, bill from
-/// its receipt with [`for_dispatched_route`] instead.
+/// its receipt with [`crate::route_billing::for_dispatched_receipt`] instead.
 #[must_use]
 pub fn for_route(config: &Config, provider: ApiProvider) -> BillingPresentation {
     let base_url = config.base_url_for_route(provider);
@@ -241,7 +241,8 @@ pub fn for_route(config: &Config, provider: ApiProvider) -> BillingPresentation 
 /// client is being built from, **at dispatch time**.
 ///
 /// Call this while the config still describes the route being dispatched. The
-/// result is what travels on [`DispatchedRoute::product`]; nothing downstream
+/// result is what travels on [`crate::route_billing::DispatchedReceipt::product`];
+/// nothing downstream
 /// may re-derive it.
 #[must_use]
 pub fn capture_product(config: &Config, provider: ApiProvider) -> RouteProduct {

--- a/crates/tui/src/skills/audit.rs
+++ b/crates/tui/src/skills/audit.rs
@@ -202,7 +202,7 @@ pub fn scan(
     scan_with_configured(workspace, home, None, mode, readiness)
 }
 
-/// Same as [`scan`] with an optional configured `skills_dir`.
+/// Scan skill roots with an optional configured `skills_dir`.
 #[must_use]
 pub fn scan_with_configured(
     workspace: &Path,

--- a/crates/tui/src/tools/verify.rs
+++ b/crates/tui/src/tools/verify.rs
@@ -26,7 +26,7 @@
 //!    construction, not by a denylist that could be forgotten.
 //! 2. **Re-entry guard (defense in depth):** [`VerifyTool::execute`] refuses if
 //!    it is entered while a critique is already in progress on the same task
-//!    (tracked via the [`struct@VERIFY_ACTIVE`] task-local). This protects any
+//!    (tracked via the [`static@VERIFY_ACTIVE`] task-local). This protects any
 //!    future path that might run the critic inside a tool loop.
 //!
 //! # Relationship to neighbouring tools

--- a/crates/tui/src/tui/display_refresh.rs
+++ b/crates/tui/src/tui/display_refresh.rs
@@ -157,7 +157,7 @@ fn probe_macos() -> Result<u32, &'static str> {
 ///
 /// Policy: target roughly `display_hz / 5` for atmosphere (calm, not steppy
 /// on high-Hz panels), clamped to [`MIN_ANIMATION_HZ`]..=[`MAX_ANIMATION_HZ`].
-/// Missing measurement falls back to [`FALLBACK_ANIMATION_HZ`] (≈12.5 fps /
+/// Missing measurement falls back to [`FALLBACK_ANIMATION_MS`] (≈12.5 fps /
 /// 80 ms historical atmosphere). `low_motion` always wins (2.4s).
 #[must_use]
 pub fn animation_interval_for_hz(display_hz: Option<u32>, low_motion: bool) -> Duration {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2215,7 +2215,8 @@ fn spawn_tui_engine(config: EngineConfig, api_config: &Config) -> EngineHandle {
 ///   text or block the turn outright. Running them would give a *preview* the
 ///   side effects of a submit. So when any are configured, nothing downstream
 ///   of the text can be claimed exact and the whole manifest reports
-///   [`PreviewUnresolved::MessageSubmitHooksConfigured`] — including under a
+///   [`crate::core::engine::preview::PreviewUnresolved::MessageSubmitHooksConfigured`] —
+///   including under a
 ///   fixed model, because the tool policy is derived from the content too.
 /// - **Consuming the active skill.** A real submit *takes* `app.active_skill`.
 ///   The preview clones it: the skill is still pending after an inspection,

--- a/crates/workflow/src/fleet_composition.rs
+++ b/crates/workflow/src/fleet_composition.rs
@@ -17,14 +17,16 @@
 //! 1. **It is pure.** No clock, no filesystem, no network, no config. It maps
 //!    an input value to an output value.
 //! 2. **It cannot save or launch.** There is no path from a
-//!    [`FleetCompositionProposal`] to an [`crate::ExactFleet`], a snapshot, or a
+//!    [`crate::fleet_composition::FleetCompositionProposal`] to an
+//!    [`crate::ExactFleet`], a snapshot, or a
 //!    spawn. Turning a proposal into a saved Fleet is a separate, explicit act
 //!    that belongs to the saved-Fleet UI lane.
 //! 3. **It cannot invent a model.** Every suggestion must name a model that is
 //!    already in the operator's explicitly configured pool; anything else is
 //!    rejected, not silently substituted.
 //!
-//! Every proposal is born [`RatificationState::Unratified`] and there is no
+//! Every proposal is born
+//! [`crate::fleet_composition::RatificationState::Unratified`] and there is no
 //! method here that ratifies one. Ratification is a human act recorded
 //! elsewhere; this module can only ever describe a suggestion.
 //!

--- a/crates/workflow/src/redaction.rs
+++ b/crates/workflow/src/redaction.rs
@@ -220,7 +220,7 @@ impl TokenOutcome {
 /// routinely written as *two* tokens (`Authorization: Bearer <token>`), so a
 /// purely per-token rule either leaks the value or redacts the English word
 /// `bearer`. Carrying "the next token is the credential" forward — and *how
-/// certainly*, see [`CredentialArm`] — is what lets this do neither.
+/// certainly*, see `CredentialArm` — is what lets this do neither.
 #[must_use]
 pub fn redact_for_disclosure(input: &str) -> Redaction {
     let mut kinds = BTreeSet::new();


### PR DESCRIPTION
Repair the strict-rustdoc failures found by the exact-SHA v0.9.2 CI run. Links now target current production APIs; private/test-only implementation names are rendered as code instead of invalid public links.

Verification:
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --locked`
- `cargo fmt --all -- --check`

Failing receipt: https://github.com/Hmbown/CodeWhale/actions/runs/30445270698

Fixes #4941.