### PR TITLE
fix(tools): make web search/fetch retrieval path coherent

### DIFF
--- a/crates/tui/src/tools/web/contract.rs
+++ b/crates/tui/src/tools/web/contract.rs
@@ -9,6 +9,12 @@ use serde::{Deserialize, Serialize};
 
 pub(crate) const MAX_SEARCH_RESULTS: u8 = 10;
 
+/// Shared retrieval defaults. `web_search` and `web.run` both derive their
+/// search knobs from these so the surfaces cannot drift apart.
+pub(crate) const DEFAULT_SEARCH_RESULTS: usize = 5;
+pub(crate) const DEFAULT_SEARCH_TIMEOUT_MS: u64 = 15_000;
+pub(crate) const MAX_SEARCH_TIMEOUT_MS: u64 = 60_000;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum BackendId {
@@ -310,6 +316,23 @@ pub(crate) struct SearchResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retrieval_defaults_are_coherent_across_search_and_fetch() {
+        use super::super::fetch::{DEFAULT_TIMEOUT, HARD_MAX_TIMEOUT};
+
+        // Search and fetch share one default and one hard-cap timeout so the
+        // two halves of the retrieval path behave identically by default.
+        assert_eq!(
+            u128::from(DEFAULT_SEARCH_TIMEOUT_MS),
+            DEFAULT_TIMEOUT.as_millis()
+        );
+        assert_eq!(
+            u128::from(MAX_SEARCH_TIMEOUT_MS),
+            HARD_MAX_TIMEOUT.as_millis()
+        );
+        assert!(DEFAULT_SEARCH_RESULTS <= usize::from(MAX_SEARCH_RESULTS));
+    }
 
     #[test]
     fn search_query_normalizes_domains_and_bounds_count() {

--- a/crates/tui/src/tools/web/fetch.rs
+++ b/crates/tui/src/tools/web/fetch.rs
@@ -19,8 +19,11 @@ pub(crate) const HARD_MAX_TIMEOUT: Duration = Duration::from_secs(60);
 pub(crate) const DEFAULT_MAX_BYTES: usize = 1_000_000;
 pub(crate) const HARD_MAX_BYTES: usize = 10 * 1024 * 1024;
 const MAX_REDIRECTS: usize = 5;
-const USER_AGENT: &str =
-    "Mozilla/5.0 (compatible; codewhale/0.9.1; +https://github.com/Hmbown/CodeWhale)";
+const USER_AGENT: &str = concat!(
+    "Mozilla/5.0 (compatible; codewhale/",
+    env!("CARGO_PKG_VERSION"),
+    "; +https://github.com/Hmbown/CodeWhale)"
+);
 
 #[derive(Debug, Clone)]
 pub(crate) struct FetchOptions {
@@ -462,6 +465,14 @@ mod tests {
         assert_eq!(&*large.bytes, b"0123456789");
         assert!(!large.truncated);
         assert!(!large.cache_hit);
+    }
+
+    #[test]
+    fn fetch_user_agent_tracks_the_crate_version() {
+        assert!(
+            USER_AGENT.contains(concat!("codewhale/", env!("CARGO_PKG_VERSION"))),
+            "guarded-fetch UA must never pin a stale release: {USER_AGENT}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tools/web/scrape.rs
+++ b/crates/tui/src/tools/web/scrape.rs
@@ -7,6 +7,11 @@ use base64::{Engine as _, engine::general_purpose};
 use regex::Regex;
 use std::sync::OnceLock;
 
+/// Shared browser-like user agent for public SERP scraping and image search.
+/// Both `web_search` and `web_run` send this so scrape behavior (including
+/// bot-challenge rates) stays identical between the two surfaces.
+pub(crate) const BROWSER_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
 /// One parsed search hit: title, absolute URL, optional snippet.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScrapedSearchResult {

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -28,16 +28,18 @@ use std::time::{Duration, Instant};
 use parking_lot::{RwLock, RwLockWriteGuard};
 
 use super::web::contract::{
-    MAX_SEARCH_RESULTS, Recency, SearchQuery, SearchReceipt, SearchResult as NormalizedSearchResult,
+    DEFAULT_SEARCH_RESULTS, DEFAULT_SEARCH_TIMEOUT_MS, MAX_SEARCH_RESULTS, MAX_SEARCH_TIMEOUT_MS,
+    Recency, SearchQuery, SearchReceipt, SearchResult as NormalizedSearchResult,
 };
+use super::web::scrape::BROWSER_USER_AGENT as USER_AGENT;
 use super::web_search::{domain_matches, execute_search};
 
-const DEFAULT_TIMEOUT_MS: u64 = 15_000;
-const DEFAULT_OPEN_TIMEOUT_MS: u64 = 15_000;
+// Search and open share the retrieval-path defaults from `web::contract` and
+// `web::fetch` so `web.run` cannot drift from `web_search` / `fetch_url`.
+const DEFAULT_OPEN_TIMEOUT_MS: u64 = super::web::fetch::DEFAULT_TIMEOUT.as_millis() as u64;
 const MAX_WEB_RUN_SESSIONS: usize = 64;
 const MAX_PAGES_PER_SESSION: usize = 256;
 const WEB_RUN_SESSION_TTL: Duration = Duration::from_secs(30 * 60);
-const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
 
 static WEB_RUN_STATE: OnceLock<WebRunCache> = OnceLock::new();
 
@@ -229,9 +231,9 @@ impl ResponseLength {
 
     fn max_results(self) -> usize {
         match self {
-            Self::Short => 5,
+            Self::Short => DEFAULT_SEARCH_RESULTS,
             Self::Medium => 8,
-            Self::Long => 10,
+            Self::Long => usize::from(MAX_SEARCH_RESULTS),
         }
     }
 
@@ -475,7 +477,8 @@ impl ToolSpec for WebRunTool {
                 ))
                 .unwrap_or(response_length.max_results())
                 .clamp(1, usize::from(MAX_SEARCH_RESULTS));
-                let timeout_ms = optional_u64(search, "timeout_ms", DEFAULT_TIMEOUT_MS).min(60_000);
+                let timeout_ms = optional_u64(search, "timeout_ms", DEFAULT_SEARCH_TIMEOUT_MS)
+                    .min(MAX_SEARCH_TIMEOUT_MS);
 
                 let domains = search
                     .get("domains")
@@ -543,7 +546,8 @@ impl ToolSpec for WebRunTool {
                 ))
                 .unwrap_or(response_length.max_results())
                 .clamp(1, usize::from(MAX_SEARCH_RESULTS));
-                let timeout_ms = optional_u64(image, "timeout_ms", DEFAULT_TIMEOUT_MS).min(60_000);
+                let timeout_ms = optional_u64(image, "timeout_ms", DEFAULT_SEARCH_TIMEOUT_MS)
+                    .min(MAX_SEARCH_TIMEOUT_MS);
 
                 let domains = image
                     .get("domains")
@@ -1058,8 +1062,8 @@ async fn page_from_fetched(
 ) -> Result<WebPage, ToolError> {
     if !(200..300).contains(&payload.status) {
         return Err(ToolError::execution_failed(format!(
-            "Web request failed: HTTP {}",
-            payload.status
+            "Web request to {} failed: HTTP {}",
+            payload.url, payload.status
         )));
     }
     let document = extract_document(
@@ -1686,6 +1690,95 @@ mod tests {
                 .expect("visible degraded warning")
                 .contains("recency")
         );
+    }
+
+    #[tokio::test]
+    async fn search_ref_ids_resolve_to_their_source_urls_for_open() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::ToolSpec;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search"))
+            .and(query_param("q", "citation handoff"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [{
+                    "title": "Handoff target",
+                    "url": "https://docs.example.com/handoff",
+                    "content": "the page a later open command fetches"
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut context = ToolContext::new(tmp.path().to_path_buf());
+        context.search_provider = SearchProvider::Searxng;
+        context.search_base_url = Some(server.uri());
+        context.state_namespace = "handoff-citation-test".to_string();
+
+        let result = WebRunTool
+            .execute(
+                json!({"search_query": [{"q": "citation handoff"}]}),
+                &context,
+            )
+            .await
+            .expect("web.run search should succeed");
+        let value: Value = serde_json::from_str(&result.content).expect("web.run json");
+        let ref_id = value["search_query"][0]["results"][0]["ref_id"]
+            .as_str()
+            .expect("every search result carries a minted ref_id")
+            .to_string();
+
+        // `open` resolves search-result refs through the shared citation
+        // registry; the handoff must preserve the exact source URL.
+        let citation = crate::tools::web::citations::resolve(&context.state_namespace, &ref_id)
+            .expect("search result ref must resolve for a later open");
+        assert_eq!(citation.url, "https://docs.example.com/handoff");
+        assert_eq!(citation.title.as_deref(), Some("Handoff target"));
+        assert!(
+            crate::tools::web::citations::resolve("foreign-session", &ref_id).is_none(),
+            "citation handles must stay session-scoped"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_failure_reports_url_and_status() {
+        let payload = crate::tools::web::fetch::FetchedPayload {
+            url: "https://example.com/missing".to_string(),
+            status: 404,
+            headers: std::collections::BTreeMap::new(),
+            content_type: "text/html".to_string(),
+            bytes: Arc::new(Vec::new()),
+            truncated: false,
+            cache_hit: false,
+            retries: 0,
+            redirects: 0,
+        };
+        let context = ToolContext::new(PathBuf::from("."));
+
+        let error = page_from_fetched(payload, &context)
+            .await
+            .expect_err("non-2xx pages must not be rendered");
+        let message = error.to_string();
+        assert!(
+            message.contains("https://example.com/missing"),
+            "transport failures must name the URL: {message}"
+        );
+        assert!(message.contains("404"), "got `{message}`");
+    }
+
+    #[test]
+    fn response_length_result_counts_are_anchored_to_the_shared_contract() {
+        assert_eq!(ResponseLength::Short.max_results(), DEFAULT_SEARCH_RESULTS);
+        assert_eq!(
+            ResponseLength::Long.max_results(),
+            usize::from(MAX_SEARCH_RESULTS)
+        );
+        assert!(ResponseLength::Medium.max_results() <= usize::from(MAX_SEARCH_RESULTS));
     }
 
     #[test]

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -29,11 +29,13 @@ use std::time::{Duration, Instant};
 use super::web::backend::SearchBackendChain;
 use super::web::cache;
 use super::web::contract::{
-    BackendId, BackendSearch, DegradedReason, HonoredQueryCapabilities, MAX_SEARCH_RESULTS,
-    QueryKnob, Recency, SearchQuery, SearchReceipt, SearchResponse, SearchResult,
+    BackendId, BackendSearch, DEFAULT_SEARCH_RESULTS, DEFAULT_SEARCH_TIMEOUT_MS, DegradedReason,
+    HonoredQueryCapabilities, MAX_SEARCH_RESULTS, MAX_SEARCH_TIMEOUT_MS, QueryKnob, Recency,
+    SearchQuery, SearchReceipt, SearchResponse, SearchResult,
 };
 use super::web::scrape::{
-    ScrapedSearchResult, is_duckduckgo_challenge, parse_bing_results as scrape_bing_results,
+    BROWSER_USER_AGENT as USER_AGENT, ScrapedSearchResult, is_duckduckgo_challenge,
+    parse_bing_results as scrape_bing_results,
     parse_duckduckgo_results as scrape_duckduckgo_results,
 };
 
@@ -79,10 +81,6 @@ fn get_bearer_token_re() -> &'static Regex {
             .expect("bearer token regex pattern is valid")
     })
 }
-
-const DEFAULT_MAX_RESULTS: usize = 5;
-const DEFAULT_TIMEOUT_MS: u64 = 15_000;
-const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
 
 #[derive(Debug, Clone, Serialize)]
 struct WebSearchEntry {
@@ -181,7 +179,8 @@ impl ToolSpec for WebSearchTool {
 
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
         let query = search_query_from_input(&input)?;
-        let timeout_ms = optional_u64(&input, "timeout_ms", DEFAULT_TIMEOUT_MS).min(60_000);
+        let timeout_ms = optional_u64(&input, "timeout_ms", DEFAULT_SEARCH_TIMEOUT_MS)
+            .min(MAX_SEARCH_TIMEOUT_MS);
         let response = execute_search(query, timeout_ms, context).await?;
         ToolResult::json(&response).map_err(|error| ToolError::execution_failed(error.to_string()))
     }
@@ -807,29 +806,33 @@ fn register_search_citations(response: &mut SearchResponse, context: &ToolContex
     }
 }
 
+/// Reject a misconfigured provider before any cache lookup or network attempt.
+///
+/// Configuration gaps are reported as `InvalidInput` ("not configured", with
+/// the exact config fix) so they stay distinguishable from transport failures
+/// (`ExecutionFailed`) and from successful-but-empty results.
 fn preflight_search_provider(context: &ToolContext) -> Result<(), ToolError> {
     let configured_key = context
         .search_api_key
         .as_deref()
         .is_some_and(|key| !key.trim().is_empty());
     let env_key = |name: &str| std::env::var_os(name).is_some_and(|value| !value.is_empty());
+    let not_configured = |message: &str| Err(ToolError::invalid_input(message));
 
     match context.search_provider {
-        SearchProvider::Tavily if !configured_key => Err(ToolError::execution_failed(
-            "Tavily search requires an API key. Set `[search] api_key = \"tvly-...\"` in config.toml.",
-        )),
-        SearchProvider::Bocha if !configured_key => Err(ToolError::execution_failed(
-            "Bocha search requires an API key. Set `[search] api_key = \"sk-...\"` in config.toml.",
-        )),
-        SearchProvider::Metaso if !configured_key && !env_key("METASO_API_KEY") => {
-            Err(ToolError::execution_failed(
-                "Metaso search requires an API key. Set `METASO_API_KEY` or `[search] api_key` in config.toml.",
-            ))
-        }
+        SearchProvider::Tavily if !configured_key => not_configured(
+            "Tavily search is not configured: it requires an API key. Set `[search] api_key = \"tvly-...\"` in config.toml.",
+        ),
+        SearchProvider::Bocha if !configured_key => not_configured(
+            "Bocha search is not configured: it requires an API key. Set `[search] api_key = \"sk-...\"` in config.toml.",
+        ),
+        SearchProvider::Metaso if !configured_key && !env_key("METASO_API_KEY") => not_configured(
+            "Metaso search is not configured: it requires an API key. Set `METASO_API_KEY` or `[search] api_key` in config.toml.",
+        ),
         SearchProvider::Baidu if !configured_key && !env_key("BAIDU_SEARCH_API_KEY") => {
-            Err(ToolError::execution_failed(
-                "Baidu search requires an API key. Set `BAIDU_SEARCH_API_KEY` or `[search] api_key` in config.toml.",
-            ))
+            not_configured(
+                "Baidu search is not configured: it requires an API key. Set `BAIDU_SEARCH_API_KEY` or `[search] api_key` in config.toml.",
+            )
         }
         SearchProvider::Volcengine
             if !configured_key
@@ -837,14 +840,19 @@ fn preflight_search_provider(context: &ToolContext) -> Result<(), ToolError> {
                 && !env_key("VOLCENGINE_ARK_API_KEY")
                 && !env_key("ARK_API_KEY") =>
         {
-            Err(ToolError::execution_failed(
-                "Volcengine search requires an API key. Set `[search] api_key`, or VOLCENGINE_API_KEY / VOLCENGINE_ARK_API_KEY / ARK_API_KEY env var.",
-            ))
+            not_configured(
+                "Volcengine search is not configured: it requires an API key. Set `[search] api_key`, or VOLCENGINE_API_KEY / VOLCENGINE_ARK_API_KEY / ARK_API_KEY env var.",
+            )
         }
-        SearchProvider::Sofya if !configured_key && !env_key("SOFYA_API_KEY") => {
-            Err(ToolError::execution_failed(
-                "Sofya search requires an API key. Set `[search] api_key = \"ay_live_...\"` in config.toml or the SOFYA_API_KEY env var.",
-            ))
+        SearchProvider::Sofya if !configured_key && !env_key("SOFYA_API_KEY") => not_configured(
+            "Sofya search is not configured: it requires an API key. Set `[search] api_key = \"ay_live_...\"` in config.toml or the SOFYA_API_KEY env var.",
+        ),
+        SearchProvider::Searxng
+            if configured_search_base_url(context.search_base_url.as_deref()).is_none() =>
+        {
+            not_configured(
+                "SearXNG search requires [search] base_url = \"https://your-searxng.example\"; no public instance is used by default.",
+            )
         }
         _ => Ok(()),
     }
@@ -1690,7 +1698,7 @@ fn optional_search_max_results(input: &Value) -> u64 {
     search_query_items(input)
         .filter_map(|item| item.get("max_results").and_then(Value::as_u64))
         .next()
-        .unwrap_or(DEFAULT_MAX_RESULTS as u64)
+        .unwrap_or(DEFAULT_SEARCH_RESULTS as u64)
 }
 
 fn search_query_from_input(input: &Value) -> Result<SearchQuery, ToolError> {
@@ -1699,7 +1707,7 @@ fn search_query_from_input(input: &Value) -> Result<SearchQuery, ToolError> {
         return Err(ToolError::invalid_input("Query cannot be empty"));
     }
     let max_results = usize::try_from(optional_search_max_results(input))
-        .unwrap_or(DEFAULT_MAX_RESULTS)
+        .unwrap_or(DEFAULT_SEARCH_RESULTS)
         .clamp(1, usize::from(MAX_SEARCH_RESULTS));
     let recency = search_option(input, "recency")
         .map(parse_recency)
@@ -2656,11 +2664,40 @@ mod tests {
             .expect_err("searxng requires explicit base_url");
         let msg = err.to_string();
         assert!(
+            matches!(err, crate::tools::spec::ToolError::InvalidInput { .. }),
+            "missing base_url is a configuration gap, not a transport failure: {err:?}"
+        );
+        assert!(
             msg.contains("SearXNG")
                 && msg.contains("base_url")
                 && msg.contains("no public instance"),
             "got `{msg}`"
         );
+    }
+
+    #[tokio::test]
+    async fn missing_provider_key_fails_closed_as_not_configured() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolError, ToolSpec};
+
+        for provider in [SearchProvider::Tavily, SearchProvider::Bocha] {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+            ctx.search_provider = provider;
+            ctx.search_api_key = None;
+
+            let error = WebSearchTool
+                .execute(json!({"query": "needs configuration"}), &ctx)
+                .await
+                .expect_err("a keyed provider without an API key must fail closed");
+            assert!(
+                matches!(error, ToolError::InvalidInput { .. }),
+                "config gaps must stay distinguishable from transport failures: {error:?}"
+            );
+            let message = error.to_string();
+            assert!(message.contains("is not configured"), "got `{message}`");
+            assert!(message.contains("api_key"), "got `{message}`");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Makes the web retrieval path coherent across `web_search`, `web.run`, and guarded fetch:

- Centralizes search result-count and timeout defaults and anchors open timeouts to the fetch contract.
- Shares one scraper user agent and replaces the stale hardcoded Codewhale version with `CARGO_PKG_VERSION`.
- Preflights missing provider configuration as `InvalidInput`, preserves transport failures as `ExecutionFailed`, and keeps empty results successful.
- Makes open failures identify the URL and status, and proves search-result `ref_id` values resolve to their exact source URLs.

Deferred: new providers, reconciling the intentionally different fetch-size limits, and the search pseudo-page URL.

## Verification

- `cargo test -p codewhale-tui --bin codewhale-tui --locked tools::web` — 168 passed, 0 failed, 1 ignored.
- `cargo test -p codewhale-tui --bin codewhale-tui --locked tools::fetch_url` — 15 passed, 0 failed.
- `cargo clippy -p codewhale-tui --bin codewhale-tui -- -D warnings` — clean.
- `git diff --check origin/main...origin/codex/wave-5037-web-coherence` — clean.

Closes #5037
