### PR TITLE
ci(tui): isolate Skills Manager PTY acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,13 @@ jobs:
       - name: Run tests
         if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
         run: cargo test --workspace --all-features --locked
+      - name: Run isolated Skills Manager PTY acceptance
+        # This real-PTY scenario is deterministic in a fresh process (10/10
+        # locally) but can inherit event starvation after the full qa_pty
+        # suite on loaded Linux runners. Keep the assertion intact and run it
+        # separately on Unix after the workspace suite has released its PTYs.
+        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'windows-latest' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
+        run: cargo test -p codewhale-tui --test qa_pty skills_opens_manager_owned_then_compatible -- --ignored --exact
       - name: Lockfile drift guard
         if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
         run: git diff --exit-code -- Cargo.lock

--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -1829,6 +1829,7 @@ fn cancelled_bang_shell_settles_transcript_card() -> anyhow::Result<()> {
 /// Bare `/skills` opens the unified Skills Manager (owned-only, zero network).
 /// Compatible roots (e.g. `.agents/skills`) appear only after toggling scan mode.
 #[test]
+#[ignore = "runs in its own CI process to avoid PTY event interference from the full suite"]
 fn skills_opens_manager_owned_then_compatible() -> anyhow::Result<()> {
     let _guard = qa_pty_test_lock();
     let ws = make_sealed_workspace()?;


### PR DESCRIPTION
## Summary
- keep the exact Skills Manager compatible-root PTY assertion intact
- exclude it from the shared `qa_pty` process, where loaded Linux runners repeatedly starve or duplicate its mode-toggle event
- run it immediately afterward in its own Unix CI process

## Verification
- isolated acceptance: pass (plus the prior 10/10 stress run)
- shared `qa_pty`: 34 passed, 2 explicitly isolated/ignored
- `cargo fmt --all -- --check`
- `actionlint -color -ignore SC2129 -ignore SC2221 -ignore SC2222`

Fixes #4941