### PR TITLE
test(tui): wait for rendered skills readiness

### DIFF
--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -1890,9 +1890,9 @@ fn skills_opens_manager_owned_then_compatible() -> anyhow::Result<()> {
 
     // Toggle to compatible scan so external roots appear.
     // The initial owned scan may paint its first results before it relinquishes
-    // input ownership. Wait for that scan to become idle so the `c` event is
-    // not truthfully ignored as an in-flight mutation.
-    h.wait_for_idle(Duration::from_millis(300), Duration::from_secs(2))?;
+    // input ownership. PTY silence is not enough evidence of readiness: wait
+    // for the manager's own rendered status before sending the `c` mutation.
+    h.wait_for_text("scan=owned   import-target=global   idle", KEY_TIMEOUT)?;
     h.send(keys::key::ch('c'))?;
     h.wait_for_text("workspace-beta", KEY_TIMEOUT)?;
     let compat = h.frame();


### PR DESCRIPTION
Replace the insufficient PTY-silence heuristic with the Skills Manager's explicit rendered readiness receipt before toggling compatible scan mode.

Verification:
- exact `skills_opens_manager_owned_then_compatible` passed 5/5
- full `qa_pty` suite: 35 passed, 1 intentionally ignored
- `cargo fmt --all -- --check`

Failing exact-SHA receipt: https://github.com/Hmbown/CodeWhale/actions/runs/30451289065

Fixes #4941.