### PR TITLE
fix: issue burn-down batch — Anthropic wire, sandbox, workflow, config scoping, session layer, input, TUI

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -4725,6 +4725,193 @@ fn config_path_from_env_value(path: &str) -> Result<Option<PathBuf>> {
     }
 }
 
+/// Whether `path` names a workspace-scoped config document —
+/// `<repo>/.codewhale/config.toml` (or the legacy `.deepseek` layout) inside a
+/// checkout — rather than a user-global config file.
+///
+/// Credential writes (api_key values, `auth_mode` markers, oauth/external
+/// credential pointers) must never target such a document: a key saved while
+/// working in one repo would be invisible from every other repo, and the repo
+/// file stores it in plaintext where it is easy to commit by accident (#5045).
+///
+/// A path is classified workspace-scoped only when its parent directory is a
+/// `.codewhale`/`.deepseek` app dir outside the user's home AND the document
+/// belongs to a workspace: it is relative (resolves against the process cwd),
+/// its base directory contains the process cwd, or its base directory is a
+/// checkout (has a `.git` entry). An explicit `$CODEWHALE_HOME` config is
+/// user-global wherever that home points, even when the directory itself
+/// happens to be named `.codewhale`; other custom locations (for example
+/// `CODEWHALE_CONFIG_PATH=~/team.toml` or an isolated test directory) stay
+/// honored as deliberate user-scoped choices.
+#[must_use]
+pub fn config_path_is_workspace_scoped(path: &Path) -> bool {
+    config_path_is_workspace_scoped_with_context(
+        path,
+        codewhale_paths::codewhale_home_override().as_deref(),
+        codewhale_paths::user_home().as_deref(),
+        std::env::current_dir().ok().as_deref(),
+    )
+}
+
+/// Environment-free core of [`config_path_is_workspace_scoped`], split out so
+/// scope classification is testable without mutating process-global state.
+fn config_path_is_workspace_scoped_with_context(
+    path: &Path,
+    explicit_codewhale_home: Option<&Path>,
+    user_home: Option<&Path>,
+    current_dir: Option<&Path>,
+) -> bool {
+    if let Some(home) = explicit_codewhale_home
+        && same_lexical_or_canonical_path(path, &home.join(CONFIG_FILE_NAME))
+    {
+        return false;
+    }
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let parent_is_app_dir = parent
+        .file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| name == CODEWHALE_APP_DIR || name == LEGACY_APP_DIR);
+    if !parent_is_app_dir {
+        return false;
+    }
+    let Some(base) = parent.parent() else {
+        return true;
+    };
+    if let Some(home) = user_home
+        && same_lexical_or_canonical_path(base, home)
+    {
+        return false;
+    }
+    if path.is_relative() {
+        // Resolves against the process cwd: repo-scoped by construction.
+        return true;
+    }
+    // The document belongs to the workspace the process is sitting in…
+    if let Some(cwd) = current_dir
+        && canonicalize_or_keep(cwd).starts_with(canonicalize_or_keep(base))
+    {
+        return true;
+    }
+    // …or to some other checkout (a `.git` entry beside the app dir).
+    base.join(".git").exists()
+}
+
+/// Lexical equality first, canonical equality as a fallback so an existing
+/// path still matches through symlinked parents (e.g. `/tmp` on macOS).
+fn same_lexical_or_canonical_path(a: &Path, b: &Path) -> bool {
+    a == b || canonicalize_or_keep(a) == canonicalize_or_keep(b)
+}
+
+fn canonicalize_or_keep(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod credential_scope_tests {
+    use super::config_path_is_workspace_scoped_with_context;
+    use std::path::Path;
+
+    #[test]
+    fn config_inside_current_workspace_is_workspace_scoped() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let cwd = repo.join("nested/dir");
+        for app_dir in [".codewhale", ".deepseek"] {
+            let config = repo.join(app_dir).join("config.toml");
+            assert!(
+                config_path_is_workspace_scoped_with_context(
+                    &config,
+                    None,
+                    Some(Path::new("/home/user")),
+                    Some(&cwd),
+                ),
+                "{} should be workspace-scoped when cwd sits inside the repo",
+                config.display()
+            );
+        }
+    }
+
+    #[test]
+    fn relative_app_dir_config_is_workspace_scoped() {
+        assert!(config_path_is_workspace_scoped_with_context(
+            Path::new(".codewhale/config.toml"),
+            None,
+            Some(Path::new("/home/user")),
+            Some(Path::new("/somewhere/else")),
+        ));
+    }
+
+    #[test]
+    fn checkout_config_outside_cwd_is_workspace_scoped_via_git_marker() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).expect("git marker");
+        std::fs::create_dir_all(repo.join(".codewhale")).expect("app dir");
+        assert!(config_path_is_workspace_scoped_with_context(
+            &repo.join(".codewhale/config.toml"),
+            None,
+            Some(Path::new("/home/user")),
+            Some(Path::new("/somewhere/else")),
+        ));
+    }
+
+    #[test]
+    fn user_global_and_custom_locations_are_not_workspace_scoped() {
+        let home = Path::new("/home/user");
+        let elsewhere = Some(Path::new("/somewhere/else"));
+        for global_config in [
+            "/home/user/.codewhale/config.toml",
+            "/home/user/.deepseek/config.toml",
+            "/home/user/team-config.toml",
+            "/etc/codewhale/config.toml",
+        ] {
+            assert!(
+                !config_path_is_workspace_scoped_with_context(
+                    Path::new(global_config),
+                    None,
+                    Some(home),
+                    elsewhere,
+                ),
+                "{global_config} should stay user-global"
+            );
+        }
+        // An isolated app-dir-shaped location with no workspace relationship
+        // (no cwd ancestry, no checkout marker) stays honored: test harnesses
+        // and deliberate overrides point there.
+        let temp = tempfile::tempdir().expect("tempdir");
+        assert!(!config_path_is_workspace_scoped_with_context(
+            &temp.path().join(".codewhale/config.toml"),
+            None,
+            Some(home),
+            elsewhere,
+        ));
+    }
+
+    #[test]
+    fn explicit_codewhale_home_config_is_user_global_even_when_dir_is_app_named() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let explicit = repo.join(".codewhale");
+        // Even with cwd inside the repo, the explicit CODEWHALE_HOME config is
+        // the user-global scope by definition.
+        assert!(!config_path_is_workspace_scoped_with_context(
+            &explicit.join("config.toml"),
+            Some(&explicit),
+            Some(Path::new("/home/user")),
+            Some(&repo),
+        ));
+        // A different repo-scoped document is still workspace-scoped.
+        assert!(config_path_is_workspace_scoped_with_context(
+            &repo.join("other/.codewhale/config.toml"),
+            Some(&explicit),
+            Some(Path::new("/home/user")),
+            Some(&repo.join("other")),
+        ));
+    }
+}
+
 #[must_use]
 pub fn permissions_path_for_config_path(config_path: &Path) -> PathBuf {
     config_sibling_path_unchecked(config_path, OsStr::new(PERMISSIONS_FILE_NAME))

--- a/crates/tui/src/client/anthropic.rs
+++ b/crates/tui/src/client/anthropic.rs
@@ -70,13 +70,13 @@ impl DeepSeekClient {
             };
         }
 
-        body["messages"] = json!(
-            request
-                .messages
-                .iter()
-                .filter_map(message_to_anthropic)
-                .collect::<Vec<_>>()
-        );
+        let mut messages: Vec<Value> = request
+            .messages
+            .iter()
+            .filter_map(message_to_anthropic)
+            .collect();
+        repair_dangling_tool_uses(&mut messages);
+        body["messages"] = Value::Array(messages);
 
         if let Some(tools) = request.tools.as_ref()
             && !tools.is_empty()
@@ -121,7 +121,10 @@ impl DeepSeekClient {
 
         // Thinking + effort shaping. MiniMax supports adaptive/disabled but
         // not Anthropic's output_config effort field; native Anthropic routes
-        // keep the existing effort mapping.
+        // keep the existing effort mapping. Other Messages-compatible
+        // gateways (#4978, e.g. Sensenova) only accept the documented
+        // enabled/disabled/auto thinking types, so non-native routes get the
+        // portable `{"type":"enabled","budget_tokens":N}` shape instead.
         let thinking_capable = crate::models::model_supports_reasoning(&model);
         let is_minimax_provider = self.api_provider == ApiProvider::MinimaxAnthropic;
         let is_minimax = crate::config::is_exact_minimax_anthropic_m3_route(
@@ -130,6 +133,10 @@ impl DeepSeekClient {
             &model,
         );
         let is_deepseek = self.api_provider == ApiProvider::DeepseekAnthropic;
+        // MiniMax's exact M3 route and DeepSeek's Messages dialect both
+        // document adaptive support; everything else needs the native host.
+        let supports_adaptive =
+            is_native_anthropic_base_url(&self.base_url) || is_minimax || is_deepseek;
         let effort = request
             .reasoning_effort
             .as_deref()
@@ -142,7 +149,7 @@ impl DeepSeekClient {
                 body["thinking"] = json!({ "type": "disabled" });
             }
             Some("off" | "disabled" | "none" | "false") => {}
-            Some(level) if thinking_capable => {
+            Some(level) if thinking_capable && supports_adaptive => {
                 body["thinking"] = json!({ "type": "adaptive" });
                 if !is_minimax {
                     let mapped = match level {
@@ -154,8 +161,14 @@ impl DeepSeekClient {
                     body["output_config"] = json!({ "effort": mapped });
                 }
             }
-            None if thinking_capable => {
+            None if thinking_capable && supports_adaptive => {
                 body["thinking"] = json!({ "type": "adaptive" });
+            }
+            _ if thinking_capable => {
+                if let Some(budget) = compat_thinking_budget(effort.as_deref(), request.max_tokens)
+                {
+                    body["thinking"] = json!({ "type": "enabled", "budget_tokens": budget });
+                }
             }
             _ => {}
         }
@@ -366,6 +379,116 @@ pub(super) fn anthropic_messages_url(base_url: &str) -> String {
     } else {
         format!("{trimmed}/v1/messages")
     }
+}
+
+/// Whether the route targets first-party Anthropic (`api.anthropic.com`),
+/// where the `{"type":"adaptive"}` thinking control is valid. Strict
+/// Anthropic-compatible gateways reject it (#4978).
+fn is_native_anthropic_base_url(base_url: &str) -> bool {
+    let rest = base_url
+        .trim()
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+    let host = rest
+        .split(['/', ':', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    host == "api.anthropic.com" || host.ends_with(".anthropic.com")
+}
+
+/// Minimum `budget_tokens` the Messages API accepts for extended thinking.
+const MIN_THINKING_BUDGET_TOKENS: u32 = 1024;
+
+/// Effort-tier `budget_tokens` for gateways that only accept the documented
+/// `{"type":"enabled","budget_tokens":N}` thinking shape (#4978). The wire
+/// contract requires `budget_tokens >= 1024` and `< max_tokens`, so requests
+/// too small to fit the minimum budget send no thinking block at all.
+fn compat_thinking_budget(effort: Option<&str>, max_tokens: u32) -> Option<u32> {
+    let tier: u32 = match effort {
+        Some("low" | "minimal") => 4_096,
+        Some("medium" | "mid") => 8_192,
+        Some("max" | "xhigh" | "highest") => 32_768,
+        // "high" and unspecified effort share the adaptive default tier.
+        _ => 16_384,
+    };
+    let budget = tier.min(max_tokens.checked_sub(1)?);
+    (budget >= MIN_THINKING_BUDGET_TOKENS).then_some(budget)
+}
+
+/// Placeholder body for a `tool_use` that never produced a `tool_result`.
+const UNEXECUTED_TOOL_RESULT: &str = "tool call was not executed";
+
+/// Defensive wire repair (#5002): every assistant `tool_use` must be answered
+/// by a `tool_result` in the immediately following user message, or the API
+/// rejects the whole conversation with a 400 on every retry. Pre-dispatch
+/// failure paths (e.g. the model calling an unavailable tool) can strand an
+/// orphaned `tool_use` in history, so missing results get an explicit
+/// error placeholder instead of poisoning the session.
+fn repair_dangling_tool_uses(messages: &mut Vec<Value>) {
+    let mut index = 0;
+    while index < messages.len() {
+        let ids = assistant_tool_use_ids(&messages[index]);
+        if ids.is_empty() {
+            index += 1;
+            continue;
+        }
+        let next_is_user = messages
+            .get(index + 1)
+            .and_then(|message| message.get("role"))
+            .and_then(Value::as_str)
+            == Some("user");
+        if !next_is_user {
+            messages.insert(index + 1, json!({ "role": "user", "content": [] }));
+        }
+        if let Some(blocks) = messages[index + 1]
+            .get_mut("content")
+            .and_then(Value::as_array_mut)
+        {
+            let answered: std::collections::HashSet<String> = blocks
+                .iter()
+                .filter(|block| block.get("type").and_then(Value::as_str) == Some("tool_result"))
+                .filter_map(|block| block.get("tool_use_id").and_then(Value::as_str))
+                .map(str::to_string)
+                .collect();
+            // tool_result blocks must lead the user turn, so placeholders are
+            // prepended in tool_use order.
+            for (offset, id) in ids
+                .iter()
+                .filter(|id| !answered.contains(id.as_str()))
+                .enumerate()
+            {
+                blocks.insert(
+                    offset,
+                    json!({
+                        "type": "tool_result",
+                        "tool_use_id": id,
+                        "content": UNEXECUTED_TOOL_RESULT,
+                        "is_error": true,
+                    }),
+                );
+            }
+        }
+        index += 1;
+    }
+}
+
+fn assistant_tool_use_ids(message: &Value) -> Vec<String> {
+    if message.get("role").and_then(Value::as_str) != Some("assistant") {
+        return Vec::new();
+    }
+    message
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|blocks| {
+            blocks
+                .iter()
+                .filter(|block| block.get("type").and_then(Value::as_str) == Some("tool_use"))
+                .filter_map(|block| block.get("id").and_then(Value::as_str))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Models that reject `temperature` / `top_p` outright (Claude 4.7+).
@@ -691,12 +814,17 @@ mod tests {
     }
 
     fn test_client() -> DeepSeekClient {
+        anthropic_test_client(None)
+    }
+
+    fn anthropic_test_client(base_url: Option<&str>) -> DeepSeekClient {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let config = crate::config::Config {
             provider: Some("anthropic".to_string()),
             providers: Some(crate::config::ProvidersConfig {
                 anthropic: crate::config::ProviderConfig {
                     api_key: Some("test-key".to_string()),
+                    base_url: base_url.map(str::to_string),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -828,6 +956,181 @@ mod tests {
         );
         assert!(body.get("thinking").is_none(), "{body}");
         assert!(body.get("output_config").is_none(), "{body}");
+    }
+
+    #[test]
+    fn compat_gateway_sends_enabled_budget_thinking_instead_of_adaptive() {
+        // #4978: strict Anthropic-compatible gateways (e.g. Sensenova) reject
+        // {"type":"adaptive"} with a 400; non-native routes must send the
+        // documented enabled+budget shape and no output_config.
+        let client = anthropic_test_client(Some("https://api.sensenova.example/v1"));
+
+        let mut request = request_with("claude-sonnet-4-6", Some("high"), None, None);
+        request.max_tokens = 64_000;
+        let body = client.build_anthropic_body(&request, true);
+        assert_eq!(
+            body.pointer("/thinking/type").and_then(Value::as_str),
+            Some("enabled"),
+            "{body}"
+        );
+        assert_eq!(
+            body.pointer("/thinking/budget_tokens")
+                .and_then(Value::as_u64),
+            Some(16_384)
+        );
+        assert!(body.get("output_config").is_none(), "{body}");
+
+        // Effort tiers map onto budgets, capped below max_tokens.
+        let mut request = request_with("claude-sonnet-4-6", Some("max"), None, None);
+        request.max_tokens = 64_000;
+        let body = client.build_anthropic_body(&request, true);
+        assert_eq!(
+            body.pointer("/thinking/budget_tokens")
+                .and_then(Value::as_u64),
+            Some(32_768)
+        );
+        let mut request = request_with("claude-sonnet-4-6", Some("max"), None, None);
+        request.max_tokens = 8_000;
+        let body = client.build_anthropic_body(&request, true);
+        assert_eq!(
+            body.pointer("/thinking/budget_tokens")
+                .and_then(Value::as_u64),
+            Some(7_999),
+            "budget stays below max_tokens: {body}"
+        );
+
+        // Unspecified effort defaults to the "high" tier.
+        let mut request = request_with("claude-sonnet-4-6", None, None, None);
+        request.max_tokens = 64_000;
+        let body = client.build_anthropic_body(&request, true);
+        assert_eq!(
+            body.pointer("/thinking/type").and_then(Value::as_str),
+            Some("enabled")
+        );
+        assert_eq!(
+            body.pointer("/thinking/budget_tokens")
+                .and_then(Value::as_u64),
+            Some(16_384)
+        );
+
+        // "off" and requests too small for the 1024-token minimum budget
+        // omit thinking entirely.
+        let mut request = request_with("claude-sonnet-4-6", Some("off"), None, None);
+        request.max_tokens = 64_000;
+        let body = client.build_anthropic_body(&request, true);
+        assert!(body.get("thinking").is_none(), "{body}");
+        let body = client.build_anthropic_body(
+            &request_with("claude-sonnet-4-6", Some("high"), None, None),
+            true,
+        );
+        assert!(
+            body.get("thinking").is_none(),
+            "max_tokens=1024 cannot fit the minimum budget: {body}"
+        );
+
+        // The native route keeps adaptive; the compat shape is only for
+        // non-anthropic.com hosts.
+        let native = test_client().build_anthropic_body(
+            &request_with("claude-sonnet-4-6", Some("high"), None, None),
+            true,
+        );
+        assert_eq!(
+            native.pointer("/thinking/type").and_then(Value::as_str),
+            Some("adaptive")
+        );
+    }
+
+    #[test]
+    fn dangling_tool_use_gets_placeholder_tool_result() {
+        // #5002: an orphaned tool_use with no matching tool_result poisons
+        // the conversation with repeated 400s; request preparation must
+        // repair it with an explicit placeholder result.
+        let client = test_client();
+        let mut request = request_with("claude-sonnet-4-6", None, None, None);
+        request.messages = vec![
+            Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "run both tools".to_string(),
+                    cache_control: None,
+                }],
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: vec![
+                    ContentBlock::ToolUse {
+                        id: "toolu_ok".to_string(),
+                        name: "read_file".to_string(),
+                        input: json!({"path": "a.txt"}),
+                        caller: None,
+                    },
+                    ContentBlock::ToolUse {
+                        id: "toolu_orphan".to_string(),
+                        name: "task".to_string(),
+                        input: json!({}),
+                        caller: None,
+                    },
+                ],
+            },
+            // Pre-dispatch failure left only one tool_result behind.
+            Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "toolu_ok".to_string(),
+                    content: "contents".to_string(),
+                    is_error: None,
+                    content_blocks: None,
+                }],
+            },
+            // Trailing assistant tool_use with no user turn at all.
+            Message {
+                role: "assistant".to_string(),
+                content: vec![ContentBlock::ToolUse {
+                    id: "toolu_tail".to_string(),
+                    name: "task".to_string(),
+                    input: json!({}),
+                    caller: None,
+                }],
+            },
+        ];
+
+        let body = client.build_anthropic_body(&request, true);
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 5, "a repair turn is appended: {body}");
+
+        // The orphaned id gets a leading placeholder; the answered one is
+        // untouched (no duplicate result).
+        let repaired = messages[2]["content"].as_array().expect("user content");
+        assert_eq!(repaired.len(), 2, "{body}");
+        assert_eq!(repaired[0]["type"].as_str(), Some("tool_result"));
+        assert_eq!(repaired[0]["tool_use_id"].as_str(), Some("toolu_orphan"));
+        assert_eq!(
+            repaired[0]["content"].as_str(),
+            Some(UNEXECUTED_TOOL_RESULT)
+        );
+        assert_eq!(repaired[0]["is_error"].as_bool(), Some(true));
+        assert_eq!(repaired[1]["tool_use_id"].as_str(), Some("toolu_ok"));
+        assert_eq!(repaired[1]["content"].as_str(), Some("contents"));
+
+        // The trailing tool_use gains a synthesized user turn.
+        assert_eq!(messages[4]["role"].as_str(), Some("user"));
+        let tail = messages[4]["content"].as_array().expect("tail content");
+        assert_eq!(tail.len(), 1, "{body}");
+        assert_eq!(tail[0]["type"].as_str(), Some("tool_result"));
+        assert_eq!(tail[0]["tool_use_id"].as_str(), Some("toolu_tail"));
+        assert_eq!(tail[0]["content"].as_str(), Some(UNEXECUTED_TOOL_RESULT));
+
+        // A fully answered history is left alone.
+        request.messages.truncate(3);
+        request.messages[1].content.retain(
+            |block| !matches!(block, ContentBlock::ToolUse { id, .. } if id == "toolu_orphan"),
+        );
+        let body = client.build_anthropic_body(&request, true);
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 3, "no repair turn appended: {body}");
+        let untouched = messages[2]["content"].as_array().expect("user content");
+        assert_eq!(untouched.len(), 1, "{body}");
+        assert_eq!(untouched[0]["tool_use_id"].as_str(), Some("toolu_ok"));
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/debug/tokens.rs
+++ b/crates/tui/src/commands/groups/debug/tokens.rs
@@ -117,6 +117,9 @@ pub fn cost(app: &mut App) -> CommandResult {
         MessageId::CmdCostReport
     };
     let mut report = tr(locale, headline).replace("{cost}", &cost_report_amount(app, locale));
+    if priced > 0 || has_saved_legacy_subtotal {
+        report.push_str(&cost_breakdown_report(app));
+    }
     report.push_str(&cost_coverage_report(app, locale));
     CommandResult::message(report)
 }
@@ -129,6 +132,132 @@ fn cost_report_amount(app: &App, locale: Locale) -> String {
     } else {
         tr(locale, MessageId::CmdCostUnknownValue).to_string()
     }
+}
+
+/// The `/cost` headline decomposed into the exact terms it is computed from.
+///
+/// The headline is `max(parent turns + sub-agents, display high-water)` in the
+/// display currency (the #244 monotonic guarantee). Those are its only inputs,
+/// so the three components below always sum back to it — asserted by test, so
+/// the breakdown can never drift from the number above it (#4939).
+struct CostComponents {
+    /// Accumulated parent-turn spend.
+    parent_turns: f64,
+    /// Accumulated sub-agent/background spend.
+    subagents: f64,
+    /// Amount by which the monotonic display floor exceeds the live
+    /// accumulators after a downward reconciliation (#244). Zero whenever the
+    /// live sum is the headline.
+    display_floor: f64,
+}
+
+impl CostComponents {
+    fn compute(app: &App) -> Self {
+        // Each term is sanitized exactly the way the accumulator fold
+        // sanitizes it, so `current` here is bitwise the `current` inside
+        // `displayed_session_cost_for_currency` and the floor is exact.
+        fn sanitize(amount: f64) -> f64 {
+            if amount.is_finite() && amount >= 0.0 {
+                amount
+            } else {
+                0.0
+            }
+        }
+        let currency = app.cost_display_currency(app.cost_currency);
+        let parent_turns = sanitize(app.session_cost_for_currency(currency));
+        let subagents = sanitize(app.subagent_cost_for_currency(currency));
+        let current = {
+            let sum = parent_turns + subagents;
+            if sum.is_finite() { sum } else { f64::MAX }
+        };
+        let headline = app.displayed_session_cost_for_currency(app.cost_currency);
+        Self {
+            parent_turns,
+            subagents,
+            display_floor: (headline - current).max(0.0),
+        }
+    }
+
+    /// The recomposed headline. Test-only: production renders the components
+    /// and the headline from the same state, and the tests assert this sum
+    /// equals the displayed headline exactly.
+    #[cfg(test)]
+    fn sum(&self) -> f64 {
+        self.parent_turns + self.subagents + self.display_floor
+    }
+}
+
+/// Append the headline decomposition: the accumulator components the headline
+/// is computed from, then parent-turn spend attributed per route from the
+/// audited turn-telemetry ring.
+///
+/// Diagnostic composition detail like `/context report`, so plain English
+/// rather than a localized template.
+fn cost_breakdown_report(app: &App) -> String {
+    let components = CostComponents::compute(app);
+    let mut out = String::from("\n\nBreakdown (components sum to the total above):");
+    out.push_str(&format!(
+        "\n  Parent turns: {}",
+        app.format_cost_amount_precise(components.parent_turns)
+    ));
+    if components.subagents > 0.0 {
+        out.push_str(&format!(
+            "\n  Sub-agents: {}",
+            app.format_cost_amount_precise(components.subagents)
+        ));
+    }
+    if components.display_floor > 0.0 {
+        out.push_str(&format!(
+            "\n  Reconciliation floor: {} (monotonic display guarantee, kept after a downward cost reconciliation)",
+            app.format_cost_amount_precise(components.display_floor)
+        ));
+    }
+
+    // Per-route attribution from the per-turn audits that fed the total. The
+    // telemetry ring is bounded, so coverage is stated instead of implied:
+    // itemized turns out of all priced turns, never a claim of completeness.
+    let currency = app.cost_display_currency(app.cost_currency);
+    let mut by_route: std::collections::BTreeMap<String, f64> = std::collections::BTreeMap::new();
+    let mut itemized: u32 = 0;
+    for record in &app.session.turn_cache_history {
+        let Some(audit) = record.cost_audit.as_ref() else {
+            continue;
+        };
+        if !audit.is_priced_in(currency) {
+            continue;
+        }
+        let Some(estimate) = audit.estimate else {
+            continue;
+        };
+        let provider = record.provider_identity.clone().unwrap_or_else(|| {
+            record.provider.map_or_else(
+                || "unknown-provider".to_string(),
+                |p| p.as_str().to_string(),
+            )
+        });
+        let model = record.model.as_deref().unwrap_or("unknown-model");
+        *by_route.entry(format!("{provider}/{model}")).or_insert(0.0) += estimate.amount(currency);
+        itemized = itemized.saturating_add(1);
+    }
+    if !by_route.is_empty() {
+        let (priced, _) = cost_coverage_counts(app);
+        out.push_str(&format!(
+            "\n  Parent-turn spend by route ({itemized} of {priced} priced turns itemized):"
+        ));
+        for (route, amount) in &by_route {
+            out.push_str(&format!(
+                "\n    {route}: {}",
+                app.format_cost_amount_precise(*amount)
+            ));
+        }
+        if itemized < priced {
+            out.push_str(&format!(
+                "\n    (earlier turns not itemized: turn telemetry keeps the last {})",
+                App::TURN_CACHE_HISTORY_CAP
+            ));
+        }
+    }
+    out
 }
 
 fn joined(values: &std::collections::BTreeSet<String>) -> String {
@@ -296,5 +425,162 @@ pub fn context(app: &mut App, arg: Option<&str>) -> CommandResult {
         other => CommandResult::error(format!(
             "Unknown /context subcommand: {other}. Use report, json, prompt-json, or summary."
         )),
+    }
+}
+
+#[cfg(test)]
+mod cost_breakdown_tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::pricing::{CostCurrency, CostEstimate, TurnCostAudit};
+    use crate::tui::app::{TuiOptions, TurnCacheRecord};
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    fn test_app() -> App {
+        let options = TuiOptions {
+            skills_dir: PathBuf::from("/tmp/test-skills"),
+            ..crate::test_support::test_tui_options(PathBuf::from("/tmp/test-workspace"))
+        };
+        let mut app = App::new(options, &Config::default());
+        app.ui_locale = crate::localization::Locale::En;
+        app.cost_currency = CostCurrency::Usd;
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app
+    }
+
+    fn priced_audit(estimate: CostEstimate) -> TurnCostAudit {
+        TurnCostAudit {
+            estimate: Some(estimate),
+            provenance: None,
+            unpriced_classes: Vec::new(),
+            unpriced_reason: None,
+            live_pricing_defect: None,
+            usd_priced: true,
+            cny_priced: estimate.cny > 0.0,
+        }
+    }
+
+    fn turn_record(model: &str, audit: TurnCostAudit) -> TurnCacheRecord {
+        TurnCacheRecord {
+            provider: Some(crate::config::ApiProvider::Deepseek),
+            provider_identity: None,
+            model: Some(model.to_string()),
+            auto_model: false,
+            input_tokens: 100,
+            output_tokens: 10,
+            cache_hit_tokens: None,
+            cache_miss_tokens: None,
+            cache_write_tokens: None,
+            reasoning_tokens: None,
+            cost_audit: Some(audit),
+            reasoning_replay_tokens: None,
+            recorded_at: Instant::now(),
+        }
+    }
+
+    /// The decomposition's terms are exactly the headline's inputs, so their
+    /// sum reproduces the headline — including when the #244 monotonic floor,
+    /// not the live accumulators, is the number on display (#4939).
+    #[test]
+    fn cost_breakdown_components_sum_to_headline() {
+        let mut app = test_app();
+        app.session.cost_priced_turns = 2;
+        app.accrue_session_cost_estimate(CostEstimate {
+            usd: 0.05,
+            cny: 0.0,
+        });
+        app.accrue_subagent_cost_estimate(CostEstimate {
+            usd: 0.02,
+            cny: 0.0,
+        });
+
+        // Live sum is the headline: no floor component.
+        let components = CostComponents::compute(&app);
+        assert_eq!(components.parent_turns, 0.05);
+        assert_eq!(components.subagents, 0.02);
+        assert_eq!(components.display_floor, 0.0);
+        assert_eq!(
+            components.sum(),
+            app.displayed_session_cost_for_currency(CostCurrency::Usd),
+            "components must sum to the /cost headline"
+        );
+
+        // After a downward reconciliation the high-water is the headline; the
+        // difference surfaces as an explicit floor component, and the sum still
+        // reproduces the headline exactly.
+        app.session.displayed_cost_high_water = 0.10;
+        let components = CostComponents::compute(&app);
+        assert!(components.display_floor > 0.0);
+        assert_eq!(
+            components.sum(),
+            app.displayed_session_cost_for_currency(CostCurrency::Usd),
+            "floor component must absorb exactly the high-water excess"
+        );
+
+        let msg = cost(&mut app).message.expect("cost report");
+        assert!(msg.contains("Breakdown"), "{msg}");
+        assert!(msg.contains("Parent turns: $0.0500"), "{msg}");
+        assert!(msg.contains("Sub-agents: $0.0200"), "{msg}");
+        assert!(msg.contains("Reconciliation floor:"), "{msg}");
+    }
+
+    /// Per-route attribution comes from the same `TurnCostAudit`s that fed the
+    /// total, in the display currency; with every priced turn itemized, the
+    /// route amounts account for the whole parent component. CNY amounts are
+    /// the audits' provider-published CNY figures — never an FX projection of
+    /// the USD column (#4939).
+    #[test]
+    fn cost_breakdown_itemizes_routes_from_turn_audits() {
+        let mut app = test_app();
+        app.cost_currency = CostCurrency::Cny;
+        let turns = [
+            CostEstimate {
+                usd: 0.01,
+                cny: 0.07,
+            },
+            CostEstimate {
+                usd: 0.02,
+                cny: 0.14,
+            },
+        ];
+        for estimate in turns {
+            let audit = priced_audit(estimate);
+            app.record_turn_cost_audit(&audit);
+            app.accrue_session_cost_estimate(estimate);
+            app.push_turn_cache_record(turn_record("deepseek-chat", audit));
+        }
+
+        let components = CostComponents::compute(&app);
+        assert_eq!(
+            components.sum(),
+            app.displayed_session_cost_for_currency(CostCurrency::Cny),
+            "CNY components must sum to the CNY headline"
+        );
+
+        let msg = cost(&mut app).message.expect("cost report");
+        assert!(
+            msg.contains("Parent-turn spend by route (2 of 2 priced turns itemized):"),
+            "{msg}"
+        );
+        // 0.07 + 0.14 accumulated in ring order equals the parent component's
+        // accumulation, so the route line shows the whole parent spend.
+        let route_amount = app.format_cost_amount_precise(components.parent_turns);
+        assert!(
+            msg.contains(&format!("deepseek/deepseek-chat: {route_amount}")),
+            "{msg}"
+        );
+        assert!(msg.contains("¥"), "CNY display must use CNY symbol: {msg}");
+    }
+
+    /// An unpriced headline renders no breakdown: decomposing a number that is
+    /// not being shown would fabricate amounts the report just declined to
+    /// claim.
+    #[test]
+    fn cost_breakdown_absent_when_headline_unknown() {
+        let mut app = test_app();
+        let msg = cost(&mut app).message.expect("cost report");
+        assert!(!msg.contains("Breakdown"), "{msg}");
+        assert!(!msg.contains("Parent turns:"), "{msg}");
     }
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -9055,6 +9055,33 @@ impl SavedCredential {
     }
 }
 
+/// Resolve the config document for CREDENTIAL writes: api_key values,
+/// `auth_mode` markers, and oauth/external-credential pointers.
+///
+/// Credentials are user-global — a key saved while working in one repo must be
+/// visible from every other repo (#5045). The ambient
+/// `CODEWHALE_CONFIG_PATH`/`DEEPSEEK_CONFIG_PATH` override can point at a
+/// workspace-scoped document (`<repo>/.codewhale/config.toml`, plaintext and
+/// easy to commit by accident), so credential writes that would land there are
+/// rescoped to the user-global config instead. Non-credential settings keep
+/// the ambient scoping, and callers that pass an explicit config path never
+/// consult this resolver.
+fn credential_config_path() -> Option<PathBuf> {
+    let resolved = default_config_path()?;
+    if !codewhale_config::config_path_is_workspace_scoped(&resolved) {
+        return Some(resolved);
+    }
+    let global = home_config_path();
+    if let Some(global) = global.as_ref() {
+        tracing::info!(
+            ambient = %resolved.display(),
+            global = %global.display(),
+            "rescoping credential write from workspace config to user-global config"
+        );
+    }
+    global
+}
+
 /// Save the active provider's API key.
 ///
 /// The selected durable secret backend is attempted first. On success the
@@ -9080,7 +9107,7 @@ fn save_root_api_key_for_secret_slot(
         anyhow::bail!("Refusing to save an empty API key.");
     }
 
-    let path = default_config_path()
+    let path = credential_config_path()
         .context("Failed to resolve config path: home directory not found.")?;
 
     if let Some(secrets) = credential_secret_store_for_save() {
@@ -9191,7 +9218,7 @@ fn save_root_api_key_metadata_without_plaintext(
 
 /// Write the `api_key` slot directly to `config.toml`.
 fn save_api_key_to_config_file(api_key: &str) -> Result<PathBuf> {
-    let config_path = default_config_path()
+    let config_path = credential_config_path()
         .context("Failed to resolve config path: home directory not found.")?;
 
     ensure_parent_dir(&config_path)?;
@@ -9646,7 +9673,7 @@ fn save_api_key_for_identity_unlocked(
     let api_key = api_key.trim();
     anyhow::ensure!(!api_key.is_empty(), "Refusing to save an empty API key.");
 
-    let config_path = default_config_path()
+    let config_path = credential_config_path()
         .context("Failed to resolve config path: home directory not found.")?;
     ensure_parent_dir(&config_path)?;
 
@@ -9952,7 +9979,7 @@ pub(crate) fn persist_external_credential_consent_for_at(
     )?;
     let config_path = match config_path {
         Some(path) => path.to_path_buf(),
-        None => default_config_path()
+        None => credential_config_path()
             .context("Failed to resolve config path: home directory not found.")?,
     };
     ensure_parent_dir(&config_path)?;
@@ -10022,7 +10049,7 @@ pub(crate) fn revoke_external_credential_consent_for_at(
     );
     let config_path = match config_path {
         Some(path) => path.to_path_buf(),
-        None => default_config_path()
+        None => credential_config_path()
             .context("Failed to resolve config path: home directory not found.")?,
     };
     ensure_parent_dir(&config_path)?;
@@ -10196,8 +10223,9 @@ pub fn clear_api_key() -> Result<()> {
 fn clear_api_key_unlocked() -> Result<()> {
     // Strip api_key entries from config.toml, including provider-scoped
     // nested entries. Clearing a config file must not trigger platform
-    // credential prompts.
-    let config_path = default_config_path()
+    // credential prompts. Clears target the same user-global document that
+    // credential saves write, so logout removes what login stored (#5045).
+    let config_path = credential_config_path()
         .context("Failed to resolve config path: home directory not found.")?;
 
     if !config_path.exists() {
@@ -10244,7 +10272,7 @@ pub fn clear_active_provider_api_key(provider: &str) -> Result<()> {
 }
 
 fn clear_active_provider_api_key_unlocked(provider: &str) -> Result<()> {
-    let config_path = default_config_path()
+    let config_path = credential_config_path()
         .context("Failed to resolve config path: home directory not found.")?;
 
     if !config_path.exists() {
@@ -10318,3 +10346,101 @@ fn clear_active_provider_api_key_unlocked(provider: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests;
+
+/// #5045 regression coverage: credential writes must never land in a
+/// workspace-scoped `.codewhale/config.toml`.
+#[cfg(test)]
+mod credential_scope_tests {
+    use super::*;
+    use crate::test_support::{EnvVarGuard, lock_test_env};
+
+    /// With the ambient config path pointing at a workspace-local
+    /// `.codewhale/config.toml` (a checkout the user works in), saving an
+    /// API key must write the user-global config under the isolated
+    /// `CODEWHALE_HOME`, never the project file. The `.git` marker stands in
+    /// for cwd-inside-the-workspace: chdir is process-global and unsafe in a
+    /// parallel test binary, and production classifies on either signal.
+    #[test]
+    fn api_key_save_rescopes_workspace_config_to_user_global() -> Result<()> {
+        let _lock = lock_test_env();
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("repo");
+        fs::create_dir_all(workspace.join(".git"))?;
+        let project_dir = workspace.join(".codewhale");
+        fs::create_dir_all(&project_dir)?;
+        let project_config = project_dir.join("config.toml");
+        fs::write(&project_config, "approval_policy = \"never\"\n")?;
+
+        let user_home = temp.path().join("user-global-home");
+        let _home = EnvVarGuard::set("CODEWHALE_HOME", user_home.as_os_str());
+        let _config = EnvVarGuard::set("CODEWHALE_CONFIG_PATH", project_config.as_os_str());
+        let _legacy_config = EnvVarGuard::remove("DEEPSEEK_CONFIG_PATH");
+        // No explicit secret backend: under cfg(test) the save takes the
+        // plaintext config-file path, which is exactly the surface this
+        // regression guards.
+        let _backend = EnvVarGuard::remove("CODEWHALE_SECRET_BACKEND");
+        let _legacy_backend = EnvVarGuard::remove("DEEPSEEK_SECRET_BACKEND");
+
+        let saved = save_api_key("workspace-rescope-test-key")?;
+
+        let global_config = user_home.join("config.toml");
+        assert_eq!(
+            saved,
+            SavedCredential::ConfigFile(global_config.clone()),
+            "credential save must surface the user-global destination"
+        );
+        let global = fs::read_to_string(&global_config)?;
+        assert!(
+            global.contains("workspace-rescope-test-key"),
+            "user-global config must hold the saved key: {global}"
+        );
+        let project = fs::read_to_string(&project_config)?;
+        assert!(
+            !project.contains("workspace-rescope-test-key"),
+            "credential leaked into workspace config: {project}"
+        );
+        assert!(
+            !project.contains("api_key"),
+            "workspace config must stay credential-free: {project}"
+        );
+        Ok(())
+    }
+
+    /// Provider-table saves go through the same resolver: an OpenRouter key
+    /// saved with a workspace-scoped ambient config path must land in the
+    /// user-global document.
+    #[test]
+    fn provider_api_key_save_rescopes_workspace_config_to_user_global() -> Result<()> {
+        let _lock = lock_test_env();
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("repo");
+        fs::create_dir_all(workspace.join(".git"))?;
+        let project_dir = workspace.join(".codewhale");
+        fs::create_dir_all(&project_dir)?;
+        let project_config = project_dir.join("config.toml");
+        fs::write(&project_config, "approval_policy = \"never\"\n")?;
+
+        let user_home = temp.path().join("user-global-home");
+        let _home = EnvVarGuard::set("CODEWHALE_HOME", user_home.as_os_str());
+        let _config = EnvVarGuard::set("CODEWHALE_CONFIG_PATH", project_config.as_os_str());
+        let _legacy_config = EnvVarGuard::remove("DEEPSEEK_CONFIG_PATH");
+        let _backend = EnvVarGuard::remove("CODEWHALE_SECRET_BACKEND");
+        let _legacy_backend = EnvVarGuard::remove("DEEPSEEK_SECRET_BACKEND");
+
+        let path = save_api_key_for(ApiProvider::Openrouter, "workspace-rescope-openrouter-key")?;
+
+        assert_eq!(
+            path,
+            user_home.join("config.toml"),
+            "provider save must report the user-global destination"
+        );
+        let global = fs::read_to_string(&path)?;
+        assert!(global.contains("workspace-rescope-openrouter-key"));
+        let project = fs::read_to_string(&project_config)?;
+        assert!(
+            !project.contains("workspace-rescope-openrouter-key"),
+            "credential leaked into workspace config: {project}"
+        );
+        Ok(())
+    }
+}

--- a/crates/tui/src/sandbox/seatbelt.rs
+++ b/crates/tui/src/sandbox/seatbelt.rs
@@ -94,6 +94,29 @@ const SEATBELT_NETWORK_POLICY: &str = r"
 (allow network-bind)
 ";
 
+/// AppleEvents/LaunchServices allowances for the trusted (full-disk-write)
+/// tier only (#4828).
+///
+/// `open`, `osascript`, and `launchctl` send AppleEvents and drive
+/// LaunchServices; under `(deny default)` those calls die with exit -54.
+/// The base policy already allows `mach-lookup` broadly, so the missing
+/// operations are `appleevent-send` and the LaunchServices `lsopen`
+/// operation. The launchservicesd/appleevents mach names are listed
+/// explicitly so a future narrowing of the blanket `mach-lookup` rule
+/// cannot silently break this tier.
+///
+/// Restrictive tiers (workspace-write, read-only) intentionally stay locked
+/// down: AppleEvents automation can instruct other apps to act outside the
+/// sandbox, which would defeat the write restrictions.
+const SEATBELT_TRUSTED_AUTOMATION_POLICY: &str = r#"
+; AppleEvents + LaunchServices (trusted full-access tier only)
+(allow appleevent-send)
+(allow lsopen)
+(allow mach-lookup
+  (global-name "com.apple.coreservices.launchservicesd")
+  (global-name "com.apple.coreservices.appleevents"))
+"#;
+
 /// Check if sandbox-exec is available and permitted on this system.
 pub fn is_available() -> bool {
     static SEATBELT_AVAILABLE: OnceLock<bool> = OnceLock::new();
@@ -160,6 +183,16 @@ fn generate_policy(policy: &SandboxPolicy, cwd: &Path) -> String {
     if policy.has_network_access() {
         full_policy.push('\n');
         full_policy.push_str(SEATBELT_NETWORK_POLICY);
+    }
+
+    // Trusted tier (#4828): full-disk-write policies also get AppleEvents +
+    // LaunchServices so `open`/`osascript`/`launchctl` work when a
+    // full-access policy is still routed through seatbelt (e.g. a forced
+    // sandbox); in the normal flow danger-full-access bypasses the wrap
+    // entirely via `should_sandbox()`.
+    if policy.has_full_disk_write_access() {
+        full_policy.push('\n');
+        full_policy.push_str(SEATBELT_TRUSTED_AUTOMATION_POLICY);
     }
 
     // Add Darwin user cache directory access (needed by many macOS tools)
@@ -664,6 +697,89 @@ mod existing_tests {
         // Should end with the original command
         assert!(args.contains(&"echo".to_string()));
         assert!(args.contains(&"hello".to_string()));
+    }
+
+    /// #4828: `open`/`osascript`/`launchctl` die with exit -54 under
+    /// `(deny default)` because AppleEvent sends and the LaunchServices
+    /// `lsopen` operation are blocked. Only the trusted (full-disk-write)
+    /// tier gains those allowances; the restrictive tiers must stay locked
+    /// down since AppleEvents automation can drive other apps to act
+    /// outside the sandbox.
+    #[test]
+    fn test_apple_events_allowed_only_in_trusted_tier() {
+        let cwd = Path::new("/tmp/test");
+
+        let trusted = generate_policy(&SandboxPolicy::DangerFullAccess, cwd);
+        assert!(
+            trusted.contains("(allow appleevent-send)"),
+            "trusted tier must allow AppleEvent sends: {trusted}"
+        );
+        assert!(
+            trusted.contains("(allow lsopen)"),
+            "trusted tier must allow LaunchServices lsopen: {trusted}"
+        );
+        assert!(
+            trusted.contains(r#"(global-name "com.apple.coreservices.launchservicesd")"#),
+            "trusted tier must pin the launchservicesd mach name: {trusted}"
+        );
+        assert!(
+            trusted.contains(r#"(global-name "com.apple.coreservices.appleevents")"#),
+            "trusted tier must pin the appleevents mach name: {trusted}"
+        );
+
+        for (name, restrictive) in [
+            (
+                "workspace-write",
+                generate_policy(&SandboxPolicy::default(), cwd),
+            ),
+            (
+                "workspace-write+network",
+                generate_policy(&SandboxPolicy::workspace_with_network(), cwd),
+            ),
+            ("read-only", generate_policy(&SandboxPolicy::ReadOnly, cwd)),
+        ] {
+            assert!(
+                !restrictive.contains("appleevent-send"),
+                "{name} tier must NOT allow AppleEvent sends: {restrictive}"
+            );
+            assert!(
+                !restrictive.contains("lsopen"),
+                "{name} tier must NOT allow LaunchServices lsopen: {restrictive}"
+            );
+        }
+    }
+
+    /// #4828: the trusted-tier policy (with the AppleEvents/LaunchServices
+    /// additions) must still be a valid SBPL profile that sandbox-exec
+    /// accepts.
+    #[test]
+    fn test_trusted_tier_policy_parses_under_sandbox_exec() {
+        // generate_policy/generate_params both read HOME/CARGO_HOME; take the
+        // env lock so sibling tests mutating those vars can't desync the
+        // policy text from its -DKEY=VALUE params mid-call.
+        let _guard = crate::test_support::lock_test_env();
+
+        assert!(
+            is_available(),
+            "UNRUN: macOS sandbox-exec is unavailable; generated policy was not parsed"
+        );
+
+        let cwd = std::env::temp_dir();
+        let args = create_seatbelt_args(
+            vec!["/usr/bin/true".to_string()],
+            &SandboxPolicy::DangerFullAccess,
+            &cwd,
+        );
+        let output = Command::new(SANDBOX_EXEC_PATH)
+            .args(args)
+            .current_dir(&cwd)
+            .output()
+            .expect("run sandbox-exec with trusted-tier policy");
+        assert!(
+            output.status.success(),
+            "sandbox-exec rejected the trusted-tier policy: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     #[test]

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -17,7 +17,7 @@ use crate::utils::write_atomic;
 use crate::work_graph::ReasoningEffortTier;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
@@ -242,6 +242,24 @@ fn live_session_conflict(session_id: &str) -> std::io::Error {
     )
 }
 
+/// File-name stem of the sidecar mapping session ids to the session
+/// instance (process boot) that created their persisted record. Lives in
+/// the sessions directory next to the `<id>.json` records it describes.
+const SESSION_BOOT_OWNERS_STEM: &str = "session_boot_owners";
+
+static SESSION_BOOT_ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Identity of this running session instance (one per process boot).
+///
+/// Mirrors the `SubAgentManager` boot id from #405: persisted records are
+/// stamped with the instance that created them, so a later Codewhale
+/// instance in the same workspace can tell restored rows from its own live
+/// work (#4416).
+#[must_use]
+pub fn current_session_boot_id() -> &'static str {
+    SESSION_BOOT_ID.get_or_init(|| format!("boot_{}", &Uuid::new_v4().to_string()[..12]))
+}
+
 /// Which archive states a session listing includes.
 ///
 /// Deliberately the same three-way shape as
@@ -369,30 +387,38 @@ pub struct SessionCostSnapshot {
 }
 
 impl SessionCostSnapshot {
-    /// Session + subagent cost in USD.
-    pub fn total_usd(&self) -> f64 {
+    /// Session + subagent spend as **one** dual-currency accumulator.
+    ///
+    /// The persisted USD and CNY columns are projections of per-turn
+    /// [`crate::pricing::CostEstimate`]s that were accumulated jointly; every
+    /// display total is derived from this single fold so the two currencies
+    /// cannot be re-summed by separate code paths that then drift (#4939).
+    /// CNY is *not* an FX multiple of USD: a turn carries CNY only when its
+    /// route published an authoritative CNY row (provider-published
+    /// dual-currency pricing, e.g. DeepSeek's CNY table), and a USD-only turn
+    /// contributes exactly zero CNY while `cny_unpriced_turns` records the gap.
+    #[must_use]
+    pub fn total_estimate(&self) -> crate::pricing::CostEstimate {
         crate::pricing::CostEstimate {
             usd: self.session_cost_usd,
-            cny: 0.0,
+            cny: self.session_cost_cny,
         }
         .saturating_add(crate::pricing::CostEstimate {
             usd: self.subagent_cost_usd,
-            cny: 0.0,
+            cny: self.subagent_cost_cny,
         })
-        .usd
+    }
+
+    /// Session + subagent cost in USD.
+    pub fn total_usd(&self) -> f64 {
+        self.total_estimate()
+            .amount(crate::pricing::CostCurrency::Usd)
     }
 
     /// Session + subagent cost in CNY.
     pub fn total_cny(&self) -> f64 {
-        crate::pricing::CostEstimate {
-            usd: 0.0,
-            cny: self.session_cost_cny,
-        }
-        .saturating_add(crate::pricing::CostEstimate {
-            usd: 0.0,
-            cny: self.subagent_cost_cny,
-        })
-        .cny
+        self.total_estimate()
+            .amount(crate::pricing::CostCurrency::Cny)
     }
 
     /// Whether this snapshot's coverage state must be shown as unknown.
@@ -539,6 +565,12 @@ impl SessionManager {
                 format!("Invalid session id '{id}'"),
             ));
         }
+        if trimmed == SESSION_BOOT_OWNERS_STEM {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Session id '{trimmed}' collides with a reserved sessions file"),
+            ));
+        }
         Ok(trimmed)
     }
 
@@ -587,6 +619,10 @@ impl SessionManager {
     /// Save a session to disk using atomic write (temp file + fsync + rename).
     pub fn save_session(&self, session: &SavedSession) -> std::io::Result<PathBuf> {
         let path = self.validated_session_path(&session.metadata.id)?;
+        let already_persisted = path.exists()
+            || self
+                .validated_checkpoint_path(&session.metadata.id)
+                .is_ok_and(|checkpoint| checkpoint.exists());
 
         self.archive_before_first_graph_write(session, &path)?;
 
@@ -595,6 +631,7 @@ impl SessionManager {
 
         // Atomic write via write_atomic (NamedTempFile + fsync + persist)
         write_atomic(&path, content.as_bytes())?;
+        self.stamp_session_boot_owner_for_new_record(&session.metadata.id, already_persisted);
 
         // Clean up old sessions if we have too many
         self.cleanup_old_sessions()?;
@@ -611,10 +648,101 @@ impl SessionManager {
         let session_path = self.validated_session_path(&session.metadata.id)?;
         self.archive_before_first_graph_write(session, &session_path)?;
         fs::create_dir_all(self.checkpoints_dir())?;
+        let already_persisted = path.exists() || session_path.exists();
         let content = serde_json::to_string_pretty(&session)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         write_atomic(&path, content.as_bytes())?;
+        self.stamp_session_boot_owner_for_new_record(&session.metadata.id, already_persisted);
         Ok(path)
+    }
+
+    fn session_boot_owners_path(&self) -> PathBuf {
+        self.sessions_dir
+            .join(format!("{SESSION_BOOT_OWNERS_STEM}.json"))
+    }
+
+    fn load_session_boot_owners(&self) -> BTreeMap<String, String> {
+        fs::read_to_string(self.session_boot_owners_path())
+            .ok()
+            .and_then(|content| serde_json::from_str(&content).ok())
+            .unwrap_or_default()
+    }
+
+    /// Does any durable record (session file or crash checkpoint) exist for
+    /// this session id?
+    fn session_record_exists(&self, session_id: &str) -> bool {
+        self.validated_session_path(session_id)
+            .is_ok_and(|path| path.exists())
+            || self
+                .validated_checkpoint_path(session_id)
+                .is_ok_and(|path| path.exists())
+    }
+
+    /// Record which session instance owns `session_id`'s persisted record.
+    ///
+    /// Entries whose durable record no longer exists are pruned on the same
+    /// write, so the sidecar cannot grow without bound.
+    pub(crate) fn record_session_boot_owner(
+        &self,
+        session_id: &str,
+        boot_id: &str,
+    ) -> std::io::Result<()> {
+        let id = self.validated_session_id(session_id)?.to_string();
+        let mut owners = self.load_session_boot_owners();
+        owners.retain(|owned, _| owned == &id || self.session_record_exists(owned));
+        owners.insert(id, boot_id.to_string());
+        let content = serde_json::to_string_pretty(&owners)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        write_atomic(&self.session_boot_owners_path(), content.as_bytes())
+    }
+
+    /// The session-instance boot id stamped on this session's persisted
+    /// record, when one was recorded.
+    #[must_use]
+    pub fn session_boot_owner(&self, session_id: &str) -> Option<String> {
+        let id = self.validated_session_id(session_id).ok()?;
+        self.load_session_boot_owners().get(id).cloned()
+    }
+
+    /// Was this session's persisted record created by a different session
+    /// instance (an earlier or sibling Codewhale process)?
+    ///
+    /// Mirrors `SubAgentManager::is_from_prior_session` (#405): a durable
+    /// record with no stamped owner predates the marker and is classified as
+    /// prior-instance work, while an id with no durable record at all is
+    /// this instance's own not-yet-persisted session.
+    #[must_use]
+    pub fn session_from_prior_instance(&self, session_id: &str) -> bool {
+        match self.session_boot_owner(session_id) {
+            Some(owner) => owner != current_session_boot_id(),
+            None => self.session_record_exists(session_id),
+        }
+    }
+
+    /// Stamp this instance as creator when a save writes the first durable
+    /// record for `session_id`. A record that already existed keeps its
+    /// original owner: re-serializing another instance's work (crash
+    /// recovery, external mutation) must not re-badge it as ours.
+    fn stamp_session_boot_owner_for_new_record(&self, session_id: &str, already_persisted: bool) {
+        if already_persisted || self.session_boot_owner(session_id).is_some() {
+            return;
+        }
+        if let Err(error) = self.record_session_boot_owner(session_id, current_session_boot_id()) {
+            tracing::warn!(session_id, %error, "could not stamp session boot owner");
+        }
+    }
+
+    fn clear_session_boot_owner(&self, session_id: &str) {
+        let Ok(id) = self.validated_session_id(session_id) else {
+            return;
+        };
+        let mut owners = self.load_session_boot_owners();
+        if owners.remove(id).is_none() {
+            return;
+        }
+        if let Ok(content) = serde_json::to_string_pretty(&owners) {
+            let _ = write_atomic(&self.session_boot_owners_path(), content.as_bytes());
+        }
     }
 
     /// Preserve the exact pre-import session once, before the first graph-
@@ -1033,6 +1161,7 @@ impl SessionManager {
     pub fn delete_session(&self, id: &str) -> std::io::Result<()> {
         let path = self.validated_session_path(id)?;
         fs::remove_file(path)?;
+        self.clear_session_boot_owner(id);
         let session_dir = self.sessions_dir.join(id.trim());
         if session_dir.exists() {
             fs::remove_dir_all(session_dir)?;
@@ -1793,6 +1922,119 @@ mod tests {
         }
     }
 
+    /// The USD and CNY totals a snapshot reports are projections of one
+    /// dual-currency accumulation, never two independent sums that could
+    /// disagree (#4939).
+    ///
+    /// For any turn sequence — dual-priced, USD-only, CNY-only, or garbage
+    /// estimates — folding the turns jointly and projecting each currency must
+    /// equal accumulating that currency on its own. This is the invariant that
+    /// makes the persisted per-currency columns safe: they are written from the
+    /// same joint fold, so a code path can no longer update one and forget the
+    /// other. CNY is derived from provider-published CNY rows, not from an FX
+    /// multiple of USD, so a USD-only turn must contribute exactly zero CNY.
+    #[test]
+    fn cost_snapshot_currency_totals_are_projections_of_one_accumulator() {
+        use crate::pricing::CostEstimate;
+
+        let turn_sequences: &[&[CostEstimate]] = &[
+            // Dual-priced turns (DeepSeek-style routes with a published CNY row).
+            &[
+                CostEstimate {
+                    usd: 0.01,
+                    cny: 0.07,
+                },
+                CostEstimate {
+                    usd: 0.02,
+                    cny: 0.14,
+                },
+            ],
+            // USD-only turns: CNY unpublished, so the CNY projection stays zero.
+            &[
+                CostEstimate {
+                    usd: 0.25,
+                    cny: 0.0,
+                },
+                CostEstimate { usd: 1.5, cny: 0.0 },
+            ],
+            // Mixed: one currency priced per turn, alternating.
+            &[
+                CostEstimate { usd: 0.5, cny: 0.0 },
+                CostEstimate { usd: 0.0, cny: 3.5 },
+                CostEstimate {
+                    usd: 0.125,
+                    cny: 0.875,
+                },
+            ],
+            // Hostile values: sanitization must apply identically per currency.
+            &[
+                CostEstimate {
+                    usd: f64::NAN,
+                    cny: 0.25,
+                },
+                CostEstimate {
+                    usd: 0.75,
+                    cny: -1.0,
+                },
+                CostEstimate {
+                    usd: f64::INFINITY,
+                    cny: 0.25,
+                },
+            ],
+        ];
+
+        for turns in turn_sequences {
+            // Joint fold: how the app accumulates (one accumulator, both
+            // currencies advance together through the same saturating_add).
+            let joint = turns.iter().fold(CostEstimate::default(), |acc, turn| {
+                acc.saturating_add(*turn)
+            });
+
+            // Independent per-currency folds: what a drifted parallel
+            // accumulator would compute if it only saw one currency.
+            let usd_alone = turns.iter().fold(CostEstimate::default(), |acc, turn| {
+                acc.saturating_add(CostEstimate {
+                    usd: turn.usd,
+                    cny: 0.0,
+                })
+            });
+            let cny_alone = turns.iter().fold(CostEstimate::default(), |acc, turn| {
+                acc.saturating_add(CostEstimate {
+                    usd: 0.0,
+                    cny: turn.cny,
+                })
+            });
+
+            let snapshot = SessionCostSnapshot {
+                session_cost_usd: joint.usd,
+                session_cost_cny: joint.cny,
+                ..SessionCostSnapshot::default()
+            };
+            assert_eq!(
+                snapshot.total_usd(),
+                usd_alone.usd,
+                "USD projection drifted from independent accumulation for {turns:?}"
+            );
+            assert_eq!(
+                snapshot.total_cny(),
+                cny_alone.cny,
+                "CNY projection drifted from independent accumulation for {turns:?}"
+            );
+            assert_eq!(snapshot.total_estimate().usd, snapshot.total_usd());
+            assert_eq!(snapshot.total_estimate().cny, snapshot.total_cny());
+        }
+
+        // A USD-only session projects zero CNY — no fabricated FX conversion —
+        // and the subagent column joins the same fold.
+        let usd_only = SessionCostSnapshot {
+            session_cost_usd: 2.5,
+            subagent_cost_usd: 0.5,
+            ..SessionCostSnapshot::default()
+        };
+        assert_eq!(usd_only.total_usd(), 3.0);
+        assert_eq!(usd_only.total_cny(), 0.0);
+    }
+
     fn write_session_record(
         manager: &SessionManager,
         id: &str,
@@ -1866,6 +2108,64 @@ mod tests {
     }
 
     #[test]
+    fn session_boot_owner_stamps_only_the_creating_instance() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().to_path_buf()).expect("manager");
+        let workspace = tmp.path().join("ws");
+
+        // A record this instance creates is stamped with this boot id and is
+        // therefore not prior-instance work.
+        write_session_record(&manager, "mine", &workspace, Utc::now());
+        assert_eq!(
+            manager.session_boot_owner("mine").as_deref(),
+            Some(current_session_boot_id())
+        );
+        assert!(!manager.session_from_prior_instance("mine"));
+
+        // An id with no durable record at all is this instance's own
+        // not-yet-persisted session.
+        assert!(!manager.session_from_prior_instance("unsaved"));
+
+        // A record stamped by another boot id stays owned by that instance,
+        // even after this instance re-serializes it (crash recovery must not
+        // re-badge restored work as ours).
+        manager
+            .record_session_boot_owner("theirs", "boot_other_instance")
+            .expect("stamp");
+        write_session_record(&manager, "theirs", &workspace, Utc::now());
+        assert_eq!(
+            manager.session_boot_owner("theirs").as_deref(),
+            Some("boot_other_instance")
+        );
+        assert!(manager.session_from_prior_instance("theirs"));
+
+        // A legacy record with no marker is classified as prior-instance
+        // work, and a later re-save keeps it unclaimed.
+        write_session_record(&manager, "legacy", &workspace, Utc::now());
+        manager.clear_session_boot_owner("legacy");
+        assert!(manager.session_from_prior_instance("legacy"));
+        write_session_record(&manager, "legacy", &workspace, Utc::now());
+        assert!(manager.session_from_prior_instance("legacy"));
+
+        // Deleting the record drops its marker.
+        manager.delete_session("theirs").expect("delete");
+        assert_eq!(manager.session_boot_owner("theirs"), None);
+    }
+
+    #[test]
+    fn session_boot_owner_sidecar_never_lists_as_a_session() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().to_path_buf()).expect("manager");
+        write_session_record(&manager, "real", &tmp.path().join("ws"), Utc::now());
+        assert!(manager.session_boot_owners_path().exists());
+        let listed = manager.list_sessions().expect("list");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, "real");
+        // The reserved stem cannot be claimed as a session id either.
+        assert!(manager.load_session("session_boot_owners").is_err());
+    }
+
+    #[test]
     fn test_session_manager_new() {
         let tmp = tempdir().expect("tempdir");
         let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
@@ -1891,6 +2191,84 @@ mod tests {
         let loaded = manager.load_session(&session_id).expect("load");
         assert_eq!(loaded.metadata.id, session_id);
         assert_eq!(loaded.messages.len(), 2);
+    }
+
+    /// #4681: reopening a session must not surface `<turn_meta>` machine
+    /// blocks in the transcript. Covers the current trailing shape and the
+    /// legacy leading shape (sessions saved before the turn-meta tail move),
+    /// while the loaded API history keeps both envelopes intact for replay.
+    #[test]
+    fn rehydrated_turn_meta_blocks_never_render_in_history_cells() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+
+        let turn_meta = "<turn_meta>\nCurrent local date: 2026-08-01\n</turn_meta>";
+        let trailing_shape = Message {
+            role: "user".to_string(),
+            content: vec![
+                ContentBlock::Text {
+                    text: "Fix the flaky test".to_string(),
+                    cache_control: None,
+                },
+                ContentBlock::Text {
+                    text: turn_meta.to_string(),
+                    cache_control: None,
+                },
+            ],
+        };
+        let legacy_leading_shape = Message {
+            role: "user".to_string(),
+            content: vec![
+                ContentBlock::Text {
+                    text: turn_meta.to_string(),
+                    cache_control: None,
+                },
+                ContentBlock::Text {
+                    text: "Now add the docs".to_string(),
+                    cache_control: None,
+                },
+            ],
+        };
+        let messages = vec![
+            trailing_shape,
+            make_test_message("assistant", "Done."),
+            legacy_leading_shape,
+        ];
+        let session = create_saved_session(&messages, "test-model", tmp.path(), 100, None);
+        let session_id = session.metadata.id.clone();
+        manager.save_session(&session).expect("save");
+
+        let loaded = manager.load_session(&session_id).expect("load");
+
+        // Display path: no rendered cell may carry turn_meta markup.
+        let rendered: Vec<HistoryCell> = loaded
+            .messages
+            .iter()
+            .flat_map(history_cells_from_message)
+            .collect();
+        let user_texts: Vec<&str> = rendered
+            .iter()
+            .filter_map(|cell| match cell {
+                HistoryCell::User { content } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(user_texts, vec!["Fix the flaky test", "Now add the docs"]);
+        assert!(
+            !user_texts.iter().any(|text| text.contains("<turn_meta")),
+            "rendered cells must not contain turn_meta markup: {user_texts:?}"
+        );
+
+        // Model-facing replay: the persisted envelopes survive the round trip.
+        let replayed_envelopes = loaded
+            .messages
+            .iter()
+            .flat_map(|message| &message.content)
+            .filter(|block| {
+                matches!(block, ContentBlock::Text { text, .. } if text.contains("<turn_meta>"))
+            })
+            .count();
+        assert_eq!(replayed_envelopes, 2);
     }
 
     #[test]

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -59,6 +59,11 @@ const WORKFLOW_HANDOFF_MAX_CHARS: usize = 4_000;
 const WORKFLOW_RESULT_EVENTS_TAIL: usize = 50;
 /// Bounded tail for free-form progress lines in model-facing payloads.
 const WORKFLOW_RESULT_PROGRESS_TAIL: usize = 20;
+/// Bounded tail for rejected child dispatches in the model-facing payload.
+/// The durable run journal retains the complete failure ledger.
+const WORKFLOW_RESULT_DISPATCH_FAILURES_TAIL: usize = 12;
+/// Per-field cap for one model-facing dispatch-failure receipt.
+const WORKFLOW_RESULT_DISPATCH_FAILURE_FIELD_MAX_CHARS: usize = 320;
 /// Char cap for the VM `result` / `verification` values in model-facing
 /// payloads (matches the handoff compaction budget); oversized values
 /// collapse to a preview plus a journal pointer.
@@ -1848,6 +1853,8 @@ fn workflow_result_for(
         "event_count": summary.event_count,
         "events_returned": bounds.events_returned,
         "events_omitted": bounds.events_omitted,
+        "dispatch_failures_returned": bounds.dispatch_failures_returned,
+        "dispatch_failures_omitted": bounds.dispatch_failures_omitted,
         "events_dropped": summary.events_dropped,
         "last_event_type": summary.last_event_type,
         "leaf_count": summary.leaf_count,
@@ -1873,6 +1880,9 @@ struct RunPayloadBounds {
     events_returned: usize,
     events_omitted: usize,
     progress_omitted: usize,
+    dispatch_failures_returned: usize,
+    dispatch_failures_omitted: usize,
+    dispatch_failure_fields_truncated: usize,
     result_truncated: bool,
     leaf_outputs_truncated: usize,
 }
@@ -1881,6 +1891,8 @@ impl RunPayloadBounds {
     fn truncated(&self) -> bool {
         self.events_omitted > 0
             || self.progress_omitted > 0
+            || self.dispatch_failures_omitted > 0
+            || self.dispatch_failure_fields_truncated > 0
             || self.result_truncated
             || self.leaf_outputs_truncated > 0
     }
@@ -1892,6 +1904,8 @@ impl RunPayloadBounds {
 ///
 /// - `events`: newest `WORKFLOW_RESULT_EVENTS_TAIL` entries.
 /// - `progress`: newest `WORKFLOW_RESULT_PROGRESS_TAIL` lines.
+/// - `dispatch_failures`: newest `WORKFLOW_RESULT_DISPATCH_FAILURES_TAIL`
+///   entries with bounded string fields.
 /// - `result` / `verification`: collapsed to a preview + journal pointer
 ///   when the serialized value exceeds `WORKFLOW_RESULT_VALUE_MAX_CHARS`.
 /// - `execution.leaf_results[*].output`: per-leaf preview capped at
@@ -1940,6 +1954,48 @@ fn bounded_run_record_value(
             json!(format!(
                 "showing the newest {WORKFLOW_RESULT_PROGRESS_TAIL} of {} progress lines; full log: {journal}",
                 omitted + WORKFLOW_RESULT_PROGRESS_TAIL,
+            )),
+        );
+    }
+
+    if let Some(failures) = obj
+        .get_mut("dispatch_failures")
+        .and_then(Value::as_array_mut)
+    {
+        if failures.len() > WORKFLOW_RESULT_DISPATCH_FAILURES_TAIL {
+            let omitted = failures.len() - WORKFLOW_RESULT_DISPATCH_FAILURES_TAIL;
+            failures.drain(..omitted);
+            bounds.dispatch_failures_omitted = omitted;
+        }
+        bounds.dispatch_failures_returned = failures.len();
+        for failure in failures {
+            let Some(fields) = failure.as_object_mut() else {
+                continue;
+            };
+            for key in ["label", "phase", "message"] {
+                let Some(slot) = fields.get_mut(key) else {
+                    continue;
+                };
+                let Some(raw) = slot.as_str() else {
+                    continue;
+                };
+                if raw.chars().count() > WORKFLOW_RESULT_DISPATCH_FAILURE_FIELD_MAX_CHARS {
+                    *slot = Value::String(truncate_chars(
+                        raw,
+                        WORKFLOW_RESULT_DISPATCH_FAILURE_FIELD_MAX_CHARS,
+                    ));
+                    bounds.dispatch_failure_fields_truncated += 1;
+                }
+            }
+        }
+    }
+    if bounds.dispatch_failures_omitted > 0 || bounds.dispatch_failure_fields_truncated > 0 {
+        obj.insert(
+            "dispatch_failures_note".to_string(),
+            json!(format!(
+                "showing {} of {} dispatch failures with bounded fields; full ledger: {journal}",
+                bounds.dispatch_failures_returned,
+                bounds.dispatch_failures_returned + bounds.dispatch_failures_omitted,
             )),
         );
     }
@@ -6906,6 +6962,10 @@ export default workflow({
             typo.contains("worker, scout, planner, reviewer, builder"),
             "{typo}"
         );
+        assert!(
+            typo.contains("consultant/oracle/advisor"),
+            "accepted advisory aliases must remain visible in the guidance: {typo}"
+        );
 
         // `custom` is Agent-only; the rejection says why and what to use.
         let custom = parse_plan_agent_type(Some("custom"))
@@ -9267,6 +9327,14 @@ FINAL RECEIPT
         for index in 0..60 {
             record.progress.push(format!("progress line {index}"));
         }
+        for index in 0..40u64 {
+            record.dispatch_failures.push(WorkflowDispatchFailure {
+                at_ms: index,
+                label: Some(format!("rejected-{index}")),
+                phase: Some("fan-out".to_string()),
+                message: format!("dispatch rejected {index}: {}", "x".repeat(2_000)),
+            });
+        }
         record.result = Some(json!({ "blob": "r".repeat(10_000) }));
         record.execution = Some(IrWorkflowExecution {
             status: IrWorkflowRunStatus::Succeeded,
@@ -9316,6 +9384,29 @@ FINAL RECEIPT
         assert_eq!(progress.len(), WORKFLOW_RESULT_PROGRESS_TAIL, "{payload}");
         assert!(payload.get("progress_note").is_some(), "{payload}");
 
+        let dispatch_failures = payload["dispatch_failures"]
+            .as_array()
+            .expect("dispatch failures");
+        assert_eq!(
+            dispatch_failures.len(),
+            WORKFLOW_RESULT_DISPATCH_FAILURES_TAIL,
+            "{payload}"
+        );
+        assert_eq!(dispatch_failures[0]["at_ms"], 28);
+        assert!(
+            dispatch_failures.iter().all(|failure| failure["message"]
+                .as_str()
+                .is_some_and(|message| message.chars().count()
+                    <= WORKFLOW_RESULT_DISPATCH_FAILURE_FIELD_MAX_CHARS)),
+            "{dispatch_failures:?}"
+        );
+        assert!(
+            payload["dispatch_failures_note"]
+                .as_str()
+                .is_some_and(|note| note.contains("workflow-runs.jsonl")),
+            "{payload}"
+        );
+
         // Oversized VM result collapses to a preview with a journal pointer.
         assert_eq!(payload["result"]["truncated"], true, "{payload}");
         assert!(
@@ -9345,6 +9436,11 @@ FINAL RECEIPT
         assert_eq!(metadata["events_returned"], WORKFLOW_RESULT_EVENTS_TAIL);
         assert_eq!(metadata["events_omitted"], 150);
         assert_eq!(metadata["event_count"], 200);
+        assert_eq!(
+            metadata["dispatch_failures_returned"],
+            WORKFLOW_RESULT_DISPATCH_FAILURES_TAIL
+        );
+        assert_eq!(metadata["dispatch_failures_omitted"], 28);
         assert_eq!(metadata["truncated"], true);
         assert!(
             metadata["journal_path"]

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -265,6 +265,7 @@ struct WorkflowRunSummary {
     token_budget: Option<u64>,
     child_count: usize,
     schema_error_count: usize,
+    dispatch_failure_count: usize,
     progress_count: usize,
     last_progress: Option<String>,
     event_count: usize,
@@ -286,6 +287,20 @@ struct WorkflowRunSummary {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct WorkflowSchemaError {
     task_id: String,
+    message: String,
+}
+
+/// One `task()` dispatch the driver rejected before any child agent existed.
+/// Inside `parallel()` the JS throw collapses into a `null` slot, so without
+/// this ledger a run whose fan-out never dispatched anything still reads as
+/// successful orchestration (#5035).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WorkflowDispatchFailure {
+    at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    phase: Option<String>,
     message: String,
 }
 
@@ -368,6 +383,13 @@ enum WorkflowUiEventKind {
     },
     TaskSchemaValidationFailed {
         task_id: String,
+        message: String,
+    },
+    TaskDispatchFailed {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        phase: Option<String>,
         message: String,
     },
     BudgetUpdated {
@@ -517,6 +539,7 @@ impl WorkflowUiEventKind {
             Self::HandoffPromoted { .. } => "handoff_promoted",
             Self::HandoffConsumed { .. } => "handoff_consumed",
             Self::TaskSchemaValidationFailed { .. } => "task_schema_validation_failed",
+            Self::TaskDispatchFailed { .. } => "task_dispatch_failed",
             Self::BudgetUpdated { .. } => "budget_updated",
             Self::Log { .. } => "log",
         }
@@ -540,6 +563,9 @@ struct WorkflowRunRecord {
     #[serde(default)]
     events: Vec<WorkflowUiEvent>,
     schema_errors: Vec<WorkflowSchemaError>,
+    /// Task dispatches the driver rejected before any child ran (#5035).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    dispatch_failures: Vec<WorkflowDispatchFailure>,
     result: Option<Value>,
     execution: Option<IrWorkflowExecution>,
     error: Option<String>,
@@ -589,6 +615,7 @@ impl WorkflowRunRecord {
             progress: Vec::new(),
             events: Vec::new(),
             schema_errors: Vec::new(),
+            dispatch_failures: Vec::new(),
             result: None,
             execution: None,
             error: None,
@@ -631,6 +658,7 @@ impl WorkflowRunRecord {
             token_budget: self.token_budget,
             child_count: self.child_ids.len(),
             schema_error_count: self.schema_errors.len(),
+            dispatch_failure_count: self.dispatch_failures.len(),
             progress_count: self.progress.len(),
             last_progress: self.progress.last().cloned(),
             event_count: usize::try_from(self.events_total.max(self.events.len() as u64))
@@ -1599,6 +1627,21 @@ async fn run_workflow_vm(
             return;
         };
         if record.status != WorkflowRunStatus::Cancelled {
+            // #5035: every dispatch was rejected before a child ran. Inside
+            // `parallel()` those throws collapsed into null slots, so without
+            // this check the run reads as successful orchestration that ran
+            // nothing.
+            if status == WorkflowRunStatus::Completed
+                && record.child_ids.is_empty()
+                && !record.dispatch_failures.is_empty()
+            {
+                status = WorkflowRunStatus::Failed;
+                error = Some(format!(
+                    "no child agents ran: all {} task dispatch(es) were rejected; first: {}",
+                    record.dispatch_failures.len(),
+                    record.dispatch_failures[0].message
+                ));
+            }
             record.status = status;
             record.result = output;
             record.error = error.clone();
@@ -1732,6 +1775,20 @@ fn render_run_report(record: &WorkflowRunRecord) -> String {
     if let Some(error) = record.error.as_deref() {
         out.push_str(&format!("- error: {error}\n"));
     }
+    if !record.dispatch_failures.is_empty() {
+        out.push_str(&format!(
+            "\n## Dispatch failures ({})\n\n",
+            record.dispatch_failures.len()
+        ));
+        for failure in &record.dispatch_failures {
+            let slot = failure
+                .label
+                .as_deref()
+                .or(failure.phase.as_deref())
+                .unwrap_or("task");
+            out.push_str(&format!("- {slot}: {}\n", failure.message));
+        }
+    }
     if !record.gate_status.is_empty() {
         out.push_str("\n## Gates\n\n");
         for line in &record.gate_status {
@@ -1787,6 +1844,7 @@ fn workflow_result_for(
         "terminal": summary.status != WorkflowRunStatus::Running,
         "child_count": summary.child_count,
         "schema_error_count": summary.schema_error_count,
+        "dispatch_failure_count": summary.dispatch_failure_count,
         "event_count": summary.event_count,
         "events_returned": bounds.events_returned,
         "events_omitted": bounds.events_omitted,
@@ -2294,17 +2352,33 @@ fn plan_children_to_leaves(
     Ok(leaves)
 }
 
+/// Plan-child `type` vocabulary. Accepts the Agent tool's canonical types and
+/// legacy aliases so the same option value works for direct Agent dispatch and
+/// for Workflow plan children (#5035), normalized onto the workflow IR schema.
+/// Rejections use the Agent tool's error contract ("Invalid sub-agent type
+/// '<value>'. Use: ...") with field-specific guidance.
 fn parse_plan_agent_type(raw: Option<&str>) -> Result<AgentType, ToolError> {
-    match raw.map(str::trim).filter(|s| !s.is_empty()) {
-        None => Ok(AgentType::General),
-        Some("general") | Some("worker") | Some("delegate") => Ok(AgentType::General),
-        Some("explore") | Some("scout") => Ok(AgentType::Explore),
-        Some("plan") | Some("planner") => Ok(AgentType::Plan),
-        Some("review") | Some("reviewer") => Ok(AgentType::Review),
-        Some("implementer") | Some("builder") | Some("implement") => Ok(AgentType::Implementer),
-        Some("verifier") | Some("verify") => Ok(AgentType::Verifier),
-        Some(other) => Err(ToolError::invalid_input(format!(
-            "Invalid plan child type '{other}'. Use general, explore, plan, review, implementer, or verifier."
+    let Some(kind) = raw.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(AgentType::General);
+    };
+    match kind.to_ascii_lowercase().as_str() {
+        "general" | "worker" | "delegate" => Ok(AgentType::General),
+        "explore" | "explorer" | "scout" => Ok(AgentType::Explore),
+        "plan" | "planner" | "awaiter" => Ok(AgentType::Plan),
+        // Consultant/oracle/advisor are the Agent tool's read-only advisory
+        // roles; Review is the workflow IR's read-only advisory posture.
+        "review" | "reviewer" | "consultant" | "oracle" | "advisor" => Ok(AgentType::Review),
+        "implementer" | "implement" | "builder" => Ok(AgentType::Implementer),
+        "verifier" | "verify" => Ok(AgentType::Verifier),
+        "custom" => Err(ToolError::invalid_input(
+            "Invalid sub-agent type 'custom' for a Workflow plan child: custom requires an \
+             explicit allowed_tools list, which plan children cannot declare. Use role/profile \
+             or another type.",
+        )),
+        _ => Err(ToolError::invalid_input(format!(
+            "Invalid sub-agent type '{kind}'. Use: worker, scout, planner, reviewer, builder, \
+             verifier (legacy aliases remain accepted: general, explore/explorer, plan/awaiter, \
+             review, implementer, consultant/oracle/advisor)."
         ))),
     }
 }
@@ -3481,6 +3555,44 @@ impl SubAgentWorkflowDriver {
         }
     }
 
+    /// A rejected dispatch never produces a child agent, and inside
+    /// `parallel()` the JS throw collapses to a `null` slot; this ledger keeps
+    /// the rejection visible on the run record and result payload (#5035).
+    fn record_dispatch_failure(
+        &self,
+        label: Option<String>,
+        phase: Option<String>,
+        message: String,
+    ) {
+        let failure = WorkflowDispatchFailure {
+            at_ms: now_ms(),
+            label,
+            phase,
+            message,
+        };
+        let slot = failure
+            .label
+            .as_deref()
+            .or(failure.phase.as_deref())
+            .unwrap_or("task");
+        let progress_line = format!("dispatch failed for {slot}: {}", failure.message);
+        let ui_event = WorkflowUiEvent::new(WorkflowUiEventKind::TaskDispatchFailed {
+            label: failure.label.clone(),
+            phase: failure.phase.clone(),
+            message: failure.message.clone(),
+        });
+        if let Ok(mut runs) = self.state.runs.lock()
+            && let Some(record) = runs.get_mut(&self.run_id)
+        {
+            record.progress.push(progress_line.clone());
+            record.push_event(ui_event.clone());
+            record.dispatch_failures.push(failure);
+        }
+        self.state.record_progress(&self.run_id, &progress_line);
+        self.state.record_event(&self.run_id, &ui_event);
+        self.emit_ui_event(&ui_event);
+    }
+
     fn record_schema_validation_failure(&self, agent_id: &str, message: String) {
         if let Ok(mut records) = self.task_records.lock()
             && let Some(record) = records.get_mut(agent_id)
@@ -3546,9 +3658,13 @@ struct CompletionState {
     pending: HashMap<String, PendingCompletion>,
 }
 
-#[async_trait]
-impl WorkflowDriver for SubAgentWorkflowDriver {
-    async fn spawn_task(&self, mut request: TaskRequest) -> Result<SpawnedTask, DriverError> {
+impl SubAgentWorkflowDriver {
+    /// The admission half of [`WorkflowDriver::spawn_task`]; every `Err` it
+    /// returns is recorded as a dispatch failure by the trait wrapper.
+    async fn spawn_task_admitted(
+        &self,
+        mut request: TaskRequest,
+    ) -> Result<SpawnedTask, DriverError> {
         // Exact fleets resolve from the frozen snapshot; legacy role maps keep
         // their previous path unchanged.
         //
@@ -3699,6 +3815,35 @@ impl WorkflowDriver for SubAgentWorkflowDriver {
             task_id,
             completion: rx,
         })
+    }
+}
+
+#[async_trait]
+impl WorkflowDriver for SubAgentWorkflowDriver {
+    async fn spawn_task(&self, request: TaskRequest) -> Result<SpawnedTask, DriverError> {
+        let label = request
+            .label
+            .as_deref()
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
+            .map(str::to_string);
+        let phase = request
+            .phase
+            .as_deref()
+            .map(str::trim)
+            .filter(|phase| !phase.is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                self.current_phase
+                    .lock()
+                    .ok()
+                    .and_then(|phase| phase.clone())
+            });
+        let result = self.spawn_task_admitted(request).await;
+        if let Err(err) = &result {
+            self.record_dispatch_failure(label, phase, err.to_string());
+        }
+        result
     }
 
     fn cancel_all(&self) {
@@ -4580,6 +4725,7 @@ mod journal {
                 progress: Vec::new(),
                 events: Vec::new(),
                 schema_errors: Vec::new(),
+                dispatch_failures: Vec::new(),
                 result: None,
                 execution: None,
                 error: None,
@@ -6703,7 +6849,9 @@ export default workflow({
         )
         .unwrap_err();
         assert!(
-            bad_type.to_string().contains("Invalid plan child type"),
+            bad_type
+                .to_string()
+                .contains("Invalid sub-agent type 'wizard'"),
             "{bad_type}"
         );
 
@@ -6721,6 +6869,53 @@ export default workflow({
                 .contains("exactly one of script, source_path, or plan"),
             "{exclusive}"
         );
+    }
+
+    #[test]
+    fn plan_child_type_shares_the_agent_tool_option_vocabulary() {
+        // #5035: type values accepted by direct Agent dispatch must not be
+        // rejected by Workflow plan authoring; aliases normalize onto the IR.
+        for (alias, expected) in [
+            ("worker", AgentType::General),
+            ("delegate", AgentType::General),
+            ("scout", AgentType::Explore),
+            ("Explorer", AgentType::Explore),
+            ("planner", AgentType::Plan),
+            ("awaiter", AgentType::Plan),
+            ("reviewer", AgentType::Review),
+            ("consultant", AgentType::Review),
+            ("oracle", AgentType::Review),
+            ("advisor", AgentType::Review),
+            ("builder", AgentType::Implementer),
+            ("verifier", AgentType::Verifier),
+        ] {
+            assert_eq!(
+                parse_plan_agent_type(Some(alias))
+                    .unwrap_or_else(|err| panic!("{alias} rejected: {err}")),
+                expected,
+                "{alias}"
+            );
+        }
+
+        // Typos fail with the Agent tool's error contract and the full set.
+        let typo = parse_plan_agent_type(Some("wizard"))
+            .unwrap_err()
+            .to_string();
+        assert!(typo.contains("Invalid sub-agent type 'wizard'"), "{typo}");
+        assert!(
+            typo.contains("worker, scout, planner, reviewer, builder"),
+            "{typo}"
+        );
+
+        // `custom` is Agent-only; the rejection says why and what to use.
+        let custom = parse_plan_agent_type(Some("custom"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            custom.contains("Invalid sub-agent type 'custom'"),
+            "{custom}"
+        );
+        assert!(custom.contains("allowed_tools"), "{custom}");
     }
 
     #[test]
@@ -7215,9 +7410,111 @@ reviewer = "reviewer"
             progress.contains("missing-profile") && progress.contains("dropped a failed slot"),
             "breadcrumb should surface the spawn rejection:\n{progress}"
         );
+        // #5035: partial success is explicit — the rejected slot lands in the
+        // run record as a structured dispatch failure, not only a log line.
+        let failures = payload["dispatch_failures"]
+            .as_array()
+            .expect("dispatch failures surfaced on the run record");
+        assert_eq!(failures.len(), 1, "{payload}");
+        assert!(
+            failures[0]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("missing-profile"),
+            "{failures:?}"
+        );
+        assert_eq!(
+            result.metadata.as_ref().expect("metadata")["dispatch_failure_count"],
+            1
+        );
         assert!(
             calls.load(Ordering::SeqCst) >= 1,
             "reduce should still run after a null parallel slot"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn parallel_fan_out_with_every_dispatch_rejected_fails_the_run() {
+        // #5035: when every parallel slot is rejected before dispatch, the run
+        // must not report overall success that ran nothing — the collected
+        // per-slot failures surface and the run fails loudly.
+        let _retry_guard = workflow_test_retry_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 2);
+        let (client, calls) = fake_chat_client("unused").await;
+        let runtime = SubAgentRuntime::new(
+            client,
+            "deepseek-v4-flash".to_string(),
+            ctx.clone(),
+            true,
+            None,
+            manager,
+        );
+        let tool = WorkflowTool::new(runtime.manager.clone(), runtime);
+
+        let result = tool
+            .execute(
+                json!({
+                    "action": "run",
+                    "script": r#"export default workflow({
+                        "goal": "total dispatch failure fan-out",
+                        "nodes": [
+                            {
+                                "branch": {
+                                    "id": "parallel",
+                                    "parallel": true,
+                                    "children": [
+                                        {
+                                            "agent": {
+                                                "id": "bad-one",
+                                                "prompt": "Rejected before model execution.",
+                                                "profile": "missing-profile"
+                                            }
+                                        },
+                                        {
+                                            "agent": {
+                                                "id": "bad-two",
+                                                "prompt": "Also rejected before model execution.",
+                                                "profile": "missing-profile"
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    });"#
+                }),
+                &ctx,
+            )
+            .await
+            .expect("total dispatch failure still returns the run record");
+        let payload: Value = serde_json::from_str(&result.content).expect("json result");
+
+        assert_eq!(payload["status"], "failed", "{payload}");
+        let error = payload["error"].as_str().expect("error surfaced");
+        assert!(
+            error.contains("all 2 task dispatch(es) were rejected"),
+            "error should name the total dispatch failure: {error}"
+        );
+        let failures = payload["dispatch_failures"]
+            .as_array()
+            .expect("collected dispatch failures");
+        assert_eq!(failures.len(), 2, "{payload}");
+        for failure in failures {
+            let message = failure["message"].as_str().expect("failure message");
+            assert!(message.contains("missing-profile"), "{message}");
+        }
+        assert_eq!(payload["child_ids"].as_array().unwrap().len(), 0);
+        assert_eq!(
+            result.metadata.as_ref().expect("metadata")["dispatch_failure_count"],
+            2
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "no provider call should be spent on an all-rejected fan-out"
         );
     }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -4419,6 +4419,12 @@ impl App {
                 todos: state.todos,
                 plan: state.plan,
             });
+            self.work_surface.record_restored_session(
+                session_id,
+                normalized_state
+                    .as_ref()
+                    .and_then(|state| state.graph.as_ref()),
+            );
             self.cached_work_summary = None;
             self.last_known_work_state = Some(normalized_state);
             return Ok(());
@@ -4444,6 +4450,7 @@ impl App {
         *plan = restored_plan;
         drop(plan);
         drop(todos);
+        self.work_surface.record_restored_session(session_id, None);
         self.cached_work_summary = None;
         self.last_known_work_state =
             Some((!normalized_state.is_empty()).then_some(normalized_state));

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -577,7 +577,7 @@ pub fn history_cells_from_message(msg: &Message) -> Vec<HistoryCell> {
     for (block_index, block) in msg.content.iter().enumerate() {
         match block {
             ContentBlock::Text { text, .. } => {
-                if is_trailing_turn_metadata_block(msg, block_index, text) {
+                if is_turn_metadata_block(msg, block_index, text) {
                     continue;
                 }
                 if text.starts_with("[tool_history_repair]") {
@@ -661,11 +661,33 @@ pub fn history_cells_from_message(msg: &Message) -> Vec<HistoryCell> {
     cells
 }
 
-fn is_trailing_turn_metadata_block(msg: &Message, block_index: usize, text: &str) -> bool {
-    if msg.role != "user" || block_index == 0 || block_index + 1 != msg.content.len() {
+/// Whether this text block is a runtime-owned `<turn_meta>` envelope that
+/// must stay out of the visible transcript.
+///
+/// Current sessions persist the envelope as the trailing block of a
+/// multi-block user message; sessions saved before the tail move
+/// (pre-v0.8.54) carry it as the *leading* block instead, so a complete
+/// envelope is hidden at any index. A single-block user message is never
+/// hidden: its text is user-authored by construction, and a literal
+/// `<turn_meta>` example the user typed must stay visible.
+fn is_turn_metadata_block(msg: &Message, block_index: usize, text: &str) -> bool {
+    if msg.role != "user" || msg.content.len() < 2 || !is_complete_turn_meta_envelope(text) {
         return false;
     }
+    if block_index > 0 {
+        return true;
+    }
+    // Leading envelope: hide it only when the trailing block is ordinary
+    // text (the legacy `[turn_meta, prompt]` persisted shape). If the tail
+    // block is itself an envelope, this message is the current shape and the
+    // leading block is user-authored literal text that must stay visible.
+    matches!(
+        msg.content.last(),
+        Some(ContentBlock::Text { text: tail, .. }) if !is_complete_turn_meta_envelope(tail)
+    )
+}
 
+fn is_complete_turn_meta_envelope(text: &str) -> bool {
     let trimmed = text.trim();
     trimmed
         .strip_prefix("<turn_meta>")

--- a/crates/tui/src/tui/shell_key_routing.rs
+++ b/crates/tui/src/tui/shell_key_routing.rs
@@ -173,7 +173,14 @@ pub fn is_help_shortcut(key: &KeyEvent) -> bool {
     if matches!(key.code, KeyCode::F(1)) {
         return true;
     }
-    if matches!(key.code, KeyCode::Char('/')) && key.modifiers.contains(KeyModifiers::CONTROL) {
+    // Windows delivers AltGr as Ctrl+Alt, so a layout-emitted glyph (e.g.
+    // AltGr+Q typing '/' on ABNT2) would satisfy a bare CONTROL check.
+    // AltGr chords are text, never shortcuts (#4723).
+    let altgr = crate::tui::widgets::key_hint::is_altgr(key.modifiers);
+    if matches!(key.code, KeyCode::Char('/'))
+        && key.modifiers.contains(KeyModifiers::CONTROL)
+        && !altgr
+    {
         return true;
     }
     // Some legacy terminal stacks encode Ctrl+/ as the ASCII unit separator,
@@ -181,6 +188,7 @@ pub fn is_help_shortcut(key: &KeyEvent) -> bool {
     // decodings so the documented fallback remains real.
     if matches!(key.code, KeyCode::Char('7') | KeyCode::Char('_'))
         && key.modifiers.contains(KeyModifiers::CONTROL)
+        && !altgr
     {
         return true;
     }
@@ -285,6 +293,33 @@ mod tests {
         )));
         let inverted_question = KeyEvent::new(KeyCode::Char('\u{00bf}'), KeyModifiers::NONE);
         assert!(!is_help_shortcut(&inverted_question));
+    }
+
+    #[test]
+    fn altgr_slash_types_text_instead_of_opening_help() {
+        // Windows encodes AltGr as Ctrl+Alt: AltGr+Q on ABNT2 delivers '/'
+        // with CONTROL|ALT and must reach the composer as text (#4723).
+        let altgr_slash = KeyEvent::new(
+            KeyCode::Char('/'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        );
+        let altgr_seven = KeyEvent::new(
+            KeyCode::Char('7'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        );
+        if cfg!(windows) {
+            assert!(!is_help_shortcut(&altgr_slash));
+            assert!(!is_help_shortcut(&altgr_seven));
+        } else {
+            // Elsewhere Ctrl+Alt is a deliberate chord and keeps working.
+            assert!(is_help_shortcut(&altgr_slash));
+            assert!(is_help_shortcut(&altgr_seven));
+        }
+        // Plain Ctrl+/ still opens help everywhere.
+        assert!(is_help_shortcut(&KeyEvent::new(
+            KeyCode::Char('/'),
+            KeyModifiers::CONTROL
+        )));
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -13605,6 +13605,10 @@ fn render_classic_header(area: Rect, buf: &mut Buffer, app: &App) {
     let model = app.model_display_label();
     let effort = app.reasoning_effort_display_label();
     let started_at = classic_header_indicator_started_at(app);
+    let workflow_chip = app
+        .workflow_panel
+        .as_ref()
+        .map(super::widgets::workflow_panel::WorkflowPanel::top_bar_chip);
     let data = HeaderData::new(
         app.mode,
         &model,
@@ -13624,7 +13628,8 @@ fn render_classic_header(area: Rect, buf: &mut Buffer, app: &App) {
         started_at,
         &app.status_indicator,
     ))
-    .with_running_agents(running_agent_count(app));
+    .with_running_agents(running_agent_count(app))
+    .with_workflow_status(workflow_chip.as_deref());
     HeaderWidget::new(data).render(area, buf);
 }
 
@@ -13723,11 +13728,14 @@ fn render(f: &mut Frame, app: &mut App, config: &Config) {
     let pending_preview = build_pending_input_preview(app);
     let desired_preview_height = pending_preview.desired_height(size.width);
 
-    // WorkflowPanel unified activity surface (#4121). Collapsed to one row
-    // while finished, expanded while running; zero height when no panel.
+    // WorkflowPanel unified activity surface (#4121). Expanded while running
+    // (interactive drill-in above the composer); when collapsed the panel
+    // takes no rows — its persistent status lives in the top status bar as a
+    // header chip instead (#5040). Zero height when no panel.
     let desired_workflow_panel_height = app
         .workflow_panel
         .as_ref()
+        .filter(|panel| panel.expanded)
         .map(|panel| panel.desired_height(size.width))
         .unwrap_or(0);
     let auxiliary_budget = body_height.saturating_sub(

--- a/crates/tui/src/tui/widgets/header.rs
+++ b/crates/tui/src/tui/widgets/header.rs
@@ -98,6 +98,10 @@ pub struct HeaderData<'a> {
     /// Live sub-agent count for the header chrome. `0` hides the chip.
     /// Drill-in is the Agents sidebar / SubAgents modal — not a transcript shelf.
     pub running_agents: usize,
+    /// Compact workflow-run status (e.g. `wf running 3/5 · 2m10s`). `None`
+    /// hides the chip. Persistent workflow status lives here in the top bar
+    /// rather than pinned above the composer (#5040).
+    pub workflow_status: Option<&'a str>,
 }
 
 impl<'a> HeaderData<'a> {
@@ -123,7 +127,15 @@ impl<'a> HeaderData<'a> {
             provider_label: None,
             status_indicator_frame: Some("cw"),
             running_agents: 0,
+            workflow_status: None,
         }
+    }
+
+    /// Attach a compact workflow-run status chip (#5040). `None` hides it.
+    #[must_use]
+    pub fn with_workflow_status(mut self, status: Option<&'a str>) -> Self {
+        self.workflow_status = status;
+        self
     }
 
     /// Live concurrent sub-agent count (`2 agents`). Hidden when zero.
@@ -566,6 +578,20 @@ impl<'a> HeaderWidget<'a> {
                 ));
             }
         }
+        // Workflow-run status (#5040): after the agents chip so identity and
+        // live-worker context still lead the row.
+        if let Some(workflow) = self.data.workflow_status
+            && !workflow.is_empty()
+            && Self::span_width(&spans) + 3 + workflow.width() <= max_width
+        {
+            spans.push(Span::styled(" · ", Style::default().fg(palette::TEXT_DIM)));
+            spans.push(Span::styled(
+                workflow.to_string(),
+                Style::default()
+                    .fg(palette::WHALE_INFO)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
         spans
     }
 
@@ -824,6 +850,39 @@ mod tests {
         assert!(
             rendered.contains("NIM"),
             "expected NIM chip in header, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn header_shows_workflow_status_chip_when_set() {
+        let rendered = render_header(
+            HeaderData::new(
+                AppMode::Agent,
+                "deepseek-ai/deepseek-v4-flash",
+                "codewhale-tui",
+                false,
+                palette::WHALE_BG,
+            )
+            .with_workflow_status(Some("wf running 3/5 · 2m10s")),
+            96,
+        );
+        assert!(
+            rendered.contains("wf running 3/5"),
+            "expected workflow chip in header, got: {rendered}"
+        );
+        let hidden = render_header(
+            HeaderData::new(
+                AppMode::Agent,
+                "deepseek-ai/deepseek-v4-flash",
+                "codewhale-tui",
+                false,
+                palette::WHALE_BG,
+            ),
+            96,
+        );
+        assert!(
+            !hidden.contains("wf "),
+            "no workflow chip without status, got: {hidden}"
         );
     }
 

--- a/crates/tui/src/tui/widgets/workflow_panel.rs
+++ b/crates/tui/src/tui/widgets/workflow_panel.rs
@@ -898,6 +898,21 @@ impl WorkflowPanel {
         truncate_line_to_width(&raw, width.max(1))
     }
 
+    /// One-chip summary for the top status bar (#5040): lifecycle,
+    /// done/total children, failures, elapsed. Intentionally terse — the
+    /// expanded panel and history card carry the detail.
+    #[must_use]
+    pub fn top_bar_chip(&self) -> String {
+        let (done, total) = self.done_total();
+        let (failed, _cancelled) = self.failure_cancel_counts();
+        let mut chip = format!("wf {} {done}/{total}", self.lifecycle.label());
+        if failed > 0 {
+            chip.push_str(&format!(" · {failed} fail"));
+        }
+        chip.push_str(&format!(" · {}", self.elapsed_label()));
+        chip
+    }
+
     /// Elapsed label shared with direct sub-agent cards.
     #[must_use]
     pub fn elapsed_label(&self) -> String {

--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -938,6 +938,98 @@ mod tests {
         assert!(body.contains("Owner cannot confirm liveness"), "{body}");
     }
 
+    /// A durable failed operation, as a fleet agent task from a crashed or
+    /// sibling instance leaves behind in the persisted graph (#4416).
+    fn durable_failed_operation_graph() -> crate::work_graph::WorkGraphSnapshot {
+        let mut graph = WorkGraph::from_snapshot(operation_graph(NodeState::Failed));
+        let operation = WorkNodeId::derive(SESSION, "operation");
+        graph
+            .apply(
+                WorkGraphChange::BindOperation {
+                    node: operation,
+                    binding: OperationBinding {
+                        external: "fleet:run_1/task_1".to_string(),
+                        durable: true,
+                        last_observation: None,
+                    },
+                },
+                ChangeCtx {
+                    session_id: SESSION.to_string(),
+                    now: 6,
+                    idempotency_key: None,
+                },
+            )
+            .expect("durable binding");
+        graph.into_snapshot()
+    }
+
+    // Regression for #4416: a persisted failed-agent record stamped by
+    // another session instance (boot id) must not appear in the default
+    // work listing of a fresh session in the same workspace.
+    #[test]
+    fn prior_instance_failed_rows_stay_out_of_the_default_listing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manager =
+            crate::session_manager::SessionManager::new(dir.path().to_path_buf()).expect("manager");
+        manager
+            .record_session_boot_owner(SESSION, "boot_other_instance")
+            .expect("stamp other instance");
+
+        let mut app = app();
+        app.work_surface.session_owner_probe_dir = Some(dir.path().to_path_buf());
+        let graph = durable_failed_operation_graph();
+        restore_graph(&mut app, &graph);
+
+        let rows = super::model::project(&mut app);
+        assert!(
+            rows.iter()
+                .all(|row| !row.label.contains("Verify installed build")),
+            "prior-instance failed row leaked into the default listing: {rows:#?}"
+        );
+        assert!(
+            rows.iter()
+                .all(|row| !row.label.contains("needs input") && !row.label.contains("1 active")),
+            "prior-instance residue must not count as live work: {rows:#?}"
+        );
+        // The record stays reachable through the explicit catalog, clearly
+        // marked historical.
+        let historical = app
+            .work_surface
+            .catalog_rows
+            .iter()
+            .find(|row| row.label.contains("Verify installed build"))
+            .expect("historical row remains in the catalog");
+        assert!(
+            historical.detail.starts_with("prior session · "),
+            "historical row must be labeled: {}",
+            historical.detail
+        );
+    }
+
+    // Ownership control for #4416: the same failed record owned by this
+    // session instance still renders as actionable work.
+    #[test]
+    fn current_instance_failed_rows_still_render_in_the_default_listing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manager =
+            crate::session_manager::SessionManager::new(dir.path().to_path_buf()).expect("manager");
+        manager
+            .record_session_boot_owner(SESSION, crate::session_manager::current_session_boot_id())
+            .expect("stamp current instance");
+
+        let mut app = app();
+        app.work_surface.session_owner_probe_dir = Some(dir.path().to_path_buf());
+        let graph = durable_failed_operation_graph();
+        restore_graph(&mut app, &graph);
+
+        let rows = super::model::project(&mut app);
+        assert!(
+            rows.iter()
+                .any(|row| row.label.contains("Verify installed build")),
+            "this instance's own failed work must stay visible: {rows:#?}"
+        );
+    }
+
     #[test]
     fn completed_operation_with_acceptance_is_not_rendered_done() {
         let mut graph = WorkGraph::from_snapshot(operation_graph(NodeState::Ready));

--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -171,6 +171,17 @@ mod tests {
             .expect("restore graph");
     }
 
+    fn restore_saved_graph(app: &mut App, graph: &crate::work_graph::WorkGraphSnapshot) {
+        app.current_session_id = Some(SESSION.to_string());
+        let state = crate::session_manager::SessionWorkState {
+            graph: Some(graph.clone()),
+            todos: crate::work_graph::project_todos(graph),
+            plan: crate::work_graph::project_plan(graph),
+        };
+        app.restore_work_state(SESSION, std::path::Path::new("."), Some(&state))
+            .expect("restore saved graph");
+    }
+
     fn render_text(app: &mut App, width: u16, height: u16) -> String {
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).expect("terminal");
@@ -978,7 +989,7 @@ mod tests {
         let mut app = app();
         app.work_surface.session_owner_probe_dir = Some(dir.path().to_path_buf());
         let graph = durable_failed_operation_graph();
-        restore_graph(&mut app, &graph);
+        restore_saved_graph(&mut app, &graph);
 
         let rows = super::model::project(&mut app);
         assert!(
@@ -1027,6 +1038,34 @@ mod tests {
             rows.iter()
                 .any(|row| row.label.contains("Verify installed build")),
             "this instance's own failed work must stay visible: {rows:#?}"
+        );
+    }
+
+    // Regression for review of #5063: if a prior session persisted no graph,
+    // the first graph captured later belongs to this process and must not be
+    // mistaken for restored residue.
+    #[test]
+    fn first_live_graph_after_empty_prior_restore_stays_visible() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manager =
+            crate::session_manager::SessionManager::new(dir.path().to_path_buf()).expect("manager");
+        manager
+            .record_session_boot_owner(SESSION, "boot_other_instance")
+            .expect("stamp other instance");
+
+        let mut app = app();
+        app.work_surface.session_owner_probe_dir = Some(dir.path().to_path_buf());
+        app.current_session_id = Some(SESSION.to_string());
+        app.restore_work_state(SESSION, std::path::Path::new("."), None)
+            .expect("restore empty prior session");
+
+        let graph = durable_failed_operation_graph();
+        restore_graph(&mut app, &graph);
+        let rows = super::model::project(&mut app);
+        assert!(
+            rows.iter()
+                .any(|row| row.label.contains("Verify installed build")),
+            "this instance's first live graph must stay visible: {rows:#?}"
         );
     }
 

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -117,9 +117,9 @@ pub(super) const SIDE_WIDTH_MAX: u16 = 80;
 pub(crate) struct SessionInstanceScope {
     pub(super) session_id: String,
     pub(super) from_prior_instance: bool,
-    /// Node ids present in the first graph capture of a prior-instance
-    /// session: the restored persisted rows, as opposed to work this
-    /// instance creates afterwards.
+    /// Node ids present in the graph supplied at session restore time: the
+    /// restored persisted rows, as opposed to work this instance creates
+    /// afterwards.
     pub(super) restored_nodes: HashSet<String>,
 }
 
@@ -242,6 +242,31 @@ impl WorkSurfaceState {
         self.user_turn_epoch = self.user_turn_epoch.wrapping_add(1);
     }
 
+    /// Record the exact graph restored from persisted session state. This
+    /// must happen at the restore boundary: the first later runtime capture
+    /// may already contain work created by this process.
+    pub(crate) fn record_restored_session(
+        &mut self,
+        session_id: &str,
+        graph: Option<&WorkGraphSnapshot>,
+    ) {
+        let from_prior_instance = session_record_from_prior_instance(self, session_id);
+        let restored_nodes = if from_prior_instance {
+            graph
+                .into_iter()
+                .flat_map(|graph| graph.nodes.iter())
+                .map(|node| node.id.as_str().to_string())
+                .collect()
+        } else {
+            HashSet::new()
+        };
+        self.session_instance = Some(SessionInstanceScope {
+            session_id: session_id.to_string(),
+            from_prior_instance,
+            restored_nodes,
+        });
+    }
+
     /// A restored graph row owned by a prior session instance whose terminal
     /// failure or staleness must not render as this session's live work
     /// (#4416). Plan steps stay: the resumed to-do list is the point of
@@ -359,7 +384,7 @@ pub(super) fn project(app: &mut App) -> Vec<WorkRow> {
         ),
     };
 
-    update_session_instance_scope(app, graph.as_ref());
+    update_session_instance_scope(app);
 
     let rows = match graph {
         Some(graph) => graph_rows(
@@ -451,9 +476,9 @@ pub(super) fn project_visible(app: &mut App) -> Vec<WorkRow> {
 
 /// Classify the current session against this process's session-instance
 /// boot id (#4416), mirroring the `SubAgentManager` prior-session pattern
-/// (#405). The probe runs once per session id; the first captured graph of
-/// a prior-instance session records which node ids are restored rows.
-fn update_session_instance_scope(app: &mut App, graph: Option<&WorkGraphSnapshot>) {
+/// (#405). The probe runs once per session id. Persisted row identity is
+/// recorded separately at the actual session restore boundary.
+fn update_session_instance_scope(app: &mut App) {
     let Some(session_id) = app.current_session_id.clone() else {
         app.work_surface.session_instance = None;
         return;
@@ -471,16 +496,6 @@ fn update_session_instance_scope(app: &mut App, graph: Option<&WorkGraphSnapshot
             from_prior_instance,
             restored_nodes: HashSet::new(),
         });
-    }
-    if let (Some(scope), Some(graph)) = (app.work_surface.session_instance.as_mut(), graph)
-        && scope.from_prior_instance
-        && scope.restored_nodes.is_empty()
-    {
-        scope.restored_nodes = graph
-            .nodes
-            .iter()
-            .map(|node| node.id.as_str().to_string())
-            .collect();
     }
 }
 

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -108,6 +108,21 @@ pub(super) const TOP_HEIGHT_MAX: u16 = 16;
 pub(super) const SIDE_WIDTH_MIN: u16 = 26;
 pub(super) const SIDE_WIDTH_MAX: u16 = 80;
 
+/// Which restored work rows belong to a prior session instance (#4416).
+///
+/// Decided once per session id and cached: this instance's own later
+/// autosaves restamp the persisted record, and re-probing after that would
+/// re-badge restored rows as live work.
+#[derive(Debug, Clone)]
+pub(crate) struct SessionInstanceScope {
+    pub(super) session_id: String,
+    pub(super) from_prior_instance: bool,
+    /// Node ids present in the first graph capture of a prior-instance
+    /// session: the restored persisted rows, as opposed to work this
+    /// instance creates afterwards.
+    pub(super) restored_nodes: HashSet<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct WorkSurfaceState {
     pub placement: WorkSurfacePlacement,
@@ -152,6 +167,11 @@ pub struct WorkSurfaceState {
     /// Bumped on accepted user turns / newly started operations.
     user_turn_epoch: u64,
     last_handled_user_turn_epoch: u64,
+    /// Session-instance ownership of the restored session record (#4416).
+    pub(crate) session_instance: Option<SessionInstanceScope>,
+    /// Test override for the sessions directory the ownership probe reads;
+    /// production resolves the default location lazily.
+    pub(crate) session_owner_probe_dir: Option<std::path::PathBuf>,
 }
 
 impl Default for WorkSurfaceState {
@@ -205,6 +225,8 @@ impl WorkSurfaceState {
             activity_suppressed: false,
             user_turn_epoch: 0,
             last_handled_user_turn_epoch: 0,
+            session_instance: None,
+            session_owner_probe_dir: None,
         }
     }
 
@@ -218,6 +240,20 @@ impl WorkSurfaceState {
     /// Recent-only live chrome collapses immediately (#4688).
     pub fn note_user_turn_or_new_operation(&mut self) {
         self.user_turn_epoch = self.user_turn_epoch.wrapping_add(1);
+    }
+
+    /// A restored graph row owned by a prior session instance whose terminal
+    /// failure or staleness must not render as this session's live work
+    /// (#4416). Plan steps stay: the resumed to-do list is the point of
+    /// restoring; failed/stale operations and blockers are the leak.
+    pub(super) fn is_prior_instance_residue(&self, node: &WorkNode) -> bool {
+        let Some(scope) = self.session_instance.as_ref() else {
+            return false;
+        };
+        scope.from_prior_instance
+            && scope.restored_nodes.contains(node.id.as_str())
+            && node.kind != NodeKind::PlanStep
+            && matches!(node.state, NodeState::Failed | NodeState::Stale)
     }
 
     fn now_ms(&self) -> u64 {
@@ -323,6 +359,8 @@ pub(super) fn project(app: &mut App) -> Vec<WorkRow> {
         ),
     };
 
+    update_session_instance_scope(app, graph.as_ref());
+
     let rows = match graph {
         Some(graph) => graph_rows(
             &mut app.work_surface,
@@ -409,6 +447,49 @@ pub(super) fn project_visible(app: &mut App) -> Vec<WorkRow> {
     todos.extend(agents);
     app.work_surface.latest_rows = todos.clone();
     todos
+}
+
+/// Classify the current session against this process's session-instance
+/// boot id (#4416), mirroring the `SubAgentManager` prior-session pattern
+/// (#405). The probe runs once per session id; the first captured graph of
+/// a prior-instance session records which node ids are restored rows.
+fn update_session_instance_scope(app: &mut App, graph: Option<&WorkGraphSnapshot>) {
+    let Some(session_id) = app.current_session_id.clone() else {
+        app.work_surface.session_instance = None;
+        return;
+    };
+    let classified = app
+        .work_surface
+        .session_instance
+        .as_ref()
+        .is_some_and(|scope| scope.session_id == session_id);
+    if !classified {
+        let from_prior_instance =
+            session_record_from_prior_instance(&app.work_surface, &session_id);
+        app.work_surface.session_instance = Some(SessionInstanceScope {
+            session_id,
+            from_prior_instance,
+            restored_nodes: HashSet::new(),
+        });
+    }
+    if let (Some(scope), Some(graph)) = (app.work_surface.session_instance.as_mut(), graph)
+        && scope.from_prior_instance
+        && scope.restored_nodes.is_empty()
+    {
+        scope.restored_nodes = graph
+            .nodes
+            .iter()
+            .map(|node| node.id.as_str().to_string())
+            .collect();
+    }
+}
+
+fn session_record_from_prior_instance(surface: &WorkSurfaceState, session_id: &str) -> bool {
+    let manager = match surface.session_owner_probe_dir.as_ref() {
+        Some(dir) => crate::session_manager::SessionManager::new(dir.clone()),
+        None => crate::session_manager::SessionManager::default_location(),
+    };
+    manager.is_ok_and(|manager| manager.session_from_prior_instance(session_id))
 }
 
 fn graph_rows(
@@ -499,6 +580,7 @@ fn ordered_rows(
                     )
                 })
                 .filter(|node| !is_settled_transient_operation(node))
+                .filter(|node| !surface.is_prior_instance_residue(node))
                 .enumerate()
                 .map(|(order, node)| RankedWorkRow {
                     bucket: node_bucket(node),
@@ -651,6 +733,23 @@ fn ordered_rows(
     // Full catalog for inspector/history even when live chrome collapses.
     let mut catalog = vec![section_heading("work", &heading_label, &detail)];
     catalog.extend(ranked.iter().map(|item| item.row.clone()));
+    // Prior-instance terminal residue stays reachable through the explicit
+    // catalog, labeled historical, but never as this session's live work
+    // (#4416).
+    if let Some(snapshot) = snapshot {
+        catalog.extend(
+            snapshot
+                .nodes
+                .iter()
+                .filter(|node| surface.is_prior_instance_residue(node))
+                .map(|node| {
+                    let mut row = graph_node_row(snapshot, node);
+                    row.detail = format!("prior session · {}", row.detail);
+                    row.tone = WorkTone::Muted;
+                    row
+                }),
+        );
+    }
     surface.catalog_rows = catalog.clone();
 
     // Live chrome policy:

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -183,8 +183,8 @@
   "document_kind": "codewhale.source_structure_budget",
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 172,
-  "max_module_lines": 19017,
-  "max_total_owned_rust_lines": 644756,
+  "max_module_lines": 18966,
+  "max_total_owned_rust_lines": 645924,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -184,7 +184,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 172,
   "max_module_lines": 18966,
-  "max_total_owned_rust_lines": 645924,
+  "max_total_owned_rust_lines": 646081,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
# Issue burn-down batch: eight user-facing fixes

Seven commits, one per fix area, each with regression tests. Root causes were produced by parallel adversarially-verified diagnosis; every fix was implemented against the diagnosed mechanism, not the symptom.

## Fixes

- **Anthropic wire** — strict Anthropic-compatible gateways get `{type: enabled, budget_tokens}` instead of the rejected `adaptive` shape (#4978); dangling `tool_use` blocks are repaired with placeholder `tool_result`s so one unavailable-tool call can't 400 the session forever (#5002)
- **macOS sandbox** — trusted seatbelt tier allows AppleEvents/lsopen so `open`/`osascript`/`launchctl` work; restrictive tiers stay locked down; profile parse-verified via sandbox-exec (#4828)
- **Workflow tool** — authoring errors share the Agent tool's vocabulary/contract; parallel fan-out dispatch failures surface in the run record instead of silently nulling slots (#5035, release blocker)
- **Config scoping** — credential writes redirect to the user-global document when the ambient config path is workspace-scoped; keys can no longer strand in a repo's plaintext `.codewhale/config.toml` (refs #5045)
- **Session layer** — prior-instance failed rows leave the default work surface (#4416); `/cost` decomposes the headline into components that provably sum, with currency as a projection (#4939); legacy leading-block `turn_meta` envelopes no longer render on session reopen (#4681)
- **Windows input** — AltGr chords (Ctrl+Alt encoding) type text instead of triggering the help shortcut; AltGr+Q on ABNT2 now types `/` (#4723, thanks @nicolassmotta for the report, @yyyCode for PR #4977)
- **TUI** — persistent workflow status moves from above the composer to a compact top-status-bar chip; the expanded interactive panel keeps its place (#5040)

## Verification

- 12 affected suites green on this branch: anthropic 20, workflow 93, seatbelt 13, key routing 10, header 26, session_manager 57, work_surface 54, cost 91, credential_scope 2, config 476, history 160, workflow_panel 32
- `cargo check --all-targets` green; CI-equivalent clippy (`-D warnings` + repo allows) clean on the source tree

## Issue linkage

Closes #4978. Closes #5002. Closes #4828. Closes #5035. Closes #4416. Closes #4939. Closes #4681. Closes #4723. Closes #5040. Refs #5045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAEuFJrqcMqF1oztnjZeMy
