### PR TITLE
refactor(tui): centralize DeepSeek pro effort mapping in a dated table

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -2956,18 +2956,23 @@ pub(super) fn apply_reasoning_effort(
     let normalized = effort.trim().to_ascii_lowercase();
     match normalized.as_str() {
         "off" | "disabled" | "none" | "false" => match provider {
+            // DeepSeek dialect: the effort mapping lives in the
+            // date-annotated `deepseek_effort::DEEPSEEK_EFFORT_MAP` table
+            // (#5055) — do not inline labels here.
             ApiProvider::Deepseek
             | ApiProvider::DeepseekCN
-            | ApiProvider::Openrouter
-            | ApiProvider::XiaomiMimo
-            | ApiProvider::Novita
             | ApiProvider::Siliconflow
             | ApiProvider::SiliconflowCn
             | ApiProvider::Sglang
             | ApiProvider::Volcengine
             | ApiProvider::Deepinfra
+            | ApiProvider::Atlascloud => {
+                deepseek_effort::apply_deepseek_chat_effort(body, &normalized);
+            }
+            ApiProvider::Openrouter
+            | ApiProvider::XiaomiMimo
+            | ApiProvider::Novita
             | ApiProvider::Together
-            | ApiProvider::Atlascloud
             | ApiProvider::Zai => {
                 body["thinking"] = json!({ "type": "disabled" });
             }
@@ -3035,7 +3040,10 @@ pub(super) fn apply_reasoning_effort(
             ApiProvider::Xai => {}
         },
         "low" | "minimal" | "medium" | "mid" | "high" | "" => match provider {
-            // DeepSeek compatibility: low/medium both map to high
+            // DeepSeek compatibility: low/medium both map to high. The label
+            // comes from the date-annotated
+            // `deepseek_effort::DEEPSEEK_EFFORT_MAP` table (#5055) — do not
+            // inline it here.
             ApiProvider::Deepseek
             | ApiProvider::DeepseekCN
             | ApiProvider::Siliconflow
@@ -3044,8 +3052,7 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Volcengine
             | ApiProvider::Deepinfra
             | ApiProvider::Atlascloud => {
-                body["reasoning_effort"] = json!("high");
-                body["thinking"] = json!({ "type": "enabled" });
+                deepseek_effort::apply_deepseek_chat_effort(body, &normalized);
             }
             // TelecomJS: see comment in the "off" branch above — the gateway's
             // Chat Completions API does not support reasoning_effort or thinking.
@@ -3131,6 +3138,9 @@ pub(super) fn apply_reasoning_effort(
             ApiProvider::Xai => {}
         },
         "xhigh" | "max" | "highest" | "ultracode" => match provider {
+            // DeepSeek dialect: the effort label comes from the
+            // date-annotated `deepseek_effort::DEEPSEEK_EFFORT_MAP` table
+            // (#5055) — do not inline it here.
             ApiProvider::Deepseek
             | ApiProvider::DeepseekCN
             | ApiProvider::Siliconflow
@@ -3139,8 +3149,7 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Volcengine
             | ApiProvider::Deepinfra
             | ApiProvider::Atlascloud => {
-                body["reasoning_effort"] = json!("max");
-                body["thinking"] = json!({ "type": "enabled" });
+                deepseek_effort::apply_deepseek_chat_effort(body, &normalized);
             }
             // TelecomJS: see comment in the "off" branch above — the gateway's
             // Chat Completions API does not support reasoning_effort or thinking.
@@ -3345,6 +3354,7 @@ impl DeepSeekClient {
 
 mod anthropic;
 mod chat;
+mod deepseek_effort;
 mod prepared;
 mod provider_native_search;
 mod responses;
@@ -6975,6 +6985,53 @@ mod tests {
         );
         assert!(body.get("reasoning_effort").is_none());
         assert!(body.get("extra_body").is_none());
+    }
+
+    #[test]
+    fn deepseek_chat_effort_mapping_pinned_to_2026_07_31_docs() {
+        // Pins the full DeepSeek mapping through the Chat Completions path;
+        // source of truth is `deepseek_effort::DEEPSEEK_EFFORT_MAP` (#5055).
+        let disabled = json!({ "thinking": { "type": "disabled" } });
+        let high = json!({ "reasoning_effort": "high", "thinking": { "type": "enabled" } });
+        let max = json!({ "reasoning_effort": "max", "thinking": { "type": "enabled" } });
+        let cases: &[(&str, &Value)] = &[
+            ("off", &disabled),
+            ("disabled", &disabled),
+            ("none", &disabled),
+            ("false", &disabled),
+            ("minimal", &high),
+            ("low", &high),
+            ("medium", &high),
+            ("mid", &high),
+            ("", &high),
+            ("high", &high),
+            ("xhigh", &max),
+            ("max", &max),
+            ("highest", &max),
+            ("ultracode", &max),
+        ];
+        for provider in [
+            ApiProvider::Deepseek,
+            ApiProvider::DeepseekCN,
+            ApiProvider::Siliconflow,
+            ApiProvider::SiliconflowCn,
+            ApiProvider::Sglang,
+            ApiProvider::Volcengine,
+            ApiProvider::Deepinfra,
+            ApiProvider::Atlascloud,
+        ] {
+            for (effort, expected) in cases {
+                let mut body = json!({});
+                apply_reasoning_effort(&mut body, Some(effort), provider);
+                assert_eq!(body, **expected, "{provider:?} {effort:?}");
+            }
+            // Tiers the Chat path does not recognize leave the body untouched.
+            for effort in ["maximum", "unknown-tier"] {
+                let mut body = json!({});
+                apply_reasoning_effort(&mut body, Some(effort), provider);
+                assert_eq!(body, json!({}), "{provider:?} {effort:?}");
+            }
+        }
     }
 
     #[test]

--- a/crates/tui/src/client/deepseek_effort.rs
+++ b/crates/tui/src/client/deepseek_effort.rs
@@ -1,0 +1,214 @@
+//! DeepSeek pro actual-effort mapping — the single source of truth (#5055).
+//!
+//! [`DEEPSEEK_EFFORT_MAP`] pins how CodeWhale's requested reasoning-effort
+//! tiers translate to the effort labels DeepSeek accepts on the wire, for
+//! BOTH request dialects:
+//!
+//! - Chat Completions (`super::apply_reasoning_effort`): top-level
+//!   `reasoning_effort` plus the `thinking` enable/disable toggle.
+//! - Responses (`super::responses::responses_reasoning_effort`): the
+//!   `reasoning.effort` field.
+//!
+//! Mapping per the DeepSeek API docs dated 2026-07-31 (the same doc revision
+//! as the DeepSeek-V4-Flash-0731 Responses contract). DeepSeek documents that
+//! the pro actual-effort mapping changes in early August 2026 — when it does,
+//! edit this table (and the doc date here), not the call sites. The former
+//! inline sites carry pointer comments back to this module so the labels do
+//! not get re-inlined.
+
+use serde_json::{Value, json};
+
+/// What the Chat Completions path emits for a requested effort tier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ChatEffort {
+    /// Emit `"thinking": {"type": "disabled"}` and no `reasoning_effort`.
+    DisableThinking,
+    /// Emit `"reasoning_effort": <label>` and `"thinking": {"type": "enabled"}`.
+    Label(&'static str),
+}
+
+/// One row of the DeepSeek effort mapping.
+pub(super) struct DeepseekEffortRow {
+    /// Normalized (trimmed, ASCII-lowercased) requested effort tier.
+    pub alias: &'static str,
+    /// Chat Completions behavior. `None` leaves the body untouched — the
+    /// Chat path does not recognize the alias today.
+    pub chat: Option<ChatEffort>,
+    /// Responses `reasoning.effort` label.
+    pub responses: &'static str,
+}
+
+/// Responses-path label for any tier absent from the table: DeepSeek maps
+/// every remaining/automatic tier to its normal high tier in thinking mode.
+/// (The Chat path instead ignores unknown tiers entirely.)
+pub(super) const DEEPSEEK_RESPONSES_DEFAULT_EFFORT: &str = "high";
+
+/// DeepSeek pro actual-effort mapping, per the docs dated 2026-07-31.
+///
+/// Asymmetries between the two columns are deliberate and pre-date this
+/// table; they are pinned by tests and must only change when the DeepSeek
+/// docs do:
+/// - Chat collapses `low`/`minimal` to `high` (DeepSeek maps both low and
+///   medium to its normal high tier in thinking mode), while Responses
+///   preserves an explicit `low` for Codex compatibility.
+/// - Responses has no off switch, so disabled tiers send its lowest
+///   documented effort; Chat disables thinking outright.
+/// - `maximum` is only recognized by the Responses path, and `highest` only
+///   reaches `max` on the Chat path.
+pub(super) const DEEPSEEK_EFFORT_MAP: &[DeepseekEffortRow] = &[
+    DeepseekEffortRow {
+        alias: "off",
+        chat: Some(ChatEffort::DisableThinking),
+        responses: "low",
+    },
+    DeepseekEffortRow {
+        alias: "disabled",
+        chat: Some(ChatEffort::DisableThinking),
+        responses: "low",
+    },
+    DeepseekEffortRow {
+        alias: "none",
+        chat: Some(ChatEffort::DisableThinking),
+        responses: "low",
+    },
+    DeepseekEffortRow {
+        alias: "false",
+        chat: Some(ChatEffort::DisableThinking),
+        responses: "low",
+    },
+    DeepseekEffortRow {
+        alias: "minimal",
+        chat: Some(ChatEffort::Label("high")),
+        responses: "low",
+    },
+    DeepseekEffortRow {
+        alias: "low",
+        chat: Some(ChatEffort::Label("high")),
+        responses: "low",
+    },
+    DeepseekEffortRow {
+        alias: "medium",
+        chat: Some(ChatEffort::Label("high")),
+        responses: "high",
+    },
+    DeepseekEffortRow {
+        alias: "mid",
+        chat: Some(ChatEffort::Label("high")),
+        responses: "high",
+    },
+    // Empty string is the "unspecified" tier the Chat path groups with high.
+    DeepseekEffortRow {
+        alias: "",
+        chat: Some(ChatEffort::Label("high")),
+        responses: "high",
+    },
+    DeepseekEffortRow {
+        alias: "high",
+        chat: Some(ChatEffort::Label("high")),
+        responses: "high",
+    },
+    DeepseekEffortRow {
+        alias: "xhigh",
+        chat: Some(ChatEffort::Label("max")),
+        responses: "max",
+    },
+    DeepseekEffortRow {
+        alias: "max",
+        chat: Some(ChatEffort::Label("max")),
+        responses: "max",
+    },
+    DeepseekEffortRow {
+        alias: "maximum",
+        chat: None,
+        responses: "max",
+    },
+    DeepseekEffortRow {
+        alias: "highest",
+        chat: Some(ChatEffort::Label("max")),
+        responses: DEEPSEEK_RESPONSES_DEFAULT_EFFORT,
+    },
+    DeepseekEffortRow {
+        alias: "ultracode",
+        chat: Some(ChatEffort::Label("max")),
+        responses: "max",
+    },
+];
+
+/// Chat Completions mapping for a normalized requested tier.
+pub(super) fn chat_effort(normalized: &str) -> Option<ChatEffort> {
+    DEEPSEEK_EFFORT_MAP
+        .iter()
+        .find(|row| row.alias == normalized)
+        .and_then(|row| row.chat)
+}
+
+/// Responses `reasoning.effort` label for a normalized requested tier.
+pub(super) fn responses_effort(normalized: &str) -> &'static str {
+    DEEPSEEK_EFFORT_MAP
+        .iter()
+        .find(|row| row.alias == normalized)
+        .map_or(DEEPSEEK_RESPONSES_DEFAULT_EFFORT, |row| row.responses)
+}
+
+/// Applies the DeepSeek Chat Completions mapping for `normalized` (a trimmed,
+/// ASCII-lowercased requested tier) to a Chat request `body`.
+pub(super) fn apply_deepseek_chat_effort(body: &mut Value, normalized: &str) {
+    match chat_effort(normalized) {
+        Some(ChatEffort::DisableThinking) => {
+            body["thinking"] = json!({ "type": "disabled" });
+        }
+        Some(ChatEffort::Label(label)) => {
+            body["reasoning_effort"] = json!(label);
+            body["thinking"] = json!({ "type": "enabled" });
+        }
+        None => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chat_column_pins_2026_07_31_docs() {
+        for alias in ["off", "disabled", "none", "false"] {
+            assert_eq!(
+                chat_effort(alias),
+                Some(ChatEffort::DisableThinking),
+                "{alias}"
+            );
+        }
+        for alias in ["minimal", "low", "medium", "mid", "", "high"] {
+            assert_eq!(
+                chat_effort(alias),
+                Some(ChatEffort::Label("high")),
+                "{alias}"
+            );
+        }
+        for alias in ["xhigh", "max", "highest", "ultracode"] {
+            assert_eq!(
+                chat_effort(alias),
+                Some(ChatEffort::Label("max")),
+                "{alias}"
+            );
+        }
+        // Unrecognized on the Chat path: leave the body untouched.
+        assert_eq!(chat_effort("maximum"), None);
+        assert_eq!(chat_effort("unknown-tier"), None);
+    }
+
+    #[test]
+    fn responses_column_pins_2026_07_31_docs() {
+        for alias in ["off", "disabled", "none", "false", "minimal", "low"] {
+            assert_eq!(responses_effort(alias), "low", "{alias}");
+        }
+        for alias in ["medium", "mid", "", "high", "highest"] {
+            assert_eq!(responses_effort(alias), "high", "{alias}");
+        }
+        for alias in ["xhigh", "max", "maximum", "ultracode"] {
+            assert_eq!(responses_effort(alias), "max", "{alias}");
+        }
+        // Unknown tiers fall back to the documented default.
+        assert_eq!(responses_effort("unknown-tier"), "high");
+    }
+}

--- a/crates/tui/src/client/deepseek_effort.rs
+++ b/crates/tui/src/client/deepseek_effort.rs
@@ -21,7 +21,7 @@ use serde_json::{Value, json};
 /// What the Chat Completions path emits for a requested effort tier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum ChatEffort {
-    /// Emit `"thinking": {"type": "disabled"}` and no `reasoning_effort`.
+    /// Emit `"thinking": {"type": "disabled"}` without setting `reasoning_effort`.
     DisableThinking,
     /// Emit `"reasoning_effort": <label>` and `"thinking": {"type": "enabled"}`.
     Label(&'static str),

--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -744,14 +744,14 @@ fn responses_reasoning_effort(raw: &str, is_deepseek: bool) -> Option<&'static s
     if !is_deepseek {
         return codex_responses_reasoning_effort(raw);
     }
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "off" | "disabled" | "none" | "false" | "minimal" | "low" => Some("low"),
-        "xhigh" | "max" | "maximum" | "ultracode" => Some("max"),
-        // DeepSeek maps both low and medium to its normal high tier in
-        // thinking mode. Preserve explicit low for Codex compatibility, and
-        // normalize every remaining/automatic tier to a documented value.
-        _ => Some("high"),
-    }
+    // DeepSeek maps both low and medium to its normal high tier in thinking
+    // mode; explicit low is preserved for Codex compatibility. The labels
+    // come from the date-annotated
+    // `super::deepseek_effort::DEEPSEEK_EFFORT_MAP` table (#5055) — do not
+    // inline them here.
+    Some(super::deepseek_effort::responses_effort(
+        &raw.trim().to_ascii_lowercase(),
+    ))
 }
 
 fn responses_event_error_details(event: &Value) -> (String, String) {
@@ -1400,11 +1400,23 @@ mod tests {
 
     #[test]
     fn deepseek_responses_reasoning_effort_uses_documented_labels() {
-        assert_eq!(responses_reasoning_effort("low", true), Some("low"));
-        assert_eq!(responses_reasoning_effort("medium", true), Some("high"));
-        assert_eq!(responses_reasoning_effort("high", true), Some("high"));
-        assert_eq!(responses_reasoning_effort("xhigh", true), Some("max"));
-        assert_eq!(responses_reasoning_effort("max", true), Some("max"));
+        // Pins the full 2026-07-31 documented mapping through the Responses
+        // path; source of truth is `deepseek_effort::DEEPSEEK_EFFORT_MAP`
+        // (#5055).
+        for raw in ["off", "disabled", "none", "false", "minimal", "low"] {
+            assert_eq!(responses_reasoning_effort(raw, true), Some("low"), "{raw}");
+        }
+        for raw in ["medium", "mid", "", "high", "highest"] {
+            assert_eq!(responses_reasoning_effort(raw, true), Some("high"), "{raw}");
+        }
+        for raw in ["xhigh", "max", "maximum", "ultracode"] {
+            assert_eq!(responses_reasoning_effort(raw, true), Some("max"), "{raw}");
+        }
+        // Unknown tiers normalize to the documented default.
+        assert_eq!(
+            responses_reasoning_effort("unknown-tier", true),
+            Some("high")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Centralizes DeepSeek Pro effort mapping in one dated source of truth, `client/deepseek_effort.rs`, annotated with the 2026-07-31 documentation date and the expected early-August update. Both Chat and Responses request paths now consume the same table while preserving their documented existing asymmetries byte-for-byte. Pointer comments at the former inline sites direct future updates back to the table.

Deferred: moving the mapping onto catalog offering rows and applying future August values once DeepSeek publishes them.

## Verification

- `cargo test -p codewhale-tui --bin codewhale-tui --locked 2026_07_31` — 3 passed, 0 failed.
- `cargo test -p codewhale-tui --bin codewhale-tui --locked deepseek_responses_reasoning` — 1 passed, 0 failed.
- Regression filters: `effort` — 82 passed; `client::` — 369 passed.
- `cargo clippy -p codewhale-tui --locked --all-targets -- -D warnings` — clean.
- `git diff --check origin/main...origin/codex/wave-5055-effort-table` — clean.

Closes #5055
