### PR TITLE
stack R4: Tier-1 core/state/MCP bugs (security, data-integrity, workflow honesty)

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2019,7 +2019,6 @@ fn run_logout_command_with_secrets_unlocked(
     secrets: &Secrets,
 ) -> Result<()> {
     let original_config = store.config.clone();
-    let active_provider = store.config.provider;
     store.config.api_key = None;
     for provider in ProviderKind::ALL {
         clear_provider_api_key_from_config(store, provider);
@@ -2037,8 +2036,16 @@ fn run_logout_command_with_secrets_unlocked(
         store.config = original_config;
         return Err(error);
     }
-    clear_provider_api_key_from_keyring(secrets, active_provider);
-    println!("logged out");
+    let keyring_failures = clear_all_provider_api_keys_from_keyring(secrets);
+    if keyring_failures.is_empty() {
+        println!("logged out");
+    } else {
+        eprintln!(
+            "failed to delete stored credentials for: {}",
+            keyring_failures.join(", ")
+        );
+        println!("logged out (some stored credentials could not be deleted)");
+    }
     Ok(())
 }
 
@@ -2305,6 +2312,30 @@ fn provider_keyring_set(secrets: &Secrets, provider: ProviderKind) -> bool {
 
 fn clear_provider_api_key_from_keyring(secrets: &Secrets, provider: ProviderKind) {
     let _ = secrets.delete(provider_slot(provider));
+}
+
+/// Delete the keyring credential of every provider that has one stored.
+///
+/// Returns a human-readable entry per slot whose deletion failed, so the
+/// caller can report the failure instead of claiming a clean logout while
+/// credentials linger in the keyring. Slots shared by several providers
+/// (e.g. the historical `siliconflow` slot) are deleted once.
+fn clear_all_provider_api_keys_from_keyring(secrets: &Secrets) -> Vec<String> {
+    let mut failures = Vec::new();
+    let mut cleared_slots = std::collections::HashSet::new();
+    for provider in ProviderKind::ALL {
+        let slot = provider_slot(provider);
+        if !cleared_slots.insert(slot) {
+            continue;
+        }
+        if !provider_keyring_set(secrets, provider) {
+            continue;
+        }
+        if let Err(error) = secrets.delete(slot) {
+            failures.push(format!("{slot}: {error}"));
+        }
+    }
+    failures
 }
 
 fn external_consent(
@@ -7548,6 +7579,43 @@ model = "qwen-2.5-7b"
         assert!(!credentials.join(generation).exists());
         assert!(!credentials.join("xai-auth.json").exists());
         assert!(credentials.join("other-provider.json").exists());
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn logout_clears_keyring_credentials_for_all_providers() {
+        // Logout used to delete the keyring secret only for the *active*
+        // provider, leaving credentials stored under other providers
+        // behind while printing "logged out".
+        let _lock = env_lock();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let home = dir
+            .path()
+            .canonicalize()
+            .expect("canonical temp root")
+            .join("codewhale-home");
+        let _home = ScopedEnvVar::set("CODEWHALE_HOME", &home.to_string_lossy());
+        let path = home.join("config.toml");
+        let mut store = ConfigStore::load(Some(path.clone())).expect("store should load");
+        store.config.provider = ProviderKind::Deepseek;
+
+        let secrets = no_keyring_secrets();
+        secrets
+            .set(provider_slot(ProviderKind::Deepseek), "sk-deepseek")
+            .expect("seed deepseek key");
+        secrets
+            .set(provider_slot(ProviderKind::Fireworks), "fw-stale")
+            .expect("seed fireworks key");
+
+        run_logout_command_with_secrets(&mut store, &secrets).expect("logout should succeed");
+
+        for provider in [ProviderKind::Deepseek, ProviderKind::Fireworks] {
+            assert!(
+                provider_keyring_api_key(&secrets, provider).is_none(),
+                "keyring credential for {provider:?} survived logout"
+            );
+        }
 
         let _ = std::fs::remove_file(path);
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -855,6 +855,10 @@ impl ThreadManager {
     }
 
     fn persist_thread(&self, thread: &Thread, rollout_path: Option<PathBuf>) -> Result<()> {
+        // This update payload carries no per-thread policy, so preserve any
+        // policy already stored for the thread rather than erasing it with
+        // NULLs on every persist/resume.
+        let existing = self.store.get_thread(&thread.id)?;
         self.store.upsert_thread(&ThreadMetadata {
             id: thread.id.clone(),
             rollout_path,
@@ -869,8 +873,12 @@ impl ThreadManager {
             cli_version: thread.cli_version.clone(),
             source: to_persisted_source(&thread.source),
             name: thread.name.clone(),
-            sandbox_policy: None,
-            approval_mode: None,
+            sandbox_policy: existing
+                .as_ref()
+                .and_then(|metadata| metadata.sandbox_policy.clone()),
+            approval_mode: existing
+                .as_ref()
+                .and_then(|metadata| metadata.approval_mode.clone()),
             archived: matches!(thread.status, ThreadStatus::Archived),
             archived_at: None,
             git_sha: None,
@@ -3203,6 +3211,53 @@ mod tests {
             .expect("resume thread")
             .expect("thread found");
         assert_eq!(message_count(&manager), 3);
+    }
+
+    #[test]
+    fn persist_thread_preserves_stored_policy() {
+        // persist_thread's update payload carries no per-thread policy;
+        // writing NULLs unconditionally erased any policy stored earlier
+        // (e.g. on every resume).
+        let store = temp_core_state("persist-policy");
+        let mut metadata = test_thread_metadata("thread-policy");
+        metadata.sandbox_policy = Some("workspace-write".to_string());
+        metadata.approval_mode = Some("on-request".to_string());
+        store.upsert_thread(&metadata).expect("seed thread");
+
+        // A fresh manager has an empty running-thread cache, so resume goes
+        // through the persisted path, which calls persist_thread.
+        let mut manager = ThreadManager::new(store);
+        let resume_params = ThreadResumeParams {
+            thread_id: "thread-policy".to_string(),
+            history: None,
+            path: None,
+            model: None,
+            model_provider: None,
+            cwd: None,
+            approval_policy: None,
+            sandbox: None,
+            config: None,
+            base_instructions: None,
+            developer_instructions: None,
+            personality: None,
+            persist_extended_history: false,
+        };
+        manager
+            .resume_thread_with_history(
+                &resume_params,
+                Path::new("/tmp/codewhale"),
+                "deepseek".to_string(),
+            )
+            .expect("resume thread")
+            .expect("thread found");
+
+        let persisted = manager
+            .state_store()
+            .get_thread("thread-policy")
+            .expect("read thread")
+            .expect("thread persisted");
+        assert_eq!(persisted.sandbox_policy.as_deref(), Some("workspace-write"));
+        assert_eq!(persisted.approval_mode.as_deref(), Some("on-request"));
     }
 
     #[tokio::test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1304,7 +1304,10 @@ impl Runtime {
             }
             ThreadRequest::Message { thread_id, input } => {
                 self.thread_manager.touch_message(&thread_id, &input)?;
-                let response_id = format!("{thread_id}:{}", input.len());
+                // Keyed by a fresh uuid, like handle_prompt: keying on
+                // `{thread_id}:{input.len()}` made any two equal-length
+                // messages share a response_id, breaking hook correlation.
+                let response_id = format!("resp-{}", Uuid::new_v4());
                 self.hooks
                     .emit(HookEvent::ResponseStart {
                         response_id: response_id.clone(),
@@ -3332,5 +3335,60 @@ mod tests {
 
         assert_eq!(result["status"], "timeout");
         assert_eq!(result["ok"], false);
+    }
+
+    #[tokio::test]
+    async fn thread_message_response_ids_are_unique_for_equal_length_inputs() {
+        // The Message arm used to key response_id as `{thread_id}:{input.len()}`,
+        // so any two equal-length messages collided and hooks could not tell
+        // their ResponseStart/ResponseEnd pairs apart.
+        let mut runtime = Runtime::new(
+            ConfigToml::default(),
+            ModelRegistry::default(),
+            temp_core_state("response-id-unique"),
+            Arc::new(ToolRegistry::default()),
+            Arc::new(McpManager::default()),
+            ExecPolicyEngine::new(vec![], vec![]),
+            HookDispatcher::default(),
+        );
+        let spawned = runtime
+            .thread_manager
+            .spawn_thread_with_history(
+                "deepseek".to_string(),
+                PathBuf::from("/tmp/codewhale"),
+                InitialHistory::New,
+                true,
+            )
+            .expect("spawn thread");
+        let thread_id = spawned.thread.id.clone();
+
+        let mut response_ids = Vec::new();
+        for input in ["aaaa", "bbbb"] {
+            let response = runtime
+                .handle_thread(ThreadRequest::Message {
+                    thread_id: thread_id.clone(),
+                    input: input.to_string(),
+                })
+                .await
+                .expect("handle message");
+            let response_id = response
+                .events
+                .iter()
+                .find_map(|frame| match frame {
+                    EventFrame::ResponseStart { response_id } => Some(response_id.clone()),
+                    _ => None,
+                })
+                .expect("response start event");
+            response_ids.push(response_id);
+        }
+
+        assert_ne!(
+            response_ids[0], response_ids[1],
+            "equal-length inputs must not share a response_id"
+        );
+        assert!(
+            response_ids.iter().all(|id| id.starts_with("resp-")),
+            "response ids should use the resp-<uuid> shape: {response_ids:?}"
+        );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -638,11 +638,32 @@ impl ThreadManager {
         self.running_threads
             .insert(thread.id.clone(), thread.clone());
         if let Some(history) = params.history.as_ref() {
+            // A read→resume flow hands back items that are already on the
+            // persisted chain; appending them again would double the
+            // conversation on every resume, compounding. Dedup by content
+            // fingerprint (the item's JSON, matching what append_message
+            // stores as content) against the persisted chain and against
+            // items already appended in this loop.
+            let mut seen: HashSet<String> = self
+                .store
+                .list_messages(&thread.id, None)?
+                .into_iter()
+                .map(|message| {
+                    message
+                        .item
+                        .as_ref()
+                        .map_or(message.content.clone(), |item| item.to_string())
+                })
+                .collect();
             for item in history {
+                let fingerprint = item.to_string();
+                if !seen.insert(fingerprint.clone()) {
+                    continue;
+                }
                 self.store.append_message(
                     &thread.id,
                     "history",
-                    &item.to_string(),
+                    &fingerprint,
                     Some(item.clone()),
                 )?;
             }
@@ -3102,6 +3123,86 @@ mod tests {
             .expect("resume unarchived thread")
             .expect("thread in cache");
         assert_eq!(restored.thread.status, ThreadStatus::Idle);
+    }
+
+    #[test]
+    fn resume_with_history_does_not_reappend_persisted_messages() {
+        // A read→resume flow hands the thread's own history back to
+        // `thread/resume`; appending it verbatim doubled the conversation on
+        // every resume, compounding.
+        let store = temp_core_state("resume-history-dedup");
+        let mut manager = ThreadManager::new(store);
+        let history = vec![
+            json!({"type": "user_message", "message": "hello"}),
+            json!({"type": "assistant_message", "message": "hi there"}),
+        ];
+        let spawned = manager
+            .spawn_thread_with_history(
+                "deepseek".to_string(),
+                PathBuf::from("/tmp/codewhale"),
+                InitialHistory::Forked(history.clone()),
+                true,
+            )
+            .expect("spawn thread");
+        let thread_id = spawned.thread.id.clone();
+        let message_count = |manager: &ThreadManager| {
+            manager
+                .state_store()
+                .list_messages(&thread_id, None)
+                .expect("list messages")
+                .len()
+        };
+        assert_eq!(message_count(&manager), 2);
+
+        let resume_params = ThreadResumeParams {
+            thread_id: thread_id.clone(),
+            history: Some(history.clone()),
+            path: None,
+            model: None,
+            model_provider: None,
+            cwd: None,
+            approval_policy: None,
+            sandbox: None,
+            config: None,
+            base_instructions: None,
+            developer_instructions: None,
+            personality: None,
+            persist_extended_history: false,
+        };
+
+        // Resuming twice with the same history must be idempotent.
+        for _ in 0..2 {
+            manager
+                .resume_thread_with_history(
+                    &resume_params,
+                    Path::new("/tmp/codewhale"),
+                    "deepseek".to_string(),
+                )
+                .expect("resume thread")
+                .expect("thread found");
+        }
+        assert_eq!(
+            message_count(&manager),
+            2,
+            "resume re-appended messages already on the persisted chain"
+        );
+
+        // A genuinely new history item is still appended, exactly once.
+        let mut extended = history.clone();
+        extended.push(json!({"type": "user_message", "message": "something new"}));
+        let resume_params = ThreadResumeParams {
+            history: Some(extended),
+            ..resume_params
+        };
+        manager
+            .resume_thread_with_history(
+                &resume_params,
+                Path::new("/tmp/codewhale"),
+                "deepseek".to_string(),
+            )
+            .expect("resume thread")
+            .expect("thread found");
+        assert_eq!(message_count(&manager), 3);
     }
 
     #[tokio::test]

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -344,11 +344,20 @@ impl McpManager {
     }
 
     /// Call a tool on a specific server by name.
+    ///
+    /// The server's [`ToolFilter`] is enforced on invocation, not just at
+    /// listing time: a denied (or not-allowed) tool cannot be executed by
+    /// addressing the server directly, whether by bare or qualified name.
     pub fn call_tool(&self, server_name: &str, tool_name: &str, arguments: Value) -> Result<Value> {
         let client = self
             .clients
             .get(server_name)
             .with_context(|| format!("MCP server '{server_name}' not available"))?;
+        if let Some((_, filter)) = self.configs.get(server_name)
+            && !allowed_by_filter(tool_name, filter)
+        {
+            bail!("tool '{tool_name}' on MCP server '{server_name}' is blocked by the tool filter");
+        }
         client.call_tool(tool_name, arguments)
     }
 
@@ -1441,6 +1450,80 @@ mod tests {
         let manager = McpManager::default();
         let err = manager.call_tool("nope", "t", json!({})).unwrap_err();
         assert!(err.to_string().contains("not available"));
+    }
+
+    #[test]
+    fn manager_call_tool_enforces_deny_filter() {
+        // The filter used to be consulted only when listing tools; a denied
+        // tool stayed callable by addressing the server directly.
+        let mut manager = McpManager::default();
+        manager
+            .register_server(
+                make_server_config("s1"),
+                ToolFilter {
+                    allow: vec![],
+                    deny: vec!["secret".to_string()],
+                },
+                Box::new(InMemoryMcpClient::default().with_tool("secret", json!({"ok": true}))),
+            )
+            .unwrap();
+        let err = manager.call_tool("s1", "secret", json!({})).unwrap_err();
+        assert!(
+            err.to_string().contains("blocked by the tool filter"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn manager_call_tool_enforces_allow_filter() {
+        let mut manager = McpManager::default();
+        manager
+            .register_server(
+                make_server_config("s1"),
+                ToolFilter {
+                    allow: vec!["allowed".to_string()],
+                    deny: vec![],
+                },
+                Box::new(
+                    InMemoryMcpClient::default()
+                        .with_tool("allowed", json!({"ok": true}))
+                        .with_tool("other", json!({"ok": false})),
+                ),
+            )
+            .unwrap();
+        let err = manager.call_tool("s1", "other", json!({})).unwrap_err();
+        assert!(
+            err.to_string().contains("blocked by the tool filter"),
+            "unexpected error: {err}"
+        );
+        // The allowed tool still runs.
+        assert_eq!(
+            manager.call_tool("s1", "allowed", json!({})).unwrap(),
+            json!({"ok": true})
+        );
+    }
+
+    #[test]
+    fn denied_tool_cannot_be_called_by_qualified_name() {
+        // Security: `mcp__s1__secret` must be as unreachable as `secret`.
+        let mut manager = McpManager::default();
+        manager
+            .register_server(
+                make_server_config("s1"),
+                ToolFilter {
+                    allow: vec![],
+                    deny: vec!["secret".to_string()],
+                },
+                Box::new(InMemoryMcpClient::default().with_tool("secret", json!({"ok": true}))),
+            )
+            .unwrap();
+        let err = manager
+            .call_qualified_tool("mcp__s1__secret", json!({}))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("blocked by the tool filter"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -251,6 +251,35 @@ impl McpManager {
             .map(String::as_str)
     }
 
+    /// Resolve a sanitized tool segment from a qualified name back to the
+    /// server's original tool name.
+    ///
+    /// `qualify_tool_name` folds `-`, `.`, and case into `_`, so the segment
+    /// carried by `mcp__server__segment` is not necessarily the name the
+    /// server expects. A literal match wins outright; otherwise, when exactly
+    /// one listed tool sanitizes to the segment, its original name is used.
+    /// When the lookup is impossible or ambiguous the segment is passed
+    /// through unchanged, preserving behavior for clients whose `list_tools`
+    /// does not enumerate every callable tool.
+    fn resolve_original_tool_name(&self, server_name: &str, tool_segment: &str) -> String {
+        let Some(client) = self.clients.get(server_name) else {
+            return tool_segment.to_string();
+        };
+        let Ok(tools) = client.list_tools() else {
+            return tool_segment.to_string();
+        };
+        if tools.iter().any(|tool| tool.tool_name == tool_segment) {
+            return tool_segment.to_string();
+        }
+        let mut matches = tools
+            .iter()
+            .filter(|tool| sanitize_component(&tool.tool_name) == tool_segment);
+        match (matches.next(), matches.next()) {
+            (Some(tool), None) => tool.tool_name.clone(),
+            _ => tool_segment.to_string(),
+        }
+    }
+
     /// Start all registered servers, emitting status updates via the callback.
     ///
     /// Returns a summary of which servers are ready, failed, or cancelled.
@@ -375,10 +404,17 @@ impl McpManager {
         // below on a *call* failure would re-execute the same tool, and for a
         // file write, a commit, or a paid API call that second invocation is a
         // second real side effect. Only a failed *lookup* falls through.
+        //
+        // The parsed tool segment is the *sanitized* name (qualify_tool_name
+        // folds `-`, `.`, and case into `_`), so resolve it back to the
+        // server's original tool name before dispatching — otherwise tools
+        // like `my-tool` are un-callable through their advertised qualified
+        // name `mcp__server__my_tool`.
         if let Ok((server_name, tool_name)) = &parsed
             && self.clients.contains_key(server_name)
         {
-            return self.call_tool(server_name, tool_name, arguments);
+            let resolved = self.resolve_original_tool_name(server_name, tool_name);
+            return self.call_tool(server_name, &resolved, arguments);
         }
 
         // No exact registration: resolve by scanning qualified names. Collect
@@ -1540,6 +1576,36 @@ mod tests {
             .call_qualified_tool("mcp__my_server__my_tool", json!({}))
             .unwrap();
         assert_eq!(result["ok"], true);
+    }
+
+    #[test]
+    fn manager_call_qualified_tool_resolves_sanitized_segment_to_original_name() {
+        // `qualify_tool_name` folds `-`/`.`/case into `_`, so the qualified
+        // name advertised for `my-tool` is `mcp__s1__my_tool`. The exact-match
+        // fast path used to dispatch that sanitized segment verbatim, and the
+        // server (which only knows `my-tool`) rejected the call.
+        let mut manager = McpManager::default();
+        manager
+            .register_server(
+                make_server_config("s1"),
+                ToolFilter::default(),
+                Box::new(
+                    InMemoryMcpClient::default()
+                        .with_tool("my-tool", json!({"via": "hyphen"}))
+                        .with_tool("other.thing", json!({"via": "dot"})),
+                ),
+            )
+            .unwrap();
+
+        let hyphen = manager
+            .call_qualified_tool("mcp__s1__my_tool", json!({}))
+            .unwrap();
+        assert_eq!(hyphen, json!({"via": "hyphen"}));
+
+        let dot = manager
+            .call_qualified_tool("mcp__s1__other_thing", json!({}))
+            .unwrap();
+        assert_eq!(dot, json!({"via": "dot"}));
     }
 
     #[test]

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -355,7 +355,22 @@ impl StateStore {
     fn init_schema(conn: &Connection) -> Result<()> {
         let mut user_version: u32 = conn.query_row("PRAGMA user_version;", [], |row| row.get(0))?;
         if user_version == 0 {
-            conn.execute_batch(
+            // Guard each ALTER: a database restored with a v0 header (or
+            // stamped by a racing process that crashed before setting
+            // user_version) can already carry these columns, and an
+            // unguarded ADD COLUMN aborts the whole open with
+            // "duplicate column name".
+            let add_parent_entry_id = if column_exists(conn, "messages", "parent_entry_id")? {
+                ""
+            } else {
+                "ALTER TABLE messages ADD COLUMN parent_entry_id INTEGER NULL;"
+            };
+            let add_current_leaf_id = if column_exists(conn, "threads", "current_leaf_id")? {
+                ""
+            } else {
+                "ALTER TABLE threads ADD COLUMN current_leaf_id INTEGER NULL;"
+            };
+            conn.execute_batch(&format!(
                 r#"
                 BEGIN;
                 CREATE TABLE IF NOT EXISTS threads (
@@ -428,7 +443,7 @@ impl StateStore {
                 CREATE INDEX IF NOT EXISTS idx_jobs_updated_at ON jobs(updated_at DESC);
 
                 -- Add parent_entry_id column, and set to last message before current message
-                ALTER TABLE messages ADD COLUMN parent_entry_id INTEGER NULL;
+                {add_parent_entry_id}
                 UPDATE messages
                     SET parent_entry_id = (
                         SELECT m2.id
@@ -444,10 +459,10 @@ impl StateStore {
                         ORDER BY m2.created_at DESC, m2.id DESC
                         LIMIT 1
                     );
-                CREATE INDEX idx_messages_parent_entry_id ON messages(parent_entry_id);
+                CREATE INDEX IF NOT EXISTS idx_messages_parent_entry_id ON messages(parent_entry_id);
 
                 -- Add current_leaf_id column, and set to last message in thread
-                ALTER TABLE threads ADD COLUMN current_leaf_id INTEGER NULL;
+                {add_current_leaf_id}
                 UPDATE threads
                     SET current_leaf_id = (
                         SELECT m.id
@@ -459,8 +474,8 @@ impl StateStore {
 
                 PRAGMA user_version = 1;
                 COMMIT;
-                "#,
-            )
+                "#
+            ))
             .context("failed to initialize thread schema")?;
             user_version = 1;
         }
@@ -594,16 +609,26 @@ impl StateStore {
             user_version = 3;
         }
         if user_version < 4 {
-            conn.execute_batch(
+            // Same restore/race guard as the v0 block: the column may
+            // already exist even though the header predates version 4.
+            let add_continuation_count = if column_exists(
+                conn,
+                "thread_goals",
+                "continuation_count",
+            )? {
+                ""
+            } else {
+                "ALTER TABLE thread_goals\n                    ADD COLUMN continuation_count INTEGER NOT NULL DEFAULT 0;"
+            };
+            conn.execute_batch(&format!(
                 r#"
                 BEGIN;
-                ALTER TABLE thread_goals
-                    ADD COLUMN continuation_count INTEGER NOT NULL DEFAULT 0;
+                {add_continuation_count}
 
                 PRAGMA user_version = 4;
                 COMMIT;
-                "#,
-            )
+                "#
+            ))
             .context("failed to initialize thread goal continuation schema")?;
         }
         Ok(())
@@ -1837,6 +1862,23 @@ fn bool_to_i64(value: bool) -> i64 {
     if value { 1 } else { 0 }
 }
 
+/// Whether `table` currently has a column named `column`.
+///
+/// Used to guard `ALTER TABLE ... ADD COLUMN` migrations so they are
+/// idempotent. Both identifiers are compile-time literals at every call
+/// site, never user input. A missing table reports `false`, matching the
+/// fresh-database case where the migration must still run.
+fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let names = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    for name in names {
+        if name? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 fn i64_to_bool(value: i64) -> bool {
     value != 0
 }
@@ -2302,6 +2344,38 @@ mod tests {
         let store = StateStore::open(Some(db_path)).expect("reopen for verify");
         let listed = store.list_jobs(Some(2)).expect("list jobs");
         assert_eq!(listed.len(), 2, "both writers should persist their jobs");
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn migration_runs_cleanly_when_schema_predates_user_version_header() {
+        // Simulate a restore (or a racing process that crashed before
+        // stamping user_version): the on-disk schema is fully migrated but
+        // the header still says 0. The v0 block used to re-run unconditional
+        // ADD COLUMN statements and abort the open with
+        // "duplicate column name".
+        let dir = temp_state_dir("migration-v0-idempotent");
+        let db_path = dir.join("state.db");
+        drop(StateStore::open(Some(db_path.clone())).expect("initial open"));
+        {
+            let conn = Connection::open(&db_path).expect("raw connection");
+            conn.pragma_update(None, "user_version", 0)
+                .expect("reset user_version");
+        }
+
+        let store = StateStore::open(Some(db_path.clone())).expect("reopen with v0 header");
+        store
+            .upsert_thread(&test_thread("thread-migrated"))
+            .expect("write after guarded migration");
+
+        // Reopening again (now stamped at the current version) still works.
+        drop(store);
+        let store = StateStore::open(Some(db_path)).expect("third open");
+        let persisted = store
+            .get_thread("thread-migrated")
+            .expect("read after reopen");
+        assert!(persisted.is_some());
 
         let _ = fs::remove_dir_all(dir);
     }

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -4150,6 +4150,17 @@ impl SubAgentManager {
         self.aggregate_budget_spent(scope_id)
     }
 
+    /// Current `(spent, limit)` for the shared budget scope this worker is
+    /// attached to, if any. `spent` is the live aggregate across every worker
+    /// in the scope, so a caller checking mid-run sees sibling spend as it
+    /// lands, not the snapshot frozen at attach time.
+    pub(crate) fn budget_scope_state(&self, worker_id: &str) -> Option<(u64, u64)> {
+        let record = self.worker_records.get(worker_id)?;
+        let scope_id = record.usage.budget_scope.as_deref()?;
+        let limit = record.usage.token_budget?;
+        Some((self.aggregate_budget_spent(scope_id), limit))
+    }
+
     /// Attach a workflow child to the run-level shared budget pool.
     pub(crate) fn attach_shared_budget_scope(
         &mut self,
@@ -9495,18 +9506,34 @@ async fn run_subagent(
         // local accumulator mirrors the manager's `record.usage.total_tokens`
         // (both derive from `response.usage`), so the scope accounting stays
         // consistent and is never inflated by this check.
+        //
+        // The shared scope is also enforced HERE, mid-run: admission alone
+        // only refuses *future* spawns, so a parallel fan-out whose children
+        // all attached while the scope was nearly full could collectively
+        // burn many times the configured budget and still report Completed.
+        // Checking the live aggregate after each turn caps the overshoot at
+        // the turns already in flight.
         tokens_used = tokens_used.saturating_add(usage_total_tokens(&response.usage));
-        if let Some(budget) = token_budget
-            && tokens_used > budget
-        {
+        let scope_exhausted = {
+            let manager = runtime.manager.read().await;
+            manager
+                .budget_scope_state(&agent_id)
+                .filter(|(spent, limit)| spent > limit)
+        };
+        let budget_exhausted_detail =
+            if let Some(budget) = token_budget.filter(|&budget| tokens_used > budget) {
+                Some(format!("token budget exhausted ({tokens_used}/{budget})"))
+            } else {
+                scope_exhausted.map(|(spent, limit)| {
+                    format!("shared token budget exhausted ({spent}/{limit} spent across the run)")
+                })
+            };
+        if let Some(detail) = budget_exhausted_detail {
             record_agent_progress(
                 runtime,
                 &agent_id,
                 AgentProgressEventMeta::new(AgentWorkerStatus::Failed).with_step(steps),
-                format!(
-                    "{}: token budget exhausted ({tokens_used}/{budget})",
-                    format_step_counter(steps, max_steps)
-                ),
+                format!("{}: {detail}", format_step_counter(steps, max_steps)),
             );
             let status = SubAgentStatus::BudgetExhausted;
             let duration_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -12045,6 +12045,153 @@ async fn per_worker_token_budget_does_not_double_count_scope_accounting() {
     );
 }
 
+/// Variant of [`spawn_budget_capped_worker`] that attaches the worker to a
+/// shared workflow budget scope before its first model turn (no per-worker
+/// cap), returning the manager, agent id, call counter, and task handle.
+async fn spawn_scope_budgeted_worker(
+    manager: &Arc<RwLock<SubAgentManager>>,
+    workspace: &Path,
+    agent_id: &str,
+    scope_id: &str,
+    scope_limit: u64,
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    max_steps: u32,
+) -> (Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+    let agent_id = agent_id.to_string();
+    let (task_input_tx, task_input_rx) = mpsc::unbounded_channel();
+    let agent = SubAgent::new(
+        agent_id.clone(),
+        FleetRole::Worker,
+        "Work within shared budget".to_string(),
+        make_assignment(),
+        "deepseek-v4-flash".to_string(),
+        Some("Budget".to_string()),
+        Some(vec![]),
+        task_input_tx,
+        workspace.to_path_buf(),
+        "boot_scope_budget".to_string(),
+    );
+    {
+        let mut manager = manager.write().await;
+        manager.agents.insert(agent_id.clone(), agent);
+        manager.register_worker(make_worker_spec(&agent_id, workspace.to_path_buf()));
+        manager.attach_shared_budget_scope(&agent_id, scope_id, scope_limit);
+    }
+
+    let (client, calls) =
+        token_heavy_chat_client(prompt_tokens, completion_tokens, "partial answer").await;
+    let mut runtime = stub_runtime();
+    runtime.client = client;
+    runtime.manager = Arc::clone(manager);
+    runtime.context = ToolContext::new(workspace.to_path_buf());
+
+    let task = SubAgentTask {
+        manager_handle: Arc::clone(manager),
+        runtime,
+        agent_id: agent_id.clone(),
+        agent_type: FleetRole::Worker,
+        prompt: "Work within shared budget".to_string(),
+        assignment: make_assignment(),
+        allowed_tools: Some(vec![]),
+        fork_context: false,
+        started_at: Instant::now(),
+        max_steps,
+        token_budget: None,
+        wall_time: DEFAULT_CHILD_WALL_TIME,
+        input_rx: task_input_rx,
+        launch_gate: None,
+    };
+    let task_handle = tokio::spawn(run_subagent_task(task));
+    (calls, task_handle)
+}
+
+#[tokio::test]
+async fn shared_scope_budget_stops_admitted_children_mid_run() {
+    // A workflow run's token_budget must be a collective ceiling for the
+    // children it admitted, not just an admission gate for future spawns:
+    // children that attach while the scope has room used to run uncapped, so
+    // a fan-out could burn many times the budget and still report Completed.
+    let tmp = tempdir().expect("tempdir");
+    let manager = Arc::new(RwLock::new(SubAgentManager::new(
+        tmp.path().to_path_buf(),
+        4,
+    )));
+    let scope_id = "run-budget-ceiling";
+    // Each model turn burns 100 tokens (60 in + 40 out); the run-level budget
+    // leaves room for exactly one full turn across ALL children.
+    let scope_limit = 150;
+
+    // First child: admitted while the scope is empty, burns its 100 and
+    // completes normally.
+    let (calls_a, handle_a) = spawn_scope_budgeted_worker(
+        &manager,
+        tmp.path(),
+        "agent_scope_a",
+        scope_id,
+        scope_limit,
+        60,
+        40,
+        4,
+    )
+    .await;
+    tokio::time::timeout(Duration::from_secs(5), handle_a)
+        .await
+        .expect("first child must terminate")
+        .expect("task should finish");
+    assert_eq!(calls_a.load(Ordering::SeqCst), 1);
+    let status_a = manager
+        .read()
+        .await
+        .get_result("agent_scope_a")
+        .expect("first child registered")
+        .status;
+    assert!(
+        matches!(status_a, SubAgentStatus::Completed),
+        "first child completes inside the shared budget, got {status_a:?}"
+    );
+
+    // Second child: also admitted without a per-worker cap (remaining 50 >=
+    // the spawn reserve). Its first turn pushes the shared scope to 200/150,
+    // so it must stop with BudgetExhausted right after that turn instead of
+    // completing or running on to max_steps.
+    let (calls_b, handle_b) = spawn_scope_budgeted_worker(
+        &manager,
+        tmp.path(),
+        "agent_scope_b",
+        scope_id,
+        scope_limit,
+        60,
+        40,
+        4,
+    )
+    .await;
+    tokio::time::timeout(Duration::from_secs(5), handle_b)
+        .await
+        .expect("second child must terminate")
+        .expect("task should finish");
+    assert_eq!(
+        calls_b.load(Ordering::SeqCst),
+        1,
+        "second child must stop after the turn that crossed the shared budget"
+    );
+    let status_b = manager
+        .read()
+        .await
+        .get_result("agent_scope_b")
+        .expect("second child registered")
+        .status;
+    assert!(
+        matches!(status_b, SubAgentStatus::BudgetExhausted),
+        "second child must hit the shared ceiling, got {status_b:?}"
+    );
+    assert_eq!(
+        manager.read().await.budget_spent_for_scope(scope_id),
+        200,
+        "collective spend is accounted once per child"
+    );
+}
+
 /// Clears the process-wide rate-limit window on drop so a panicking test
 /// body cannot leak a live pause into concurrently running tests.
 struct ClearRateLimitOnDrop;

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -3350,19 +3350,20 @@ impl SubAgentWorkflowDriver {
         }
 
         let (blocked, handoffs) = {
-            let board = self
+            let mut board = self
                 .gate_board
                 .lock()
                 .map_err(|_| DriverError::Rejected("workflow gate board lock poisoned".into()))?;
             let blocked = board.role_is_blocked(&self.gate_specs, role).cloned();
-            let handoffs = board
-                .artifacts
-                .iter()
-                .filter(|artifact| artifact.to_role.eq_ignore_ascii_case(role))
-                .rev()
-                .take(4)
-                .cloned()
-                .collect::<Vec<_>>();
+            // Handoffs are consumed (removed from the board) as they are
+            // delivered — but only when the role is actually admitted. A
+            // blocked task must leave them in place for the retry after the
+            // gate clears.
+            let handoffs = if blocked.is_none() {
+                board.consume_handoffs_for(role, 4)
+            } else {
+                Vec::new()
+            };
             (blocked, handoffs)
         };
 
@@ -7971,6 +7972,125 @@ reviewer = "reviewer"
     }
 
     #[tokio::test]
+    async fn workflow_handoff_is_delivered_to_exactly_one_task() {
+        // LaneGateBoard.artifacts used to be append-only: every same-role
+        // task re-received up to 4 prior handoff payloads while
+        // HandoffConsumed receipts fired as if they were spent.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 2);
+        let runtime = SubAgentRuntime::new(
+            stub_client(),
+            "deepseek-v4-flash".to_string(),
+            ctx.clone(),
+            true,
+            None,
+            manager.clone(),
+        );
+        let state = WorkflowWorkspaceState::open(tmp.path());
+        let run_id = "workflow_handoff_once".to_string();
+        let gates = vec![GateSpec {
+            id: "scout-findings".to_string(),
+            role: "scout".to_string(),
+            on: GateOn::RoleComplete,
+            gate: GateKind::Approve,
+            on_fail: codewhale_workflow::GateOnFail::Block,
+            blocks_role: Some("implementer".to_string()),
+            max_retries: 0,
+            artifact_kind: Some("findings".to_string()),
+            require_explicit_verdict: false,
+        }];
+        let spec = WorkflowSpec {
+            id: Some("handoff-once-fixture".to_string()),
+            goal: "handoff delivered once".to_string(),
+            description: None,
+            budget: BudgetSpec::default(),
+            permissions: Default::default(),
+            model_policy: Default::default(),
+            promotion_policy: Default::default(),
+            gates: gates.clone(),
+            nodes: Vec::new(),
+        };
+        state.runs.lock().expect("runs").insert(
+            run_id.clone(),
+            WorkflowRunRecord::new(run_id.clone(), None, None, Some(&spec)),
+        );
+        let driver = SubAgentWorkflowDriver::new(
+            run_id.clone(),
+            manager,
+            runtime,
+            state.clone(),
+            None,
+            WorkflowFleetBinding::None,
+            gates,
+        );
+
+        driver.evaluate_gates_for_completed_role(&RuntimeTaskRecord {
+            agent_id: "scout-agent".to_string(),
+            label: Some("scout".to_string()),
+            role: Some("scout".to_string()),
+            status: IrWorkflowRunStatus::Succeeded,
+            output: Some("findings: exactly once".to_string()),
+            schema_error: None,
+            usage: None,
+        });
+
+        let implementer = TaskRequest {
+            description: "Use the findings.".to_string(),
+            subagent_type: Some("implementer".to_string()),
+            role: Some("implementer".to_string()),
+            profile: None,
+            model: None,
+            model_strength: None,
+            thinking: None,
+            cwd: None,
+            worktree: false,
+            write_authority: Some("workspace_write".to_string()),
+            write_roots: vec!["src".to_string()],
+            exact_files: Vec::new(),
+            coordination_contracts: Vec::new(),
+            dependencies: Vec::new(),
+            acceptance: Vec::new(),
+            allowed_tools: Some(Vec::new()),
+            disallowed_tools: Vec::new(),
+            max_depth: None,
+            token_budget: None,
+            max_steps: None,
+            wall_time_secs: None,
+            response_schema: None,
+            label: Some("fix".to_string()),
+            phase: None,
+        };
+
+        let mut first = implementer.clone();
+        let handoffs = driver
+            .prepare_request_for_gates(&mut first)
+            .expect("passed gate should admit first implementer");
+        assert_eq!(handoffs.len(), 1, "{handoffs:?}");
+        assert!(first.description.contains("exactly once"));
+
+        // A second same-role task must not re-receive the spent handoff.
+        let mut second = TaskRequest {
+            description: "Second implementer task.".to_string(),
+            ..implementer
+        };
+        let handoffs = driver
+            .prepare_request_for_gates(&mut second)
+            .expect("passed gate should admit second implementer");
+        assert!(
+            handoffs.is_empty(),
+            "handoff already consumed must not re-deliver: {handoffs:?}"
+        );
+        assert!(
+            !second
+                .description
+                .contains("Workflow handoff artifacts available"),
+            "{}",
+            second.description
+        );
+    }
+
+    #[tokio::test]
     async fn workflow_gate_evaluation_error_persists_blocked_and_denies_target_role() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path().to_path_buf());
@@ -8537,7 +8657,11 @@ reviewer = "reviewer"
             admitted_verifier.description
         );
         let board = driver.gate_board.lock().expect("gate board");
-        assert_eq!(board.artifacts.len(), 1, "{:?}", board.artifacts);
+        assert!(
+            board.artifacts.is_empty(),
+            "the admitted verifier consumed the handoff; spent artifacts leave the board: {:?}",
+            board.artifacts
+        );
         assert!(matches!(
             board.gates.get("review-findings"),
             Some(GateState::Passed)

--- a/crates/tui/src/tui/user_input.rs
+++ b/crates/tui/src/tui/user_input.rs
@@ -226,8 +226,11 @@ impl UserInputView {
     /// Resolve a digit/Enter activation for the currently highlighted row.
     ///
     /// - "Other" row → enter free-text input mode.
-    /// - multi-select option → toggle into the pending set (Enter confirms on
-    ///   the dedicated "Confirm" step; here it just toggles, like Space).
+    /// - multi-select option → add to the pending set (never remove — that is
+    ///   Space's job) and move focus to the Confirm row, so the single-select
+    ///   muscle memory of Enter-then-Enter submits the highlighted option
+    ///   instead of toggling it back out and submitting an empty set.
+    /// - multi-select Confirm row → submit the pending set.
     /// - single-select option → submit immediately (legacy behavior).
     fn activate_or_confirm_selection(&mut self) -> ViewAction {
         if self.is_other_selected() {
@@ -253,8 +256,15 @@ impl UserInputView {
                     .collect();
                 return self.advance_question(answers);
             }
-            // Enter/Space on a real option toggles it into the pending set.
-            self.toggle_pending(self.selected);
+            // Enter on a real option selects it and moves to Confirm. It
+            // never toggles out: double-Enter must submit the highlighted
+            // option, matching single-select on the same view.
+            if !self.multi_pending.contains(&self.selected) {
+                self.multi_pending.push(self.selected);
+            }
+            if let Some(confirm) = self.confirm_index() {
+                self.selected = confirm;
+            }
             return ViewAction::None;
         }
         // Single-select: submit immediately.
@@ -451,7 +461,7 @@ impl ModalView for UserInputView {
                     Span::styled(" toggle", Style::default().fg(palette::TEXT_MUTED)),
                     Span::raw("  "),
                     Span::styled("Enter", Style::default().fg(palette::WHALE_INFO).bold()),
-                    Span::styled(" toggle/confirm", Style::default().fg(palette::TEXT_MUTED)),
+                    Span::styled(" select/confirm", Style::default().fg(palette::TEXT_MUTED)),
                     Span::raw("  "),
                     Span::styled("Esc", Style::default().fg(palette::WHALE_INFO).bold()),
                     Span::styled(" cancel", Style::default().fg(palette::TEXT_MUTED)),
@@ -668,6 +678,64 @@ mod tests {
                 if tool_id == "tool-1" && response.answers.first().is_some_and(|a| a.value == "Ship it")),
             "Enter on confirm submits the toggled options"
         );
+    }
+
+    #[test]
+    fn user_input_modal_double_enter_never_submits_empty_multi_select() {
+        // Enter on a multi-select option used to toggle it into the pending
+        // set, so a second Enter (single-select muscle memory) toggled it
+        // back out — and Confirm then submitted an empty answer set.
+        let mut view = sample_view();
+        view.request.questions[0].multi_select = true;
+        view.selected = 0;
+
+        // First Enter: option 0 joins the pending set, focus moves to Confirm.
+        let action = view.handle_selecting_key(KeyEvent::from(KeyCode::Enter));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(
+            view.multi_pending,
+            vec![0],
+            "Enter selects the highlighted option"
+        );
+        assert!(
+            view.is_confirm_selected(),
+            "focus moves to the Confirm row after Enter"
+        );
+
+        // Second Enter submits exactly that option — never an empty set.
+        let action = view.handle_selecting_key(KeyEvent::from(KeyCode::Enter));
+        assert!(
+            matches!(action, ViewAction::EmitAndClose(ViewEvent::UserInputSubmitted { tool_id, response })
+                if tool_id == "tool-1"
+                    && response.answers.len() == 1
+                    && response.answers[0].value == "Ship it"),
+            "double-Enter must submit the highlighted option, not an empty set"
+        );
+    }
+
+    #[test]
+    fn user_input_modal_enter_never_deselects_multi_select_option() {
+        // Deselecting remains Space's job: Enter on an already-toggled option
+        // keeps it in the pending set.
+        let mut view = sample_view();
+        view.request.questions[0].multi_select = true;
+        view.selected = 0;
+
+        let _ = view.handle_selecting_key(KeyEvent::from(KeyCode::Char(' ')));
+        assert_eq!(view.multi_pending, vec![0], "Space toggles option 0 in");
+
+        let action = view.handle_selecting_key(KeyEvent::from(KeyCode::Enter));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(
+            view.multi_pending,
+            vec![0],
+            "Enter must not toggle the option back out"
+        );
+
+        // Space still toggles both ways.
+        view.selected = 0;
+        let _ = view.handle_selecting_key(KeyEvent::from(KeyCode::Char(' ')));
+        assert!(view.multi_pending.is_empty(), "Space toggles option 0 out");
     }
 
     #[test]

--- a/crates/workflow/src/gates.rs
+++ b/crates/workflow/src/gates.rs
@@ -269,6 +269,32 @@ impl LaneGateBoard {
         })
     }
 
+    /// Remove and return the latest handoffs addressed to `to_role` (newest
+    /// first), up to `limit`.
+    ///
+    /// Handoffs are single-use: the consumer that receives one is also issued
+    /// a `HandoffConsumed` receipt, so leaving the artifact on the board would
+    /// re-deliver it to every later same-role task — stale evidence, repeated
+    /// token cost, and a receipt that lies about being spent.
+    pub fn consume_handoffs_for(&mut self, to_role: &str, limit: usize) -> Vec<HandoffArtifact> {
+        // Collect matching indices newest-first; removing in descending index
+        // order keeps every not-yet-removed index valid.
+        let mut picked: Vec<usize> = Vec::new();
+        for (index, artifact) in self.artifacts.iter().enumerate().rev() {
+            if picked.len() >= limit {
+                break;
+            }
+            if artifact.to_role.eq_ignore_ascii_case(to_role) {
+                picked.push(index);
+            }
+        }
+        let mut consumed = Vec::with_capacity(picked.len());
+        for index in picked {
+            consumed.push(self.artifacts.remove(index));
+        }
+        consumed
+    }
+
     /// Persist board under a lane directory (JSON).
     pub fn save_to_dir(&self, dir: &Path) -> Result<PathBuf, GateError> {
         std::fs::create_dir_all(dir).map_err(|e| GateError::Io(e.to_string()))?;
@@ -390,6 +416,43 @@ mod tests {
         let state = board.evaluate(&gates[0], GateOutcome::Pass).unwrap();
         assert_eq!(state, GateState::Passed);
         assert!(board.role_is_blocked(&gates, "implementer").is_none());
+    }
+
+    #[test]
+    fn handoff_is_consumed_exactly_once() {
+        let mut board = LaneGateBoard::new("lane-consume");
+        let record = |board: &mut LaneGateBoard, id: &str, to_role: &str, payload: &str| {
+            board
+                .record_handoff(HandoffArtifact {
+                    id: id.into(),
+                    lane_id: "lane-consume".into(),
+                    from_role: "scout".into(),
+                    to_role: to_role.into(),
+                    kind: "findings".into(),
+                    payload: payload.into(),
+                    created_at: "2026-08-03T00:00:00Z".into(),
+                })
+                .unwrap();
+        };
+        record(&mut board, "art-old", "implementer", "first");
+        record(&mut board, "art-new", "implementer", "second");
+        record(&mut board, "art-other", "reviewer", "untouched");
+
+        let consumed = board.consume_handoffs_for("implementer", 4);
+        assert_eq!(consumed.len(), 2);
+        assert_eq!(consumed[0].id, "art-new", "newest handoff delivers first");
+        assert_eq!(consumed[1].id, "art-old");
+
+        assert!(
+            board.consume_handoffs_for("implementer", 4).is_empty(),
+            "a consumed handoff must not be delivered again"
+        );
+        assert_eq!(
+            board.artifacts.len(),
+            1,
+            "handoffs for other roles stay on the board"
+        );
+        assert_eq!(board.artifacts[0].id, "art-other");
     }
 
     #[test]


### PR DESCRIPTION
Stack **R4** — chains on R3 (#5148) ← R1 (#5147, merged) ← train (#5135). 10 fixes + 2 stuck-guard merge repairs (already on the train), one concern per commit. From the owner-verified Tier-1 audit (#5152–#5162).

## What's in it

- **#5157 MCP ToolFilter deny/allow bypassed at call time (security)** — filter enforced on every invocation path; denied tools cannot be called by qualified name.
- **#5158 MCP hyphen/dot tool names un-callable** — exact-match resolves original names; hyphenated tools work end-to-end.
- **#5152 thread/resume history doubling** — dedup against the persisted chain; resume-with-history is idempotent.
- **#5154 persist_thread policy wipe** — stored approval/sandbox policy preserved across resume.
- **#5153 response_id collisions** — `resp-<uuid>` everywhere; equal-length inputs get distinct ids.
- **#5160 state migration v0→v1 non-idempotent** — guarded ALTERs; migration runs twice cleanly.
- **#5159 logout leaves orphaned keyring credentials** — all providers' secrets deleted, failures reported not swallowed.
- **#5162 multi-select Enter toggles out** — Enter is select-and-advance; double-Enter can never submit an empty answer.
- **#5155 workflow gate handoffs never consumed** — handoffs actually consumed on delivery; receipts tell the truth.
- **#5156 token_budget not a ceiling for fan-out** — shared scope budget enforced mid-run, not frozen per child at admission.

## Gates

- Pre-rebase full suite: 9597 pass / 2 pre-existing fails. Post-rebase onto R3: **9612 pass / 3 fail** = 2 pre-existing `config::credential_scope_tests::*` + `immediate_submit_custom_provider_missing_key_preflight_*` — that one is #5104-merge debris being repaired separately (lands below this in the chain via the train).
- `cargo fmt --all -- --check` exit=0; `cargo check --workspace --all-targets --locked` exit=0.

No-Issue: v0.9.4 program stack PR. Closes #5152, Closes #5153, Closes #5154, Closes #5155, Closes #5156, Closes #5157, Closes #5158, Closes #5159, Closes #5160, Closes #5162.