### PR TITLE
fix(undo): keep workspace rollback inside the current session

### DIFF
--- a/crates/tui/src/commands/groups/debug/mod.rs
+++ b/crates/tui/src/commands/groups/debug/mod.rs
@@ -188,12 +188,15 @@ pub(in crate::commands) fn dispatch(
         "diff" => undo::diff(app),
         "undo" => {
             // Try surgical patch-undo first; fall back to conversation undo
-            // if no snapshots are available or if the snapshot undo couldn't
-            // find anything useful.
+            // when there is no snapshot-level change to revert. Never fall
+            // through when the trusted-mode gate refused the file rollback —
+            // that would silently crop the conversation instead of telling
+            // the user to switch modes.
             let result = undo::patch_undo(app);
             if result.message.as_deref().is_none_or(|m| {
                 m.starts_with("No snapshots found")
                     || m.starts_with("No older tool or pre-turn")
+                    || m.starts_with("No undoable snapshot")
                     || m.starts_with("Snapshot repo")
             }) {
                 undo::undo_conversation(app)

--- a/crates/tui/src/commands/groups/debug/tests.rs
+++ b/crates/tui/src/commands/groups/debug/tests.rs
@@ -1273,13 +1273,16 @@ fn test_patch_undo_requests_session_resync_after_restore() {
 
     let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
     std::fs::write(workspace.join("a.txt"), b"original").unwrap();
-    repo.snapshot("pre-turn:1").unwrap();
+    repo.snapshot_with_session("pre-turn:1", Some("test-session"))
+        .unwrap();
     std::fs::write(workspace.join("a.txt"), b"modified").unwrap();
-    repo.snapshot("post-turn:1").unwrap();
+    repo.snapshot_with_session("post-turn:1", Some("test-session"))
+        .unwrap();
 
     let mut app = create_test_app();
     app.workspace = workspace.clone();
     app.yolo = true;
+    app.current_session_id = Some("test-session".to_string());
     app.api_messages.push(Message {
         role: "user".to_string(),
         content: vec![ContentBlock::Text {
@@ -1302,7 +1305,7 @@ fn test_patch_undo_requests_session_resync_after_restore() {
 }
 
 #[test]
-fn test_patch_undo_legacy_chain_stops_at_matching_newest_snapshot() {
+fn test_undo_legacy_chain_falls_back_to_conversation_only() {
     use crate::snapshot::SnapshotRepo;
     use crate::test_support::lock_test_env;
     use tempfile::tempdir;
@@ -1349,27 +1352,26 @@ fn test_patch_undo_legacy_chain_stops_at_matching_newest_snapshot() {
 
     let mut app = create_test_app();
     app.workspace = workspace.clone();
-    app.yolo = true;
+    app.current_session_id = Some("current-session".to_string());
+    app.history.push(HistoryCell::User {
+        content: "chat only".to_string(),
+    });
+    app.history.push(HistoryCell::Assistant {
+        content: "reply".to_string(),
+        streaming: false,
+    });
 
-    let first = patch_undo(&mut app);
-    assert!(!first.is_error);
-    assert_eq!(std::fs::read_to_string(&file).unwrap(), "one");
-
-    // A legacy (untagged) chain never walks past a snapshot that matches
-    // the current workspace: there is no session boundary to stop it from
-    // rolling back another conversation's work, so the second /undo
-    // reports nothing to revert instead of restoring "zero".
-    let second = patch_undo(&mut app);
-    assert!(!second.is_error);
+    let result = super::dispatch(&mut app, "undo", None).expect("registered command");
+    assert!(!result.is_error);
     assert!(
-        second
+        result
             .message
             .as_deref()
-            .is_some_and(|m| m.contains("No undoable snapshot")),
-        "expected 'nothing to revert' message, got: {:?}",
-        second.message
+            .is_some_and(|m| m.contains("Removed")),
+        "expected conversation fallback, got: {:?}",
+        result.message
     );
-    assert_eq!(std::fs::read_to_string(&file).unwrap(), "one");
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "two");
 }
 
 #[test]
@@ -1413,12 +1415,14 @@ fn test_patch_undo_prunes_tool_turn_context() {
     let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
     let file = workspace.join("a.txt");
     std::fs::write(&file, b"alpha").unwrap();
-    repo.snapshot("tool:call-1").unwrap();
+    repo.snapshot_with_session("tool:call-1", Some("test-session"))
+        .unwrap();
     std::fs::write(&file, b"alpha-fixed").unwrap();
 
     let mut app = create_test_app();
     app.workspace = workspace.clone();
     app.yolo = true;
+    app.current_session_id = Some("test-session".to_string());
     app.history.push(HistoryCell::User {
         content: "please edit a.txt".to_string(),
     });
@@ -1544,12 +1548,14 @@ fn test_patch_undo_prunes_pre_turn_context() {
     let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
     let file = workspace.join("a.txt");
     std::fs::write(&file, b"alpha").unwrap();
-    repo.snapshot("pre-turn:1").unwrap();
+    repo.snapshot_with_session("pre-turn:1", Some("test-session"))
+        .unwrap();
     std::fs::write(&file, b"alpha-fixed").unwrap();
 
     let mut app = create_test_app();
     app.workspace = workspace.clone();
     app.yolo = true;
+    app.current_session_id = Some("test-session".to_string());
     app.history.push(HistoryCell::User {
         content: "please edit a.txt".to_string(),
     });
@@ -1983,12 +1989,14 @@ fn test_patch_undo_refuses_outside_trusted_mode() {
 
     let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
     std::fs::write(workspace.join("a.txt"), b"original").unwrap();
-    repo.snapshot("pre-turn:1").unwrap();
+    repo.snapshot_with_session("pre-turn:1", Some("test-session"))
+        .unwrap();
     std::fs::write(workspace.join("a.txt"), b"modified").unwrap();
 
     // yolo/trust_mode stay false (create_test_app defaults).
     let mut app = create_test_app();
     app.workspace = workspace.clone();
+    app.current_session_id = Some("test-session".to_string());
 
     let result = patch_undo(&mut app);
     assert!(!result.is_error);
@@ -2066,5 +2074,17 @@ fn test_patch_undo_never_crosses_session_boundary() {
     let result = patch_undo(&mut app);
     assert!(!result.is_error);
     // Must restore session B's pre-turn state — never session A's.
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "b-before");
+
+    let repeated = patch_undo(&mut app);
+    assert!(!repeated.is_error);
+    assert!(
+        repeated
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("No undoable snapshot")),
+        "repeated undo must stop at the session boundary: {:?}",
+        repeated.message
+    );
     assert_eq!(std::fs::read_to_string(&file).unwrap(), "b-before");
 }

--- a/crates/tui/src/commands/groups/debug/tests.rs
+++ b/crates/tui/src/commands/groups/debug/tests.rs
@@ -1279,6 +1279,7 @@ fn test_patch_undo_requests_session_resync_after_restore() {
 
     let mut app = create_test_app();
     app.workspace = workspace.clone();
+    app.yolo = true;
     app.api_messages.push(Message {
         role: "user".to_string(),
         content: vec![ContentBlock::Text {
@@ -1301,7 +1302,7 @@ fn test_patch_undo_requests_session_resync_after_restore() {
 }
 
 #[test]
-fn test_patch_undo_walks_back_to_older_snapshot_on_repeat() {
+fn test_patch_undo_legacy_chain_stops_at_matching_newest_snapshot() {
     use crate::snapshot::SnapshotRepo;
     use crate::test_support::lock_test_env;
     use tempfile::tempdir;
@@ -1348,14 +1349,27 @@ fn test_patch_undo_walks_back_to_older_snapshot_on_repeat() {
 
     let mut app = create_test_app();
     app.workspace = workspace.clone();
+    app.yolo = true;
 
     let first = patch_undo(&mut app);
     assert!(!first.is_error);
     assert_eq!(std::fs::read_to_string(&file).unwrap(), "one");
 
+    // A legacy (untagged) chain never walks past a snapshot that matches
+    // the current workspace: there is no session boundary to stop it from
+    // rolling back another conversation's work, so the second /undo
+    // reports nothing to revert instead of restoring "zero".
     let second = patch_undo(&mut app);
     assert!(!second.is_error);
-    assert_eq!(std::fs::read_to_string(&file).unwrap(), "zero");
+    assert!(
+        second
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("No undoable snapshot")),
+        "expected 'nothing to revert' message, got: {:?}",
+        second.message
+    );
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "one");
 }
 
 #[test]
@@ -1404,6 +1418,7 @@ fn test_patch_undo_prunes_tool_turn_context() {
 
     let mut app = create_test_app();
     app.workspace = workspace.clone();
+    app.yolo = true;
     app.history.push(HistoryCell::User {
         content: "please edit a.txt".to_string(),
     });
@@ -1534,6 +1549,7 @@ fn test_patch_undo_prunes_pre_turn_context() {
 
     let mut app = create_test_app();
     app.workspace = workspace.clone();
+    app.yolo = true;
     app.history.push(HistoryCell::User {
         content: "please edit a.txt".to_string(),
     });
@@ -1927,4 +1943,128 @@ fn tools_command_rejects_unknown_formats_without_mutating_state() {
 
     assert!(result.is_error);
     assert_eq!(app.session.last_tool_request_snapshot, before);
+}
+
+#[test]
+fn test_patch_undo_refuses_outside_trusted_mode() {
+    use crate::snapshot::SnapshotRepo;
+    use crate::test_support::lock_test_env;
+    use tempfile::tempdir;
+
+    struct HomeGuard {
+        prev: Option<std::ffi::OsString>,
+        _lock: crate::test_support::TestEnvLock,
+    }
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: process-wide lock still held.
+            unsafe {
+                match self.prev.take() {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+    fn scoped_home(home: &std::path::Path) -> HomeGuard {
+        let lock = lock_test_env();
+        let prev = std::env::var_os("HOME");
+        // SAFETY: serialised by the global env lock.
+        unsafe {
+            std::env::set_var("HOME", home);
+        }
+        HomeGuard { prev, _lock: lock }
+    }
+
+    let tmp = tempdir().unwrap();
+    let workspace = tmp.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let _guard = scoped_home(tmp.path());
+
+    let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
+    std::fs::write(workspace.join("a.txt"), b"original").unwrap();
+    repo.snapshot("pre-turn:1").unwrap();
+    std::fs::write(workspace.join("a.txt"), b"modified").unwrap();
+
+    // yolo/trust_mode stay false (create_test_app defaults).
+    let mut app = create_test_app();
+    app.workspace = workspace.clone();
+
+    let result = patch_undo(&mut app);
+    assert!(!result.is_error);
+    assert!(
+        result
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("Refusing to undo workspace files")),
+        "expected refusal message, got: {:?}",
+        result.message
+    );
+    // Workspace must be untouched by the gate.
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("a.txt")).unwrap(),
+        "modified"
+    );
+}
+
+#[test]
+fn test_patch_undo_never_crosses_session_boundary() {
+    use crate::snapshot::SnapshotRepo;
+    use crate::test_support::lock_test_env;
+    use tempfile::tempdir;
+
+    struct HomeGuard {
+        prev: Option<std::ffi::OsString>,
+        _lock: crate::test_support::TestEnvLock,
+    }
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: process-wide lock still held.
+            unsafe {
+                match self.prev.take() {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+    fn scoped_home(home: &std::path::Path) -> HomeGuard {
+        let lock = lock_test_env();
+        let prev = std::env::var_os("HOME");
+        // SAFETY: serialised by the global env lock.
+        unsafe {
+            std::env::set_var("HOME", home);
+        }
+        HomeGuard { prev, _lock: lock }
+    }
+
+    let tmp = tempdir().unwrap();
+    let workspace = tmp.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let _guard = scoped_home(tmp.path());
+
+    let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
+    let file = workspace.join("a.txt");
+
+    // Session A: an earlier conversation that modified the workspace.
+    std::fs::write(&file, b"a-before").unwrap();
+    repo.snapshot_with_session("pre-turn:1", Some("session-a"))
+        .unwrap();
+    std::fs::write(&file, b"a-after").unwrap();
+
+    // Session B (current): a later conversation that also modified it.
+    std::fs::write(&file, b"b-before").unwrap();
+    repo.snapshot_with_session("pre-turn:1", Some("session-b"))
+        .unwrap();
+    std::fs::write(&file, b"b-after").unwrap();
+
+    let mut app = create_test_app();
+    app.workspace = workspace.clone();
+    app.yolo = true;
+    app.current_session_id = Some("session-b".to_string());
+
+    let result = patch_undo(&mut app);
+    assert!(!result.is_error);
+    // Must restore session B's pre-turn state — never session A's.
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "b-before");
 }

--- a/crates/tui/src/commands/groups/debug/undo.rs
+++ b/crates/tui/src/commands/groups/debug/undo.rs
@@ -143,16 +143,6 @@ fn tool_result_id(block: &ContentBlock) -> Option<&String> {
 pub fn patch_undo(app: &mut App) -> CommandResult {
     let workspace = app.workspace.clone();
 
-    // Trust gate: restoring workspace files is a one-shot mutation. Align
-    // with `/restore` — require trusted mode (Full Access or `/trust on`)
-    // so a stray `/undo` can't silently roll back the working tree.
-    if !(app.yolo || app.trust_mode) {
-        return CommandResult::message(
-            "Refusing to undo workspace files outside trusted mode.\n\
-             Run `/trust on` or select Full Access with Shift+Tab, then re-run `/undo`.",
-        );
-    }
-
     let repo = match crate::snapshot::SnapshotRepo::open_or_init(&workspace) {
         Ok(r) => r,
         Err(e) => {
@@ -174,25 +164,19 @@ pub fn patch_undo(app: &mut App) -> CommandResult {
         return CommandResult::message("No snapshots found to undo — nothing to revert.");
     }
 
-    // Scope candidates to the current session when it is known. Snapshots
-    // taken before session tagging (`session_id == None`) may belong to a
-    // *different* conversation on the same workspace; auto-restoring them
-    // is what caused cross-session rollbacks. Once the chain has *any*
-    // tagged snapshot we never auto-pick untagged ones; when the current
-    // session id is known, a fully legacy (untagged) chain yields zero
-    // candidates and `/undo` safely degrades to conversation undo. Only
-    // when no session id is known at all (fresh process, `/clear`) does a
-    // legacy chain fall back to the newest-candidate walk.
-    let current_session = app.current_session_id.as_deref();
-    let has_tagged = snapshots.iter().any(|s| s.session_id.is_some());
+    // Automatic file rollback is allowed only when ownership is provable.
+    // Untagged legacy snapshots and snapshots from another conversation may
+    // describe unrelated user work in this same workspace, so fail closed
+    // and let the command dispatcher fall back to conversation-only undo.
+    let Some(current_session) = app.current_session_id.as_deref() else {
+        return CommandResult::message(
+            "No undoable snapshot is tagged for the current session — nothing to revert.",
+        );
+    };
     let candidates: Vec<crate::snapshot::Snapshot> = snapshots
         .into_iter()
         .filter(|s| s.label.starts_with("tool:") || s.label.starts_with("pre-turn:"))
-        .filter(|s| match current_session {
-            Some(sid) => s.session_id.as_deref() == Some(sid),
-            None if has_tagged => false,
-            None => true,
-        })
+        .filter(|s| s.session_id.as_deref() == Some(current_session))
         .collect();
 
     if candidates.is_empty() {
@@ -201,21 +185,13 @@ pub fn patch_undo(app: &mut App) -> CommandResult {
         );
     }
 
-    // Pick the newest candidate whose tree differs from the current
-    // workspace. On a session-tagged chain the candidate set is already
-    // scoped to this conversation, so skipping identical snapshots keeps
-    // repeated `/undo` working without ever crossing into another
-    // session. On a legacy chain we only ever consider the newest
-    // candidate — walking further back has no session boundary to stop
-    // us from rolling back someone else's work.
+    // Pick the newest current-session candidate whose tree differs from the
+    // workspace. Skipping identical snapshots makes repeated `/undo` walk
+    // backward only inside the proven session boundary.
     let differs = |s: &&crate::snapshot::Snapshot| {
         matches!(repo.work_tree_matches_snapshot(&s.id), Ok(false))
     };
-    let target = if has_tagged {
-        candidates.iter().find(differs)
-    } else {
-        candidates.iter().take(1).find(differs)
-    };
+    let target = candidates.iter().find(differs);
 
     let Some(target) = target else {
         return CommandResult::message(
@@ -223,6 +199,14 @@ pub fn patch_undo(app: &mut App) -> CommandResult {
         );
     };
 
+    // Restoring workspace files is a mutation. Apply the trust gate only
+    // after finding a real, current-session target so chat-only `/undo` can
+    // still fall back to conversation history in ordinary mode.
+    if !(app.yolo || app.trust_mode) {
+        return CommandResult::message(
+            "Refusing to undo workspace files outside trusted mode.\n\
+             Run `/trust on` or select Full Access with Shift+Tab, then re-run `/undo`.",
+        );
     }
 
     if let Err(e) = repo.restore(&target.id) {

--- a/crates/tui/src/commands/groups/debug/undo.rs
+++ b/crates/tui/src/commands/groups/debug/undo.rs
@@ -143,6 +143,16 @@ fn tool_result_id(block: &ContentBlock) -> Option<&String> {
 pub fn patch_undo(app: &mut App) -> CommandResult {
     let workspace = app.workspace.clone();
 
+    // Trust gate: restoring workspace files is a one-shot mutation. Align
+    // with `/restore` — require trusted mode (Full Access or `/trust on`)
+    // so a stray `/undo` can't silently roll back the working tree.
+    if !(app.yolo || app.trust_mode) {
+        return CommandResult::message(
+            "Refusing to undo workspace files outside trusted mode.\n\
+             Run `/trust on` or select Full Access with Shift+Tab, then re-run `/undo`.",
+        );
+    }
+
     let repo = match crate::snapshot::SnapshotRepo::open_or_init(&workspace) {
         Ok(r) => r,
         Err(e) => {
@@ -153,7 +163,7 @@ pub fn patch_undo(app: &mut App) -> CommandResult {
         }
     };
 
-    let snapshots = match repo.list(20) {
+    let snapshots = match repo.list(100) {
         Ok(s) => s,
         Err(e) => {
             return CommandResult::error(format!("Failed to list snapshots: {e}"));
@@ -164,23 +174,56 @@ pub fn patch_undo(app: &mut App) -> CommandResult {
         return CommandResult::message("No snapshots found to undo — nothing to revert.");
     }
 
-    // Prefer the newest revertable `tool:` / `pre-turn:` snapshot whose
-    // tracked content differs from the current workspace. This lets
-    // repeated `/undo` walk back through older snapshots instead of
-    // restoring the same no-op target forever.
-    let target = snapshots
-        .iter()
+    // Scope candidates to the current session when it is known. Snapshots
+    // taken before session tagging (`session_id == None`) may belong to a
+    // *different* conversation on the same workspace; auto-restoring them
+    // is what caused cross-session rollbacks. Once the chain has *any*
+    // tagged snapshot we never auto-pick untagged ones; when the current
+    // session id is known, a fully legacy (untagged) chain yields zero
+    // candidates and `/undo` safely degrades to conversation undo. Only
+    // when no session id is known at all (fresh process, `/clear`) does a
+    // legacy chain fall back to the newest-candidate walk.
+    let current_session = app.current_session_id.as_deref();
+    let has_tagged = snapshots.iter().any(|s| s.session_id.is_some());
+    let candidates: Vec<crate::snapshot::Snapshot> = snapshots
+        .into_iter()
         .filter(|s| s.label.starts_with("tool:") || s.label.starts_with("pre-turn:"))
-        .find(|s| match repo.work_tree_matches_snapshot(&s.id) {
-            Ok(matches) => !matches,
-            Err(_) => true,
-        });
+        .filter(|s| match current_session {
+            Some(sid) => s.session_id.as_deref() == Some(sid),
+            None if has_tagged => false,
+            None => true,
+        })
+        .collect();
+
+    if candidates.is_empty() {
+        return CommandResult::message(
+            "No undoable snapshots for the current session — nothing to revert.",
+        );
+    }
+
+    // Pick the newest candidate whose tree differs from the current
+    // workspace. On a session-tagged chain the candidate set is already
+    // scoped to this conversation, so skipping identical snapshots keeps
+    // repeated `/undo` working without ever crossing into another
+    // session. On a legacy chain we only ever consider the newest
+    // candidate — walking further back has no session boundary to stop
+    // us from rolling back someone else's work.
+    let differs = |s: &&crate::snapshot::Snapshot| {
+        matches!(repo.work_tree_matches_snapshot(&s.id), Ok(false))
+    };
+    let target = if has_tagged {
+        candidates.iter().find(differs)
+    } else {
+        candidates.iter().take(1).find(differs)
+    };
 
     let Some(target) = target else {
         return CommandResult::message(
-            "No older tool or pre-turn snapshots differ from the current workspace — nothing to revert.",
+            "No undoable snapshot differs from the current workspace — nothing to revert.",
         );
     };
+
+    }
 
     if let Err(e) = repo.restore(&target.id) {
         return CommandResult::error(format!("Restore failed: {e}"));

--- a/crates/tui/src/commands/groups/session/export.rs
+++ b/crates/tui/src/commands/groups/session/export.rs
@@ -1216,6 +1216,7 @@ mod tests {
             id: crate::snapshot::SnapshotId(id.to_string()),
             label: label.to_string(),
             timestamp,
+            session_id: None,
         }
     }
 

--- a/crates/tui/src/commands/groups/skills/restore.rs
+++ b/crates/tui/src/commands/groups/skills/restore.rs
@@ -297,6 +297,7 @@ mod tests {
             id: crate::snapshot::SnapshotId("abcdef123456".to_string()),
             label: "turn:demo".to_string(),
             timestamp: 1_700_000_000,
+            session_id: None,
         }];
 
         let msg = format_listing(&snapshots);

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1385,8 +1385,15 @@ impl Engine {
             let pre_seq = self.turn_counter;
             let pre_cap = self.config.snapshots_max_workspace_bytes;
             let pre_prompt = snapshot_prompt.clone();
+            let pre_sid = self.session.id.clone();
             let _ = tokio::task::spawn_blocking(move || {
-                pre_turn_snapshot(&pre_workspace, pre_seq, pre_cap, Some(&pre_prompt))
+                pre_turn_snapshot(
+                    &pre_workspace,
+                    pre_seq,
+                    pre_cap,
+                    Some(&pre_prompt),
+                    Some(&pre_sid),
+                )
             })
             .await;
         }
@@ -1618,8 +1625,15 @@ impl Engine {
             let post_workspace = self.session.workspace.clone();
             let post_seq = self.turn_counter;
             let post_cap = self.config.snapshots_max_workspace_bytes;
+            let post_sid = self.session.id.clone();
             crate::utils::spawn_blocking_supervised("post-shell-turn-snapshot", move || {
-                post_turn_snapshot(&post_workspace, post_seq, post_cap, Some(&snapshot_prompt));
+                post_turn_snapshot(
+                    &post_workspace,
+                    post_seq,
+                    post_cap,
+                    Some(&snapshot_prompt),
+                    Some(&post_sid),
+                );
             });
         }
     }
@@ -3928,8 +3942,15 @@ impl Engine {
             let pre_workspace = self.session.workspace.clone();
             let pre_seq = self.turn_counter;
             let pre_cap = self.config.snapshots_max_workspace_bytes;
+            let pre_sid = self.session.id.clone();
             let _ = tokio::task::spawn_blocking(move || {
-                pre_turn_snapshot(&pre_workspace, pre_seq, pre_cap, Some(&snapshot_prompt))
+                pre_turn_snapshot(
+                    &pre_workspace,
+                    pre_seq,
+                    pre_cap,
+                    Some(&snapshot_prompt),
+                    Some(&pre_sid),
+                )
             })
             .await;
         }
@@ -4168,12 +4189,14 @@ impl Engine {
             let post_workspace = self.session.workspace.clone();
             let post_seq = self.turn_counter;
             let post_cap = self.config.snapshots_max_workspace_bytes;
+            let post_sid = self.session.id.clone();
             crate::utils::spawn_blocking_supervised("post-turn-snapshot", move || {
                 post_turn_snapshot(
                     &post_workspace,
                     post_seq,
                     post_cap,
                     Some(&snapshot_prompt_post),
+                    Some(&post_sid),
                 );
             });
         }

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -2878,8 +2878,9 @@ impl Engine {
                             let ws = self.session.workspace.clone();
                             let tid = tool_id.clone();
                             let cap = self.config.snapshots_max_workspace_bytes;
+                            let sid = self.session.id.clone();
                             let _ = tokio::task::spawn_blocking(move || {
-                                crate::core::turn::pre_tool_snapshot(&ws, &tid, cap)
+                                crate::core::turn::pre_tool_snapshot(&ws, &tid, cap, Some(&sid))
                             })
                             .await;
                         }

--- a/crates/tui/src/core/turn.rs
+++ b/crates/tui/src/core/turn.rs
@@ -260,11 +260,13 @@ pub fn pre_turn_snapshot(
     turn_seq: u64,
     cap_bytes: u64,
     user_prompt: Option<&str>,
+    session_id: Option<&str>,
 ) -> Option<String> {
     snapshot_with_label(
         workspace,
         &format_snapshot_label("pre-turn", turn_seq, user_prompt),
         cap_bytes,
+        session_id,
     )
 }
 
@@ -276,8 +278,13 @@ pub fn pre_turn_snapshot(
 ///
 /// Returns the snapshot SHA on success, `None` on any error. Errors are
 /// logged at WARN and are non-fatal.
-pub fn pre_tool_snapshot(workspace: &Path, call_id: &str, cap_bytes: u64) -> Option<String> {
-    snapshot_with_label(workspace, &format!("tool:{call_id}"), cap_bytes)
+pub fn pre_tool_snapshot(
+    workspace: &Path,
+    call_id: &str,
+    cap_bytes: u64,
+    session_id: Option<&str>,
+) -> Option<String> {
+    snapshot_with_label(workspace, &format!("tool:{call_id}"), cap_bytes, session_id)
 }
 
 /// Take a `post-turn:<seq>` workspace snapshot. Same failure model as
@@ -287,18 +294,25 @@ pub fn post_turn_snapshot(
     turn_seq: u64,
     cap_bytes: u64,
     user_prompt: Option<&str>,
+    session_id: Option<&str>,
 ) -> Option<String> {
     snapshot_with_label(
         workspace,
         &format_snapshot_label("post-turn", turn_seq, user_prompt),
         cap_bytes,
+        session_id,
     )
 }
 
-fn snapshot_with_label(workspace: &Path, label: &str, cap_bytes: u64) -> Option<String> {
+fn snapshot_with_label(
+    workspace: &Path,
+    label: &str,
+    cap_bytes: u64,
+    session_id: Option<&str>,
+) -> Option<String> {
     match SnapshotRepo::open_or_init_with_cap(workspace, cap_bytes) {
         Ok(repo) => {
-            let id = match repo.snapshot(label) {
+            let id = match repo.snapshot_with_session(label, session_id) {
                 Ok(id) => Some(id.0),
                 Err(e) => {
                     tracing::warn!(target: "snapshot", "snapshot '{label}' failed: {e}");

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1904,7 +1904,7 @@ async fn patch_undo_thread_turn(
         .get_thread(&id)
         .await
         .map_err(map_thread_err)?;
-    let patch_result = patch_undo_workspace_files(&thread.workspace);
+    let patch_result = patch_undo_workspace_files(&thread.workspace, thread.session_id.as_deref());
 
     // Step 2: Remove the last conversation turn (undo_conversation).
     let (forked_thread, original_user_text) = state
@@ -1925,7 +1925,10 @@ async fn patch_undo_thread_turn(
 
 /// Restore the newest `tool:` or `pre-turn:` snapshot that differs from the
 /// current workspace — same target selection as the TUI's `patch_undo`.
-fn patch_undo_workspace_files(workspace: &FsPath) -> PatchUndoResult {
+fn patch_undo_workspace_files(
+    workspace: &FsPath,
+    current_session_id: Option<&str>,
+) -> PatchUndoResult {
     let repo = match crate::snapshot::SnapshotRepo::open_or_init(workspace) {
         Ok(repo) => repo,
         Err(e) => {
@@ -1936,7 +1939,17 @@ fn patch_undo_workspace_files(workspace: &FsPath) -> PatchUndoResult {
             };
         }
     };
-    let snapshots = match repo.list(20) {
+    let Some(current_session_id) = current_session_id else {
+        return PatchUndoResult {
+            files_restored: false,
+            summary: Some(
+                "No current session is bound to this thread; workspace files were not changed."
+                    .to_string(),
+            ),
+            snapshot_label: None,
+        };
+    };
+    let snapshots = match repo.list(100) {
         Ok(snapshots) => snapshots,
         Err(e) => {
             return PatchUndoResult {
@@ -1949,12 +1962,13 @@ fn patch_undo_workspace_files(workspace: &FsPath) -> PatchUndoResult {
     let target = snapshots
         .iter()
         .filter(|s| s.label.starts_with("tool:") || s.label.starts_with("pre-turn:"))
-        .find(|s| matches!(repo.work_tree_matches_snapshot(&s.id), Ok(false) | Err(_)));
+        .filter(|s| s.session_id.as_deref() == Some(current_session_id))
+        .find(|s| matches!(repo.work_tree_matches_snapshot(&s.id), Ok(false)));
     let Some(target) = target else {
         return PatchUndoResult {
             files_restored: false,
             summary: Some(
-                "No older tool or pre-turn snapshots differ from the current workspace."
+                "No current-session tool or pre-turn snapshots differ from the current workspace."
                     .to_string(),
             ),
             snapshot_label: None,

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -4050,6 +4050,38 @@ async fn patch_undo_endpoint_forks_and_reports_file_rollback_state() -> Result<(
     Ok(())
 }
 
+#[test]
+fn patch_undo_helper_restores_only_the_bound_session() -> Result<()> {
+    let _lock = lock_test_env();
+    let root = tempfile::tempdir()?;
+    let home = root.path().join("home");
+    fs::create_dir_all(&home)?;
+    let _home = EnvVarGuard::set("HOME", &home);
+
+    let workspace = root.path().join("workspace");
+    fs::create_dir_all(&workspace)?;
+    let repo = crate::snapshot::SnapshotRepo::open_or_init(&workspace)?;
+    let file = workspace.join("a.txt");
+
+    fs::write(&file, "legacy")?;
+    repo.snapshot("pre-turn:legacy")?;
+    fs::write(&file, "current-before")?;
+    repo.snapshot_with_session("pre-turn:current", Some("session-current"))?;
+    fs::write(&file, "foreign-before")?;
+    repo.snapshot_with_session("pre-turn:foreign", Some("session-foreign"))?;
+    fs::write(&file, "current-after")?;
+
+    let restored = patch_undo_workspace_files(&workspace, Some("session-current"));
+    assert!(restored.files_restored, "{:?}", restored.summary);
+    assert_eq!(fs::read_to_string(&file)?, "current-before");
+
+    fs::write(&file, "must-stay")?;
+    let unbound = patch_undo_workspace_files(&workspace, None);
+    assert!(!unbound.files_restored);
+    assert_eq!(fs::read_to_string(&file)?, "must-stay");
+    Ok(())
+}
+
 #[tokio::test]
 async fn retry_endpoint_reuses_dropped_user_text_to_start_a_turn() -> Result<()> {
     let root = std::env::temp_dir().join(format!("deepseek-retry-endpoint-{}", Uuid::new_v4()));

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -42,6 +42,10 @@ pub struct Snapshot {
     pub label: String,
     /// Author timestamp (Unix seconds).
     pub timestamp: i64,
+    /// Session this snapshot belongs to, when recorded (encoded as a
+    /// `[sid=...] ` label prefix). `None` for legacy snapshots taken
+    /// before session tagging existed.
+    pub session_id: Option<String>,
 }
 
 /// Wrapper around the per-workspace side-git repo.
@@ -322,7 +326,24 @@ impl SnapshotRepo {
     /// [`MAX_SNAPSHOT_SIZE_MB`] and prunes the oldest snapshots if it does.
     ///
     /// Returns the snapshot's commit SHA.
+    #[allow(dead_code)] // convenience entry kept for tests and legacy callers; production writes go through snapshot_with_session
     pub fn snapshot(&self, label: &str) -> io::Result<SnapshotId> {
+        self.snapshot_with_session(label, None)
+    }
+
+    /// Take a snapshot, tagging it with the owning session id.
+    ///
+    /// The session id is encoded into the commit message as a `[sid=...] `
+    /// label prefix. [`Self::list`] decodes it back into
+    /// [`Snapshot::session_id`] and strips the prefix from the visible
+    /// label, so existing listing surfaces keep showing the plain label.
+    /// Legacy snapshots taken through [`Self::snapshot`] carry no prefix
+    /// and decode with `session_id == None`.
+    pub fn snapshot_with_session(
+        &self,
+        label: &str,
+        session_id: Option<&str>,
+    ) -> io::Result<SnapshotId> {
         // Guard against disk blowup (#1112): if the snapshot directory has
         // grown beyond the limit, prune aggressively before adding more.
         if let Ok(current_mb) = dir_size_mb(&self.git_dir)
@@ -402,7 +423,7 @@ impl SnapshotRepo {
             args.push(parent);
         }
         args.push("-m".to_string());
-        args.push(label.to_string());
+        args.push(Self::encode_session_label(label, session_id));
         let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
         // `commit-tree` creates marker commits even when the tree matches its
@@ -431,6 +452,33 @@ impl SnapshotRepo {
         Ok(SnapshotId(sha))
     }
 
+    /// Prefix a snapshot label with its owning session id, if any.
+    fn encode_session_label(label: &str, session_id: Option<&str>) -> String {
+        match session_id {
+            Some(sid) if !sid.is_empty() => format!("[sid={sid}] {label}"),
+            _ => label.to_string(),
+        }
+    }
+
+    /// Split a possibly session-tagged label back into `(session_id, label)`.
+    ///
+    /// Returns `(None, label)` for untagged labels. The decoded label is
+    /// the original one without the `[sid=...] ` prefix, so consumers that
+    /// match on `pre-turn:`/`tool:`/`redo:` prefixes keep working unchanged.
+    fn decode_session_label(label: &str) -> (Option<String>, String) {
+        let Some(rest) = label.strip_prefix("[sid=") else {
+            return (None, label.to_string());
+        };
+        let Some(end) = rest.find("] ") else {
+            return (None, label.to_string());
+        };
+        let sid = &rest[..end];
+        let plain = &rest[end + 2..];
+        if sid.is_empty() || plain.is_empty() {
+            return (None, label.to_string());
+        }
+        (Some(sid.to_string()), plain.to_string())
+    }
     /// Restore the workspace to the state at `id`.
     ///
     /// Uses `git checkout <sha> -- :/` which checks out every path in the
@@ -552,10 +600,12 @@ impl SnapshotRepo {
             if sha.is_empty() {
                 continue;
             }
+            let (session_id, label) = Self::decode_session_label(&subject);
             out.push(Snapshot {
                 id: SnapshotId(sha),
-                label: subject,
+                label,
                 timestamp: ts,
+                session_id,
             });
         }
         Ok(out)
@@ -685,7 +735,7 @@ impl SnapshotRepo {
             let mut args = vec![
                 "commit-tree".to_string(),
                 "-m".to_string(),
-                s.label.clone(),
+                Self::encode_session_label(&s.label, s.session_id.as_deref()),
                 tree_hash,
             ];
             if let Some(ref p) = prev_sha {
@@ -1549,5 +1599,83 @@ mod tests {
             .snapshot("pre-turn:1")
             .expect("snapshot under disabled cap");
         assert_eq!(id.as_str().len(), 40);
+    }
+
+    #[test]
+    fn session_tagged_snapshot_round_trips_through_list() {
+        let tmp = tempdir().unwrap();
+        let (repo, _home) = make_repo(tmp.path());
+        std::fs::write(repo.work_tree().join("a.txt"), b"x").unwrap();
+
+        repo.snapshot_with_session("pre-turn:1", Some("sess-42"))
+            .expect("snapshot with session");
+
+        let list = repo.list(10).expect("list");
+        assert_eq!(list.len(), 1);
+        // The visible label stays clean; the session id is decoded separately.
+        assert_eq!(list[0].label, "pre-turn:1");
+        assert_eq!(list[0].session_id.as_deref(), Some("sess-42"));
+    }
+
+    #[test]
+    fn untagged_snapshot_decodes_without_session() {
+        let tmp = tempdir().unwrap();
+        let (repo, _home) = make_repo(tmp.path());
+        std::fs::write(repo.work_tree().join("a.txt"), b"x").unwrap();
+
+        repo.snapshot("pre-turn:1").expect("snapshot");
+
+        let list = repo.list(10).expect("list");
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].label, "pre-turn:1");
+        assert_eq!(list[0].session_id, None);
+    }
+
+    #[test]
+    #[test]
+    fn prune_keep_last_n_preserves_session_tags() {
+        let tmp = tempdir().unwrap();
+        let (repo, _home) = make_repo(tmp.path());
+        let file = repo.work_tree().join("a.txt");
+
+        // More snapshots than DEFAULT_MAX_SNAPSHOTS (50) so the survivor
+        // chain is rebuilt as orphan commits — the path that previously
+        // dropped the [sid=...] label prefix and turned every surviving
+        // snapshot into a "legacy" (untagged) one.
+        for i in 0..55 {
+            std::fs::write(&file, format!("v{i}")).unwrap();
+            repo.snapshot_with_session(&format!("pre-turn:{i}"), Some("sess-p"))
+                .expect("tagged snapshot");
+        }
+
+        let removed = repo.prune_keep_last_n(50).expect("prune");
+        assert!(removed > 0, "expected prune to drop older snapshots");
+
+        let list = repo.list(usize::MAX).expect("list");
+        assert_eq!(list.len(), 50);
+        assert!(
+            list.iter()
+                .all(|s| s.session_id.as_deref() == Some("sess-p")),
+            "prune must preserve [sid=...] prefixes; got untagged survivors"
+        );
+    }
+
+    fn tagged_and_untagged_snapshots_coexist_in_one_chain() {
+        let tmp = tempdir().unwrap();
+        let (repo, _home) = make_repo(tmp.path());
+        std::fs::write(repo.work_tree().join("a.txt"), b"v1").unwrap();
+
+        // Legacy untagged snapshot, then a session-tagged one.
+        repo.snapshot("pre-turn:1").expect("legacy snapshot");
+        std::fs::write(repo.work_tree().join("a.txt"), b"v2").unwrap();
+        repo.snapshot_with_session("pre-turn:1", Some("sess-a"))
+            .expect("tagged snapshot");
+
+        let list = repo.list(10).expect("list");
+        assert_eq!(list.len(), 2);
+        // Newest first.
+        assert_eq!(list[0].session_id.as_deref(), Some("sess-a"));
+        assert_eq!(list[1].session_id, None);
+        assert_eq!(list[1].label, "pre-turn:1");
     }
 }

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -1632,7 +1632,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn prune_keep_last_n_preserves_session_tags() {
         let tmp = tempdir().unwrap();
         let (repo, _home) = make_repo(tmp.path());
@@ -1660,6 +1659,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn tagged_and_untagged_snapshots_coexist_in_one_chain() {
         let tmp = tempdir().unwrap();
         let (repo, _home) = make_repo(tmp.path());

--- a/crates/tui/src/tools/revert_turn.rs
+++ b/crates/tui/src/tools/revert_turn.rs
@@ -74,6 +74,7 @@ impl ToolSpec for RevertTurnTool {
 
         let workspace = context.workspace.clone();
         let label = format!("revert_turn(offset={offset})");
+        let session = context.state_namespace.clone();
         let result = tokio::task::spawn_blocking(move || -> Result<String, String> {
             let repo = SnapshotRepo::open_or_init(&workspace)
                 .map_err(|e| format!("Snapshot repo init failed: {e}"))?;
@@ -84,9 +85,17 @@ impl ToolSpec for RevertTurnTool {
             let snapshots = repo
                 .list((MAX_OFFSET as usize).saturating_mul(2) + 16)
                 .map_err(|e| format!("Snapshot list failed: {e}"))?;
+            let has_tagged = snapshots.iter().any(|s| s.session_id.is_some());
             let pre_turns: Vec<_> = snapshots
                 .into_iter()
                 .filter(|s| s.label.starts_with("pre-turn:"))
+                .filter(|s| {
+                    // On session-tagged chains only the current session's
+                    // snapshots are eligible, mirroring /undo's scoping so
+                    // the model can't roll back another conversation's work.
+                    // Fully legacy chains keep the old behavior.
+                    !has_tagged || s.session_id.as_deref() == Some(session.as_str())
+                })
                 .collect();
             let target = pre_turns
                 .get((offset - 1) as usize)

--- a/crates/tui/src/tools/revert_turn.rs
+++ b/crates/tui/src/tools/revert_turn.rs
@@ -85,23 +85,19 @@ impl ToolSpec for RevertTurnTool {
             let snapshots = repo
                 .list((MAX_OFFSET as usize).saturating_mul(2) + 16)
                 .map_err(|e| format!("Snapshot list failed: {e}"))?;
-            let has_tagged = snapshots.iter().any(|s| s.session_id.is_some());
             let pre_turns: Vec<_> = snapshots
                 .into_iter()
                 .filter(|s| s.label.starts_with("pre-turn:"))
-                .filter(|s| {
-                    // On session-tagged chains only the current session's
-                    // snapshots are eligible, mirroring /undo's scoping so
-                    // the model can't roll back another conversation's work.
-                    // Fully legacy chains keep the old behavior.
-                    !has_tagged || s.session_id.as_deref() == Some(session.as_str())
-                })
+                // Session ownership must be exact. Legacy snapshots are not
+                // safe automatic targets because they may belong to another
+                // conversation that used this workspace.
+                .filter(|s| s.session_id.as_deref() == Some(session.as_str()))
                 .collect();
             let target = pre_turns
                 .get((offset - 1) as usize)
                 .ok_or_else(|| {
                     format!(
-                        "Only {} pre-turn snapshot(s) exist; turn_offset={offset} is out of range.",
+                        "Only {} current-session pre-turn snapshot(s) exist; turn_offset={offset} is out of range.",
                         pre_turns.len(),
                     )
                 })?
@@ -182,9 +178,11 @@ mod tests {
         // Setup: create pre-turn:1, post-turn:1 with file modifications.
         let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
         std::fs::write(workspace.join("a.txt"), b"original").unwrap();
-        repo.snapshot("pre-turn:1").unwrap();
+        repo.snapshot_with_session("pre-turn:1", Some("workspace"))
+            .unwrap();
         std::fs::write(workspace.join("a.txt"), b"modified").unwrap();
-        repo.snapshot("post-turn:1").unwrap();
+        repo.snapshot_with_session("post-turn:1", Some("workspace"))
+            .unwrap();
 
         let tool = RevertTurnTool;
         let ctx = ToolContext::new(workspace.clone());
@@ -217,7 +215,8 @@ mod tests {
 
         let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
         std::fs::write(workspace.join("a.txt"), b"unchanged").unwrap();
-        repo.snapshot("pre-turn:1").unwrap();
+        repo.snapshot_with_session("pre-turn:1", Some("workspace"))
+            .unwrap();
 
         let tool = RevertTurnTool;
         let ctx = ToolContext::new(workspace);
@@ -238,5 +237,35 @@ mod tests {
         let r = tool.execute(json!({}), &ctx).await.expect("execute");
         assert!(!r.success);
         assert!(r.content.contains("out of range"));
+    }
+
+    #[tokio::test]
+    async fn revert_turn_rejects_legacy_and_foreign_session_snapshots() {
+        let tmp = tempdir().unwrap();
+        let workspace = tmp.path().join("ws");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let _guard = scoped_home(tmp.path());
+
+        let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
+        std::fs::write(workspace.join("a.txt"), b"legacy").unwrap();
+        repo.snapshot("pre-turn:legacy").unwrap();
+        std::fs::write(workspace.join("a.txt"), b"foreign").unwrap();
+        repo.snapshot_with_session("pre-turn:foreign", Some("other-session"))
+            .unwrap();
+        std::fs::write(workspace.join("a.txt"), b"current").unwrap();
+
+        let tool = RevertTurnTool;
+        let ctx = ToolContext::new(workspace.clone());
+        let r = tool.execute(json!({}), &ctx).await.expect("execute");
+        assert!(!r.success);
+        assert!(
+            r.content.contains("Only 0 current-session"),
+            "{}",
+            r.content
+        );
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("a.txt")).unwrap(),
+            "current"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- preserve @SparkofSpike’s session-tagged snapshot design and authored commit from #5086
- stamp pre-turn, post-turn, and pre-tool snapshots with the owning session
- make `/undo`, `revert_turn`, and the runtime patch-undo endpoint require an exact current-session tag
- let chat-only `/undo` fall back to conversation history before applying the trusted-mode gate
- preserve session tags when snapshot history is pruned

Legacy, unbound, and foreign-session snapshots now fail closed for automatic workspace restoration. The experimental redo commit from #5086 is intentionally not included; its stack/cursor semantics need a separate design.

## Verification

- `cargo fmt -p codewhale-tui -- --check`
- undo-focused suite: 16 passed
- snapshot repository suite: 29 passed
- `revert_turn` suite: 5 passed
- restore suite: 13 passed
- runtime patch-undo boundary tests: 2 passed

Closes #5089