### PR TITLE
fix(ohos): re-quote Windows linker arguments containing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Re-quote each linker argument in the Windows OpenHarmony clang launcher so a
+  spaced SDK path (e.g. the default `D:\DevEco Studio\...` install) keeps its
+  `--sysroot` intact through the final Rust link, and extend the no-SDK release
+  guard to keep the re-quoting contract (#5095 by @shenjackyuanjie).
+
 ## [0.9.3] - 2026-07-31
 
 This is the Codewhale v0.9.3 source candidate. It is not a published release

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Re-quote each linker argument in the Windows OpenHarmony clang launcher so a
+  spaced SDK path (e.g. the default `D:\DevEco Studio\...` install) keeps its
+  `--sysroot` intact through the final Rust link, and extend the no-SDK release
+  guard to keep the re-quoting contract (#5095 by @shenjackyuanjie).
+
 ## [0.9.3] - 2026-07-31
 
 This is the Codewhale v0.9.3 source candidate. It is not a published release

--- a/docs/HarmonyOS.md
+++ b/docs/HarmonyOS.md
@@ -63,7 +63,10 @@ On Windows, `ohos-env.ps1` points Cargo at the repository's
 `ohos-clang.cmd` launcher. The launcher delegates to `ohos-clang.ps1`, so the
 final Rust link—not only C/C++ compilation and bindgen—always carries
 `-target aarch64-linux-ohos`, the SDK sysroot, and `-D__MUSL__` while preserving
-Cargo's linker arguments and exit status.
+Cargo's linker arguments and exit status. The launcher re-quotes every
+argument before forwarding, so an SDK path containing spaces (for example the
+default `D:\DevEco Studio\...` install) keeps its `--sysroot` intact through
+the final link.
 
 ## Compiler Wrappers
 

--- a/scripts/ohos/ohos-clang.cmd
+++ b/scripts/ohos/ohos-clang.cmd
@@ -7,5 +7,18 @@ if not exist "%OHOS_LINKER_SCRIPT%" (
     exit /b 1
 )
 
-"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "%OHOS_LINKER_SCRIPT%" %*
+rem Re-quote every argument before forwarding: cmd's %* expansion strips the
+rem quotes that rustc put around arguments containing spaces, so a sysroot like
+rem "D:\DevEco Studio\...\sysroot" would otherwise arrive at clang split on the
+rem space. %~1 strips the caller's quoting, then we wrap the argument in quotes
+rem again so PowerShell -File hands it to the script as one argument.
+set "ARGS="
+:argloop
+if "%~1"=="" goto run
+set "ARGS=%ARGS% "%~1""
+shift
+goto argloop
+
+:run
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "%OHOS_LINKER_SCRIPT%" %ARGS%
 exit /b %ERRORLEVEL%

--- a/scripts/release/check-ohos-deps.sh
+++ b/scripts/release/check-ohos-deps.sh
@@ -31,7 +31,11 @@ require_literal() {
 # Rust link receives the OHOS target, sysroot, and musl flags as reliably as C,
 # C++, and bindgen invocations do. This is a static, no-SDK contract check; the
 # launcher delegates to the PowerShell compiler wrapper that validates the SDK
-# and preserves Cargo's linker arguments and exit status.
+# and preserves Cargo's linker arguments and exit status. The launcher must
+# also re-quote each argument it forwards: cmd's %* expansion strips the quotes
+# rustc puts around arguments containing spaces, so a spaced SDK path (for
+# example the default "D:\DevEco Studio\..." install) would otherwise arrive at
+# clang with --sysroot split on the space.
 require_literal \
   scripts/ohos-env.ps1 \
   '$linker = [System.IO.Path]::Combine($PSScriptRoot, "ohos", "ohos-clang.cmd")' \
@@ -50,8 +54,12 @@ require_literal \
   "the cmd-to-PowerShell delegation"
 require_literal \
   scripts/ohos/ohos-clang.cmd \
-  '-File "%OHOS_LINKER_SCRIPT%" %*' \
+  '-File "%OHOS_LINKER_SCRIPT%" %ARGS%' \
   "linker argument forwarding"
+require_literal \
+  scripts/ohos/ohos-clang.cmd \
+  'set "ARGS=%ARGS% "%~1""' \
+  "argument re-quoting for space-containing paths"
 require_literal \
   scripts/ohos/ohos-clang.cmd \
   'exit /b %ERRORLEVEL%' \


### PR DESCRIPTION
## Summary

rustc passes Cargo's linker arguments as quoted strings when they contain
spaces, but cmd's `%*` expansion strips that quoting, so an OpenHarmony SDK
installed under a spaced path (e.g. the default `D:\DevEco Studio\...\native`)
arrived at the clang launcher with `--sysroot` split on the space and the
final Rust link failed. The launcher now walks every argument with `%~1` and
re-wraps each in quotes before forwarding to `ohos-clang.ps1`, and the no-SDK
release guard asserts the re-quoting contract so it cannot regress.

Verified by building `codewhale-cli` for `aarch64-unknown-linux-ohos` on
Windows with this SDK: HEAD, v0.9.3, and v0.9.2 all link successfully with the
fix, and a forced relink (`cargo build --target aarch64-unknown-linux-ohos -p
codewhale-cli`) passes through the updated launcher.

No-Issue: Windows-only launcher hardening surfaced during local OpenHarmony
builds; the HarmonyOS port issues (#2625, #2970) are closed and no tracked
issue covers the spaced-path link failure.

## Testing

- [x] `bash scripts/release/check-ohos-deps.sh` — linker wrapper contract, OHOS dependency graph, and rquickjs bindgen feature edge all pass
- [x] `cargo build --target aarch64-unknown-linux-ohos -p codewhale-cli` (forced relink through the updated launcher)
- [ ] CI: `versions` job guard, `ohos.yml` real-SDK `cargo check`, Lint co-author check

## Checklist

- [x] Updated docs or comments as needed (docs/HarmonyOS.md, guard comments)
- [x] Added or updated tests where relevant (no-SDK release guard assertion)
- [ ] Verified TUI behavior manually if UI changes (n/a — no UI change)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (n/a — no harvest; authored by @shenjackyuanjie)

---

Assisted by Claude Code.
