### PR TITLE
docs: sync localization matrices for 0.9.2

### DIFF
--- a/docs/LOCALIZATION.id.md
+++ b/docs/LOCALIZATION.id.md
@@ -2,7 +2,7 @@
 
 Dokumen pelacakan kanonik untuk setiap bahasa yang didukung, sedang dibangun, direncanakan, atau ditunda oleh Codewhale.
 
-> **Catatan Cakupan (2026-07-12):** Matriks ini mencakup tiga permukaan utama — paket bahasa TUI (`crates/tui/locales/`), README terjemahan (root repositori), dan situs web (`web/`). Ketiganya rilis pada ritme yang berbeda, sehingga suatu bahasa bisa berstatus **shipped** di satu permukaan dan **planned** di permukaan lain.
+> **Catatan Cakupan (diperbarui 2026-07-29):** Matriks ini mencakup tiga permukaan utama — paket bahasa TUI (`crates/tui/locales/`), README terjemahan (root repositori), dan situs web (`web/`). Ketiganya rilis pada ritme yang berbeda, sehingga suatu bahasa bisa berstatus **shipped** di satu permukaan dan **planned** di permukaan lain.
 
 ---
 
@@ -21,17 +21,23 @@ Dokumen pelacakan kanonik untuk setiap bahasa yang didukung, sedang dibangun, di
 
 Paket TUI di bawah `crates/tui/locales/` adalah permukaan terjemahan terbesar di repositori. `en.json` adalah acuan utama; sebuah paket dianggap **lengkap** (complete) jika memiliki paritas kunci persis dengannya, yang ditegakkan oleh `scripts/check-tui-locale-parity.py` (CI) dan pengujian paritas di `crates/tui/src/localization.rs`.
 
-| Bahasa | Berkas | Kunci vs `en.json` (1134) | Status | Catatan |
+| Bahasa | Berkas | Kunci vs `en.json` (1248) | Status | Catatan |
 |--------|------|--------------------------|--------|-------|
-| Bahasa Inggris | `en.json` | 1134/1134 | **shipped** | Paket acuan utama. |
-| Bahasa Indonesia | `id.json` | 1134/1134 | **shipped** | Lengkap (100% paritas kunci). |
-| Bahasa Jepang | `ja.json` | 1134/1134 | **shipped** | Lengkap. |
-| Bahasa Mandarin Sederhana | `zh-Hans.json` | 1134/1134 | **shipped** | Lengkap. |
-| Bahasa Mandarin Tradisional | `zh-Hant.json` | 480/1134 | **partial** | Hanya inti pengaturan; kunci yang hilang menggunakan fallback Bahasa Inggris. |
-| Bahasa Portugis Brasil | `pt-BR.json` | 1134/1134 | **shipped** | Lengkap. |
-| Bahasa Spanyol Amerika Latin | `es-419.json` | 1134/1134 | **shipped** | Lengkap. |
-| Bahasa Vietnam | `vi.json` | 1134/1134 | **shipped** | Lengkap. |
-| Bahasa Korea | `ko.json` | 1134/1134 | **shipped** | Lengkap. |
+| Bahasa Inggris | `en.json` | 1248/1248 | **shipped** | Paket acuan utama. |
+| Bahasa Indonesia | `id.json` | 1248/1248 | **shipped** | Lengkap (100% paritas kunci). |
+| Bahasa Jepang | `ja.json` | 1248/1248 | **shipped** | Lengkap. |
+| Bahasa Mandarin Sederhana | `zh-Hans.json` | 1248/1248 | **shipped** | Lengkap. |
+| Bahasa Mandarin Tradisional | `zh-Hant.json` | 499/1248 | **partial** | Hanya inti pengaturan; kunci yang hilang menggunakan fallback Bahasa Inggris. |
+| Bahasa Portugis Brasil | `pt-BR.json` | 1248/1248 | **shipped** | Lengkap. |
+| Bahasa Spanyol Amerika Latin | `es-419.json` | 1248/1248 | **shipped** | Lengkap. |
+| Bahasa Vietnam | `vi.json` | 1248/1248 | **shipped** | Lengkap. |
+| Bahasa Korea | `ko.json` | 1248/1248 | **shipped** | Lengkap. |
+| Bahasa Katalan | `ca.json` | 1248/1248 | **shipped** | Lengkap; menunggu tinjauan penutur asli. |
+| Bahasa Jerman | `de.json` | 1248/1248 | **shipped** | Lengkap; menunggu tinjauan penutur asli. |
+| Bahasa Prancis | `fr.json` | 1248/1248 | **shipped** | Lengkap; menunggu tinjauan penutur asli. |
+| Bahasa Hindi | `hi.json` | 1248/1248 | **shipped** | Lengkap; QA visual terminal masih terbuka. |
+| Bahasa Rusia | `ru.json` | 1248/1248 | **shipped** | Lengkap; menunggu tinjauan penutur asli. |
+| Bahasa Ukraina | `uk.json` | 1248/1248 | **shipped** | Lengkap; menunggu tinjauan penutur asli. |
 
 ---
 
@@ -47,6 +53,8 @@ Paket TUI di bawah `crates/tui/locales/` adalah permukaan terjemahan terbesar di
 | Bahasa Korea | `README.ko-KR.md` | **shipped** | Ditinjau per rilis |
 | Bahasa Spanyol | `README.es-419.md` | **shipped** | Ditinjau per rilis |
 | Bahasa Portugis Brasil | `README.pt-BR.md` | **shipped** | Ditinjau per rilis |
+| Bahasa Rusia | `README.ru.md` | **shipped** | Ditinjau per rilis |
+| Bahasa Ukraina | `README.uk.md` | **shipped** | Ditinjau per rilis |
 
 ---
 

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -15,7 +15,7 @@ Customer-visible copy also follows the [Codewhale voice and terminal
 charter](VOICE.md); commands, key names, and glyphs remain code-owned around
 localized prose.
 
-Last updated: 2026-07-27 (v0.9.2 wave).
+Last updated: 2026-07-29 (v0.9.2 wave).
 Source-of-truth README: `README.md` (English, post-#3087).
 
 ## Status legend
@@ -38,23 +38,23 @@ only at exact raw key parity with it, enforced by
 `crates/tui/src/localization.rs`. See `crates/tui/locales/AGENTS.md` for the
 authoring contract.
 
-| Locale | File | Keys vs `en.json` (1153) | Status | Notes |
+| Locale | File | Keys vs `en.json` (1248) | Status | Notes |
 |--------|------|--------------------------|--------|-------|
-| English | `en.json` | 1153/1153 | **shipped** | Reference pack. |
-| Japanese | `ja.json` | 1153/1153 | **shipped** | Complete. |
-| Simplified Chinese | `zh-Hans.json` | 1153/1153 | **shipped** | Complete. |
-| Traditional Chinese | `zh-Hant.json` | 483/1153 | **partial** | Setup core only; missing keys fall back to English at runtime. Deliberate scope per #4057. |
-| Brazilian Portuguese | `pt-BR.json` | 1153/1153 | **shipped** | Complete. |
-| Latin American Spanish | `es-419.json` | 1153/1153 | **shipped** | Complete. Note the website tracks `es` — the shipped TUI pack is Latin American Spanish, not `es-ES`. |
-| Vietnamese | `vi.json` | 1153/1153 | **shipped** | Complete. |
-| Korean | `ko.json` | 1153/1153 | **shipped** | Complete. |
-| Catalan | `ca.json` | 1153/1153 | **shipped** | Complete (#4749/#4788). Awaiting native-speaker review. |
-| German | `de.json` | 1153/1153 | **shipped** | Complete (#4788). Awaiting native-speaker review. |
-| French | `fr.json` | 1153/1153 | **shipped** | Complete (#4788). Awaiting native-speaker review. |
-| Indonesian | `id.json` | 1153/1153 | **shipped** | Complete (#4789). Awaiting native-speaker review. |
-| Hindi | `hi.json` | 1153/1153 | **shipped** | Complete (#4790). Devanagari shaping spike: `docs/evidence/v092-devanagari-terminal-shaping.md` — code-level guarantees only; terminal visual QA and native review still open. |
-| Russian | `ru.json` | 1153/1153 | **shipped** | Complete (#3092). Cyrillic script fixtures guard against mixed-language copy. Awaiting native-speaker review. |
-| Ukrainian | `uk.json` | 1153/1153 | **shipped** | Complete (#4791). Cyrillic script fixtures keep it distinct from Russian (no ы/э/ъ; і/ї/є/ґ present). Awaiting native-speaker review. |
+| English | `en.json` | 1248/1248 | **shipped** | Reference pack. |
+| Japanese | `ja.json` | 1248/1248 | **shipped** | Complete. |
+| Simplified Chinese | `zh-Hans.json` | 1248/1248 | **shipped** | Complete. |
+| Traditional Chinese | `zh-Hant.json` | 499/1248 | **partial** | Setup core only; missing keys fall back to English at runtime. Deliberate scope per #4057. |
+| Brazilian Portuguese | `pt-BR.json` | 1248/1248 | **shipped** | Complete. |
+| Latin American Spanish | `es-419.json` | 1248/1248 | **shipped** | Complete. Note the website tracks `es` — the shipped TUI pack is Latin American Spanish, not `es-ES`. |
+| Vietnamese | `vi.json` | 1248/1248 | **shipped** | Complete. |
+| Korean | `ko.json` | 1248/1248 | **shipped** | Complete. |
+| Catalan | `ca.json` | 1248/1248 | **shipped** | Complete (#4749/#4788). Awaiting native-speaker review. |
+| German | `de.json` | 1248/1248 | **shipped** | Complete (#4788). Awaiting native-speaker review. |
+| French | `fr.json` | 1248/1248 | **shipped** | Complete (#4788). Awaiting native-speaker review. |
+| Indonesian | `id.json` | 1248/1248 | **shipped** | Complete (#4789). Awaiting native-speaker review. |
+| Hindi | `hi.json` | 1248/1248 | **shipped** | Complete (#4790). Devanagari shaping spike: `docs/evidence/v092-devanagari-terminal-shaping.md` — code-level guarantees only; terminal visual QA and native review still open. |
+| Russian | `ru.json` | 1248/1248 | **shipped** | Complete (#3092). Cyrillic script fixtures guard against mixed-language copy. Awaiting native-speaker review. |
+| Ukrainian | `uk.json` | 1248/1248 | **shipped** | Complete (#4791). Cyrillic script fixtures keep it distinct from Russian (no ы/э/ъ; і/ї/є/ґ present). Awaiting native-speaker review. |
 
 ## Website locales
 
@@ -104,6 +104,7 @@ filling in a page is a dictionary edit, not plumbing.
 | Brazilian Portuguese | `README.pt-BR.md` | **shipped** | Same |
 | Russian | `README.ru.md` | **shipped** | Same (#3092). Awaiting native-speaker review. |
 | Ukrainian | `README.uk.md` | **shipped** | Same (#4791). Awaiting native-speaker review. |
+| Indonesian | `README.id.md` | **shipped** | Same (#4789). Awaiting native-speaker review. |
 
 ## Drift checks
 


### PR DESCRIPTION
## Summary
- sync the canonical and Indonesian TUI locale matrices to the verified 1,248-key release state
- record the current 499-key Traditional Chinese partial pack
- include the shipped Indonesian README in the canonical README inventory

## Verification
- `python3 scripts/check-tui-locale-parity.py`
- `python3 scripts/check-readme-translations.py`
- `bash scripts/check-readme-locales.sh`
- `git diff --check`

No-Issue: factual follow-up to the merged Indonesian documentation contribution in #4962.