### PR TITLE
feat(tui): notification quiet mode, per-category switches, action-first copy

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1614,6 +1614,68 @@ pub struct NotificationsConfig {
     /// Disabled by default; see `tui::sound_policy` for the decision rules.
     #[serde(default)]
     pub event_sound: EventSoundConfig,
+
+    /// Quiet mode: suppress every desktop notification (all categories, all
+    /// delivery methods) and the paired `[notifications.event_sound]` cues,
+    /// without editing `method` or the per-category switches under
+    /// `[notifications.events]`. The turn-completion chime
+    /// (`completion_sound`) is governed separately. Default: `false`.
+    #[serde(default)]
+    pub quiet: bool,
+
+    /// Per-category desktop-notification switches
+    /// (`[notifications.events]`). Every category defaults to enabled; set
+    /// one to `false` to silence that event kind without touching the rest.
+    #[serde(default)]
+    pub events: NotificationEventsConfig,
+}
+
+fn default_notification_event_enabled() -> bool {
+    true
+}
+
+/// Per-category desktop-notification switches (`[notifications.events]`).
+///
+/// Categories mirror the closed set of notification kinds in
+/// `tui::notification_payload::NotificationKind`. Each defaults to `true`;
+/// a disabled category is suppressed across every delivery mechanism
+/// (OSC 9, Kitty OSC 99, Ghostty OSC 777, BEL, macOS Notification Center).
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct NotificationEventsConfig {
+    /// An agent turn finished successfully. Default: `true`.
+    #[serde(default = "default_notification_event_enabled")]
+    pub turn_complete: bool,
+    /// A sub-agent reached a terminal status. Default: `true`.
+    #[serde(default = "default_notification_event_enabled")]
+    pub subagent_terminal: bool,
+    /// A tool call is blocked waiting for approval. Default: `true`.
+    #[serde(default = "default_notification_event_enabled")]
+    pub approval_needed: bool,
+    /// The agent asked a question and is blocked on the answer.
+    /// Default: `true`.
+    #[serde(default = "default_notification_event_enabled")]
+    pub input_needed: bool,
+    /// The sandbox denied an operation and the user must decide.
+    /// Default: `true`.
+    #[serde(default = "default_notification_event_enabled")]
+    pub elevation_needed: bool,
+    /// The model called the `notify` tool. Default: `true`.
+    #[serde(default = "default_notification_event_enabled")]
+    pub model_notify: bool,
+}
+
+impl Default for NotificationEventsConfig {
+    fn default() -> Self {
+        Self {
+            turn_complete: true,
+            subagent_terminal: true,
+            approval_needed: true,
+            input_needed: true,
+            elevation_needed: true,
+            model_notify: true,
+        }
+    }
 }
 
 fn default_event_sound_events() -> Vec<String> {

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -9999,6 +9999,44 @@ fn notifications_event_sound_defaults_when_table_absent() {
 }
 
 #[test]
+fn notifications_parse_quiet_and_event_categories() {
+    let config: Config = toml::from_str(
+        r#"
+        [notifications]
+        quiet = true
+
+        [notifications.events]
+        approval-needed = false
+        model-notify = false
+        "#,
+    )
+    .expect("quiet + events config should parse");
+
+    let notifications = config.notifications_config();
+    assert!(notifications.quiet);
+    let events = notifications.events;
+    assert!(!events.approval_needed);
+    assert!(!events.model_notify);
+    // Unlisted categories keep their enabled default.
+    assert!(events.turn_complete);
+    assert!(events.subagent_terminal);
+    assert!(events.input_needed);
+    assert!(events.elevation_needed);
+}
+
+#[test]
+fn notifications_quiet_and_events_default_off_and_all_enabled() {
+    let config: Config = toml::from_str("[notifications]\nmethod = \"auto\"\n")
+        .expect("bare notifications table should parse");
+
+    let notifications = config.notifications_config();
+    assert!(!notifications.quiet);
+    assert_eq!(notifications.events, NotificationEventsConfig::default());
+    assert!(notifications.events.turn_complete);
+    assert!(notifications.events.model_notify);
+}
+
+#[test]
 fn huggingface_short_custom_env_url_does_not_inherit_ambient_key() -> Result<()> {
     let _lock = lock_test_env();
     let nanos = SystemTime::now()

--- a/crates/tui/src/tools/notify.rs
+++ b/crates/tui/src/tools/notify.rs
@@ -44,8 +44,11 @@ impl ToolSpec for NotifyTool {
          routine progress updates, conversational acknowledgements, or \
          confirmation that the model is alive — that's noise. The user \
          can disable notifications entirely via \
-         `[notifications].method = \"off\"` in `~/.deepseek/config.toml`; \
-         when disabled this tool is a silent no-op."
+         `[notifications].method = \"off\"` or `[notifications].quiet = \
+         true`, or just this tool's category via \
+         `[notifications.events].model-notify = false`, in \
+         `~/.deepseek/config.toml`; when disabled this tool is a silent \
+         no-op."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/notify.rs
+++ b/crates/tui/src/tools/notify.rs
@@ -36,19 +36,14 @@ impl ToolSpec for NotifyTool {
     }
 
     fn description(&self) -> &'static str {
-        "Fire a single desktop notification (OSC 9 / terminal bell). Use \
-         sparingly — only when a long-running task completes, when a turn \
-         was waiting on a remote operation that just finished, or when \
-         the user genuinely needs to come back to the terminal. Pass a \
-         short `title` and an optional `body`. Do NOT use this for \
-         routine progress updates, conversational acknowledgements, or \
-         confirmation that the model is alive — that's noise. The user \
-         can disable notifications entirely via \
-         `[notifications].method = \"off\"` or `[notifications].quiet = \
-         true`, or just this tool's category via \
-         `[notifications.events].model-notify = false`, in \
-         `~/.deepseek/config.toml`; when disabled this tool is a silent \
-         no-op."
+        "Send a desktop notification only when the user must act: a long task \
+         completed, a blocking error needs a decision, or progress cannot \
+         continue without an answer. Never notify for routine progress, \
+         acknowledgements, or liveness. Pass a short `title` and optional \
+         `body`. Users can silence everything with \
+         `[notifications].method = \"off\"` or `[notifications].quiet = true`, \
+         or this category with `[notifications.events].model-notify = false`; \
+         disabled notifications are silent no-ops."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -340,6 +340,9 @@ pub fn notify_done_to<W: Write>(
     if elapsed < threshold {
         return;
     }
+    if method == Method::Off {
+        return;
+    }
     if !gate.allows(payload.kind()) {
         tracing::debug!(
             kind = ?payload.kind(),
@@ -349,7 +352,7 @@ pub fn notify_done_to<W: Write>(
         return;
     }
     let effective = match method {
-        Method::Off => return,
+        Method::Off => unreachable!("Method::Off returned before gate evaluation"),
         Method::Auto => resolve_method(),
         other => other,
     };
@@ -1161,6 +1164,20 @@ mod tests {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
+    struct NotificationGateRestore(NotificationGate);
+
+    impl NotificationGateRestore {
+        fn capture() -> Self {
+            Self(current_notification_gate())
+        }
+    }
+
+    impl Drop for NotificationGateRestore {
+        fn drop(&mut self) {
+            install_notification_gate(self.0);
+        }
+    }
+
     /// Escape-protocol tests care about the bytes, not the composition
     /// policy, so they go through the least-privileged constructor.
     fn capture(
@@ -1288,6 +1305,7 @@ mod tests {
     #[test]
     fn settings_installs_gate_from_config() {
         let _lock = env_lock();
+        let _gate_restore = NotificationGateRestore::capture();
         let config: crate::config::Config = toml::from_str(
             r#"
             [notifications]
@@ -1305,9 +1323,6 @@ mod tests {
         assert!(gate.quiet);
         assert!(!gate.approval_needed);
         assert!(gate.turn_complete);
-
-        // Restore the process-wide default for the other tests.
-        install_notification_gate(NotificationGate::default());
     }
 
     /// #5041 copy contract: interactive banners lead with the action and

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -15,6 +15,11 @@
 //! redaction-aware value — rather than a free-form `String` (#4834). See
 //! [`crate::tui::notification_payload`] for the per-kind disclosure
 //! policy.
+//!
+//! Delivery is governed by one [`NotificationGate`] (#5041):
+//! `[notifications].quiet` silences everything and
+//! `[notifications.events]` disables individual categories, enforced at
+//! the emission path so no protocol can leak a suppressed event.
 
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Diagnostics::Debug::MessageBeep;
@@ -28,6 +33,7 @@ use std::sync::atomic::{AtomicU8, AtomicU64};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
+use super::notification_payload::NotificationKind;
 pub use super::notification_payload::NotificationPayload;
 
 #[cfg(target_os = "windows")]
@@ -195,19 +201,151 @@ fn build_escape(method: Method, in_tmux: bool, msg: &str) -> Vec<u8> {
     }
 }
 
-/// Emit a notification to `sink` if the elapsed time meets or exceeds
-/// `threshold`, and `method` is not `Off`.
+// ── Notification gate (#5041) ────────────────────────────────────────
+//
+// One policy switchboard between "an event happened" and "the user's
+// desktop is interrupted". `[notifications].quiet` silences every
+// category; `[notifications.events]` disables individual categories. The
+// gate is installed from config by [`settings`] and consulted by
+// [`notify_done`] ahead of every delivery mechanism, so a disabled
+// category can never leak through one specific protocol.
+
+/// Which notification categories may reach the user's desktop.
 ///
-/// This variant takes a `W: Write` sink for testability.
+/// The category set mirrors [`NotificationKind`] one-to-one. Default:
+/// everything enabled, quiet off — matching the pre-#5041 behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NotificationGate {
+    /// Suppress every category when `true` (`[notifications].quiet`).
+    pub quiet: bool,
+    pub turn_complete: bool,
+    pub subagent_terminal: bool,
+    pub approval_needed: bool,
+    pub input_needed: bool,
+    pub elevation_needed: bool,
+    pub model_notify: bool,
+}
+
+impl Default for NotificationGate {
+    fn default() -> Self {
+        Self {
+            quiet: false,
+            turn_complete: true,
+            subagent_terminal: true,
+            approval_needed: true,
+            input_needed: true,
+            elevation_needed: true,
+            model_notify: true,
+        }
+    }
+}
+
+impl NotificationGate {
+    /// Project the `[notifications]` config block onto a gate.
+    #[must_use]
+    pub fn from_config(notif: &crate::config::NotificationsConfig) -> Self {
+        Self {
+            quiet: notif.quiet,
+            turn_complete: notif.events.turn_complete,
+            subagent_terminal: notif.events.subagent_terminal,
+            approval_needed: notif.events.approval_needed,
+            input_needed: notif.events.input_needed,
+            elevation_needed: notif.events.elevation_needed,
+            model_notify: notif.events.model_notify,
+        }
+    }
+
+    /// Whether an event of `kind` may be delivered under this gate.
+    #[must_use]
+    pub fn allows(self, kind: NotificationKind) -> bool {
+        if self.quiet {
+            return false;
+        }
+        match kind {
+            NotificationKind::TurnComplete => self.turn_complete,
+            NotificationKind::SubagentTerminal => self.subagent_terminal,
+            NotificationKind::ApprovalNeeded => self.approval_needed,
+            NotificationKind::InputNeeded => self.input_needed,
+            NotificationKind::ElevationNeeded => self.elevation_needed,
+            NotificationKind::ModelNotify => self.model_notify,
+        }
+    }
+
+    const QUIET_BIT: u8 = 1 << 0;
+    const TURN_COMPLETE_BIT: u8 = 1 << 1;
+    const SUBAGENT_TERMINAL_BIT: u8 = 1 << 2;
+    const APPROVAL_NEEDED_BIT: u8 = 1 << 3;
+    const INPUT_NEEDED_BIT: u8 = 1 << 4;
+    const ELEVATION_NEEDED_BIT: u8 = 1 << 5;
+    const MODEL_NOTIFY_BIT: u8 = 1 << 6;
+
+    const fn to_bits(self) -> u8 {
+        (self.quiet as u8 * Self::QUIET_BIT)
+            | (self.turn_complete as u8 * Self::TURN_COMPLETE_BIT)
+            | (self.subagent_terminal as u8 * Self::SUBAGENT_TERMINAL_BIT)
+            | (self.approval_needed as u8 * Self::APPROVAL_NEEDED_BIT)
+            | (self.input_needed as u8 * Self::INPUT_NEEDED_BIT)
+            | (self.elevation_needed as u8 * Self::ELEVATION_NEEDED_BIT)
+            | (self.model_notify as u8 * Self::MODEL_NOTIFY_BIT)
+    }
+
+    const fn from_bits(bits: u8) -> Self {
+        Self {
+            quiet: bits & Self::QUIET_BIT != 0,
+            turn_complete: bits & Self::TURN_COMPLETE_BIT != 0,
+            subagent_terminal: bits & Self::SUBAGENT_TERMINAL_BIT != 0,
+            approval_needed: bits & Self::APPROVAL_NEEDED_BIT != 0,
+            input_needed: bits & Self::INPUT_NEEDED_BIT != 0,
+            elevation_needed: bits & Self::ELEVATION_NEEDED_BIT != 0,
+            model_notify: bits & Self::MODEL_NOTIFY_BIT != 0,
+        }
+    }
+}
+
+/// Everything on, quiet off — the pre-#5041 behavior, and the effective
+/// policy until the first [`settings`] call installs the configured gate.
+const GATE_DEFAULT_BITS: u8 = 0b0111_1110;
+
+/// Process-wide gate, packed to one byte so reads on the emission path are
+/// a single atomic load (same pattern as `COMPLETION_SOUND_MODE`).
+static NOTIFICATION_GATE: AtomicU8 = AtomicU8::new(GATE_DEFAULT_BITS);
+
+/// Install `gate` as the process-wide notification policy.
+pub fn install_notification_gate(gate: NotificationGate) {
+    NOTIFICATION_GATE.store(gate.to_bits(), Ordering::SeqCst);
+}
+
+/// The currently installed process-wide notification gate.
+#[must_use]
+pub fn current_notification_gate() -> NotificationGate {
+    NotificationGate::from_bits(NOTIFICATION_GATE.load(Ordering::SeqCst))
+}
+
+/// Emit a notification to `sink` if the elapsed time meets or exceeds
+/// `threshold`, `method` is not `Off`, and `gate` allows the payload's
+/// category.
+///
+/// This variant takes a `W: Write` sink and an explicit gate for
+/// testability; production callers go through [`notify_done`], which
+/// loads the installed process-wide gate.
 pub fn notify_done_to<W: Write>(
     method: Method,
     in_tmux: bool,
     payload: &NotificationPayload,
     threshold: Duration,
     elapsed: Duration,
+    gate: NotificationGate,
     sink: &mut W,
 ) {
     if elapsed < threshold {
+        return;
+    }
+    if !gate.allows(payload.kind()) {
+        tracing::debug!(
+            kind = ?payload.kind(),
+            quiet = gate.quiet,
+            "notification suppressed by [notifications] gate"
+        );
         return;
     }
     let effective = match method {
@@ -280,6 +418,7 @@ pub fn notify_done(
         payload,
         threshold,
         elapsed,
+        current_notification_gate(),
         &mut io::stdout(),
     );
 }
@@ -775,6 +914,9 @@ use crate::tui::app::App;
 /// `Off`).
 pub fn settings(config: &crate::config::Config) -> Option<(Method, Duration, bool)> {
     let notif = config.notifications_config();
+    // Install the category/quiet gate (#5041) so `notify_done` honors
+    // `[notifications].quiet` and `[notifications.events]`.
+    install_notification_gate(NotificationGate::from_config(&notif));
     // Initialize completion sound mode from config.
     set_completion_sound(notif.completion_sound, notif.sound_file);
     // Initialize the opt-in event-sound policy (#4817) from the sibling
@@ -870,6 +1012,35 @@ pub fn subagent_terminal_payload(
     let preview = result_line.and_then(text_summary);
 
     NotificationPayload::subagent_terminal(&headline, id).with_preview(preview.as_deref())
+}
+
+/// Action-first approval banner (#5041): leads with the decision the user
+/// must make and names the tool it concerns. The tool *description* — the
+/// pending command — intentionally stays in the terminal (#4834).
+#[must_use]
+pub fn approval_needed_payload(tool_name: &str) -> NotificationPayload {
+    NotificationPayload::approval_needed(
+        &format!("Approve or deny '{tool_name}' to continue"),
+        tool_name,
+    )
+}
+
+/// Action-first blocked-on-input banner (#5041): says what to do and
+/// where. The question text itself never leaves the terminal (#4834).
+#[must_use]
+pub fn input_needed_payload() -> NotificationPayload {
+    NotificationPayload::input_needed("Answer the question in the terminal to continue")
+}
+
+/// Action-first sandbox-elevation banner (#5041): leads with the decision
+/// and names the blocked tool; the denial reason rides in the body.
+#[must_use]
+pub fn elevation_needed_payload(tool_name: &str, denial_reason: &str) -> NotificationPayload {
+    NotificationPayload::elevation_needed(
+        &format!("Allow or deny elevated access for '{tool_name}'"),
+        tool_name,
+        denial_reason,
+    )
 }
 
 fn completion_status(
@@ -1006,9 +1177,158 @@ mod tests {
             &NotificationPayload::input_needed(msg),
             Duration::from_secs(threshold_secs),
             Duration::from_secs(elapsed_secs),
+            NotificationGate::default(),
             &mut buf,
         );
         buf
+    }
+
+    /// Emit `payload` through OSC 9 under an explicit `gate`, returning the
+    /// bytes. The gate is passed by value, so these tests never touch the
+    /// process-wide gate and cannot race the other capture tests.
+    fn capture_gated(payload: &NotificationPayload, gate: NotificationGate) -> Vec<u8> {
+        let mut buf = Vec::new();
+        notify_done_to(
+            Method::Osc9,
+            false,
+            payload,
+            Duration::ZERO,
+            Duration::from_secs(1),
+            gate,
+            &mut buf,
+        );
+        buf
+    }
+
+    #[test]
+    fn gate_defaults_allow_every_kind() {
+        let gate = NotificationGate::default();
+        for kind in [
+            NotificationKind::TurnComplete,
+            NotificationKind::SubagentTerminal,
+            NotificationKind::ApprovalNeeded,
+            NotificationKind::InputNeeded,
+            NotificationKind::ElevationNeeded,
+            NotificationKind::ModelNotify,
+        ] {
+            assert!(gate.allows(kind), "default gate must allow {kind:?}");
+        }
+    }
+
+    #[test]
+    fn quiet_gate_suppresses_every_kind() {
+        let gate = NotificationGate {
+            quiet: true,
+            ..NotificationGate::default()
+        };
+        for kind in [
+            NotificationKind::TurnComplete,
+            NotificationKind::SubagentTerminal,
+            NotificationKind::ApprovalNeeded,
+            NotificationKind::InputNeeded,
+            NotificationKind::ElevationNeeded,
+            NotificationKind::ModelNotify,
+        ] {
+            assert!(!gate.allows(kind), "quiet gate must suppress {kind:?}");
+        }
+    }
+
+    #[test]
+    fn disabled_category_suppresses_only_that_kind() {
+        let gate = NotificationGate {
+            approval_needed: false,
+            ..NotificationGate::default()
+        };
+        assert!(!gate.allows(NotificationKind::ApprovalNeeded));
+        assert!(gate.allows(NotificationKind::TurnComplete));
+        assert!(gate.allows(NotificationKind::InputNeeded));
+        assert!(gate.allows(NotificationKind::ModelNotify));
+    }
+
+    #[test]
+    fn gate_bits_roundtrip_and_default_constant_agree() {
+        assert_eq!(NotificationGate::default().to_bits(), GATE_DEFAULT_BITS);
+        let odd = NotificationGate {
+            quiet: true,
+            turn_complete: false,
+            subagent_terminal: true,
+            approval_needed: false,
+            input_needed: true,
+            elevation_needed: false,
+            model_notify: true,
+        };
+        assert_eq!(NotificationGate::from_bits(odd.to_bits()), odd);
+    }
+
+    /// The gate acts on the emission path itself: a suppressed category
+    /// produces zero bytes on every protocol entry point, not just a
+    /// filtered list somewhere upstream.
+    #[test]
+    fn gated_emission_produces_no_bytes() {
+        let payload = approval_needed_payload("bash");
+
+        let quiet = NotificationGate {
+            quiet: true,
+            ..NotificationGate::default()
+        };
+        assert!(capture_gated(&payload, quiet).is_empty());
+
+        let no_approvals = NotificationGate {
+            approval_needed: false,
+            ..NotificationGate::default()
+        };
+        assert!(capture_gated(&payload, no_approvals).is_empty());
+
+        let out = capture_gated(&payload, NotificationGate::default());
+        assert!(!out.is_empty(), "enabled category must still emit");
+    }
+
+    /// `settings()` is the single place config reaches the emission path;
+    /// it must install the configured gate for `notify_done` to load.
+    #[test]
+    fn settings_installs_gate_from_config() {
+        let _lock = env_lock();
+        let config: crate::config::Config = toml::from_str(
+            r#"
+            [notifications]
+            quiet = true
+
+            [notifications.events]
+            approval-needed = false
+            "#,
+        )
+        .expect("gated notifications config should parse");
+
+        let _ = settings(&config);
+
+        let gate = current_notification_gate();
+        assert!(gate.quiet);
+        assert!(!gate.approval_needed);
+        assert!(gate.turn_complete);
+
+        // Restore the process-wide default for the other tests.
+        install_notification_gate(NotificationGate::default());
+    }
+
+    /// #5041 copy contract: interactive banners lead with the action and
+    /// name the subject, instead of a bare "Approval needed".
+    #[test]
+    fn interactive_banners_are_action_first_and_name_the_subject() {
+        let approval = approval_needed_payload("bash");
+        assert_eq!(approval.headline(), "Approve or deny 'bash' to continue");
+
+        let input = input_needed_payload();
+        assert_eq!(
+            input.headline(),
+            "Answer the question in the terminal to continue"
+        );
+
+        let elevation = elevation_needed_payload("bash", "network blocked");
+        assert_eq!(
+            elevation.headline(),
+            "Allow or deny elevated access for 'bash'"
+        );
+        assert!(elevation.body().contains("network blocked"));
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4828,10 +4828,10 @@ async fn run_event_loop(
                                     // pending command. It stays in the
                                     // terminal, where the user can read it
                                     // in context; the banner names only the
-                                    // tool.
+                                    // tool. Copy is centralized (#5041) so
+                                    // the action-first phrasing is tested.
                                     let payload =
-                                        crate::tui::notifications::NotificationPayload::approval_needed(
-                                            "Approval needed",
+                                        crate::tui::notifications::approval_needed_payload(
                                             &tool_name,
                                         );
                                     crate::tui::notifications::notify_done(
@@ -4893,10 +4893,7 @@ async fn run_event_loop(
                                 crate::tui::notifications::settings(config)
                             {
                                 let in_tmux = std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
-                                let payload =
-                                    crate::tui::notifications::NotificationPayload::input_needed(
-                                        "Action required: please respond in the terminal",
-                                    );
+                                let payload = crate::tui::notifications::input_needed_payload();
                                 crate::tui::notifications::notify_done(
                                     method,
                                     in_tmux,
@@ -4962,12 +4959,10 @@ async fn run_event_loop(
                                 crate::tui::notifications::settings(config)
                             {
                                 let in_tmux = std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
-                                let payload =
-                                    crate::tui::notifications::NotificationPayload::elevation_needed(
-                                        "Sandbox blocked a tool",
-                                        &tool_name,
-                                        &denial_reason,
-                                    );
+                                let payload = crate::tui::notifications::elevation_needed_payload(
+                                    &tool_name,
+                                    &denial_reason,
+                                );
                                 crate::tui::notifications::notify_done(
                                     method,
                                     in_tmux,

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -19471,6 +19471,8 @@ fn notification_settings_tui_always_keeps_configured_method_no_threshold() {
             include_summary: true,
             subagent_completion: crate::config::SubagentCompletionNotification::default(),
             event_sound: crate::config::EventSoundConfig::default(),
+            quiet: false,
+            events: crate::config::NotificationEventsConfig::default(),
         }),
         ..Config::default()
     };
@@ -19506,6 +19508,8 @@ fn notification_settings_no_tui_override_uses_notifications_block() {
             include_summary: false,
             subagent_completion: crate::config::SubagentCompletionNotification::default(),
             event_sound: crate::config::EventSoundConfig::default(),
+            quiet: false,
+            events: crate::config::NotificationEventsConfig::default(),
         }),
         ..Config::default()
     };

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1750,6 +1750,17 @@ If you are upgrading from older releases:
   `[notifications].sound_file` on Windows.
 - `[notifications].sound_file` (path, optional): path to a custom WAV file
   used when `completion_sound = "file"`.
+- `[notifications].quiet` (bool, optional): defaults to `false`. Quiet
+  mode — suppresses every desktop notification (all categories, all
+  delivery methods) and the paired `event_sound` cues, without changing
+  `method` or the per-category switches. The turn-completion chime
+  (`completion_sound`) is governed separately.
+- `[notifications.events]` (table, optional): per-category
+  desktop-notification switches; every key defaults to `true`. Keys:
+  `turn-complete`, `subagent-terminal`, `approval-needed`,
+  `input-needed`, `elevation-needed`, `model-notify`. A disabled
+  category is suppressed on every delivery mechanism (OSC 9, Kitty,
+  Ghostty, BEL, macOS Notification Center).
 - `[notifications.event_sound]` (table, optional): opt-in, deterministic
   per-event sound cues. Keys: `enabled` (bool, default `false`), `events`
   (array of kebab-case event names, default `["turn-complete",
@@ -1821,7 +1832,26 @@ threshold_secs  = 30      # only notify when the turn took >= this many seconds
 include_summary = false   # include elapsed time + cost in the notification body
 completion_sound = "beep" # off | beep | bell | file
 sound_file = "E:\\google\\downloads\\notify.wav" # for completion_sound = "file"
+quiet = false             # true suppresses every desktop notification
+
+[notifications.events]    # per-category switches; all default to true
+turn-complete     = true  # an agent turn finished
+subagent-terminal = true  # a sub-agent reached a terminal status
+approval-needed   = true  # a tool call is blocked on your approval
+input-needed      = true  # the agent asked a question and is blocked
+elevation-needed  = true  # the sandbox denied a tool and needs a decision
+model-notify      = true  # the model called the `notify` tool
 ```
+
+`quiet = true` is the one-flag "stop interrupting me" switch: it silences
+every category on every delivery mechanism while leaving the rest of your
+notification configuration intact, so flipping it back restores your exact
+previous policy. `[notifications.events]` disables single categories the
+same way — a disabled category is suppressed at the emission path, so it
+cannot leak through one specific protocol. A suppressed notification also
+suppresses its paired `[notifications.event_sound]` cue (no orphaned bells
+for events you turned off); the turn-completion chime (`completion_sound`)
+is governed separately.
 
 Method semantics:
 
@@ -1883,7 +1913,7 @@ per-event disclosure policy rather than from whatever text was on hand:
 | Turn complete | status line (+ elapsed/cost when `include_summary`), preview of the assistant's reply | — |
 | Sub-agent finished | status line, agent id, preview of the child's summary line | — |
 | Approval needed | the tool name | the tool description, the command, the arguments |
-| Input needed | "please respond in the terminal" | the question |
+| Input needed | "Answer the question in the terminal to continue" | the question |
 | Sandbox elevation needed | the tool name and the denial reason | the command |
 | `notify` tool | model-supplied title and body | — |
 


### PR DESCRIPTION
## Summary

Adds a notification policy gate at the shared emission path so every desktop delivery protocol and paired event-sound cue honors the same configuration:

- `[notifications].quiet` silences every category without discarding the user's configured methods or event switches.
- `[notifications.events]` provides per-category switches for turn completion, subagent terminal states, approvals, input, elevation, and model notifications.
- Interactive banners use centralized, tested action-first copy that names the subject.

The separate `completion_sound` setting remains independently governed.

Deferred: the CWC signal-phase mark asset, the broader footer-toast copy sweep, and sharing one test environment lock to remove a pre-existing notification-settings race.

## Verification

- `cargo test -p codewhale-tui --bin codewhale-tui --locked notification` — 63 passed, 0 failed; stable across four consecutive runs.
- Targeted filters: `notifications_parse` — 3 passed; `notifications_quiet` — 1 passed; `tools::notify` — 6 passed.
- `cargo clippy -p codewhale-tui --locked --all-targets` — 0 warnings.
- One pre-existing `settings_installs_custom_completion_sound_file` race failed once and passed on every rerun; it is documented as deferred follow-up.
- `git diff --check origin/main...origin/codex/wave-5041-notifications` — clean.

Closes #5041
