### PR TITLE
test(tui): await idle skills scan before toggle

### DIFF
--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -1889,6 +1889,10 @@ fn skills_opens_manager_owned_then_compatible() -> anyhow::Result<()> {
     );
 
     // Toggle to compatible scan so external roots appear.
+    // The initial owned scan may paint its first results before it relinquishes
+    // input ownership. Wait for that scan to become idle so the `c` event is
+    // not truthfully ignored as an in-flight mutation.
+    h.wait_for_idle(Duration::from_millis(300), Duration::from_secs(2))?;
     h.send(keys::key::ch('c'))?;
     h.wait_for_text("workspace-beta", KEY_TIMEOUT)?;
     let compat = h.frame();


### PR DESCRIPTION
Remove a PTY race found by the exact-SHA v0.9.2 CI run. The Skills Manager may paint owned results while its initial scan still owns input, so the test now waits for idle before sending the compatible-scan toggle.

Verification:
- exact `skills_opens_manager_owned_then_compatible` PTY test passed three consecutive runs
- `cargo fmt --all -- --check`

Failing receipt: https://github.com/Hmbown/CodeWhale/actions/runs/30447705934

Fixes #4941.