### PR TITLE
fix(ci): source-structure budget update for the #5001 vendored crate

### DIFF
--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -184,7 +184,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 172,
   "max_module_lines": 19017,
-  "max_total_owned_rust_lines": 644756,
+  "max_total_owned_rust_lines": 644811,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
The #5001 merge (vendored patched unicode-width) grew the counted aggregate owned Rust source to 644811 lines — over the 644756 pin set by #5017. Main is therefore red on its own Lint, and every PR's merge ref fails the source-structure check (the dependabot batch included). Reviewed ratchet update: raise the ceiling to the measured value.

No-Issue: budget ratchet follow-up from the #5001 merge within the v0.9.4 CI repair train; not a single user-facing issue.