### PR TITLE
stack R3: runtime P0s (transcript escapes, #5099 route inheritance, roster shadowing + trust gate)

### DIFF
--- a/crates/cli/src/cloud/tests.rs
+++ b/crates/cli/src/cloud/tests.rs
@@ -798,3 +798,72 @@ fn fake_store_is_profile_safe() {
     store.delete("missing").unwrap();
     assert_eq!(store.get("unrelated").unwrap().as_deref(), Some("keep-me"));
 }
+
+#[test]
+fn account_login_timeout_fails_the_command() {
+    // §2.3 / #5033 class: a timed-out device login printed the timeout yet the
+    // process exited 0. Pin the contract at the run_with seam — the command
+    // must return Err so run_cli maps it to ExitCode::FAILURE. Verified live
+    // against a stub server: `error: Codewhale account login timed out` now
+    // exits 1.
+    let (temp, config) = test_config();
+    let _keep_temp = temp;
+    let (secrets, _) = test_secrets();
+    // Device start succeeds once; every token poll stays pending forever.
+    struct PendingLogin;
+    impl CloudTransport for PendingLogin {
+        fn execute(&self, request: CloudRequest) -> Result<CloudResponse> {
+            if request.path == "/api/cli/device/start" {
+                return Ok(response(
+                    200,
+                    json!({
+                        "deviceCode": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "userCode": "ABCD-EFGH-JKLM",
+                        "verificationUri": "https://app.codewhale.net/cli/authorize",
+                        "verificationUriComplete": "https://app.codewhale.net/cli/authorize?user_code=ABCD-EFGH-JKLM",
+                        "expiresIn": 600,
+                        "interval": 1
+                    }),
+                ));
+            }
+            Ok(response(202, json!({ "status": "authorization_pending" })))
+        }
+    }
+    let pending = PendingLogin;
+    let mut output = Vec::new();
+    let mut key_reader = |_| bail!("key reader should not be called");
+    let mut opener = |_| true;
+    // A real (short) sleep keeps the pending loop from busy-spinning while
+    // still reaching the 1s client timeout quickly.
+    let mut sleeper = |duration: std::time::Duration| {
+        std::thread::sleep(duration.min(std::time::Duration::from_millis(50)))
+    };
+    let result = run_with(
+        command(&[
+            "codewhale",
+            "cloud",
+            "login",
+            "--no-open",
+            "--timeout-seconds",
+            "1",
+        ]),
+        "default",
+        "https://api.codewhale.net",
+        &config,
+        &secrets,
+        &secrets,
+        &pending,
+        &mut output,
+        &mut key_reader,
+        &mut opener,
+        &mut sleeper,
+    );
+    let err = match result {
+        Ok(()) => panic!("a timed-out login must return Err so the exit code is non-zero"),
+        Err(err) => err,
+    };
+    assert!(
+        err.to_string().contains("login timed out"),
+        "timeout error text: {err}"
+    );
+}

--- a/crates/tui/src/core/turn.rs
+++ b/crates/tui/src/core/turn.rs
@@ -319,6 +319,10 @@ fn snapshot_with_label(workspace: &Path, label: &str, cap_bytes: u64) -> Option<
     }
 }
 
+// The stderr print is deliberate: headless/CLI stderr is the user surface for
+// this once-per-workspace warning, matching the pre-TUI notices in
+// runtime_log.rs.
+#[allow(clippy::print_stderr)]
 fn maybe_notify_snapshots_disabled_once(workspace: &Path, error: &std::io::Error) {
     let message = error.to_string();
     if !(message.contains("workspace too large for snapshots")

--- a/crates/tui/src/core/turn.rs
+++ b/crates/tui/src/core/turn.rs
@@ -313,9 +313,39 @@ fn snapshot_with_label(workspace: &Path, label: &str, cap_bytes: u64) -> Option<
         }
         Err(e) => {
             tracing::warn!(target: "snapshot", "snapshot repo init failed: {e}");
+            maybe_notify_snapshots_disabled_once(workspace, &e);
             None
         }
     }
+}
+
+fn maybe_notify_snapshots_disabled_once(workspace: &Path, error: &std::io::Error) {
+    let message = error.to_string();
+    if !(message.contains("workspace too large for snapshots")
+        || message.contains("workspace snapshots are disabled"))
+    {
+        return;
+    }
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+    static NOTIFIED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    let key = workspace.to_string_lossy().into_owned();
+    let set = NOTIFIED.get_or_init(|| Mutex::new(HashSet::new()));
+    let Ok(mut guard) = set.lock() else {
+        return;
+    };
+    if !guard.insert(key) {
+        return;
+    }
+    // One prominent notice per workspace process lifetime — silent disable is
+    // the §2.7 failure mode. Opt-in remains `[snapshots] max_workspace_gb`
+    // (raise the cap or set 0 to disable the size gate).
+    eprintln!(
+        "warning: workspace snapshots/undo are OFF for {}
+  {message}
+  raise `[snapshots] max_workspace_gb` in config.toml (or set it to 0 to disable the cap) to opt in.",
+        workspace.display()
+    );
 }
 
 #[cfg(test)]

--- a/crates/tui/src/fleet/roster.rs
+++ b/crates/tui/src/fleet/roster.rs
@@ -12,6 +12,16 @@
 //! Precedence is Workspace > Personal > Config > BuiltIn, merged by id. Loading never
 //! fails the session: an unreadable workspace profile dir degrades to the
 //! built-in + config layers with a log line.
+//!
+//! Two guardrails (#5098):
+//!
+//! - Shadowing is recorded, not silent: when a higher layer displaces a
+//!   lower-precedence file for the same id, the roster keeps a
+//!   [`ShadowedProfile`] receipt (logged at load, badged in the roster view)
+//!   so an edit in the losing layer is visibly ignored rather than dropped.
+//! - Project-scope profiles (`.codewhale/agents/*.toml`) join the roster only
+//!   when project-level config is trusted for the launch; `--no-project-config`
+//!   opts the whole layer out, same as `.codewhale/config.toml` (#485).
 
 #![allow(dead_code)]
 
@@ -57,6 +67,41 @@ impl std::fmt::Display for ProfileOrigin {
 #[derive(Debug, Clone)]
 pub struct FleetRoster {
     members: Vec<AgentProfile>,
+    /// Lower-precedence profiles displaced by a higher layer for the same id
+    /// (#5098). Shadowing is normal precedence, but it must be VISIBLE: a
+    /// personal edit that loses to a stale project copy otherwise changes
+    /// nothing anywhere with no signal why.
+    shadowed: Vec<ShadowedProfile>,
+}
+
+/// A lower-precedence profile displaced by a higher layer for the same id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowedProfile {
+    pub id: String,
+    pub shadowed_origin: ProfileOrigin,
+    pub shadowed_source: PathBuf,
+    pub winner_origin: ProfileOrigin,
+    pub winner_source: PathBuf,
+}
+
+/// Process-launch decision: whether project-scope agent profiles
+/// (`.codewhale/agents/*.toml`) may join the dispatch roster (#5098). Set
+/// once from `--no-project-config` at launch so every roster re-read (spawn
+/// refresh, dispatch, views) honors the same trust decision other
+/// project-level config already has (#485). Defaults to enabled, matching
+/// project config itself.
+static PROJECT_AGENT_PROFILES_ENABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(true);
+
+/// Record the launch-time trust decision for project-scope agent profiles.
+pub fn set_project_agent_profiles_enabled(enabled: bool) {
+    PROJECT_AGENT_PROFILES_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether project-scope agent profiles join the roster in this process.
+#[must_use]
+pub fn project_agent_profiles_enabled() -> bool {
+    PROJECT_AGENT_PROFILES_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 impl FleetRoster {
@@ -66,6 +111,7 @@ impl FleetRoster {
     pub fn built_ins_only() -> Self {
         Self {
             members: Self::built_in_members(),
+            shadowed: Vec::new(),
         }
     }
 
@@ -76,7 +122,10 @@ impl FleetRoster {
     /// start and must not pick up built-in or workspace profiles by name.
     #[must_use]
     pub fn from_members(members: Vec<AgentProfile>) -> Self {
-        Self { members }
+        Self {
+            members,
+            shadowed: Vec::new(),
+        }
     }
 
     /// Load and merge the full roster for a workspace.
@@ -88,16 +137,23 @@ impl FleetRoster {
     #[must_use]
     pub fn load(fleet_config: &FleetConfigToml, workspace: &Path) -> Self {
         let personal_dir = personal_agent_profile_dir().ok();
-        Self::load_with_personal_dir(fleet_config, workspace, personal_dir.as_deref())
+        Self::load_with_personal_dir(
+            fleet_config,
+            workspace,
+            personal_dir.as_deref(),
+            project_agent_profiles_enabled(),
+        )
     }
 
     fn load_with_personal_dir(
         fleet_config: &FleetConfigToml,
         workspace: &Path,
         personal_dir: Option<&Path>,
+        include_workspace_profiles: bool,
     ) -> Self {
         let mut built_ins = Self::built_in_members();
         let mut extras: Vec<AgentProfile> = Vec::new();
+        let mut shadowed: Vec<ShadowedProfile> = Vec::new();
 
         for (id, profile) in &fleet_config.profiles {
             let mut profile = profile.clone();
@@ -111,7 +167,10 @@ impl FleetRoster {
                 source: PathBuf::from("config.toml"),
                 origin: ProfileOrigin::Config,
             };
-            merge_member(&mut built_ins, &mut extras, member);
+            record_shadow(
+                merge_member(&mut built_ins, &mut extras, member),
+                &mut shadowed,
+            );
         }
 
         if let Some(personal_dir) = personal_dir {
@@ -123,7 +182,10 @@ impl FleetRoster {
                         );
                     }
                     for member in profiles {
-                        merge_member(&mut built_ins, &mut extras, member);
+                        record_shadow(
+                            merge_member(&mut built_ins, &mut extras, member),
+                            &mut shadowed,
+                        );
                     }
                 }
                 Err(err) => {
@@ -132,22 +194,54 @@ impl FleetRoster {
             }
         }
 
-        match load_workspace_agent_profiles_tolerant(workspace) {
-            Ok((profiles, issues)) => {
-                for issue in issues {
+        // #5098: project-scope profiles join the dispatch roster only when the
+        // launch trusted project-level config (`--no-project-config` opts the
+        // whole layer out, same as `.codewhale/config.toml`).
+        if include_workspace_profiles {
+            match load_workspace_agent_profiles_tolerant(workspace) {
+                Ok((profiles, issues)) => {
+                    for issue in issues {
+                        tracing::warn!(
+                            workspace = %workspace.display(),
+                            "fleet roster: skipping invalid workspace agent profile: {issue}"
+                        );
+                    }
+                    for member in profiles {
+                        record_shadow(
+                            merge_member(&mut built_ins, &mut extras, member),
+                            &mut shadowed,
+                        );
+                    }
+                }
+                Err(err) => {
                     tracing::warn!(
                         workspace = %workspace.display(),
-                        "fleet roster: skipping invalid workspace agent profile: {issue}"
+                        "fleet roster: skipping workspace agent profiles: {err:#}"
                     );
                 }
-                for member in profiles {
-                    merge_member(&mut built_ins, &mut extras, member);
-                }
             }
-            Err(err) => {
+        }
+
+        for shadow in &shadowed {
+            // Overriding a built-in is the intended customization path —
+            // keep it quiet. A file layer (config/personal) losing to another
+            // file layer is the #5098 footgun: the edit changes nothing
+            // anywhere and must be visible.
+            if shadow.shadowed_origin == ProfileOrigin::BuiltIn {
+                tracing::debug!(
+                    "fleet roster: '{}' {} copy at {} overrides the built-in default",
+                    shadow.id,
+                    shadow.winner_origin,
+                    shadow.winner_source.display()
+                );
+            } else {
                 tracing::warn!(
-                    workspace = %workspace.display(),
-                    "fleet roster: skipping workspace agent profiles: {err:#}"
+                    "fleet roster: '{}' {} copy at {} shadows the {} copy at {} (ignored)",
+                    shadow.id,
+                    shadow.winner_origin,
+                    shadow.winner_source.display(),
+                    shadow.shadowed_origin,
+                    shadow.shadowed_source.display()
                 );
             }
         }
@@ -157,7 +251,7 @@ impl FleetRoster {
         extras.sort_by_key(|a| a.id.to_lowercase());
         let mut members = built_ins;
         members.extend(extras);
-        Self { members }
+        Self { members, shadowed }
     }
 
     /// The default party. Built-ins carry no permission grants (permissions
@@ -296,23 +390,60 @@ impl FleetRoster {
             })
             .collect()
     }
+    /// Lower-precedence profiles displaced by higher layers (#5098). Empty
+    /// for `built_ins_only` / `from_members` rosters.
+    #[must_use]
+    pub fn shadowed(&self) -> &[ShadowedProfile] {
+        &self.shadowed
+    }
+
+    /// Shadow records for one member id (trimmed, case-insensitive).
+    pub fn shadowed_for<'a>(&'a self, id: &'a str) -> impl Iterator<Item = &'a ShadowedProfile> {
+        let id = id.trim().to_lowercase();
+        self.shadowed
+            .iter()
+            .filter(move |shadow| shadow.id.trim().eq_ignore_ascii_case(&id))
+    }
+}
+
+/// Fold a displaced layer (if any) into the shadow log.
+fn record_shadow(displaced: Option<ShadowedProfile>, shadowed: &mut Vec<ShadowedProfile>) {
+    if let Some(shadow) = displaced {
+        shadowed.push(shadow);
+    }
 }
 
 /// Overlay `member` onto the roster layers: replace an existing member with
 /// the same id (case-insensitive) in place, otherwise collect it as an extra.
+/// Returns a shadow record when a lower-precedence layer was displaced so the
+/// load can log it and the roster can surface it (#5098).
 fn merge_member(
     built_ins: &mut [AgentProfile],
     extras: &mut Vec<AgentProfile>,
     member: AgentProfile,
-) {
+) -> Option<ShadowedProfile> {
     let matches =
         |existing: &AgentProfile| existing.id.trim().eq_ignore_ascii_case(member.id.trim());
-    if let Some(slot) = built_ins.iter_mut().find(|existing| matches(existing)) {
-        *slot = member;
-    } else if let Some(slot) = extras.iter_mut().find(|existing| matches(existing)) {
-        *slot = member;
-    } else {
-        extras.push(member);
+    let slot = built_ins
+        .iter_mut()
+        .find(|existing| matches(existing))
+        .or_else(|| extras.iter_mut().find(|existing| matches(existing)));
+    match slot {
+        Some(existing) => {
+            let shadow = ShadowedProfile {
+                id: existing.id.clone(),
+                shadowed_origin: existing.origin,
+                shadowed_source: existing.source.clone(),
+                winner_origin: member.origin,
+                winner_source: member.source.clone(),
+            };
+            *existing = member;
+            Some(shadow)
+        }
+        None => {
+            extras.push(member);
+            None
+        }
     }
 }
 
@@ -427,7 +558,7 @@ mod tests {
         ]));
 
         // Isolate from ambient personal agent profiles on developer machines.
-        let roster = FleetRoster::load_with_personal_dir(&config, tmp.path(), None);
+        let roster = FleetRoster::load_with_personal_dir(&config, tmp.path(), None, true);
 
         let ids: Vec<&str> = roster.members().iter().map(|m| m.id.as_str()).collect();
         assert_eq!(
@@ -499,6 +630,7 @@ mod tests {
             &FleetConfigToml::default(),
             &workspace,
             Some(&personal_dir),
+            true,
         );
         let reviewer = personal.get("reviewer").unwrap();
         assert_eq!(reviewer.origin, ProfileOrigin::Personal);
@@ -513,6 +645,7 @@ mod tests {
             &FleetConfigToml::default(),
             &workspace,
             Some(&personal_dir),
+            true,
         );
         let reviewer = project.get("reviewer").unwrap();
         assert_eq!(reviewer.origin, ProfileOrigin::Workspace);
@@ -593,8 +726,12 @@ mod tests {
         );
 
         // Isolate from ambient personal agent profiles on developer machines.
-        let roster =
-            FleetRoster::load_with_personal_dir(&FleetConfigToml::default(), tmp.path(), None);
+        let roster = FleetRoster::load_with_personal_dir(
+            &FleetConfigToml::default(),
+            tmp.path(),
+            None,
+            true,
+        );
 
         let scout = roster.get("scout").expect("valid scout remains visible");
         assert_eq!(scout.origin, ProfileOrigin::Workspace);
@@ -647,5 +784,113 @@ mod tests {
         assert_eq!(ProfileOrigin::Config.to_string(), "config");
         assert_eq!(ProfileOrigin::Personal.to_string(), "personal");
         assert_eq!(ProfileOrigin::Workspace.to_string(), "project");
+    }
+}
+
+#[cfg(test)]
+mod shadow_and_trust_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_profile(dir: &Path, filename: &str, contents: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(filename), contents).unwrap();
+    }
+
+    #[test]
+    fn workspace_shadow_of_personal_file_is_recorded_and_reported() {
+        // #5098: editing the personal builder.toml changed nothing because a
+        // project copy silently shadowed it. The roster must report that the
+        // shadowed personal file exists and is ignored.
+        let tmp = TempDir::new().unwrap();
+        let personal_dir = tmp.path().join("personal");
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        write_profile(
+            &personal_dir,
+            "builder.toml",
+            "id = \"builder\"\nrole_hint = \"builder\"\nmodel = \"deepseek-v4-flash\"\n",
+        );
+        write_profile(
+            &workspace.join(".codewhale").join("agents"),
+            "builder.toml",
+            "id = \"builder\"\nrole_hint = \"builder\"\nmodel = \"deepseek-v4-pro\"\n",
+        );
+
+        let roster = FleetRoster::load_with_personal_dir(
+            &FleetConfigToml::default(),
+            &workspace,
+            Some(&personal_dir),
+            true,
+        );
+
+        let builder = roster.get("builder").expect("builder member");
+        assert_eq!(builder.origin, ProfileOrigin::Workspace);
+        let shadows: Vec<_> = roster.shadowed_for("builder").collect();
+        // The chain is built-in → personal → workspace; both displacements
+        // are recorded, and the file-on-file one names the ignored personal
+        // copy explicitly.
+        assert_eq!(shadows.len(), 2, "full shadow chain: {shadows:?}");
+        let shadow = shadows
+            .iter()
+            .find(|shadow| shadow.shadowed_origin == ProfileOrigin::Personal)
+            .expect("personal file shadow is recorded");
+        assert!(shadow.shadowed_source.ends_with("builder.toml"));
+        assert_eq!(shadow.winner_origin, ProfileOrigin::Workspace);
+        assert!(
+            shadows
+                .iter()
+                .any(|shadow| shadow.shadowed_origin == ProfileOrigin::BuiltIn),
+            "the built-in displacement is recorded too: {shadows:?}"
+        );
+        assert!(
+            roster.shadowed().iter().any(|s| s.id == "builder"),
+            "roster-level shadow log carries the record"
+        );
+    }
+
+    #[test]
+    fn project_scope_profiles_are_skipped_when_the_layer_is_not_trusted() {
+        // #5098: `load_workspace_agent_profiles_tolerant` applied no trust
+        // check — a cloned repo's .codewhale/agents/*.toml silently joined
+        // the dispatch roster. With project config disabled
+        // (`--no-project-config`), the whole layer stays out.
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        write_profile(
+            &workspace.join(".codewhale").join("agents"),
+            "builder.toml",
+            "id = \"builder\"\nrole_hint = \"builder\"\nmodel = \"gpt-5.6-luna\"\n",
+        );
+
+        let gated = FleetRoster::load_with_personal_dir(
+            &FleetConfigToml::default(),
+            &workspace,
+            None,
+            false,
+        );
+        let builder = gated.get("builder").expect("built-in builder remains");
+        assert_eq!(
+            builder.origin,
+            ProfileOrigin::BuiltIn,
+            "untrusted project profile must not join the roster"
+        );
+        assert_ne!(
+            builder.profile.model.as_deref(),
+            Some("gpt-5.6-luna"),
+            "foreign project pin must not reach dispatch"
+        );
+
+        let trusted = FleetRoster::load_with_personal_dir(
+            &FleetConfigToml::default(),
+            &workspace,
+            None,
+            true,
+        );
+        assert_eq!(
+            trusted.get("builder").expect("builder").origin,
+            ProfileOrigin::Workspace,
+            "trusted project profile wins as before"
+        );
     }
 }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -2402,7 +2402,13 @@ async fn run_fleet_command(workspace: &Path, config: &Config, args: FleetArgs) -
             let contents = std::fs::read_to_string(&path)
                 .with_context(|| format!("reading fleet log {}", path.display()))?;
             let preview: String = contents.chars().take(16 * 1024).collect();
-            print!("{preview}");
+            // Worker logs can contain captured terminal bytes (a child TUI's
+            // mouse-tracking handshake, SGR, OSC). Printing them raw would
+            // re-arm mouse reporting in the caller's shell and leave it
+            // executing escape fragments after this command exits.
+            let mut safe_preview = String::with_capacity(preview.len());
+            crate::tui::osc8::strip_ansi_into(&preview, &mut safe_preview);
+            print!("{safe_preview}");
             if contents.chars().count() > preview.chars().count() {
                 println!("\n[truncated]");
             } else if !preview.ends_with('\n') {

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1392,6 +1392,11 @@ fn main() -> Result<()> {
     // discovery. Plugin discovery therefore runs first, and the loader below
     // admits only built-in provider credential names from a stable file read.
     let cli = Cli::parse();
+    // #5098: project-scope fleet agent profiles (`.codewhale/agents/*.toml`)
+    // join the dispatch roster under the same trust decision as the rest of
+    // project-level config — `--no-project-config` opts the layer out for
+    // every roster read in this process.
+    crate::fleet::roster::set_project_agent_profiles_enabled(!cli.no_project_config);
     let workspace = resolve_workspace(&cli);
     let mut plugin_discovery = None;
     let mut plugin_registry = None;

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -1910,7 +1910,12 @@ mod tests {
     #[test]
     fn tool_descriptions_carry_edit_and_shell_guidance() {
         let write = WriteFileTool.description();
-        assert!(write.contains("instead of heredocs") && write.contains("exec_shell"));
+        assert!(
+            write.contains("instead of heredocs")
+                && write.contains("`Bash`")
+                && !write.contains("exec_shell"),
+            "write guidance must name the live Bash tool and never the retired exec_shell name"
+        );
 
         let edit = EditFileTool.description();
         assert!(edit.contains("read_file"));

--- a/crates/tui/src/skills/tests.rs
+++ b/crates/tui/src/skills/tests.rs
@@ -1585,3 +1585,34 @@ fn workspace_and_dir_entry_point_shares_the_same_cache() {
     assert_eq!(first.len(), second.len());
     assert!(second.get("configured").is_some());
 }
+
+#[test]
+fn global_skill_roots_come_from_the_os_home_only() {
+    // §2.5: global skill roots resolve under the OS user's home (or an
+    // explicit `$CODEWHALE_HOME`), never an account/GitHub handle. A wrong
+    // home once produced `Failed to read /Users/<handle>/.codewhale/skills/
+    // delegate/SKILL.md`; pin the source so every global root is provably
+    // under the faked OS home.
+    let _env_lock = crate::test_support::lock_test_env();
+    let tmpdir = TempDir::new().unwrap();
+    let home = tmpdir.path().join("os-home");
+    let workspace = tmpdir.path().join("workspace");
+    std::fs::create_dir_all(home.join(".codewhale").join("skills")).unwrap();
+    std::fs::create_dir_all(&workspace).unwrap();
+    let _home = crate::test_support::EnvVarGuard::set("HOME", &home);
+    let _userprofile = crate::test_support::EnvVarGuard::set("USERPROFILE", &home);
+    let _codewhale_home = crate::test_support::EnvVarGuard::remove("CODEWHALE_HOME");
+
+    let dirs =
+        super::skills_directories_for_mode(&workspace, super::SkillDiscoveryMode::Compatible);
+
+    assert!(
+        dirs.iter().any(|dir| dir.starts_with(&home)),
+        "expected at least one global root under the OS home: {dirs:?}"
+    );
+    assert!(
+        dirs.iter()
+            .all(|dir| dir.starts_with(&home) || dir.starts_with(&workspace)),
+        "every runtime root is under the OS home or the workspace: {dirs:?}"
+    );
+}

--- a/crates/tui/src/snapshot/mod.rs
+++ b/crates/tui/src/snapshot/mod.rs
@@ -32,6 +32,13 @@
 //! the disk is full, or the workspace is on a read-only filesystem, the
 //! turn proceeds and the engine logs a warning. The snapshot is a
 //! safety net, not a correctness gate.
+//!
+//! Workspaces over the configured size cap (`[snapshots] max_workspace_gb`,
+//! default 2 GB of non-excluded content) skip snapshot init entirely. That
+//! disable is intentionally loud: the operator is told once that undo is off
+//! for the workspace, with the opt-in knobs (raise the cap, or set
+//! `max_workspace_gb = 0` to disable the size gate). Scoped snapshot roots are
+//! not yet a first-class config; the practical opt-in today is the cap override.
 
 pub mod paths;
 pub mod prune;

--- a/crates/tui/src/tools/skill.rs
+++ b/crates/tui/src/tools/skill.rs
@@ -157,6 +157,7 @@ impl ToolSpec for LoadSkillTool {
         };
 
         ensure_reviewed_plugin_skill_is_current(skill, &context.workspace)?;
+        ensure_native_skill_file_present(skill)?;
         let body = format_skill_body(skill);
         let (skill_path, skill_source) = match &skill.source {
             SkillSource::Native => (Some(skill.path.display().to_string()), "native".to_string()),
@@ -179,6 +180,26 @@ impl ToolSpec for LoadSkillTool {
                 .collect::<Vec<String>>(),
         })))
     }
+}
+
+/// A native registry entry whose SKILL.md vanished from disk after discovery
+/// (deleted, or resolved under a wrong home directory) must fail loudly with
+/// the exact path — never silently serve the stale cached body while the user
+/// believes the skill loaded (§2.5).
+fn ensure_native_skill_file_present(skill: &Skill) -> Result<(), ToolError> {
+    if !matches!(skill.source, SkillSource::Native) || skill.path.is_file() {
+        return Ok(());
+    }
+    let message = format!(
+        "Skill `{}` is registered at {} but that file no longer exists on disk, \
+         so the skill did not load. Restore the file, or fix the skills directory it \
+         came from (`skills_dir` in config.toml, `$CODEWHALE_HOME`, or the OS home) — \
+         the path above shows exactly where the runtime looked.",
+        skill.name,
+        skill.path.display()
+    );
+    crate::logging::warn(&message);
+    Err(ToolError::execution_failed(message))
 }
 
 fn ensure_reviewed_plugin_skill_is_current(
@@ -352,6 +373,63 @@ mod tests {
             names,
             vec!["data.json".to_string(), "script.py".to_string()]
         );
+    }
+
+    #[test]
+    fn native_skill_with_vanished_file_fails_loudly_with_the_path() {
+        // §2.5: a registry entry pointing at a SKILL.md that no longer exists
+        // must surface the exact path instead of silently serving the stale
+        // cached body — this is the "delegate skill silently never loads"
+        // symptom class.
+        let tmp = tempdir().unwrap();
+        let missing = tmp.path().join("delegate").join("SKILL.md");
+        let skill = Skill {
+            name: "delegate".to_string(),
+            description: "delegate work".to_string(),
+            localized_descriptions: std::collections::HashMap::new(),
+            invocation: crate::skills::SkillInvocation::ModelAndUser,
+            aliases: Vec::new(),
+            body: "cached body".to_string(),
+            path: missing.clone(),
+            source: SkillSource::Native,
+        };
+        let err = ensure_native_skill_file_present(&skill)
+            .expect_err("a vanished SKILL.md must fail loudly");
+        let message = err.to_string();
+        assert!(
+            message.contains(&missing.display().to_string()),
+            "error names the exact path: {message}"
+        );
+        assert!(
+            message.contains("did not load"),
+            "error says the skill did not load: {message}"
+        );
+
+        // An existing file passes, and plugin skills are untouched (their
+        // content-bound snapshot never consults the mutable path).
+        let present_dir = tempdir().unwrap();
+        let present = present_dir.path().join("SKILL.md");
+        fs::write(&present, "body").unwrap();
+        let mut on_disk = skill.clone();
+        on_disk.path = present;
+        ensure_native_skill_file_present(&on_disk).expect("present file loads");
+        let mut plugin = skill;
+        plugin.source = SkillSource::Plugin {
+            plugin_id: "workspace/1/demo".to_string(),
+            plugin_name: "demo".to_string(),
+            authority: Box::new(crate::plugins::types::PluginAuthority {
+                plugin_id: crate::plugins::types::PluginId("workspace/1/demo".to_string()),
+                plugin_name: "demo".to_string(),
+                workspace: tmp.path().to_path_buf(),
+                state_path: tmp.path().join("state.json"),
+                source_manifest: tmp.path().join("plugin.toml"),
+                staged_manifest: tmp.path().join("staged/plugin.toml"),
+                content_hash: "0".repeat(64),
+                capability_hash: "0".repeat(64),
+                state_generation: 0,
+            }),
+        };
+        ensure_native_skill_file_present(&plugin).expect("plugin snapshot skips the disk check");
     }
 
     #[test]

--- a/crates/tui/src/tools/subagent/coord.rs
+++ b/crates/tui/src/tools/subagent/coord.rs
@@ -1553,6 +1553,20 @@ pub struct CoordinationDetailProjection {
     pub metrics: CoordinationDetailMetrics,
     pub bounded: bool,
     pub limit: usize,
+    /// Whether this process currently holds the workspace coordination flock.
+    /// When false, durable ledger writes are skipped and the UI must say so —
+    /// a counter must never tick on a turn the engine has already settled.
+    #[serde(default = "default_process_lock_held")]
+    pub process_lock_held: bool,
+    /// Human-readable reason when [`Self::process_lock_held`] is false.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_lock_note: Option<String>,
+}
+
+fn default_process_lock_held() -> bool {
+    // Legacy projections (tests, older sessions) assume the lock is held so
+    // they do not spuriously light the unavailable banner.
+    true
 }
 
 /// Durable, bounded coordination state owned by `SubAgentManager`.

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -7238,6 +7238,7 @@ async fn spawn_subagent_from_input(
     mut runtime: SubAgentRuntime,
 ) -> Result<(SubAgentResult, WorkflowTaskSpawnMetadata), ToolError> {
     apply_session_spawn_defaults(&mut runtime);
+    refresh_spawn_route_sources(&mut runtime);
     let mut spawn_request = parse_spawn_request(&input)?;
     let profile_member = apply_spawn_profile(&mut spawn_request, &runtime.fleet_roster)?;
     // Profile-backed requests cannot be classified safely until the roster
@@ -10492,6 +10493,27 @@ fn validate_roster_token(value: &str, field: &str) -> Result<String, ToolError> 
 /// and the child's capability posture is governed by the member's
 /// `FleetRole` via `WorkerRuntimeProfile::for_role` — applying the block
 /// here could only widen that posture.
+/// Re-read the fleet roster — and the role-model defaults derived from it —
+/// from disk at spawn time (#5099). The runtime's roster and `role_models`
+/// are launch-time snapshots (built once in main.rs), so a mid-session
+/// `agents/*.toml` edit was invisible: spawns kept supplying the launch-time
+/// model id — a value that may exist nowhere on current disk — straight into
+/// the unpinned-provider guard. Personal and project profile files are
+/// re-read here; explicit `[subagents]` config overrides keep winning on top.
+/// Without the session `Config` (tests, legacy runtimes) the launch-time
+/// snapshot is the only source available and is kept.
+fn refresh_spawn_route_sources(runtime: &mut SubAgentRuntime) {
+    let Some(config) = runtime.api_config.as_deref() else {
+        return;
+    };
+    let roster =
+        crate::fleet::roster::FleetRoster::load(&config.fleet_config(), &runtime.context.workspace);
+    let mut role_models = roster.model_overrides();
+    role_models.extend(config.subagent_model_overrides());
+    runtime.role_models = role_models;
+    runtime.fleet_roster = std::sync::Arc::new(roster);
+}
+
 fn apply_spawn_profile(
     request: &mut SpawnRequest,
     roster: &crate::fleet::roster::FleetRoster,
@@ -10735,6 +10757,13 @@ fn resolve_spawn_model_selection(
 /// pins also receive the conservative known-foreign check; explicit provider
 /// pairs keep their deliberate route intent. Inherited/strength routes stay
 /// unchanged.
+///
+/// #5099: the known-foreign check distinguishes who asked for the model. An
+/// explicit `task.model` is the caller's deliberate pin and still fails with
+/// the pin-vs-inherit error. A provider-less DEFAULT the session never chose
+/// (fleet profile model or role/type default) must not hard-fail the spawn —
+/// the child inherits the session route instead of colliding with a foreign
+/// provider's bare model id, and the downgrade is logged.
 fn resolve_fixed_spawn_model_route(
     runtime: &SubAgentRuntime,
     selection: &mut SpawnModelSelection,
@@ -10752,6 +10781,27 @@ fn resolve_fixed_spawn_model_route(
         return Ok(());
     };
     let provider = runtime.client.api_provider();
+    if providerless
+        && let Err(reason) = crate::route_runtime::validate_unpinned_model_provider(
+            provider,
+            model,
+            runtime.client.base_url(),
+        )
+    {
+        if matches!(selection.source, SpawnRouteSource::TaskModel) {
+            return Err(ToolError::invalid_input(reason));
+        }
+        tracing::warn!(
+            model = %model,
+            source = selection.source.as_str(),
+            session_provider = %provider.as_str(),
+            "provider-less spawn default is foreign to the session route; \
+             the child inherits the session route instead ({reason})"
+        );
+        selection.model_route = ModelRoute::Inherit;
+        selection.source = SpawnRouteSource::RunModel;
+        return Ok(());
+    }
     let candidate = if providerless {
         crate::route_runtime::resolve_unpinned_model_candidate(
             provider,

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -3188,10 +3188,7 @@ impl SubAgentManager {
             process_lock_note: if self.holds_coordination_process_lock() {
                 None
             } else {
-                match self.coordination_process_lock_status() {
-                    Ok(()) => None,
-                    Err(error) => Some(error),
-                }
+                self.coordination_process_lock_status().err()
             },
         }
     }

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -3179,6 +3179,20 @@ impl SubAgentManager {
             },
             bounded: true,
             limit,
+            process_lock_held: {
+                // Retry acquire on each projection so a session that lost the
+                // flock at construction recovers once the previous owner exits.
+                let _ = self.coordination_process_lock_status();
+                self.holds_coordination_process_lock()
+            },
+            process_lock_note: if self.holds_coordination_process_lock() {
+                None
+            } else {
+                match self.coordination_process_lock_status() {
+                    Ok(()) => None,
+                    Err(error) => Some(error),
+                }
+            },
         }
     }
 
@@ -3319,6 +3333,27 @@ impl SubAgentManager {
             }
             Err(error) => Err(error.to_string()),
         }
+    }
+
+    /// Whether this process currently owns the workspace coordination flock.
+    /// Read-only inspection of the in-process slot — does not attempt acquire.
+    #[must_use]
+    pub fn holds_coordination_process_lock(&self) -> bool {
+        if !self.coordination_process_lock_required {
+            // Tests and non-durable managers do not require the flock.
+            return true;
+        }
+        self.coordination_process_lock
+            .lock()
+            .expect("coordination lock slot poisoned")
+            .is_some()
+    }
+
+    /// Probe lock ownership for UI/inspect surfaces. Retries acquire when the
+    /// slot is empty so a session that started without the lock can recover
+    /// after the previous owner exits (#2.6 / #5036).
+    pub fn coordination_process_lock_status(&self) -> Result<(), String> {
+        self.ensure_coordination_process_lock()
     }
 
     #[must_use]
@@ -5469,37 +5504,87 @@ impl SubAgentManager {
             .filter(|agent| {
                 agent.status == SubAgentStatus::Running
                     && !agent.completion_claimed
-                    && agent.task_handle.is_some()
                     && agent.last_activity_at.elapsed() >= timeout
             })
             .map(|agent| agent.id.clone())
             .collect::<Vec<_>>();
         for agent_id in stale_agent_ids {
+            let orphan = self
+                .agents
+                .get(&agent_id)
+                .is_some_and(|agent| agent.task_handle.is_none());
             if let Some(agent) = self.agents.get(&agent_id) {
                 tracing::warn!(
                     target: "subagent",
                     agent_id = %agent.id,
                     timeout_secs = timeout.as_secs(),
+                    orphan,
                     "auto-cancelling stale sub-agent with no manager-visible progress"
                 );
             }
             let Some(mut terminal) = self.agents.get(&agent_id).map(SubAgent::snapshot) else {
                 continue;
             };
-            terminal.status = SubAgentStatus::Cancelled;
-            terminal.result = Some(format!(
-                "Auto-cancelled after {}s without sub-agent progress.",
-                timeout.as_secs()
-            ));
+            // Orphans have no live executor — Interrupted is more honest than
+            // Cancelled (nothing was stopped; the process was already gone).
+            if orphan {
+                terminal.status = SubAgentStatus::Interrupted(
+                    "No live executor; marked terminal locally after heartbeat timeout".to_string(),
+                );
+                terminal.result = Some(format!(
+                    "Marked terminal after {}s with no live task handle (local-only; durable coordination may be owned elsewhere).",
+                    timeout.as_secs()
+                ));
+            } else {
+                terminal.status = SubAgentStatus::Cancelled;
+                terminal.result = Some(format!(
+                    "Auto-cancelled after {}s without sub-agent progress.",
+                    timeout.as_secs()
+                ));
+            }
             terminal.needs_input = None;
             // Cleanup batches stale transitions and persists the final fleet
             // snapshot once below. Spawning one unordered background write
             // per child could let an earlier partial snapshot rename last and
             // resurrect a cancelled worker after restart.
-            if self.finish_terminal_result(&agent_id, terminal, true, false) {
+            // persist_after_commit=true still best-efforts; lock loss only
+            // skips disk — in-memory terminal state always commits.
+            if self.finish_terminal_result(&agent_id, terminal, true, true) {
                 auto_cancelled += 1;
             }
         }
+        // When this process does not own the coordination flock, any Running
+        // agent without a live task handle cannot make durable progress from
+        // here. Terminalize immediately so the UI never shows a ticking
+        // counter on a dead job while we wait for heartbeat timeout (#2.6).
+        if !self.holds_coordination_process_lock() {
+            let orphan_ids = self
+                .agents
+                .values()
+                .filter(|agent| {
+                    agent.status == SubAgentStatus::Running
+                        && !agent.completion_claimed
+                        && agent.task_handle.is_none()
+                })
+                .map(|agent| agent.id.clone())
+                .collect::<Vec<_>>();
+            for agent_id in orphan_ids {
+                let Some(mut terminal) = self.agents.get(&agent_id).map(SubAgent::snapshot) else {
+                    continue;
+                };
+                terminal.status = SubAgentStatus::Interrupted(
+                    "Delegated coordination unavailable in this process".to_string(),
+                );
+                terminal.result = Some(
+                    "Marked terminal locally because this session does not hold the workspace coordination lock and the agent has no live executor.".to_string(),
+                );
+                terminal.needs_input = None;
+                if self.finish_terminal_result(&agent_id, terminal, false, true) {
+                    auto_cancelled += 1;
+                }
+            }
+        }
+
         self.agents.retain(|_, agent| {
             if agent.status == SubAgentStatus::Running {
                 true

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1016,6 +1016,88 @@ fn isolated_worktree_workers_skip_the_coordination_process_lock() {
 }
 
 #[test]
+fn coordination_detail_projection_reports_process_lock_ownership() {
+    let tmp = tempdir().expect("tempdir");
+    let workspace = tmp.path().canonicalize().expect("canonical workspace");
+
+    let holder = SubAgentManager::new(workspace.clone(), 4).require_coordination_process_lock();
+    holder
+        .ensure_coordination_process_lock()
+        .expect("holder owns the lock");
+    let held = holder.coordination_detail_projection(None, 8);
+    assert!(held.process_lock_held, "holder projection must report lock held");
+    assert!(held.process_lock_note.is_none());
+
+    let contender = SubAgentManager::new(workspace, 4).require_coordination_process_lock();
+    // Contender construction may leave the slot empty; projection must say so.
+    let missing = contender.coordination_detail_projection(None, 8);
+    // After projection's re-acquire probe, either held recovered (holder dropped)
+    // or still missing. Holder is still in scope so must be missing.
+    assert!(
+        !missing.process_lock_held,
+        "contender projection must report lock unavailable while holder lives"
+    );
+    let note = missing
+        .process_lock_note
+        .expect("unavailable projection carries a note");
+    assert!(
+        note.contains("another Codewhale process")
+            || note.contains("timed out")
+            || note.contains("lock"),
+        "note names the contention: {note}"
+    );
+}
+
+#[test]
+fn cleanup_terminalizes_running_orphans_without_task_handle_when_lock_missing() {
+    let tmp = tempdir().expect("tempdir");
+    let workspace = tmp.path().canonicalize().expect("canonical workspace");
+
+    let holder = SubAgentManager::new(workspace.clone(), 4).require_coordination_process_lock();
+    holder
+        .ensure_coordination_process_lock()
+        .expect("holder owns the lock");
+
+    let mut contender = SubAgentManager::new(workspace, 4).require_coordination_process_lock();
+    contender
+        .ensure_coordination_process_lock()
+        .expect_err("contender must not own the lock");
+
+    let (input_tx, _input_rx) = mpsc::unbounded_channel();
+    let mut agent = SubAgent::new(
+        "orphan-no-handle".to_string(),
+        FleetRole::Scout,
+        "explore".to_string(),
+        make_assignment(),
+        "deepseek-v4-flash".to_string(),
+        None,
+        None,
+        input_tx,
+        PathBuf::from("."),
+        contender.session_boot_id().to_string(),
+    );
+    // Explicit orphan: Running, no task_handle (SubAgent::new already sets None).
+    assert!(agent.task_handle.is_none());
+    agent.last_activity_at = Instant::now() - Duration::from_secs(10);
+    let agent_id = agent.id.clone();
+    contender.agents.insert(agent_id.clone(), agent);
+
+    let cancelled = contender.cleanup(Duration::from_secs(3600));
+    assert!(
+        cancelled >= 1,
+        "orphan without task handle must terminalize under lock loss"
+    );
+    let snap = contender
+        .get_result(&agent_id)
+        .expect("agent still listed after local terminalization");
+    assert!(
+        matches!(snap.status, SubAgentStatus::Interrupted(_)),
+        "orphan becomes Interrupted locally, not left Running: {:?}",
+        snap.status
+    );
+}
+
+#[test]
 fn neutral_reconciliation_requires_the_nearest_common_planner() {
     let tmp = tempdir().expect("tempdir");
     let mut manager = SubAgentManager::new(tmp.path().to_path_buf(), 8);

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1025,7 +1025,10 @@ fn coordination_detail_projection_reports_process_lock_ownership() {
         .ensure_coordination_process_lock()
         .expect("holder owns the lock");
     let held = holder.coordination_detail_projection(None, 8);
-    assert!(held.process_lock_held, "holder projection must report lock held");
+    assert!(
+        held.process_lock_held,
+        "holder projection must report lock held"
+    );
     assert!(held.process_lock_note.is_none());
 
     let contender = SubAgentManager::new(workspace, 4).require_coordination_process_lock();

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -3115,6 +3115,110 @@ fn providerless_spawn_model_gate_rejects_known_foreign_route_before_spawn() {
 }
 
 #[test]
+fn providerless_foreign_spawn_default_inherits_session_route() {
+    // #5099 / checklist §2.2: a moonshot parent spawning a default child whose
+    // role default — or unpinned fleet profile model — is a provider-less
+    // deepseek id must inherit the session route instead of hard-failing the
+    // spawn on a model the session never chose.
+    let runtime = stub_runtime_for_provider("moonshot");
+    for source in [
+        SpawnRouteSource::RoleDefault,
+        SpawnRouteSource::AgentProfileModel,
+    ] {
+        let mut selection = SpawnModelSelection {
+            model_route: ModelRoute::Fixed("deepseek-v4-flash".to_string()),
+            source,
+        };
+        resolve_fixed_spawn_model_route(&runtime, &mut selection, true)
+            .expect("provider-less foreign default must not fail the spawn");
+        assert_eq!(
+            selection.model_route,
+            ModelRoute::Inherit,
+            "default from {source:?} downgrades to the session route"
+        );
+        assert_eq!(
+            selection.source,
+            SpawnRouteSource::RunModel,
+            "receipt provenance reflects the inherit for {source:?}"
+        );
+    }
+
+    // An explicit caller `task.model` pin keeps the pin-vs-inherit error; the
+    // guard is only bypassed for defaults the session did not choose.
+    let mut explicit = SpawnModelSelection {
+        model_route: ModelRoute::Fixed("deepseek-v4-flash".to_string()),
+        source: SpawnRouteSource::TaskModel,
+    };
+    let err = resolve_fixed_spawn_model_route(&runtime, &mut explicit, true)
+        .expect_err("explicit task.model keeps the known-foreign guard");
+    let message = err.to_string();
+    assert!(
+        message.contains("inherit the session route"),
+        "error names the exact fix: {message}"
+    );
+
+    // A same-provider default still resolves to the exact wire id.
+    let deepseek = stub_runtime();
+    let mut owned = SpawnModelSelection {
+        model_route: ModelRoute::Fixed("deepseek-v4-flash".to_string()),
+        source: SpawnRouteSource::RoleDefault,
+    };
+    resolve_fixed_spawn_model_route(&deepseek, &mut owned, true)
+        .expect("same-provider default resolves normally");
+    assert!(
+        matches!(owned.model_route, ModelRoute::Fixed(_)),
+        "owned default stays fixed: {:?}",
+        owned.model_route
+    );
+}
+
+#[test]
+fn spawn_route_sources_refresh_reads_current_disk() {
+    // #5099 second defect: the launch-time roster/role_models snapshot kept
+    // supplying a model id that existed nowhere on current disk after a
+    // mid-session profile edit. The spawn path must re-read.
+    let _env_lock = crate::test_support::lock_test_env();
+    let home = tempfile::tempdir().expect("home tempdir");
+    let _codewhale_home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", home.path());
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let agents = workspace.path().join(".codewhale").join("agents");
+    std::fs::create_dir_all(&agents).expect("agents dir");
+    std::fs::write(
+        agents.join("builder.toml"),
+        "id = \"builder\"\nrole_hint = \"builder\"\nmodel = \"fresh-disk-model\"\n",
+    )
+    .expect("write workspace profile");
+
+    let mut runtime = stub_runtime();
+    runtime.context = ToolContext::new(workspace.path().to_path_buf());
+    // Simulate the launch-time snapshot: a stale pin nowhere on disk.
+    runtime
+        .role_models
+        .insert("builder".to_string(), "stale-launch-model".to_string());
+
+    refresh_spawn_route_sources(&mut runtime);
+
+    let member = runtime
+        .fleet_roster
+        .get("builder")
+        .expect("workspace profile joins the fresh roster");
+    assert_eq!(
+        member.profile.model.as_deref(),
+        Some("fresh-disk-model"),
+        "roster re-reads current disk"
+    );
+    assert_eq!(
+        member.origin,
+        crate::fleet::profile::ProfileOrigin::Workspace
+    );
+    assert_eq!(
+        runtime.role_models.get("builder").map(String::as_str),
+        Some("fresh-disk-model"),
+        "role defaults re-read current disk"
+    );
+}
+
+#[test]
 fn test_child_max_spawn_depth_profile_hint_only_narrows() {
     // Profile hint narrows the inherited budget...
     assert_eq!(child_max_spawn_depth_for_spawn(3, 1, None, Some(1)), 2);

--- a/crates/tui/src/tui/coordination_detail.rs
+++ b/crates/tui/src/tui/coordination_detail.rs
@@ -25,10 +25,11 @@ pub(crate) fn summary(locale: Locale, projection: &CoordinationDetailProjection)
 
 #[must_use]
 pub(crate) fn needs_attention(projection: &CoordinationDetailProjection) -> bool {
-    projection
-        .decisions
-        .iter()
-        .any(|decision| decision.status == DecisionStatus::Proposed)
+    !projection.process_lock_held
+        || projection
+            .decisions
+            .iter()
+            .any(|decision| decision.status == DecisionStatus::Proposed)
         || projection
             .reconciliations
             .iter()
@@ -57,6 +58,13 @@ pub(crate) fn format(locale: Locale, projection: &CoordinationDetailProjection) 
         tr(locale, MessageId::CoordinationPerSectionLimit)
             .replace("{limit}", &projection.limit.to_string())
     );
+    if !projection.process_lock_held {
+        let note = projection
+            .process_lock_note
+            .as_deref()
+            .unwrap_or("another Codewhale process owns this workspace lock");
+        let _ = writeln!(out, "Coordination lock: unavailable — {note}");
+    }
 
     section(
         &mut out,
@@ -344,6 +352,8 @@ mod tests {
             },
             bounded: true,
             limit: 24,
+            process_lock_held: true,
+            process_lock_note: None,
         }
     }
 

--- a/crates/tui/src/tui/pager.rs
+++ b/crates/tui/src/tui/pager.rs
@@ -123,8 +123,17 @@ impl PagerView {
     }
 
     pub fn from_text(title: impl Into<String>, text: &str, width: u16) -> Self {
+        // Pager bodies frequently carry tool output or worker transcripts
+        // (e.g. the sub-agent chat pager re-reads the raw JSONL artifact from
+        // disk). Any CSI/OSC bytes in that content are emitted verbatim by
+        // the terminal backend, which can re-enable mouse tracking or leave
+        // the user's shell executing fragments after the TUI exits. Strip
+        // every escape sequence and stray control byte at this chokepoint so
+        // no pager surface can inject terminal state.
+        let mut sanitized = String::with_capacity(text.len());
+        crate::tui::osc8::strip_ansi_into(text, &mut sanitized);
         let mut lines = Vec::new();
-        for raw in text.lines() {
+        for raw in sanitized.lines() {
             for wrapped in wrap_text(raw, width.max(1) as usize) {
                 lines.push(Line::from(Span::raw(wrapped)));
             }
@@ -951,6 +960,65 @@ mod tests {
     fn from_text_keeps_one_display_row_per_blank_source_line() {
         let pager = PagerView::from_text("T", "first\n\nthird", 80);
         assert_eq!(pager.body_text(), "first\n\nthird");
+    }
+
+    #[test]
+    fn from_text_strips_csi_mouse_and_osc_sequences() {
+        // A worker transcript can carry captured terminal bytes (a child TUI's
+        // mouse-tracking handshake, SGR color, OSC hyperlinks). Rendering them
+        // raw emits the escapes to the user's terminal, which re-enables mouse
+        // reporting after exit and leaves the shell executing fragments.
+        let hostile = "── assistant ──\n\
+                       enabling \u{1b}[?1003h\u{1b}[?1006h mouse tracking\n\
+                       click bytes \u{1b}[<65;72;17M\u{1b}[<35;131;42M arrived\n\
+                       \u{1b}[31mred text\u{1b}[0m and an \u{1b}]8;;https://example.com\u{7}OSC link\u{1b}]8;;\u{1b}\\\n\
+                       trailing stray \u{1b}\u{7}bytes\u{1b}c done";
+        let pager = PagerView::from_text("Agent transcript", hostile, 200);
+        let body = pager.body_text();
+        assert!(
+            !body.contains('\u{1b}'),
+            "no ESC byte may survive into the pager body: {body:?}"
+        );
+        assert!(
+            !body.contains('\u{7}'),
+            "no BEL byte may survive into the pager body: {body:?}"
+        );
+        for fragment in ["?1003h", "?1006h", "<65;72;17M", "<35;131;42M", "]8;;"] {
+            assert!(
+                !body.contains(fragment),
+                "escape fragment {fragment:?} must be stripped, not painted: {body:?}"
+            );
+        }
+        assert!(body.contains("red text"), "visible text survives: {body:?}");
+        assert!(body.contains("OSC link"), "link label survives: {body:?}");
+        assert!(body.contains("done"), "trailing text survives: {body:?}");
+    }
+
+    #[test]
+    fn from_text_sanitizes_jsonl_transcript_shaped_content() {
+        // Regression for the sub-agent transcript pager corrupting the parent
+        // terminal: content shaped like the raw artifact lines, with embedded
+        // mouse/CSI sequences inside a tool result, must render inert.
+        let transcript_like = concat!(
+            "── assistant ──\n",
+            "I'll run the build now.\n",
+            "← tool result (call-1)\n",
+            // JSON-escaped text is literal backslash-u bytes — inert, kept as-is.
+            "{\"line\":\"\\u{1b}[<0;9;4Mprogress done\"}\n",
+            // Raw event bytes are the dangerous form and must be stripped.
+            "raw \u{1b}[<0;10;5M event bytes\u{1b}[2K after\n",
+        );
+        let pager = PagerView::from_text("Agent transcript", transcript_like, 200);
+        let body = pager.body_text();
+        assert!(!body.contains('\u{1b}'), "inert body required: {body:?}");
+        assert!(
+            !body.contains("<0;10;5M"),
+            "mouse event fragment must not render: {body:?}"
+        );
+        assert!(
+            body.contains("progress") && body.contains("after"),
+            "readable content survives: {body:?}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7539,6 +7539,30 @@ fn apply_coordination_detail_projection(
     app: &mut App,
     projection: crate::tools::subagent::CoordinationDetailProjection,
 ) {
+    // §2.6: when this process does not own the workspace coordination flock,
+    // say so on the sticky status strip. A silent "running (543s)" row on a
+    // settled turn is a lie; surface the lock loss the same way we surface
+    // other session hazards.
+    if !projection.process_lock_held {
+        let note = projection
+            .process_lock_note
+            .as_deref()
+            .unwrap_or("another Codewhale process owns delegated coordination for this workspace");
+        let message = format!(
+            "Delegated coordination unavailable — {note}. Job rows still settle locally; durable fleet state is owned elsewhere."
+        );
+        let already = app
+            .sticky_status
+            .as_ref()
+            .is_some_and(|toast| toast.text.contains("Delegated coordination unavailable"));
+        if !already {
+            app.set_sticky_status(
+                message,
+                crate::tui::app::StatusToastLevel::Warning,
+                Some(30_000),
+            );
+        }
+    }
     app.coordination_detail = Some(projection);
 }
 

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -775,8 +775,8 @@ fn coordination_event_projection_is_retained_as_typed_app_state() {
         },
         bounded: true,
         limit: 24,
-            process_lock_held: true,
-            process_lock_note: None,
+        process_lock_held: true,
+        process_lock_note: None,
     };
 
     apply_coordination_detail_projection(&mut app, projection.clone());

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -775,6 +775,8 @@ fn coordination_event_projection_is_retained_as_typed_app_state() {
         },
         bounded: true,
         limit: 24,
+            process_lock_held: true,
+            process_lock_note: None,
     };
 
     apply_coordination_detail_projection(&mut app, projection.clone());

--- a/crates/tui/src/tui/views/fleet_roster.rs
+++ b/crates/tui/src/tui/views/fleet_roster.rs
@@ -73,6 +73,9 @@ impl OperatorInfo {
 pub struct FleetRosterView {
     operator: OperatorInfo,
     members: Vec<AgentProfile>,
+    /// Shadow records from the roster load (#5098): which lower-precedence
+    /// files the displayed members are ignoring.
+    shadowed: Vec<crate::fleet::roster::ShadowedProfile>,
     /// Selected row: 0 is the pinned operator row, members follow at 1..
     selected: usize,
     detail_scroll: usize,
@@ -105,6 +108,7 @@ impl FleetRosterView {
                 .filter(|m| !m.id.trim().eq_ignore_ascii_case("operator"))
                 .cloned()
                 .collect(),
+            shadowed: roster.shadowed().to_vec(),
             selected: 0,
             detail_scroll: 0,
             locale: Locale::En,
@@ -327,8 +331,25 @@ impl FleetRosterView {
             } else {
                 let member = &self.members[idx - 1];
                 let mark = member_role_mark(member);
+                // #5098: badge rows whose winning layer is ignoring a
+                // lower-precedence file, so a shadowed personal/project edit
+                // is visible from the list, not just the detail pane.
+                let shadow_badge = if self
+                    .shadowed
+                    .iter()
+                    .any(|shadow| shadow.id.trim().eq_ignore_ascii_case(member.id.trim()))
+                {
+                    " ⚠shadows"
+                } else {
+                    ""
+                };
                 (
-                    format!("{pointer}{mark} {}  {}", member.id, member_routing(member)),
+                    format!(
+                        "{pointer}{mark} {}  {}{}",
+                        member.id,
+                        member_routing(member),
+                        shadow_badge
+                    ),
                     Style::default().fg(palette::TEXT_PRIMARY),
                 )
             };
@@ -350,7 +371,11 @@ impl FleetRosterView {
         } else if let Some(member) = self.selected_member() {
             // Session model is the operator route so "fast" loadouts resolve
             // to the fast sibling the runtime will actually launch.
-            member_detail_lines_with_session(member, Some(self.operator.model.as_str()))
+            member_detail_lines_with_session(
+                member,
+                Some(self.operator.model.as_str()),
+                &self.shadowed,
+            )
         } else {
             vec![Line::from(Span::styled(
                 "Roster is empty.",
@@ -477,6 +502,7 @@ fn member_routing_with_session(member: &AgentProfile, session_model: Option<&str
 fn member_detail_lines_with_session(
     member: &AgentProfile,
     session_model: Option<&str>,
+    shadowed: &[crate::fleet::roster::ShadowedProfile],
 ) -> Vec<Line<'static>> {
     let mut lines: Vec<Line> = Vec::new();
 
@@ -495,6 +521,22 @@ fn member_detail_lines_with_session(
             _ => format!("{} · {}", member.origin, member.source.display()),
         },
     );
+    // #5098: every layer this member is displacing, so a shadowed personal or
+    // project file is visible instead of silently dropped from the merge.
+    for shadow in shadowed
+        .iter()
+        .filter(|shadow| shadow.id.trim().eq_ignore_ascii_case(member.id.trim()))
+    {
+        detail_field(
+            &mut lines,
+            "Shadows",
+            format!(
+                "{} copy at {} (ignored)",
+                shadow.shadowed_origin,
+                shadow.shadowed_source.display()
+            ),
+        );
+    }
     detail_field(&mut lines, "Slot", member.profile.slot.as_str().to_string());
     detail_field(&mut lines, "Posture", member_posture(member));
     detail_field(
@@ -591,6 +633,7 @@ mod tests {
         FleetRosterView {
             operator: operator(),
             members,
+            shadowed: Vec::new(),
             selected: 0,
             detail_scroll: 0,
             locale: Locale::En,
@@ -802,7 +845,7 @@ mod tests {
     fn detail_lines_carry_overlay_source_for_project_members() {
         let view = view_with_overrides();
         let reviewer = view.members.iter().find(|m| m.id == "reviewer").unwrap();
-        let text = member_detail_lines_with_session(reviewer, None)
+        let text = member_detail_lines_with_session(reviewer, None, &view.shadowed)
             .iter()
             .map(|line| {
                 line.spans
@@ -852,6 +895,37 @@ mod tests {
         assert_eq!(
             member_routing(extra),
             "route preset fast (resolved at launch)"
+        );
+    }
+
+    #[test]
+    fn detail_pane_reports_shadowed_lower_layers() {
+        // #5098: a member whose winning layer ignores a personal file must
+        // say so in the detail pane — the shadowed edit is no longer dropped
+        // from every surface.
+        let mut view = view_with_overrides();
+        view.shadowed.push(crate::fleet::roster::ShadowedProfile {
+            id: "reviewer".to_string(),
+            shadowed_origin: ProfileOrigin::Personal,
+            shadowed_source: PathBuf::from("/home/op/.codewhale/agents/reviewer.toml"),
+            winner_origin: ProfileOrigin::Workspace,
+            winner_source: PathBuf::from(".codewhale/agents/reviewer.toml"),
+        });
+        let reviewer = view.members.iter().find(|m| m.id == "reviewer").unwrap();
+        let text = member_detail_lines_with_session(reviewer, None, &view.shadowed)
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.clone().into_owned())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("Shadows"), "detail names the shadow: {text}");
+        assert!(
+            text.contains("personal copy at /home/op/.codewhale/agents/reviewer.toml (ignored)"),
+            "detail names the ignored file: {text}"
         );
     }
 

--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -255,6 +255,8 @@ mod tests {
             },
             bounded: true,
             limit: 24,
+            process_lock_held: true,
+            process_lock_note: None,
         });
 
         let rows = super::model::project(&mut app);
@@ -327,6 +329,8 @@ mod tests {
             },
             bounded: true,
             limit: 24,
+            process_lock_held: true,
+            process_lock_note: None,
         });
 
         let rows = super::model::project(&mut app);
@@ -365,6 +369,8 @@ mod tests {
             },
             bounded: true,
             limit: 24,
+            process_lock_held: true,
+            process_lock_note: None,
         });
 
         let rows = super::model::project(&mut app);
@@ -417,6 +423,8 @@ mod tests {
             },
             bounded: true,
             limit: 24,
+            process_lock_held: true,
+            process_lock_note: None,
         });
 
         let rows = super::model::project(&mut app);


### PR DESCRIPTION
Stack **R3** of the v0.9.4 program — chains on R1 (#5147), which chains on the train (#5135). 9 commits, one concern each.

## What's in it

- **§2.1 transcript escape corruption** (`7b087a272` lineage): `PagerView::from_text` sanitizes through `osc8::strip_ansi_into` at the single chokepoint — child-TUI bytes (mouse tracking, CSI) can never reach the parent terminal raw again; `codewhale fleet logs` preview sanitized too. Tests feed CSI/mouse/OSC-laden transcripts and assert inert output.
- **#5099 sub-agent route inheritance** (`380f342de`): provider-less *defaults* that fail the known-foreign guard now downgrade to `ModelRoute::Inherit` (session route) with a warn — explicit pins still error correctly. The stale second resolution path is gone: spawn re-reads the roster from current disk (`refresh_spawn_route_sources`). Moonshot-parent/default-child pinned by test. Closes #5099.
- **§2.3 login exit code**: already fixed on the train; regression pin added (`account_login_timeout_fails_the_command`, live-verified exit=1 against a stub device-flow server).
- **§2.5 home-dir bug**: negative finding — no code constructs home from an account handle (all paths funnel through the OS user / ``); the observed `/Users/hmbown` was a model-constructed argument. The real silent half fixed: a vanished native `SKILL.md` now fails loudly with the exact path instead of serving a stale cached body.
- **§2.6 phantom job rows** (`05b374dc6` cherry-pick): coordination projection carries `process_lock_held`; the Work surface shows the sticky "Delegated coordination unavailable" status; Running agents with no live task handle are terminalized locally.
- **§2.7 snapshot notice** (`0304b412c` cherry-pick): once-per-workspace prominent notice naming `[snapshots] max_workspace_gb` as the documented opt-in.
- **#5098 fleet roster shadowing** (`190e4138d`): (a) every layer displacement recorded as `ShadowedProfile`, badged `⚠shadows` in the roster with the ignored path named; (b) project-scope agent profiles join the roster only when project config is trusted (`--no-project-config` opts out — same gate as `.codewhale/config.toml`). The layer-collapse proposal stays owner-decision-pending, so this does NOT close #5098.
- Test-contract repair: the shell-guidance pin now asserts the live `Bash` name, never retired `exec_shell`.

## Gates

- Pre-rebase full workspace: 10899 pass / 2 pre-existing fails; clippy clean (agent receipts).
- Post-rebase onto R1: `cargo fmt --all -- --check` exit=0; `cargo check --workspace --all-targets --locked` exit=0; full tui bin suite 9600 pass / 2 pre-existing + 1 stale pin (fixed in `a0c613094`; `tui_and_api_listings_agree` is the known parallel-load flake — passes solo).

No-Issue: v0.9.4 program stack PR. Closes #5099. Refs #5098, #5033.