### PR TITLE
fix(docs): restore the v0.9.3 rustdoc gate

### DIFF
--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -727,7 +727,7 @@ fn suggest_tool_names(catalog: &[Tool], requested: &str, limit: usize) -> Vec<St
 /// Catalog tools the engine injects itself rather than registering, plus the
 /// legacy tool-search spellings. Exposed so the read-only request projection
 /// can label their provenance as `synthetic` from the same source of truth as
-/// [`is_synthetic_catalog_tool`] instead of guessing.
+/// `is_synthetic_catalog_tool` test coverage instead of guessing.
 ///
 /// MCP-contributed names are deliberately *not* here: those resolve through the
 /// real pool, and stay unknown when the pool did not resolve them.


### PR DESCRIPTION
## Summary

- render the test-only synthetic-catalog helper as code instead of an intra-doc link
- restore the workflow-dispatch Documentation gate for the v0.9.3 release candidate

## Verification

- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`

The prior exact-main CI run exposed this because PR change detection skipped the scheduled/workflow-dispatch-only Documentation job.

No-Issue: v0.9.3 release hotfix for a workflow-dispatch-only rustdoc failure.