### PR TITLE
fix(nix): make the sandboxed check phase pass

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,9 +11,21 @@
   python3,
   gitMinimal,
   cacert,
+  procps,
 
   rev ? "dirty",
 }:
+let
+  # Shared libraries the check-phase test binaries need at runtime
+  # (libdbus, libgcc_s). Derived once so LD_LIBRARY_PATH and the patchelf
+  # RPATH can never drift apart.
+  runtimeLibraryPath = lib.makeLibraryPath (
+    lib.optionals stdenv.isLinux [
+      dbus.lib
+      stdenv.cc.cc.lib
+    ]
+  );
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codewhale";
   version = "git-${rev}";
@@ -42,6 +54,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     python3
     gitMinimal
     cacert
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    # fleet host memory/zombie sampling shells out to `ps`; NixOS has no
+    # system-wide /usr/bin/ps, so make it resolvable through PATH.
+    procps
   ];
 
   cargoBuildFlags = [
@@ -53,10 +70,60 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoTestFlags = finalAttrs.cargoBuildFlags ++ [
     "--lib"
     "--bins"
+    "--"
+    # Requires the checkout itself to be a git repository (the test walks up
+    # from the current dir); the Nix source tree has no .git.
+    "--skip"
+    "tools::subagent::tests::git_repo_root_reports_attempted_paths_when_no_repo_found"
+    # The header width table is calibrated against the git chrome label
+    # populated by the surrounding checkout state, which the sandboxed test
+    # process does not see.
+    "--skip"
+    "tui::underwater::tests::configured_session_tokens_follow_underwater_header_width_priority"
   ];
 
   preCheck = ''
+    # Tests write to the default config/home locations; the sandbox HOME
+    # (/homeless-shelter) is not writable.
+    export HOME="$(mktemp -d)"
     export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+  ''
+  + lib.optionalString stdenv.isLinux ''
+    # nixpkgs no longer derives LD_LIBRARY_PATH from buildInputs; the cargo
+    # test binaries link libdbus/libgcc_s dynamically and have no RPATH until
+    # autoPatchelfHook runs at fixup (after the check phase).
+    export LD_LIBRARY_PATH=${runtimeLibraryPath}
+  '';
+
+  # Two-stage check: build the harnesses first, give them an explicit RPATH,
+  # then run. Fleet and shell tests re-execute the test binary through a
+  # scrubbed environment (no LD_LIBRARY_PATH), so without this the re-spawned
+  # harness cannot load libdbus and every descendant-tree test times out.
+  checkPhase = ''
+    runHook preCheck
+
+    # Tests mutate process-global environment (PATH/HOME/cwd) via the shared
+    # EnvVarGuard; a concurrent test spawning a shell can then fail to resolve
+    # the interpreter. Run the harness serially so the check is deterministic.
+    export RUST_TEST_THREADS=1
+
+    flagsArray=(-j "$NIX_BUILD_CORES" --profile release --target ${stdenv.hostPlatform.config} --offline)
+    concatTo flagsArray cargoTestFlags checkFlags
+
+    echo "Building test binaries"
+    cargo test --no-run "''${flagsArray[@]}"
+
+    ${lib.optionalString stdenv.isLinux ''
+      echo "Patching runtime RPATH into test binaries"
+      find "target/${stdenv.hostPlatform.config}/release/deps" \
+        -maxdepth 1 -type f -executable \
+        -exec patchelf --add-rpath "${runtimeLibraryPath}" {} +
+    ''}
+
+    echo "Running tests"
+    cargo test "''${flagsArray[@]}"
+
+    runHook postCheck
   '';
 
   meta = {


### PR DESCRIPTION
## Summary

`nix build` of the flake (v0.9.3) always failed in the cargo check phase:
the test harness could not load `libdbus-1.so.3`, and after that was fixed
a batch of sandbox-environment tests failed. This PR makes the sandboxed
check phase pass so Nix/NixOS users can build and install CodeWhale from
the flake. All changes are in `nix/package.nix` (no Rust code changed).

- `preCheck` exports `LD_LIBRARY_PATH` (dbus/gcc libs) — modern nixpkgs
  no longer derives it from `buildInputs`, and `autoPatchelfHook` only
  runs at fixup, after the check phase.
- `preCheck` points `HOME` at a writable `mktemp` dir — the sandbox home
  (`/homeless-shelter`) is not writable, which broke config/secret tests.
- `procps` added as a Linux `nativeCheckInput` — fleet memory/zombie
  sampling shells out to `ps`, which NixOS does not provide system-wide.
- `checkPhase` is now two-stage: `cargo test --no-run`, then an explicit
  RPATH patch on the deps executables, then `cargo test` — fleet/shell
  tests re-execute the test harness with a scrubbed environment (no
  `LD_LIBRARY_PATH`), so the harness needs an embedded RPATH.
- The runtime library list is derived once with `lib.makeLibraryPath` and
  shared by `LD_LIBRARY_PATH` and the patchelf step (which uses
  `--add-rpath` so existing RPATHs are preserved).
- `RUST_TEST_THREADS=1` — tests mutate the process-global
  `PATH`/`HOME`/`cwd` via `EnvVarGuard`, so a concurrent shell spawn can
  fail to resolve the interpreter; serial execution makes the check
  deterministic (compilation stays parallel).
- Two tests are skipped for the Nix check only because they cannot run in
  the sandbox: `git_repo_root_reports_attempted_paths_when_no_repo_found`
  (needs the source tree to be a git repository) and
  `configured_session_tokens_follow_underwater_header_width_priority`
  (its width table depends on the process-global git-status cache, which
  is only populated by the surrounding checkout/test order). Both skips
  still run in non-Nix CI; the other sandbox-sensitive failures were fixed
  by the environment changes above.

## Testing

The standard cargo gates are unaffected (no Rust source changed); the
relevant gate is the Nix build itself, which I ran end-to-end:

- [x] `nix build '.#packages.x86_64-linux.default'` — exit 0
- [x] cli: 186 passed / 0 failed
- [x] tui: 9491 passed / 0 failed (9 ignored, 2 filtered)
- [x] `auto-patchelf: 0 dependencies could not be satisfied`

## Checklist

- [x] Updated docs or comments as needed (explanatory comments in `nix/package.nix`)
- [x] Added or updated tests where relevant (the Nix check phase is the test surface)
- [ ] Verified TUI behavior manually if UI changes (N/A — no Rust/UI changes)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address 



Closes #5026
