### PR TITLE
fix(tui): run operate goals to the completion gate, make continuation cap a configurable backstop

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1901,6 +1901,20 @@ pub struct ToolsConfig {
     pub overrides: Option<HashMap<String, ToolOverride>>,
 }
 
+/// Persistent-goal loop controls (`[goal]` table in config.toml, #5052).
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+pub struct GoalConfig {
+    /// Safety backstop on automatic goal continuation passes. The completion
+    /// gate and token/time budgets are the real terminal stops; this only
+    /// halts a pathological loop that never emits a terminal signal.
+    ///
+    /// `None` uses the built-in default
+    /// ([`crate::goal_loop::DEFAULT_MAX_GOAL_CONTINUATIONS`]); `0` disables
+    /// the backstop entirely so only budget/terminal stops end the run.
+    #[serde(default)]
+    pub max_continuations: Option<u32>,
+}
+
 /// One configurable footer item.
 ///
 /// Order in the user's `Vec<StatusItem>` is preserved: items in the left
@@ -2496,6 +2510,12 @@ pub struct Config {
     /// requires a trusted `base_url`.
     #[serde(default)]
     pub search: Option<SearchConfig>,
+
+    /// Persistent-goal loop controls (#5052). When absent, the continuation
+    /// backstop falls back to
+    /// [`crate::goal_loop::DEFAULT_MAX_GOAL_CONTINUATIONS`].
+    #[serde(default)]
+    pub goal: Option<GoalConfig>,
 
     /// User-level memory (#489). Default behaviour is **opt-in**:
     /// loading + injection happens only when `[memory] enabled = true` or
@@ -6045,6 +6065,18 @@ impl Config {
             .unwrap_or(false)
     }
 
+    /// Effective safety backstop on automatic goal continuation passes
+    /// (#5052). `[goal] max_continuations` overrides the built-in default;
+    /// `0` disables the backstop so only completion/blocked or token/time
+    /// budget exhaustion stop an operate-mode goal run.
+    #[must_use]
+    pub fn goal_max_continuations(&self) -> u32 {
+        self.goal
+            .as_ref()
+            .and_then(|goal| goal.max_continuations)
+            .unwrap_or(crate::goal_loop::DEFAULT_MAX_GOAL_CONTINUATIONS)
+    }
+
     /// Resolve the explicit local-memory backend.
     #[must_use]
     pub fn memory_backend(&self) -> MemoryBackend {
@@ -8981,6 +9013,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         skills: merge_skills_config(base.skills, override_cfg.skills),
         snapshots: override_cfg.snapshots.or(base.snapshots),
         search: override_cfg.search.or(base.search),
+        goal: override_cfg.goal.or(base.goal),
         memory: override_cfg.memory.or(base.memory),
         speech: override_cfg.speech.or(base.speech),
         auto: override_cfg.auto.or(base.auto),

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -207,6 +207,36 @@ fn deepseek_api_key_reads_metadata_env_vars_for_newer_providers() -> Result<()> 
 }
 
 #[test]
+fn goal_max_continuations_loads_from_goal_table() -> Result<()> {
+    // Absent table → generous built-in default (#5052).
+    let config: Config = toml::from_str("")?;
+    assert_eq!(
+        config.goal_max_continuations(),
+        crate::goal_loop::DEFAULT_MAX_GOAL_CONTINUATIONS
+    );
+
+    // Explicit backstop override.
+    let config: Config = toml::from_str(
+        r#"
+[goal]
+max_continuations = 25
+"#,
+    )?;
+    assert_eq!(config.goal_max_continuations(), 25);
+
+    // 0 = unlimited-with-budget-stops.
+    let config: Config = toml::from_str(
+        r#"
+[goal]
+max_continuations = 0
+"#,
+    )?;
+    assert_eq!(config.goal_max_continuations(), 0);
+
+    Ok(())
+}
+
+#[test]
 fn provider_context_window_loads_from_provider_table() -> Result<()> {
     let config: Config = toml::from_str(
         r#"

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -328,6 +328,11 @@ pub struct EngineConfig {
     pub goal_objective: Option<String>,
     pub goal_token_budget: Option<u32>,
     pub goal_status: GoalStatus,
+    /// Safety backstop on automatic goal continuation passes (#5052).
+    /// Resolved from `[goal] max_continuations` in config.toml; `0` disables
+    /// the backstop so only completion/blocked or token/time budget
+    /// exhaustion stop an operate-mode goal run.
+    pub goal_max_continuations: u32,
     /// Tool restriction from custom slash command frontmatter.
     /// `None` means the current turn may use the normal tool set.
     pub allowed_tools: Option<Vec<String>>,
@@ -448,6 +453,7 @@ impl Default for EngineConfig {
             goal_objective: None,
             goal_token_budget: None,
             goal_status: GoalStatus::Active,
+            goal_max_continuations: crate::goal_loop::DEFAULT_MAX_GOAL_CONTINUATIONS,
             allowed_tools: None,
             disallowed_tools: None,
             max_tool_calls: None,
@@ -741,6 +747,7 @@ fn claim_subagent_completion(
         .then_some(completion)
 }
 
+#[derive(Debug)]
 enum GoalContinuationAction {
     Inactive,
     Dispatch {
@@ -3163,9 +3170,11 @@ impl Engine {
     /// Returns a continuation to dispatch, an explicit terminal budget stop,
     /// or `Inactive` when no follow-up turn belongs in the queue.
     ///
-    /// There is no continuation cap — a goal runs until the model self-reports
-    /// done/blocked, the user pauses or clears, or an optional token/time
-    /// budget is exhausted. The loop is "until done," not "until N turns."
+    /// A goal runs until the model self-reports done/blocked, the user pauses
+    /// or clears, or an optional token/time budget is exhausted. The loop is
+    /// "until done," not "until N turns" (#5052); a configurable safety
+    /// backstop (`[goal] max_continuations`, `0` = unlimited) still halts a
+    /// pathological loop that never emits a terminal signal.
     fn goal_continuation_if_active(&self) -> GoalContinuationAction {
         let mut state = match self.config.goal_state.lock() {
             Ok(state) => state,
@@ -3198,6 +3207,7 @@ impl Engine {
             crate::goal_loop::GoalBudget {
                 token_budget: snapshot.token_budget.map(u64::from),
                 time_budget_seconds: None,
+                max_continuations: self.config.goal_max_continuations,
             },
         );
 
@@ -3237,8 +3247,8 @@ impl Engine {
                     ),
                     crate::goal_loop::StopReason::ContinuationLimit => (
                         format!(
-                            "Goal paused after {} automatic continuations without a terminal result; inspect progress, then resume if useful.",
-                            crate::goal_loop::MAX_GOAL_CONTINUATIONS,
+                            "Goal paused after {} automatic continuations without a terminal result (safety backstop; raise or disable via [goal] max_continuations); inspect progress, then resume if useful.",
+                            self.config.goal_max_continuations,
                         ),
                         GoalPauseReason::Backoff,
                     ),

--- a/crates/tui/src/core/engine/preview.rs
+++ b/crates/tui/src/core/engine/preview.rs
@@ -202,6 +202,7 @@ impl Engine {
                         crate::goal_loop::GoalBudget {
                             token_budget: snapshot.token_budget.map(u64::from),
                             time_budget_seconds: None,
+                            max_continuations: self.config.goal_max_continuations,
                         },
                     ))
             }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2163,12 +2163,18 @@ async fn exhausted_goal_pauses_before_invalid_route_resolution() {
 
 #[tokio::test]
 async fn continuation_circuit_breaker_pauses_with_run_limit_reason() {
+    // #5052: the backstop is configurable ([goal] max_continuations) and set
+    // deliberately past the retired hardcoded cap of 10 to prove an operate
+    // goal is no longer stopped there — only the configured backstop halts a
+    // pathological loop that never emits a terminal signal.
+    let backstop = 12u32;
     let config = Config::default();
     let (engine, handle) = Engine::new(
         EngineConfig {
             snapshots_enabled: false,
             terminal_chrome_enabled: false,
             goal_objective: Some("stop a runaway continuation loop".to_string()),
+            goal_max_continuations: backstop,
             ..EngineConfig::default()
         },
         &config,
@@ -2176,7 +2182,7 @@ async fn continuation_circuit_breaker_pauses_with_run_limit_reason() {
     let goal_state = engine.config.goal_state.clone();
     {
         let mut goal = goal_state.lock().expect("goal lock");
-        for _ in 0..crate::goal_loop::MAX_GOAL_CONTINUATIONS {
+        for _ in 0..backstop {
             goal.record_continuation();
         }
     }
@@ -2209,10 +2215,8 @@ async fn continuation_circuit_breaker_pauses_with_run_limit_reason() {
                 saw_pause = true;
             }
             Event::Status { message } if message.contains("automatic continuations") => {
-                assert!(
-                    message.contains(&crate::goal_loop::MAX_GOAL_CONTINUATIONS.to_string()),
-                    "{message}"
-                );
+                assert!(message.contains(&backstop.to_string()), "{message}");
+                assert!(message.contains("[goal] max_continuations"), "{message}");
                 saw_reason = true;
             }
             _ => {}
@@ -2221,6 +2225,64 @@ async fn continuation_circuit_breaker_pauses_with_run_limit_reason() {
 
     handle.send(Op::Shutdown).await.expect("shutdown engine");
     run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn goal_continues_past_legacy_ten_pass_cap_when_budget_remains() {
+    // #5052 regression: 10 automatic continuations used to be a terminal stop.
+    // With the default backstop and budget remaining, the loop must keep
+    // dispatching toward the completion gate.
+    let config = Config::default();
+    let (engine, _handle) = Engine::new(
+        EngineConfig {
+            snapshots_enabled: false,
+            terminal_chrome_enabled: false,
+            goal_objective: Some("run to the completion gate, not a pass count".to_string()),
+            goal_token_budget: Some(1_000_000),
+            ..EngineConfig::default()
+        },
+        &config,
+    );
+    {
+        let mut goal = engine.config.goal_state.lock().expect("goal lock");
+        for _ in 0..10 {
+            goal.record_continuation();
+        }
+    }
+
+    match engine.goal_continuation_if_active() {
+        GoalContinuationAction::Dispatch { snapshot, .. } => {
+            assert_eq!(snapshot.continuation_count, 11);
+        }
+        other => panic!("goal must continue past 10 passes, got {other:?}"),
+    }
+
+    // A backstop of 0 means unlimited-with-budget-stops: even a pathological
+    // pass count keeps continuing while budget remains.
+    let (engine, _handle) = Engine::new(
+        EngineConfig {
+            snapshots_enabled: false,
+            terminal_chrome_enabled: false,
+            goal_objective: Some("unlimited backstop".to_string()),
+            goal_token_budget: Some(1_000_000),
+            goal_max_continuations: 0,
+            ..EngineConfig::default()
+        },
+        &config,
+    );
+    {
+        let mut goal = engine.config.goal_state.lock().expect("goal lock");
+        for _ in 0..500 {
+            goal.record_continuation();
+        }
+    }
+    assert!(
+        matches!(
+            engine.goal_continuation_if_active(),
+            GoalContinuationAction::Dispatch { .. }
+        ),
+        "backstop 0 must not stop an in-budget goal"
+    );
 }
 
 #[tokio::test]

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -3489,10 +3489,12 @@ impl Engine {
         }
 
         // Route the continuation decision through the goal-loop decision core.
-        // There is no run-level cap — a goal runs until complete/blocked,
-        // paused, or an optional token/time budget is exhausted. The per-turn
-        // guard (`per_turn_max`) only bounds how many continuation passes
-        // happen *within* a single turn before yielding back to the engine.
+        // A goal runs until complete/blocked, paused, or an optional
+        // token/time budget is exhausted (#5052); the configurable run-level
+        // backstop (`[goal] max_continuations`) only halts a pathological
+        // loop. The per-turn guard (`per_turn_max`) only bounds how many
+        // continuation passes happen *within* a single turn before yielding
+        // back to the engine.
         let decision = crate::goal_loop::decide_continuation(
             crate::goal_loop::GoalRunStatus::Active,
             crate::goal_loop::GoalProgress {
@@ -3503,6 +3505,7 @@ impl Engine {
             crate::goal_loop::GoalBudget {
                 token_budget: snapshot.token_budget.map(u64::from),
                 time_budget_seconds: None,
+                max_continuations: self.config.goal_max_continuations,
             },
         );
         if let crate::goal_loop::ContinuationDecision::Stop(reason) = decision {

--- a/crates/tui/src/goal_loop.rs
+++ b/crates/tui/src/goal_loop.rs
@@ -12,15 +12,21 @@
 //!
 //! Scope: **decision logic + types**. The engine (`core/engine.rs`) reads the
 //! `SharedGoalState` snapshot after each turn and calls `decide_continuation`
-//! to decide whether to re-dispatch. A small cross-turn circuit breaker keeps
-//! an unbounded goal from silently spending forever when the model never emits
-//! a terminal signal; explicit token/time budgets still take precedence.
+//! to decide whether to re-dispatch. For operate-mode goals the only terminal
+//! stops are a verified completion, a blocked report, or an exhausted
+//! token/time budget (#5052); a configurable safety backstop
+//! (`[goal] max_continuations`) still halts a pathological loop that never
+//! emits a terminal signal, and logs when it fires.
 
-/// Maximum automatic cross-turn continuation passes for one goal.
+/// Default safety backstop on automatic cross-turn continuation passes for one
+/// goal run (#5052).
 ///
-/// This matches the conservative run-cap used by the peer goal lifecycle while
-/// avoiding its much larger classifier/strategist subsystem.
-pub const MAX_GOAL_CONTINUATIONS: u32 = 10;
+/// This is deliberately generous: the completion gate and token/time budgets
+/// are the real terminal stops, and the backstop only exists to halt a
+/// pathological loop that never emits a terminal signal. Override with
+/// `[goal] max_continuations` in config.toml; `0` disables the backstop
+/// entirely so only budget/terminal stops end the run.
+pub const DEFAULT_MAX_GOAL_CONTINUATIONS: u32 = 100;
 
 /// Terminal or active state of a persistent goal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,21 +69,27 @@ pub struct GoalProgress {
 }
 
 /// The optional token/time bounds on a goal run. `None` fields mean unbounded
-/// for that resource; the fixed continuation circuit breaker still applies.
+/// for that resource; the continuation backstop (`max_continuations`) still
+/// applies unless configured to `0`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GoalBudget {
     pub token_budget: Option<u64>,
     pub time_budget_seconds: Option<u64>,
+    /// Safety backstop on automatic continuation passes (#5052). `0` disables
+    /// the backstop: only terminal status, user control, or token/time budget
+    /// exhaustion stop the run.
+    pub max_continuations: u32,
 }
 
 impl GoalBudget {
-    /// No token or time cap. Terminal status, user control, and the fixed
-    /// continuation circuit breaker still stop the run.
+    /// No token or time cap. Terminal status, user control, and the default
+    /// continuation backstop still stop the run.
     #[allow(dead_code)]
     pub const fn unbounded() -> Self {
         Self {
             token_budget: None,
             time_budget_seconds: None,
+            max_continuations: DEFAULT_MAX_GOAL_CONTINUATIONS,
         }
     }
 
@@ -88,7 +100,16 @@ impl GoalBudget {
         Self {
             token_budget: Some(token_budget),
             time_budget_seconds: None,
+            max_continuations: DEFAULT_MAX_GOAL_CONTINUATIONS,
         }
+    }
+
+    /// Override the continuation backstop (`0` = unlimited-with-budget-stops).
+    #[allow(dead_code)]
+    #[must_use]
+    pub const fn with_max_continuations(mut self, max_continuations: u32) -> Self {
+        self.max_continuations = max_continuations;
+        self
     }
 }
 
@@ -106,8 +127,10 @@ pub enum ContinuationDecision {
 /// Precedence (most authoritative first):
 /// 1. A terminal model status (Completed / Blocked) ends the run.
 /// 2. An optional token or time budget, if exhausted, ends the run.
-/// 3. The continuation circuit breaker stops a runaway loop.
-/// 4. Otherwise continue.
+/// 3. The configurable continuation backstop stops a pathological loop
+///    (skipped entirely when configured to `0`).
+/// 4. Otherwise continue — the loop runs to the completion gate, not to a
+///    fixed pass count (#5052).
 #[must_use]
 pub fn decide_continuation(
     status: GoalRunStatus,
@@ -133,8 +156,14 @@ pub fn decide_continuation(
 
     // 3. Runaway-cost backstop. This deliberately uses the already-durable
     // continuation counter instead of adding verifier fingerprints or another
-    // orchestration subsystem.
-    if progress.continuations >= MAX_GOAL_CONTINUATIONS {
+    // orchestration subsystem. `0` disables it — budget/terminal stops only.
+    if budget.max_continuations > 0 && progress.continuations >= budget.max_continuations {
+        tracing::warn!(
+            continuations = progress.continuations,
+            max_continuations = budget.max_continuations,
+            "goal continuation backstop fired: no terminal signal after the configured \
+             continuation limit ([goal] max_continuations)"
+        );
         return ContinuationDecision::Stop(StopReason::ContinuationLimit);
     }
 
@@ -199,6 +228,7 @@ mod tests {
         let budget = GoalBudget {
             token_budget: Some(1000),
             time_budget_seconds: Some(600),
+            max_continuations: DEFAULT_MAX_GOAL_CONTINUATIONS,
         };
         assert_eq!(
             decide_continuation(GoalRunStatus::Active, progress, budget),
@@ -209,7 +239,7 @@ mod tests {
     #[test]
     fn active_under_continuation_limit_without_budget_continues() {
         let progress = GoalProgress {
-            continuations: MAX_GOAL_CONTINUATIONS - 1,
+            continuations: DEFAULT_MAX_GOAL_CONTINUATIONS - 1,
             ..GoalProgress::default()
         };
         assert_eq!(
@@ -221,12 +251,73 @@ mod tests {
     #[test]
     fn continuation_limit_stops_unbounded_run() {
         let progress = GoalProgress {
-            continuations: MAX_GOAL_CONTINUATIONS,
+            continuations: DEFAULT_MAX_GOAL_CONTINUATIONS,
             ..GoalProgress::default()
         };
         assert_eq!(
             decide_continuation(GoalRunStatus::Active, progress, GoalBudget::unbounded()),
             ContinuationDecision::Stop(StopReason::ContinuationLimit)
+        );
+    }
+
+    #[test]
+    fn operate_goal_continues_past_ten_when_budget_remains() {
+        // #5052 regression: the old hardcoded cap of 10 must not be a terminal
+        // stop. With budget remaining and no terminal signal, pass 10, 11, and
+        // far beyond keep continuing under the default backstop.
+        for continuations in [10, 11, DEFAULT_MAX_GOAL_CONTINUATIONS - 1] {
+            let progress = GoalProgress {
+                tokens_used: 5_000,
+                time_used_seconds: 300,
+                continuations,
+                ..GoalProgress::default()
+            };
+            let budget = GoalBudget::with_token_budget(1_000_000);
+            assert_eq!(
+                decide_continuation(GoalRunStatus::Active, progress, budget),
+                ContinuationDecision::Continue,
+                "pass {continuations} must continue toward the completion gate",
+            );
+        }
+    }
+
+    #[test]
+    fn configured_backstop_halts_pathological_loop() {
+        let backstop = 25;
+        let progress = GoalProgress {
+            continuations: backstop,
+            ..GoalProgress::default()
+        };
+        let budget = GoalBudget::unbounded().with_max_continuations(backstop);
+        assert_eq!(
+            decide_continuation(GoalRunStatus::Active, progress, budget),
+            ContinuationDecision::Stop(StopReason::ContinuationLimit)
+        );
+    }
+
+    #[test]
+    fn zero_backstop_is_unlimited_but_budget_still_stops() {
+        // 0 = unlimited-with-budget-stops: no continuation count ends the run…
+        let progress = GoalProgress {
+            continuations: 10_000,
+            ..GoalProgress::default()
+        };
+        let budget = GoalBudget::unbounded().with_max_continuations(0);
+        assert_eq!(
+            decide_continuation(GoalRunStatus::Active, progress, budget),
+            ContinuationDecision::Continue
+        );
+
+        // …but an exhausted token budget still does.
+        let progress = GoalProgress {
+            tokens_used: 1_000,
+            continuations: 10_000,
+            ..GoalProgress::default()
+        };
+        let budget = GoalBudget::with_token_budget(1_000).with_max_continuations(0);
+        assert_eq!(
+            decide_continuation(GoalRunStatus::Active, progress, budget),
+            ContinuationDecision::Stop(StopReason::TokenBudget)
         );
     }
 
@@ -254,6 +345,7 @@ mod tests {
         let budget = GoalBudget {
             token_budget: None,
             time_budget_seconds: Some(600),
+            max_continuations: DEFAULT_MAX_GOAL_CONTINUATIONS,
         };
         assert_eq!(
             decide_continuation(GoalRunStatus::Active, progress, budget),
@@ -268,6 +360,7 @@ mod tests {
         let budget = GoalBudget {
             token_budget: Some(1_000_000),
             time_budget_seconds: Some(86_400),
+            max_continuations: DEFAULT_MAX_GOAL_CONTINUATIONS,
         };
         assert_eq!(
             decide_continuation(GoalRunStatus::Completed, progress, budget),

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -10658,6 +10658,7 @@ async fn run_exec_agent(
         goal_objective: None,
         goal_token_budget: None,
         goal_status: crate::tools::goal::GoalStatus::Active,
+        goal_max_continuations: execution_config.goal_max_continuations(),
         allowed_tools: allowed_tools.clone(),
         disallowed_tools: disallowed_tools.clone(),
         max_tool_calls: None,

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -5720,6 +5720,7 @@ impl RuntimeThreadManager {
                 goal_objective: None,
                 goal_token_budget: None,
                 goal_status: crate::tools::goal::GoalStatus::Active,
+                goal_max_continuations: cfg.goal_max_continuations(),
                 allowed_tools: None,
                 disallowed_tools: None,
                 max_tool_calls: None,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2438,6 +2438,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         goal_objective: app.hunt.quarry.clone(),
         goal_token_budget: app.hunt.token_budget,
         goal_status: app.hunt.verdict.goal_status(),
+        goal_max_continuations: config.goal_max_continuations(),
         locale_tag: app.ui_locale.tag().to_string(),
         workshop: config.workshop.clone(),
         search_provider: config.search_provider(),

--- a/crates/tui/src/tui/views/fleet_roster_capability_tests.rs
+++ b/crates/tui/src/tui/views/fleet_roster_capability_tests.rs
@@ -4,7 +4,7 @@
 #[test]
 fn detail_shows_capability_badges_for_pinned_models_only() {
     fn detail_text(member: &AgentProfile) -> String {
-        member_detail_lines_with_session(member, None)
+        member_detail_lines_with_session(member, None, &[])
             .iter()
             .map(|line| {
                 line.spans

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1806,6 +1806,25 @@ Notes:
 - See [`MEMORY.md`](MEMORY.md) for examples and the full `/memory`
   command surface.
 
+### Goal loop (`[goal]`)
+
+Operate-mode goals run to their completion gate: the only terminal stops are a
+verified completion, a blocked report, or an exhausted token/time budget
+(#5052). A configurable safety backstop still halts a pathological loop that
+never emits a terminal signal:
+
+```toml
+[goal]
+# Safety backstop on automatic goal continuation passes.
+# Default: 100. Set 0 to disable the backstop entirely so only
+# completion/blocked or budget exhaustion stop the run.
+max_continuations = 100
+```
+
+When the backstop fires, the goal pauses with a status message naming
+`[goal] max_continuations` and a warning is logged; resume the goal after
+inspecting progress, or raise/disable the backstop.
+
 ### Notifications
 
 The TUI can emit a desktop notification (OSC 9 escape or plain BEL) when a turn **completes successfully** and took longer than a threshold, so you can tab away while a long task runs. Failed or cancelled turns are intentionally silent — the notification is a "your task is ready" cue, not a generic ping. Configuration lives under `[notifications]`:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1809,9 +1809,10 @@ Notes:
 ### Goal loop (`[goal]`)
 
 Operate-mode goals run to their completion gate: the only terminal stops are a
-verified completion, a blocked report, or an exhausted token/time budget
-(#5052). A configurable safety backstop still halts a pathological loop that
-never emits a terminal signal:
+verified completion, a blocked report, or an exhausted configured token budget
+(#5052). The decision core also accepts an optional time budget, but the TUI
+does not currently configure or expose one. A configurable safety backstop
+still halts a pathological loop that never emits a terminal signal:
 
 ```toml
 [goal]


### PR DESCRIPTION
## Summary

Removes the hardcoded ten-continuation terminal stop from operate-mode goals. Goals now run until completion is verified, they are blocked, or their token/time budget is exhausted; the cap becomes a configurable safety backstop:

- Adds `[goal] max_continuations` with a default of 100; `0` means unlimited while budget stops still apply.
- Plumbs the setting through cross-turn dispatch, intra-turn passes, and preview gating.
- Logs when the backstop fires and names `[goal] max_continuations` in the pause message.

This intentionally raises the default autonomous-run backstop from 10 to 100.

Deferred: a per-goal runtime override command and time-budget wiring, which remains unset as before.

## Verification

- `cargo test -p codewhale-tui --bin codewhale-tui --locked goal` — 93 passed, 0 failed.
- Targeted filters: `goal_loop` — 11 passed; `continuation` — 17 passed.
- Regression coverage proves goals continue past ten when budget remains, a configured backstop still halts pathological loops, and `0` remains budget-bounded.
- `cargo clippy -p codewhale-tui --locked -- -D warnings` — clean.
- `git diff --check origin/main...origin/codex/wave-5052-goal-cap` — clean.

Closes #5052
