### PR TITLE
fix(tui): let AltGr-typed "/" reach the composer instead of opening help (#4723)

### DIFF
--- a/crates/tui/src/tui/shell_key_routing.rs
+++ b/crates/tui/src/tui/shell_key_routing.rs
@@ -173,13 +173,25 @@ pub fn is_help_shortcut(key: &KeyEvent) -> bool {
     if matches!(key.code, KeyCode::F(1)) {
         return true;
     }
-    if matches!(key.code, KeyCode::Char('/')) && key.modifiers.contains(KeyModifiers::CONTROL) {
+    // AltGr on European/Latin keyboards (e.g. Brazilian ABNT2, where `/` is
+    // AltGr+Q, or AZERTY) is reported by Windows as Ctrl+Alt. Such chords are
+    // AltGr-typed text, not the `Ctrl+/` help chord, so leave them to the
+    // composer as a literal character. Reuse the same platform-gated primitive
+    // the composer's `is_plain_char` guard uses so the two agree exactly on
+    // what counts as text; Alt-only chords (e.g. the unadvertised Alt+? below)
+    // stay live. Same philosophy as the sidebar-focus fix in #2863/#2867.
+    let is_altgr = crate::tui::widgets::key_hint::is_altgr(key.modifiers);
+    if !is_altgr
+        && matches!(key.code, KeyCode::Char('/'))
+        && key.modifiers.contains(KeyModifiers::CONTROL)
+    {
         return true;
     }
     // Some legacy terminal stacks encode Ctrl+/ as the ASCII unit separator,
     // which crossterm reports as Ctrl+7 or Ctrl+_. Accept both portable
     // decodings so the documented fallback remains real.
-    if matches!(key.code, KeyCode::Char('7') | KeyCode::Char('_'))
+    if !is_altgr
+        && matches!(key.code, KeyCode::Char('7') | KeyCode::Char('_'))
         && key.modifiers.contains(KeyModifiers::CONTROL)
     {
         return true;
@@ -285,6 +297,43 @@ mod tests {
         )));
         let inverted_question = KeyEvent::new(KeyCode::Char('\u{00bf}'), KeyModifiers::NONE);
         assert!(!is_help_shortcut(&inverted_question));
+    }
+
+    // On Windows, AltGr is delivered as Ctrl+Alt (e.g. Brazilian ABNT2 types
+    // `/` via AltGr+Q, AZERTY via other keys). Those chords must fall through
+    // to the composer as literal characters instead of opening help. This is
+    // platform-specific: `key_hint::is_altgr` only treats Ctrl+Alt as AltGr on
+    // Windows, matching the composer's own `is_plain_char` guard.
+    #[cfg(windows)]
+    #[test]
+    fn altgr_typed_slash_is_text_not_the_help_chord() {
+        let altgr = |c| KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL | KeyModifiers::ALT);
+        assert!(!is_help_shortcut(&altgr('/')));
+        // The legacy ASCII-unit-separator fallbacks must stay guarded too, so
+        // an AltGr chord that happens to land on `7`/`_` still types text.
+        assert!(!is_help_shortcut(&altgr('7')));
+        assert!(!is_help_shortcut(&altgr('_')));
+        // Plain Ctrl+/ (no Alt) still opens help.
+        assert!(is_help_shortcut(&KeyEvent::new(
+            KeyCode::Char('/'),
+            KeyModifiers::CONTROL
+        )));
+    }
+
+    // Off Windows there is no AltGr remapping, so a genuine Ctrl+Alt+/ chord
+    // is not layout text and help still fires — the fix must not regress it.
+    #[cfg(not(windows))]
+    #[test]
+    fn ctrl_alt_slash_still_opens_help_off_windows() {
+        let chord = KeyEvent::new(
+            KeyCode::Char('/'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        );
+        assert!(is_help_shortcut(&chord));
+        assert!(is_help_shortcut(&KeyEvent::new(
+            KeyCode::Char('/'),
+            KeyModifiers::CONTROL
+        )));
     }
 
     #[test]

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -29,6 +29,8 @@ Global key chords are not yet user-configurable — tracked for a future release
 | `Ctrl-Alt-0`         | Hide/show the pinned sidebar                                    |
 | `Esc`                | Close topmost modal · cancel slash menu · dismiss toast        |
 
+> **AltGr layouts:** On Windows, AltGr is reported to applications as `Ctrl+Alt`. On layouts where a printable character needs AltGr (for example `/` is `AltGr+Q` on Brazilian ABNT2), that keystroke is treated as literal text and typed into the composer — it does not trigger the `Ctrl-/` help chord. Use `F1` (or `/help`) for help on those layouts.
+
 ## Composer
 
 Editing the message you're about to send.


### PR DESCRIPTION
## Summary

Fixes #4723.

On Windows, AltGr is reported to applications as `Ctrl+Alt`. On the Brazilian ABNT2 layout `/` is `AltGr+Q`, which arrives as `Ctrl+Alt+Q` and was matched against the global `Ctrl-/` help chord — so the help overlay opened every time the reporter tried to type a slash. AZERTY and other Latin layouts hit the same class of bug for characters behind AltGr. The reporter isolated it cleanly: `AltGr+W` (`?`) works because there's no `Ctrl-?` binding, so only the `Ctrl-/` chord is affected.

This is the same bug class as the sidebar-focus AltGr fix in #2863/#2867, which scoped its fix to `Alt-!`/`Alt-@`/etc. but not the one global chord (`Ctrl-/`) that this issue hits.

### Fix

`is_help_shortcut` (`crates/tui/src/tui/shell_key_routing.rs`) now treats any AltGr chord as text and falls through to the composer, instead of matching it as help. It reuses the existing platform-gated `key_hint::is_altgr` primitive that the composer's own `is_plain_char` guard already uses, so the help matcher and the composer agree exactly on what counts as layout text. Once the overlay stops stealing the key, the composer inserts the literal `/` (AltGr chords already qualify as plain text on Windows via `key_hint::has_ctrl_or_alt`).

Behavior preserved:
- Plain `Ctrl-/` still opens help.
- Legacy `Ctrl-7` / `Ctrl-_` unit-separator fallbacks still open help.
- `Alt+?` stays live (Alt-only, not AltGr).
- Off Windows, `is_altgr` is always `false`, so a genuine `Ctrl+Alt+/` chord is unaffected.

Also adds a KEYBINDINGS.md note documenting the AltGr behavior (issue was tagged `documentation`).

## Testing

Full disclosure: this machine has no MSVC toolchain installed (`mimalloc-sys` can't build under the gnu toolchain either), so I could not run the workspace `cargo` gates locally. What I did verify:

- [x] `rustfmt --edition 2024 --check` clean on the changed Rust file
- [x] Logic verified by extracting `is_help_shortcut` into a standalone harness (replicating crossterm `KeyModifiers` semantics) and asserting all chords for **both** Windows and non-Windows `is_altgr` behavior — all pass
- [x] `scripts/check-coauthor-trailers.py` passes
- [ ] `cargo fmt --all -- --check` — not run locally (no MSVC)
- [ ] `cargo clippy --workspace ...` — not run locally (no MSVC)
- [ ] `cargo test --workspace ...` — not run locally (no MSVC); **please rely on CI** for the added regression tests

Added regression tests are platform-split:
- `altgr_typed_slash_is_text_not_the_help_chord` (`#[cfg(windows)]`) — AltGr `/`, `7`, `_` fall through; plain `Ctrl-/` still opens help.
- `ctrl_alt_slash_still_opens_help_off_windows` (`#[cfg(not(windows))]`) — genuine `Ctrl+Alt+/` still opens help.

## Checklist

- [x] Updated docs or comments as needed (KEYBINDINGS.md + inline rationale)
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually — could not launch a build locally (no MSVC linker); reasoned through the composer key path instead
- [x] No `Co-authored-by` trailers added (agent-assisted; issue reporter credited via `Reported-by`)