### PR TITLE
test(tui): remove skills viewport ordering assumption

### DIFF
--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -1833,12 +1833,6 @@ fn cancelled_bang_shell_settles_transcript_card() -> anyhow::Result<()> {
 fn skills_opens_manager_owned_then_compatible() -> anyhow::Result<()> {
     let _guard = qa_pty_test_lock();
     let ws = make_sealed_workspace()?;
-    // Owned global root — visible in the default owned-only manager scan.
-    write_skill(
-        ws.home().join(".codewhale").join("skills"),
-        "global-alpha",
-        "Global alpha skill",
-    )?;
     // Compatible external root — hidden until the user presses `c`.
     write_skill(
         ws.workspace().join(".agents").join("skills"),
@@ -1869,14 +1863,10 @@ fn skills_opens_manager_owned_then_compatible() -> anyhow::Result<()> {
     h.wait_for_idle(Duration::from_millis(300), Duration::from_secs(2))?;
     h.send(keys::key::enter())?;
     h.wait_for_text("Skills Manager", KEY_TIMEOUT)?;
-    h.wait_for_text("global-alpha", KEY_TIMEOUT)?;
+    h.wait_for_text("scan=owned   import-target=global   idle", KEY_TIMEOUT)?;
 
     let owned = h.frame();
     let owned_dump = owned.debug_dump();
-    assert!(
-        owned.contains("global-alpha"),
-        "owned global skill missing:\n{owned_dump}"
-    );
     assert!(
         !owned.contains("workspace-beta"),
         "compatible skill must stay hidden in owned-only scan:\n{owned_dump}"
@@ -1895,7 +1885,6 @@ fn skills_opens_manager_owned_then_compatible() -> anyhow::Result<()> {
     // hashing the bundled skill tree can legitimately take longer than an
     // ordinary key response. Wait for the explicit mode receipt with the scan
     // budget, then use the ordinary interaction budget for the rendered row.
-    h.wait_for_text("scan=owned   import-target=global   idle", KEY_TIMEOUT)?;
     h.send(keys::key::ch('c'))?;
     h.wait_for_text("scan=compatible", SKILL_SCAN_TIMEOUT)?;
     h.wait_for_text("workspace-beta", KEY_TIMEOUT)?;


### PR DESCRIPTION
## Summary

- remove the synthetic owned-skill row from the Skills Manager PTY test
- wait for the owned-scan receipt instead of assuming a named row is inside the bounded viewport
- retain the owned-only, zero-network, compatible-toggle, and compatible-root assertions

No-Issue: release-blocking regression-test correction discovered by exact-main Ubuntu CI.

## Root cause

The two exact-main Ubuntu failures timed out before the test sent `c`. Startup installs bundled skills into the same owned root, discovery follows platform-dependent `read_dir` order, and Linux placed the synthetic row below the visible viewport. The manager and key routing remained healthy.

## Verification

- focused PTY scenario: 11/11 local passes
- `owned_only_skips_compatible_and_codex`: pass
- exact-SHA hosted Ubuntu full suite: pass
- exact-SHA hosted Ubuntu isolated Skills Manager PTY: pass in 1.17s
- `cargo fmt --all -- --check`
- `git diff --check`