### PR TITLE
fix(devcontainer): support Windows development (community integration)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+ARG RUST_VERSION=1.88
+FROM rust:${RUST_VERSION}-slim-bookworm
+
+# Native DBus headers and pkg-config are required by libdbus-sys during
+# `cargo build`. Keep these development dependencies in the Dev Container,
+# rather than adding them to the production runtime image.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        libdbus-1-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# The official Rust image keeps its toolchain here. Preserve it after switching
+# from the image's root user to the non-root development user below.
+ENV PATH=/usr/local/cargo/bin:${PATH}
+RUN printf '%s\n' 'export PATH=/usr/local/cargo/bin:$PATH' \
+    > /etc/profile.d/codewhale-rust.sh
+RUN rustup component add rustfmt
+
+RUN groupadd --gid 1000 codewhale \
+    && useradd --create-home --shell /bin/bash --uid 1000 --gid 1000 codewhale \
+    && install -d -m 0700 -o codewhale -g codewhale /home/codewhale/.codewhale \
+    && install -d -m 0755 -o codewhale -g codewhale /home/codewhale/.cargo \
+    && install -d -m 0755 -o codewhale -g codewhale /home/codewhale/.cargo/target
+
+USER codewhale
+WORKDIR /workspaces/CodeWhale

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
   "name": "CodeWhale",
-  "dockerFile": "../Dockerfile",
   "build": {
+    "context": "..",
+    "dockerfile": "Dockerfile",
     "args": {
       "RUST_VERSION": "1.88"
     }
@@ -20,15 +21,13 @@
     }
   },
   "remoteEnv": {
-    "DEEPSEEK_API_KEY": "${localEnv:DEEPSEEK_API_KEY}"
+    "DEEPSEEK_API_KEY": "${localEnv:DEEPSEEK_API_KEY}",
+    "CARGO_TARGET_DIR": "/home/codewhale/.cargo/target"
   },
   "mounts": [
-    "source=${localEnv:HOME}/.codewhale,target=/home/codewhale/.codewhale,type=bind,consistency=cached"
+    "source=codewhale-state,target=/home/codewhale/.codewhale,type=volume",
+    "source=codewhale-cargo-target,target=/home/codewhale/.cargo/target,type=volume"
   ],
-  "features": {
-    "ghcr.io/devcontainers/features/rust:1": {},
-    "ghcr.io/devcontainers/features/git:1": {}
-  },
-  "postCreateCommand": "cargo build",
+  "postCreateCommand": "cargo build --locked",
   "remoteUser": "codewhale"
 }

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -281,9 +281,16 @@ docker buildx build --platform linux/amd64,linux/arm64 -t codewhale .
 ## Devcontainer
 
 The repository includes a [`.devcontainer/devcontainer.json`](../.devcontainer/devcontainer.json)
-configuration for VS Code / GitHub Codespaces. It pre-installs the Rust toolchain,
-rust-analyzer, and the `codewhale` binary. Open the repo in a devcontainer to get a
-ready-to-use development environment.
+configuration for VS Code / GitHub Codespaces. It builds a dedicated development
+image with the Rust toolchain, Git, `pkg-config`, and the DBus development headers
+required by the workspace. The first open runs `cargo build --locked` and installs
+rust-analyzer and the other editor extensions.
+
+The source checkout remains mounted from the host. CodeWhale state and Cargo build
+artifacts use Docker named volumes instead, so the configuration works when VS Code
+cannot provide a POSIX-style `HOME` variable (notably on Windows), and builds do not
+write thousands of small files through a Windows bind mount. Rebuild the container
+after changing the Dev Container configuration.
 
 ## Release status
 


### PR DESCRIPTION
Community integration of #4990 onto current main.

Preserves pingg02 as the Git author and records the original commit in the cherry-pick trailer. The maintainer sign-off attests this repository-approved integration while keeping contributor authorship intact.

What this carries forward:
- dedicated Rust development image with DBus/pkg-config dependencies
- Windows-safe named volumes for Codewhale state and Cargo artifacts
- locked post-create build and updated Docker documentation

Current-base verification:
- clean no-commit merge simulation against main
- Dev Container image built successfully with Docker Desktop/Colima
- official Dev Container CLI 0.88.0 build passed and selected the dedicated development image
- non-root UID 1000 verified
- cargo 1.88, rustfmt, Git, pkg-config, and DBus discovery verified inside the image
- both named-volume mount targets verified writable as the non-root user
- diff check passed

Closes #5080