### PR TITLE
feat(web): add Indonesian (id) website locale dictionary

### DIFF
--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -82,7 +82,7 @@ fallback, never a dictionary key on screen.
 | French | `fr` | **planned** | #4788 — TUI pack shipped in v0.9.2; website next wave. |
 | German | `de` | **planned** | #4788 — TUI pack shipped in v0.9.2; website next wave. |
 | Catalan | `ca` | **planned** | #4749/#4788 — TUI pack shipped in v0.9.2; website next wave. |
-| Indonesian | `id` | **planned** | #4789 — TUI pack shipped in v0.9.2; website next wave. |
+| Indonesian | `id` | **partial** | #4789. Same scope as Japanese. |
 | Hindi | `hi` | **planned** | #4790 — TUI pack shipped in v0.9.2; website next wave. |
 | Arabic | `ar` | **deferred** | RTL candidate. Deferred until layout/typography QA exists (bidirectional text, mirrored chrome, number formatting). |
 

--- a/web/lib/i18n/config.test.ts
+++ b/web/lib/i18n/config.test.ts
@@ -30,7 +30,7 @@ describe("locale registry (single canonical taxonomy)", () => {
   });
 
   it("ships the v0.9.2 website wave as partial with visible status", () => {
-    for (const code of ["ja", "vi", "ko", "ru", "uk", "es", "pt-BR"]) {
+    for (const code of ["ja", "vi", "ko", "ru", "uk", "es", "pt-BR", "id"]) {
       expect(isValidLocale(code)).toBe(true);
       expect(isPartialLocale(code)).toBe(true);
     }

--- a/web/lib/i18n/config.ts
+++ b/web/lib/i18n/config.ts
@@ -113,8 +113,8 @@ export const ALL_LOCALES: LocaleEntry[] = [
   {
     code: "id",
     label: "Bahasa Indonesia",
-    status: "planned",
-    note: "#4789 — TUI pack shipped in v0.9.2; website next wave",
+    status: "partial",
+    note: "#4789 — chrome + home localized; page bodies fall back to English",
   },
   {
     code: "hi",

--- a/web/lib/i18n/detect.test.ts
+++ b/web/lib/i18n/detect.test.ts
@@ -19,6 +19,7 @@ describe("matchLocaleTag", () => {
     expect(matchLocaleTag("ja-JP")).toBe("ja");
     expect(matchLocaleTag("ko-KR")).toBe("ko");
     expect(matchLocaleTag("vi-VN")).toBe("vi");
+    expect(matchLocaleTag("id-ID")).toBe("id");
   });
 
   it("routes pt to the only shipped Portuguese variant", () => {

--- a/web/lib/i18n/dictionaries.test.ts
+++ b/web/lib/i18n/dictionaries.test.ts
@@ -31,7 +31,7 @@ function flattenStrings(dict: object): Record<string, string> {
 describe("website dictionaries", () => {
   it("cover exactly the v0.9.2 partial locales", () => {
     expect([...DICTIONARY_LOCALES].sort()).toEqual(
-      ["es", "ja", "ko", "pt-BR", "ru", "uk", "vi"].sort(),
+      ["es", "id", "ja", "ko", "pt-BR", "ru", "uk", "vi"].sort(),
     );
   });
 

--- a/web/lib/i18n/dictionaries/id/chrome.ts
+++ b/web/lib/i18n/dictionaries/id/chrome.ts
@@ -1,0 +1,24 @@
+import type { ChromeDict } from "../types";
+
+export const chrome: ChromeDict = {
+  navDocs: "Dokumentasi",
+  navInstall: "Instalasi",
+  navCommunity: "Komunitas",
+  navContribute: "Kontribusi",
+  installCta: "Instal →",
+  footerTagline:
+    "Dokumentasi, kode sumber, dan komunitas untuk runtime Codewhale sumber terbuka.",
+  footerProduct: "Produk",
+  footerProject: "Proyek",
+  footerDocs: "Dokumentasi",
+  footerInstall: "Instalasi",
+  footerModels: "Model",
+  footerRuntime: "Runtime",
+  footerIssues: "Issue",
+  footerContribute: "Kontribusi",
+  footerLicense: "Lisensi MIT",
+  footerCanonicalSource: "Sumber kanonis: ",
+  footerReleases: " · Rilis: ",
+  switcherLabel: "Bahasa",
+  partialBadge: "(sebagian)",
+};

--- a/web/lib/i18n/dictionaries/id/home.ts
+++ b/web/lib/i18n/dictionaries/id/home.ts
@@ -1,0 +1,60 @@
+import type { HomeDict } from "../types";
+
+export const home: HomeDict = {
+  kicker: "Lautan data dan kode",
+  heroTitleA: "Menyelam ke kedalaman",
+  heroTitleB: "agar Anda tidak perlu melakukannya.",
+  heroIntro:
+    "Codewhale memberikan kemampuan LLM kepada siapa saja untuk membangun sesuatu. Di terminal, Codewhale membaca repositori, mengedit berkas, menjalankan pemeriksaan, dan meninggalkan tanda terima — tanpa menganggap Anda sudah mahir berkode. Berjalan di mesin Anda sendiri.",
+  install: "Instalasi",
+  docs: "Dokumentasi",
+  copy: "Salin",
+  copied: "Tersalin ✓",
+  latestRelease: "Rilis terbaru {tag}",
+  releaseUnavailable: "Status rilis tidak tersedia",
+  currentSource: "Sumber saat ini",
+  sourceCandidate: "Kandidat sumber",
+  providerRoutes: "{count} rute penyedia",
+  screenshotAlt:
+    "Sesi terminal Codewhale v{version} baru menggunakan rute Ollama lokal, tanpa bilah Work kosong",
+  figcaption: "v{version} {state} · rute Ollama lokal · Plan / Act / Operate",
+  publishedRelease: "rilis terpublikasi",
+  figcaptionSourceCandidate: "kandidat sumber",
+  proofHeading: "Terminal shell bawah air. Netral model. Mengutamakan lokal.",
+  proofBody:
+    "Bawa model di-host, gateway, atau lokal yang sudah Anda gunakan. Codewhale berjalan di mesin Anda dan memperlakukan model sebagai komponen yang dapat dipilih—bukan sebagai produk. Mode Plan / Act / Operate dan postur izin yang eksplisit menjaga penyelaman mendalam tetap dalam kendali Anda.",
+  workflowHeading: "Dari tugas hingga perubahan terverifikasi.",
+  workflow: [
+    ["Inspeksi", "Baca repositori, instruksinya, dan tugas."],
+    ["Act", "Edit berkas melalui batasan persetujuan yang eksplisit."],
+    ["Verifikasi", "Jalankan pemeriksaan dan periksa hasilnya."],
+    ["Lapor", "Tinggalkan tanda terima kerja yang ringkas dan tahan lama."],
+  ],
+  receiptAria: "Contoh tanda terima kerja",
+  boundariesHeadingA: "Model Anda.",
+  boundariesHeadingB: "Batasan Anda.",
+  boundariesBody:
+    "Pilih model, mode kerja, dan postur izin secara eksplisit. Biaya yang tidak diketahui tetap tidak diketahui, dan tampilan pratinjau tetap diberi label demikian.",
+  hostedGatewayLocal: "Model di-host, gateway, dan lokal",
+  planActOperateDesc: "Perencanaan baca-saja hingga pengoperasian otonom",
+  askAutoReviewDesc: "Pilih postur izin untuk pekerjaan tersebut",
+  tuiExecWebDesc: "Antarmuka runtime interaktif dan headless",
+  surfacesHeading: "Gunakan runtime di mana pekerjaan dilakukan.",
+  surfaces: [
+    ["TUI", "Pekerjaan terminal interaktif"],
+    ["codewhale exec", "Skrip dan CI"],
+    ["Klien Web", "Klien browser berbasis loopback-only"],
+    ["Runtime API + MCP", "Integrasi lokal"],
+    ["Fleet", "Pekerjaan multi-agent tahan lama"],
+  ],
+  runtimeLink: "Lihat antarmuka runtime dan catatan stabilitas →",
+  installBandHeading: "Mulai dengan satu perintah.",
+  binaries: "Biner",
+  chinaMirrors: "Mirror Tiongkok",
+  installGuideLink: "Baca panduan instalasi →",
+  communityHeading: "Dibuat secara terbuka",
+  communityBody:
+    "Berlisensi MIT dan dibentuk oleh kontributor di seluruh runtime, penyedia, platform, dokumentasi, dan pengujian.",
+  communityLinksAria: "Tautan komunitas",
+  contribute: "Kontribusi",
+};

--- a/web/lib/i18n/dictionaries/index.ts
+++ b/web/lib/i18n/dictionaries/index.ts
@@ -25,6 +25,8 @@ import { chrome as esChrome } from "./es/chrome";
 import { home as esHome } from "./es/home";
 import { chrome as ptBrChrome } from "./pt-BR/chrome";
 import { home as ptBrHome } from "./pt-BR/home";
+import { chrome as idChrome } from "./id/chrome";
+import { home as idHome } from "./id/home";
 
 const CHROME: Record<string, ChromeDict> = {
   ja: jaChrome,
@@ -34,6 +36,7 @@ const CHROME: Record<string, ChromeDict> = {
   uk: ukChrome,
   es: esChrome,
   "pt-BR": ptBrChrome,
+  id: idChrome,
 };
 
 const HOME: Record<string, HomeDict> = {
@@ -44,6 +47,7 @@ const HOME: Record<string, HomeDict> = {
   uk: ukHome,
   es: esHome,
   "pt-BR": ptBrHome,
+  id: idHome,
 };
 
 /** Locales with a dictionary (English and Chinese stay inline in the


### PR DESCRIPTION
Closes #4789

Adds Bahasa Indonesia (`id`) website locale dictionary (`chrome.ts` + `home.ts`) for `codewhale.net`, bringing the website localization layer to full parity alongside the shipped Indonesian TUI pack (#4789) and `README.id.md`.

- Scaffolds `web/lib/i18n/dictionaries/id/chrome.ts` (19/19 keys) and `home.ts` (40/40 keys).
- Flips `id` status from `planned` to `partial` in `web/lib/i18n/config.ts` and registers dictionary in `web/lib/i18n/dictionaries/index.ts`.
- Updates Vitest suite and `docs/LOCALIZATION.md` matrix.
