### PR TITLE
stack R5: wave-3 truths (secrets fail-closed, stdio hooks, config-set, budget refund, resume guard, keyring probe)

### DIFF
--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -297,7 +297,7 @@ fn app_router(state: AppState, cors_origins: &[String]) -> Router {
 }
 
 pub async fn run_stdio(config_path: Option<PathBuf>) -> Result<()> {
-    let state = build_state(config_path, None)?;
+    let state = build_state_with_transport(config_path, None, AppTransport::Stdio)?;
     let reader = BufReader::new(tokio::io::stdin()).lines();
     let writer = tokio::io::BufWriter::new(tokio::io::stdout());
     run_stdio_loop(&state, reader, writer).await
@@ -615,6 +615,14 @@ fn app_response_status(response: &AppResponse) -> StatusCode {
 }
 
 fn build_state(config_path: Option<PathBuf>, auth_token: Option<String>) -> Result<AppState> {
+    build_state_with_transport(config_path, auth_token, AppTransport::Http)
+}
+
+fn build_state_with_transport(
+    config_path: Option<PathBuf>,
+    auth_token: Option<String>,
+    transport: AppTransport,
+) -> Result<AppState> {
     let has_explicit_config_path = config_path.is_some();
     let store = ConfigStore::load(config_path)?;
     let config_path = has_explicit_config_path.then(|| store.path().to_path_buf());
@@ -628,7 +636,12 @@ fn build_state(config_path: Option<PathBuf>, auth_token: Option<String>) -> Resu
     let state_store = StateStore::open(state_db_path)?;
 
     let mut hooks = HookDispatcher::default();
-    hooks.add_sink(Arc::new(StdoutHookSink));
+    // Stdio carries JSON-RPC on stdout: printing raw hook events there
+    // corrupts the protocol stream (#5165). HTTP mode keeps the stdout
+    // sink for local development visibility.
+    if transport == AppTransport::Http {
+        hooks.add_sink(Arc::new(StdoutHookSink));
+    }
     let hook_log_path = config_path
         .as_ref()
         .and_then(|p| p.parent().map(|parent| parent.join("events.jsonl")))
@@ -2013,6 +2026,27 @@ mod tests {
                     .expect("canonical config")
                     .as_path()
             )
+        );
+    }
+
+    #[tokio::test]
+    async fn stdio_transport_never_registers_the_stdout_hook_sink() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_path = tmp.path().join("config.toml");
+        fs::write(&config_path, "api_key = \"sk-deepseek-secret\"\n").expect("write config");
+
+        let http_state =
+            build_state_with_transport(Some(config_path.clone()), None, AppTransport::Http)
+                .expect("http state");
+        let stdio_state = build_state_with_transport(Some(config_path), None, AppTransport::Stdio)
+            .expect("stdio state");
+
+        let http_sinks = http_state.runtime.read().await.hooks.sink_count();
+        let stdio_sinks = stdio_state.runtime.read().await.hooks.sink_count();
+        assert_eq!(
+            http_sinks,
+            stdio_sinks + 1,
+            "HTTP mode keeps StdoutHookSink + JsonlHookSink; stdio must drop the stdout sink (#5165)"
         );
     }
 

--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -851,6 +851,18 @@ impl JsonRpcError {
         }
     }
 
+    /// Server error (-32000..-32099): the named thread does not exist.
+    fn thread_not_found(thread_id: &str) -> Self {
+        Self {
+            code: -32004,
+            message: format!("thread not found: {thread_id}"),
+            data: Some(json!({
+                "error": "thread_not_found",
+                "thread_id": thread_id,
+            })),
+        }
+    }
+
     fn internal(message: impl Into<String>) -> Self {
         Self {
             code: -32603,
@@ -914,6 +926,17 @@ async fn handle_stdio_thread_message<W: AsyncWrite + Unpin>(
         object.insert("thread_id".to_string(), Value::String(parsed.thread_id));
     }
     Ok(result)
+}
+
+/// Resuming or forking a thread the runtime reports as `missing` must fail
+/// with a named not-found error. Recording the null model/workspace of that
+/// response as a stdio hint would clobber any previously cached hint for
+/// the same thread id (#5171).
+fn ensure_thread_found(response: &ThreadResponse) -> std::result::Result<(), JsonRpcError> {
+    if response.status == "missing" {
+        return Err(JsonRpcError::thread_not_found(&response.thread_id));
+    }
+    Ok(())
 }
 
 async fn record_stdio_thread_hint(state: &AppState, response: &ThreadResponse) {
@@ -1575,6 +1598,7 @@ async fn dispatch_stdio_request_with_writer<W: AsyncWrite + Unpin>(
         "thread/resume" => {
             let request = ThreadRequest::Resume(parse_params(params_or_object(params))?);
             let response = handle_thread_request(state, request).await?;
+            ensure_thread_found(&response)?;
             record_stdio_thread_hint(state, &response).await;
             StdioDispatchResult {
                 result: serde_json::to_value(response)
@@ -1585,6 +1609,7 @@ async fn dispatch_stdio_request_with_writer<W: AsyncWrite + Unpin>(
         "thread/fork" => {
             let request = ThreadRequest::Fork(parse_params(params_or_object(params))?);
             let response = handle_thread_request(state, request).await?;
+            ensure_thread_found(&response)?;
             record_stdio_thread_hint(state, &response).await;
             StdioDispatchResult {
                 result: serde_json::to_value(response)
@@ -2668,10 +2693,55 @@ mod tests {
         assert_eq!(cleared.result["data"]["cleared"], true);
     }
 
+    #[tokio::test]
+    async fn stdio_resume_of_missing_thread_fails_without_clobbering_the_hint() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_path = tmp.path().join("config.toml");
+        fs::write(&config_path, "").expect("write config");
+        let state = build_state(Some(config_path), None).expect("state");
+
+        // A cached hint for a thread the runtime no longer knows: the exact
+        // clobber scenario from #5171.
+        let workspace = tmp.path().join("ws");
+        {
+            let mut hints = state.stdio_thread_hints.lock().await;
+            hints.insert(
+                "ghost-thread".to_string(),
+                RuntimeThreadHint {
+                    model: Some("deepseek-v4-pro".to_string()),
+                    workspace: Some(workspace.clone()),
+                },
+            );
+        }
+
+        let err = dispatch_stdio_request(
+            &state,
+            "thread/resume",
+            json!({ "thread_id": "ghost-thread" }),
+        )
+        .await
+        .expect_err("resuming a missing thread must fail with a named not-found error");
+        assert_eq!(err.code, -32004);
+        assert!(err.message.contains("ghost-thread"), "{}", err.message);
+
+        let fork_err = dispatch_stdio_request(
+            &state,
+            "thread/fork",
+            json!({ "thread_id": "ghost-thread" }),
+        )
+        .await
+        .expect_err("forking a missing thread must fail with a named not-found error");
+        assert_eq!(fork_err.code, -32004);
+
+        let hints = state.stdio_thread_hints.lock().await;
+        let hint = hints.get("ghost-thread").expect("cached hint survives");
+        assert_eq!(hint.model.as_deref(), Some("deepseek-v4-pro"));
+        assert_eq!(hint.workspace.as_deref(), Some(workspace.as_path()));
+    }
+
     fn sse_frame(event: &str, payload: Value) -> String {
         format!("event: {event}\ndata: {payload}\n\n")
     }
-
     /// A runtime whose turn never ends on its own — only an interrupt stops
     /// it. That is the shape of the runaway turn this protects against.
     async fn spawn_uninterruptible_until_asked_runtime() -> (

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -756,6 +756,26 @@ fn parse_provider_config_key(key: &str) -> Option<(ProviderKind, ProviderConfigF
     Some((provider, field))
 }
 
+/// Split a `providers.<id>.<field>` key without resolving the provider. Used
+/// for custom providers, whose ids live in `[providers.<id>]` tables inside
+/// `ProvidersToml::extras` rather than in [`ProviderKind::ALL`].
+fn parse_custom_provider_config_key(key: &str) -> Option<(&str, &str)> {
+    let suffix = key.strip_prefix("providers.")?;
+    let (provider_id, field_key) = suffix.split_once('.')?;
+    (!provider_id.is_empty()).then_some((provider_id, field_key))
+}
+
+fn is_builtin_provider_config_id(provider_id: &str) -> bool {
+    ProviderKind::ALL
+        .iter()
+        .any(|kind| kind.provider().provider_config_key() == provider_id)
+}
+
+/// Field legs a `[providers.<id>]` custom table accepts through
+/// `config set`, including the required `kind` marker.
+const CUSTOM_PROVIDER_FIELD_HINT: &str = "api_key, base_url, model, context_window, mode, auth_mode, \
+     insecure_skip_tls_verify, http_headers, path_suffix, kind";
+
 fn provider_config_key(provider: ProviderKind, field: ProviderConfigField) -> String {
     format!(
         "providers.{}.{}",
@@ -2130,6 +2150,111 @@ impl ConfigToml {
             .ok()
     }
 
+    /// Mutable access to a custom provider's `[providers.<id>]` table,
+    /// creating it on the first `config set providers.<id>.<field>`.
+    fn custom_provider_table_mut(&mut self, provider_id: &str) -> Result<&mut toml::value::Table> {
+        let entry = self
+            .providers
+            .extras
+            .entry(provider_id.to_string())
+            .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+        entry.as_table_mut().with_context(|| {
+            format!("custom provider '{provider_id}' must be a [providers.{provider_id}] table")
+        })
+    }
+
+    /// Write one leg of a custom provider table. Named custom providers are
+    /// not in [`ProviderKind::ALL`], so without this path
+    /// `config set providers.<custom>.<field>` fell through to a literal
+    /// top-level extras key and silently never took effect (#5167).
+    fn set_custom_provider_value(
+        &mut self,
+        provider_id: &str,
+        field_key: &str,
+        value: &str,
+    ) -> Result<()> {
+        if is_builtin_provider_config_id(provider_id) {
+            bail!(
+                "unknown field '{field_key}' for built-in provider '{provider_id}': \
+                 expected one of api_key, base_url, model, context_window, mode, auth_mode, \
+                 insecure_skip_tls_verify, http_headers, path_suffix"
+            );
+        }
+        if field_key == "kind" {
+            let compatible =
+                value.trim().to_ascii_lowercase().replace('_', "-") == "openai-compatible";
+            if !compatible {
+                bail!(
+                    "custom provider '{provider_id}' must set [providers.{provider_id}].kind = \"openai-compatible\""
+                );
+            }
+            self.custom_provider_table_mut(provider_id)?.insert(
+                "kind".to_string(),
+                toml::Value::String(value.trim().to_string()),
+            );
+            return Ok(());
+        }
+        let Some(field) = ProviderConfigField::parse(field_key) else {
+            bail!(
+                "unknown field '{field_key}' for custom provider '{provider_id}': \
+                 expected one of {CUSTOM_PROVIDER_FIELD_HINT}"
+            );
+        };
+        let toml_value = match field {
+            ProviderConfigField::ApiKey
+            | ProviderConfigField::BaseUrl
+            | ProviderConfigField::Model
+            | ProviderConfigField::Mode
+            | ProviderConfigField::AuthMode
+            | ProviderConfigField::PathSuffix => toml::Value::String(value.to_string()),
+            ProviderConfigField::ContextWindow => {
+                toml::Value::Integer(i64::from(parse_context_window(value)?))
+            }
+            ProviderConfigField::InsecureSkipTlsVerify => toml::Value::Boolean(parse_bool(value)?),
+            ProviderConfigField::HttpHeaders => toml::Value::Table(
+                parse_http_headers(value)?
+                    .into_iter()
+                    .map(|(name, header)| (name, toml::Value::String(header)))
+                    .collect(),
+            ),
+        };
+        self.custom_provider_table_mut(provider_id)?
+            .insert(field.key().to_string(), toml_value);
+        Ok(())
+    }
+
+    fn get_custom_provider_value_with(
+        &self,
+        provider_id: &str,
+        field_key: &str,
+        render: fn(&ProviderConfigToml, ProviderConfigField) -> Option<String>,
+    ) -> Option<String> {
+        let table = self.providers.extras.get(provider_id)?.as_table()?;
+        if field_key == "kind" {
+            return table.get("kind")?.as_str().map(str::to_string);
+        }
+        let field = ProviderConfigField::parse(field_key)?;
+        let config: ProviderConfigToml = toml::Value::Table(table.clone()).try_into().ok()?;
+        render(&config, field)
+    }
+
+    fn unset_custom_provider_value(&mut self, provider_id: &str, field_key: &str) {
+        let Some(table) = self
+            .providers
+            .extras
+            .get_mut(provider_id)
+            .and_then(toml::Value::as_table_mut)
+        else {
+            return;
+        };
+        let leg = if field_key == "kind" {
+            "kind"
+        } else {
+            ProviderConfigField::parse(field_key).map_or(field_key, |field| field.key())
+        };
+        table.remove(leg);
+    }
+
     fn bind_persisted_provider_id(&mut self, provider_id: &str) -> Result<()> {
         self.selected_provider_id = None;
         if self.provider != ProviderKind::Custom || provider_id == ProviderKind::Custom.as_str() {
@@ -2191,6 +2316,13 @@ impl ConfigToml {
         if let Some((provider, field)) = parse_provider_config_key(key) {
             return get_provider_config_value(self.providers.for_provider(provider), field);
         }
+        if let Some((provider_id, field_key)) = parse_custom_provider_config_key(key) {
+            return self.get_custom_provider_value_with(
+                provider_id,
+                field_key,
+                get_provider_config_value,
+            );
+        }
 
         match key {
             "provider" => Some(self.provider_id().to_string()),
@@ -2236,6 +2368,13 @@ impl ConfigToml {
     pub fn get_display_value(&self, key: &str) -> Option<String> {
         if let Some((provider, field)) = parse_provider_config_key(key) {
             return get_provider_config_display_value(self.providers.for_provider(provider), field);
+        }
+        if let Some((provider_id, field_key)) = parse_custom_provider_config_key(key) {
+            return self.get_custom_provider_value_with(
+                provider_id,
+                field_key,
+                get_provider_config_display_value,
+            );
         }
 
         if key == "http_headers" {
@@ -2284,6 +2423,9 @@ impl ConfigToml {
     pub fn set_value(&mut self, key: &str, value: &str) -> Result<()> {
         if let Some((provider, field)) = parse_provider_config_key(key) {
             return set_provider_config_value(self, provider, field, value);
+        }
+        if let Some((provider_id, field_key)) = parse_custom_provider_config_key(key) {
+            return self.set_custom_provider_value(provider_id, field_key, value);
         }
 
         match key {
@@ -2334,6 +2476,10 @@ impl ConfigToml {
     pub fn unset_value(&mut self, key: &str) -> Result<()> {
         if let Some((provider, field)) = parse_provider_config_key(key) {
             unset_provider_config_value(self, provider, field);
+            return Ok(());
+        }
+        if let Some((provider_id, field_key)) = parse_custom_provider_config_key(key) {
+            self.unset_custom_provider_value(provider_id, field_key);
             return Ok(());
         }
 

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -2291,6 +2291,112 @@ fn moonshot_provider_config_values_round_trip() -> Result<()> {
 }
 
 #[test]
+fn custom_provider_config_set_get_unset_round_trip() -> Result<()> {
+    let mut config = ConfigToml::default();
+
+    // The owner flow from #5174: build an Alibaba Model Studio custom
+    // provider entirely through `config set providers.<id>.<field>`.
+    config.set_value("providers.alibaba_studio.kind", "openai-compatible")?;
+    config.set_value(
+        "providers.alibaba_studio.base_url",
+        "https://coding.dashscope.aliyuncs.com/v1",
+    )?;
+    config.set_value("providers.alibaba_studio.model", "qwen3-coder-plus")?;
+    config.set_value("providers.alibaba_studio.api_key", "sk-studio-secret")?;
+    config.set_value("providers.alibaba_studio.context_window", "256000")?;
+
+    assert_eq!(
+        config.get_value("providers.alibaba_studio.kind").as_deref(),
+        Some("openai-compatible")
+    );
+    assert_eq!(
+        config
+            .get_value("providers.alibaba_studio.base_url")
+            .as_deref(),
+        Some("https://coding.dashscope.aliyuncs.com/v1")
+    );
+    assert_eq!(
+        config
+            .get_value("providers.alibaba_studio.model")
+            .as_deref(),
+        Some("qwen3-coder-plus")
+    );
+    assert_eq!(
+        config
+            .get_value("providers.alibaba_studio.context_window")
+            .as_deref(),
+        Some("256000")
+    );
+    assert_eq!(
+        config
+            .get_display_value("providers.alibaba_studio.api_key")
+            .as_deref(),
+        Some("********")
+    );
+
+    // The set must land in a real `[providers.alibaba_studio]` table, never
+    // in a literal top-level extras key (#5167).
+    let serialized = toml::to_string(&config)?;
+    assert!(
+        serialized.contains("[providers.alibaba_studio]"),
+        "custom provider legs must serialize as a providers table, got:\n{serialized}"
+    );
+    assert!(
+        config
+            .extras
+            .keys()
+            .all(|key| !key.starts_with("providers.")),
+        "no literal 'providers.*' extras key may round-trip: {:?}",
+        config.extras.keys().collect::<Vec<_>>()
+    );
+
+    // The table must satisfy the runtime binding contract for named custom
+    // providers.
+    config.set_value("provider", "alibaba_studio")?;
+    assert_eq!(config.provider_id(), "alibaba_studio");
+
+    config.unset_value("providers.alibaba_studio.api_key")?;
+    assert_eq!(config.get_value("providers.alibaba_studio.api_key"), None);
+    assert_eq!(
+        config
+            .get_value("providers.alibaba_studio.model")
+            .as_deref(),
+        Some("qwen3-coder-plus")
+    );
+    Ok(())
+}
+
+#[test]
+fn custom_provider_set_rejects_unknown_field_with_corrective_error() {
+    let mut config = ConfigToml::default();
+
+    let err = config
+        .set_value("providers.alibaba_studio.bogus", "x")
+        .expect_err("unknown custom provider fields must not fall into extras");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("bogus") && message.contains("base_url"),
+        "error must name the bad leg and the valid shape, got: {message}"
+    );
+    assert!(config.providers.extras.is_empty());
+}
+
+#[test]
+fn builtin_provider_set_rejects_unknown_field_with_corrective_error() {
+    let mut config = ConfigToml::default();
+
+    let err = config
+        .set_value("providers.deepseek.bogus", "x")
+        .expect_err("unknown built-in provider fields must not fall into extras");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("bogus") && message.contains("deepseek"),
+        "error must name the bad leg and provider, got: {message}"
+    );
+    assert!(config.providers.extras.is_empty());
+}
+
+#[test]
 fn siliconflow_cn_provider_config_values_round_trip() -> Result<()> {
     let mut config = ConfigToml::default();
 

--- a/crates/config/src/user_constitution.rs
+++ b/crates/config/src/user_constitution.rs
@@ -561,8 +561,10 @@ impl UserConstitution {
     ///
     /// This is the single ingestion gate for text CodeWhale did not author:
     ///
-    /// - Extracts the first JSON object, so fenced or prose-wrapped output
-    ///   still parses; anything without one is [`Invalid`].
+    /// - Extracts balanced JSON objects in order until one parses, so fenced
+    ///   or prose-wrapped output still parses — including prose that itself
+    ///   contains braces before the real draft. Anything without a parseable
+    ///   object is [`Invalid`], and every drop is logged loudly (#5169).
     /// - Unknown keys are ignored by serde, so a draft cannot smuggle
     ///   runtime-policy fields (`approval_policy`, `sandbox_mode`, …) into the
     ///   persisted file — the schema simply has nowhere to put them.
@@ -576,20 +578,35 @@ impl UserConstitution {
     /// [`Invalid`]: UntrustedDraftParse::Invalid
     #[must_use]
     pub fn from_untrusted_json(raw: &str) -> UntrustedDraftParse {
-        let Some(json) = extract_first_json_object(raw) else {
-            return UntrustedDraftParse::Invalid("no JSON object found in draft".to_string());
-        };
-        match serde_json::from_str::<UserConstitution>(json) {
-            Err(err) => UntrustedDraftParse::Invalid(err.to_string()),
-            Ok(draft) => {
-                let sanitized = draft.sanitized_untrusted().bounded();
-                if sanitized.is_empty() {
-                    UntrustedDraftParse::Empty
-                } else {
-                    UntrustedDraftParse::Drafted(Box::new(sanitized))
+        let mut candidates = 0usize;
+        let mut last_error = String::new();
+        for json in extract_json_objects(raw) {
+            candidates += 1;
+            match serde_json::from_str::<UserConstitution>(json) {
+                Ok(draft) => {
+                    let sanitized = draft.sanitized_untrusted().bounded();
+                    return if sanitized.is_empty() {
+                        UntrustedDraftParse::Empty
+                    } else {
+                        UntrustedDraftParse::Drafted(Box::new(sanitized))
+                    };
                 }
+                Err(err) => last_error = err.to_string(),
             }
         }
+        let reason = if candidates == 0 {
+            "no JSON object found in draft".to_string()
+        } else if candidates == 1 {
+            last_error
+        } else {
+            format!(
+                "{candidates} JSON objects found, none parse as a constitution draft; last error: {last_error}"
+            )
+        };
+        // A dropped draft is a failed model turn the user is otherwise never
+        // told about; drops must log loudly.
+        tracing::warn!("dropping unparseable constitution draft: {reason}");
+        UntrustedDraftParse::Invalid(reason)
     }
 
     /// Sanitize every text field of an untrusted draft. See
@@ -1083,38 +1100,59 @@ pub enum UntrustedDraftParse {
     Invalid(String),
 }
 
-/// Extract the first balanced top-level JSON object from `raw`, tolerating
-/// fences and prose around it. Strings and escapes are respected so braces
-/// inside field values do not end the scan early.
-fn extract_first_json_object(raw: &str) -> Option<&str> {
-    let start = raw.find('{')?;
-    let mut depth = 0usize;
-    let mut in_string = false;
-    let mut escaped = false;
-    for (offset, ch) in raw[start..].char_indices() {
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == '"' {
-                in_string = false;
-            }
-            continue;
-        }
-        match ch {
-            '"' => in_string = true,
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(&raw[start..=start + offset]);
+/// Extract every balanced top-level JSON object from `raw` in order of
+/// appearance, tolerating fences and prose around them. Strings and escapes
+/// are respected so braces inside field values do not end the scan early.
+/// An unbalanced `{` is skipped so prose containing braces cannot hide a
+/// later, valid draft object (#5169).
+fn extract_json_objects(raw: &str) -> impl Iterator<Item = &str> {
+    JsonObjectSpans { raw, offset: 0 }
+}
+
+struct JsonObjectSpans<'a> {
+    raw: &'a str,
+    offset: usize,
+}
+
+impl<'a> Iterator for JsonObjectSpans<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<&'a str> {
+        loop {
+            let start = self.offset + self.raw[self.offset..].find('{')?;
+            let mut depth = 0usize;
+            let mut in_string = false;
+            let mut escaped = false;
+            for (rel, ch) in self.raw[start..].char_indices() {
+                if in_string {
+                    if escaped {
+                        escaped = false;
+                    } else if ch == '\\' {
+                        escaped = true;
+                    } else if ch == '"' {
+                        in_string = false;
+                    }
+                    continue;
+                }
+                match ch {
+                    '"' => in_string = true,
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            let end = start + rel + ch.len_utf8();
+                            self.offset = end;
+                            return Some(&self.raw[start..end]);
+                        }
+                    }
+                    _ => {}
                 }
             }
-            _ => {}
+            // No balancing `}` from this `{`: skip it and keep scanning so a
+            // later object can still be found.
+            self.offset = start + 1;
         }
     }
-    None
 }
 
 /// Strip control characters (keeping `\n` and `\t`) and neutralize
@@ -1459,6 +1497,39 @@ mod tests {
             panic!("braces inside strings should not end the object scan");
         };
         assert_eq!(c.notes.as_deref(), Some("a } b"));
+    }
+
+    #[test]
+    fn untrusted_draft_survives_prose_braces_before_the_draft() {
+        // #5169: keying off the first `{` used to drop this draft — the prose
+        // brace pair is not the constitution object.
+        let raw = "Use the {about, notes} shape like this:\n```json\n{\"about\":\"I value concise answers\"}\n```";
+        let UntrustedDraftParse::Drafted(c) = UserConstitution::from_untrusted_json(raw) else {
+            panic!("prose braces must not hide the real draft object");
+        };
+        assert_eq!(c.about.as_deref(), Some("I value concise answers"));
+    }
+
+    #[test]
+    fn untrusted_draft_survives_unbalanced_prose_brace_before_the_draft() {
+        let raw = "I started an example { but here is the draft:\n{\"about\":\"direct edits win\"}";
+        let UntrustedDraftParse::Drafted(c) = UserConstitution::from_untrusted_json(raw) else {
+            panic!("an unbalanced prose brace must not hide the real draft object");
+        };
+        assert_eq!(c.about.as_deref(), Some("direct edits win"));
+    }
+
+    #[test]
+    fn untrusted_draft_drop_names_every_candidate_it_tried() {
+        let UntrustedDraftParse::Invalid(reason) =
+            UserConstitution::from_untrusted_json("{bad} {also bad}")
+        else {
+            panic!("two unparseable objects must be Invalid");
+        };
+        assert!(
+            reason.contains("2 JSON objects found"),
+            "the drop reason must name the tried candidates: {reason}"
+        );
     }
 
     #[test]

--- a/crates/hooks/src/lib.rs
+++ b/crates/hooks/src/lib.rs
@@ -325,6 +325,13 @@ impl HookDispatcher {
         self.sinks.push(sink);
     }
 
+    /// Number of registered sinks. Exposed so transport setup can assert
+    /// exactly which sinks were wired (e.g. no stdout sink in stdio mode).
+    #[must_use]
+    pub fn sink_count(&self) -> usize {
+        self.sinks.len()
+    }
+
     /// Broadcast an event to every registered sink.
     ///
     /// Errors from individual sinks are silently discarded so that one failing

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -130,6 +130,16 @@ impl DefaultKeyringStore {
 
     /// Probe the OS keyring without writing anything. Returns `Ok(())` if
     /// a backend is reachable, otherwise an error describing why not.
+    ///
+    /// The probe reads a deliberately-nonexistent entry: reaching the
+    /// backend and learning the entry is absent *is* the reachability
+    /// signal. This does not prompt on any supported platform — macOS only
+    /// surfaces Keychain UI when accessing an *existing* item owned by
+    /// another application, and Windows Credential Manager never prompts
+    /// for a missing target — so `__probe__` under our own service name is
+    /// safe to read. `Entry::new` alone validates only argument shapes,
+    /// which left this probe a no-op on macOS/Windows and the documented
+    /// file-store fallback unreachable there (#5172).
     pub fn probe(&self) -> Result<(), SecretsError> {
         #[cfg(any(
             target_os = "macos",
@@ -141,18 +151,8 @@ impl DefaultKeyringStore {
             )
         ))]
         {
-            // `Entry::new` is enough to validate the native macOS/Windows
-            // backend path. Avoid a dummy read there because it can trigger
-            // a second user-visible Keychain/Credential Manager access before
-            // the real provider key lookup.
             let entry = keyring::Entry::new(&self.service, "__probe__")
                 .map_err(|err| SecretsError::Keyring(err.to_string()))?;
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
-            {
-                let _ = entry;
-                Ok(())
-            }
-            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
             match entry.get_password() {
                 Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
                 Err(keyring::Error::PlatformFailure(err)) => {
@@ -1307,6 +1307,20 @@ mod tests {
                 None => unsafe { std::env::remove_var(self.name) },
             }
         }
+    }
+
+    /// Live check for #5172: on macOS/Windows the probe used to return Ok
+    /// without touching the backend at all. Run explicitly with
+    /// `cargo test -p codewhale-secrets -- --ignored` on a desktop machine:
+    /// a healthy native keyring answers a read of the deliberately absent
+    /// `__probe__` entry with NoEntry, silently, and the probe succeeds.
+    #[test]
+    #[ignore = "touches the real OS keyring; run on a desktop machine"]
+    fn probe_performs_a_real_backend_read() {
+        let store = DefaultKeyringStore::new("codewhale-probe-live-check");
+        store
+            .probe()
+            .expect("the native keyring backend should be reachable on this machine");
     }
 
     #[test]

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -1015,10 +1015,20 @@ impl Secrets {
     /// credential prompt.
     #[must_use]
     pub fn file_backed_read_only() -> Self {
-        let store = ReadOnlyFileKeyringStore::default_for_diagnostics().unwrap_or_else(|_| {
-            ReadOnlyFileKeyringStore::new(PathBuf::from(".codewhale-secrets.json"), None)
-        });
-        Self::new(Arc::new(store))
+        // Fail closed like the writable path in `file_backed_from_default_path`:
+        // never fall back to a cwd-relative credential path. A planted
+        // `.codewhale-secrets.json` beside the working directory must not
+        // become the credential store when home resolution fails.
+        match ReadOnlyFileKeyringStore::default_for_diagnostics() {
+            Ok(store) => Self::new(Arc::new(store)),
+            Err(err) => {
+                tracing::error!(
+                    "could not resolve the file-backed secret path ({err}); credentials will not be read. \
+                     Fix: set CODEWHALE_HOME to an absolute path or make HOME/USERPROFILE resolvable"
+                );
+                Self::read_only_empty_store()
+            }
+        }
     }
 
     /// Construct the file-backed default backend directly.
@@ -1444,6 +1454,58 @@ mod tests {
         assert!(
             !primary.exists(),
             "a refused isolated diagnostic write must not create the primary store"
+        );
+    }
+
+    /// Cwd is process-global, so tests that move it serialise on `env_lock`
+    /// like the env-mutating tests and restore on drop.
+    struct CwdGuard {
+        previous: PathBuf,
+    }
+
+    impl CwdGuard {
+        fn enter(path: &Path) -> Self {
+            let previous = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self { previous }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.previous).unwrap();
+        }
+    }
+
+    #[test]
+    fn file_backed_read_only_never_reads_a_cwd_relative_store() {
+        let _lock = env_lock();
+        clear_known_envs();
+        let tmp = tempfile::tempdir().unwrap();
+        // A relative override fails home resolution deterministically, which
+        // used to fall back to a planted `.codewhale-secrets.json` in the cwd.
+        let _codewhale_home = EnvVarGuard::set("CODEWHALE_HOME", "relative-codewhale-home");
+        let planted = tmp.path().join(".codewhale-secrets.json");
+        std::fs::write(
+            &planted,
+            r#"{"entries":{"deepseek":"planted-cwd-credential"}}"#,
+        )
+        .unwrap();
+        let _cwd = CwdGuard::enter(tmp.path());
+
+        let secrets = Secrets::file_backed_read_only();
+
+        assert_eq!(
+            secrets.get("deepseek").unwrap(),
+            None,
+            "a failed home resolution must not turn a planted cwd file into the credential store"
+        );
+        assert!(
+            matches!(
+                secrets.set("deepseek", "replacement"),
+                Err(SecretsError::ReadOnly)
+            ),
+            "the failed-resolution diagnostic facade must still refuse writes"
         );
     }
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3305,6 +3305,55 @@ async fn tool_call_budget_admits_exactly_the_cap_and_rejects_the_ninth() {
     }
 }
 
+/// #5170: a call stopped by an admission gate never executes, so its
+/// debited budget slot is refunded — the cap counts admitted calls only.
+/// With a cap of 1, a blocked first proposal must leave room for the
+/// second proposal to run.
+#[tokio::test]
+async fn tool_call_budget_refunds_calls_blocked_by_admission_gates() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let workspace = tempdir().expect("tempdir");
+    fs::write(workspace.path().join("fixture.txt"), "fixture\n").expect("write fixture");
+    let mock = std::sync::Arc::new(MockLlmClient::new(vec![
+        tool_batch_turn(&[
+            (
+                "call-blocked",
+                "definitely_not_a_tool",
+                r#"{"path":"fixture.txt"}"#,
+            ),
+            ("call-admitted", "read_file", r#"{"path":"fixture.txt"}"#),
+        ]),
+        canned::simple_text_turn("done"),
+    ]));
+
+    let (status, error, completions) =
+        run_budgeted_read_turn(workspace.path(), Some(1), mock.clone()).await;
+    assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
+    assert_eq!(
+        completions.len(),
+        2,
+        "every proposed call reports a completion"
+    );
+
+    let blocked = completions[0]
+        .1
+        .as_ref()
+        .expect_err("the unknown tool must be blocked by the missing-tool gate");
+    assert!(
+        blocked.to_string().contains("definitely_not_a_tool"),
+        "{blocked}"
+    );
+    let admitted = completions[1]
+        .1
+        .as_ref()
+        .expect("a gate-blocked call refunds its slot, so the second call still fits the cap of 1");
+    assert!(
+        admitted.content.contains("fixture"),
+        "the admitted call must return its file contents: {admitted:?}"
+    );
+}
+
 /// #4415 AC(b): a 4-call parallel batch proposed with 2 calls remaining is
 /// truncated to the first 2 calls in proposal order; the excess 2 are
 /// rejected with the same typed reason, and the batch is counted in full.

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1861,14 +1861,17 @@ impl Engine {
                 let mut hook_requires_approval = false;
 
                 // #4415: hard per-turn tool-call budget. This gate runs first
-                // so the budget counts every proposed call in the batch: while
-                // calls remain, the call is admitted and the count decrements;
-                // once exhausted, the call is rejected with a typed reason and
-                // never executes — an over-budget batch is truncated to exactly
-                // the calls that still fit, in proposal order.
-                if let Err(exceeded) = tool_call_budget.admit()
-                    && blocked_error.is_none()
-                {
+                // so proposal order decides which calls fit: while calls
+                // remain, the call is admitted and the count decrements; once
+                // exhausted, the call is rejected with a typed reason and
+                // never executes — an over-budget batch is truncated to
+                // exactly the calls that still fit, in proposal order.
+                // #5170: the cap counts *admitted* calls — a debited call
+                // stopped by any gate below is refunded before plan
+                // construction, so blocked calls cannot burn the budget.
+                let admission = tool_call_budget.admit();
+                let budget_debited = admission.is_ok();
+                if let Err(exceeded) = admission {
                     blocked_error = Some(exceeded.into_tool_error(&tool_name));
                 }
 
@@ -2320,6 +2323,14 @@ impl Engine {
                     approval_description = format!(
                         "{approval_description} — note: the execution sandbox is read-only for this session; approving runs the command without write access (approval cannot lift the sandbox)"
                     );
+                }
+
+                // #5170: a call stopped by any admission gate above never
+                // executes, so hand its debited budget slot back. Only the
+                // budget gate's own rejection leaves nothing to refund —
+                // it never debited in the first place.
+                if blocked_error.is_some() && budget_debited {
+                    tool_call_budget.refund();
                 }
 
                 plans.push(ToolExecutionPlan {

--- a/crates/tui/src/native_memory.rs
+++ b/crates/tui/src/native_memory.rs
@@ -4,7 +4,7 @@
 //! index and may be deleted at any time. This module deliberately has no model
 //! or network dependency: callers decide when a note is reviewed and written.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -240,13 +240,10 @@ impl NativeMemoryStore {
 
     pub fn search(&self, query: &str, limit: usize) -> Result<Vec<MemoryHit>> {
         let query = validate_query(query)?;
-        // Markdown is authoritative. Refresh before retrieval so direct edits
-        // become visible even when no file-watcher thread is running.
-        self.with_write_lock(|| {
-            self.reindex_unlocked()?;
-            let conn = self.connection_unlocked()?;
-            self.query_hits(&conn, query, limit, None)
-        })
+        // Markdown stays authoritative, but the freshness check runs under
+        // a shared read lock; only a real tree change escalates to the
+        // write-locked reindex (#5173).
+        self.with_fresh_index(|conn| self.query_hits(conn, &query, limit, None))
     }
 
     /// Search global memory plus the current repository's origin-scoped
@@ -263,12 +260,10 @@ impl NativeMemoryStore {
             return self.search(query, limit);
         }
         let global = self.global_path();
-        self.with_write_lock(|| {
-            self.reindex_unlocked()?;
-            let conn = self.connection_unlocked()?;
+        self.with_fresh_index(|conn| {
             self.query_hits(
-                &conn,
-                query,
+                conn,
+                &query,
                 limit,
                 Some((&global, workspace_path.as_deref())),
             )
@@ -276,9 +271,7 @@ impl NativeMemoryStore {
     }
 
     pub fn get(&self, id: i64) -> Result<Option<MemoryHit>> {
-        self.with_write_lock(|| {
-            self.reindex_unlocked()?;
-            let conn = self.connection_unlocked()?;
+        self.with_fresh_index(|conn| {
             Ok(conn
                 .query_row(
                     "SELECT e.id,e.text,e.source,e.line_start,e.line_end,
@@ -306,9 +299,7 @@ impl NativeMemoryStore {
     }
 
     fn get_from_sources(&self, id: i64, sources: &[PathBuf]) -> Result<Option<MemoryHit>> {
-        self.with_write_lock(|| {
-            self.reindex_unlocked()?;
-            let conn = self.connection_unlocked()?;
+        self.with_fresh_index(|conn| {
             let mut stmt = conn.prepare(
                 "SELECT e.id,e.text,e.source,e.line_start,e.line_end,
                         CASE WHEN e.source_mtime != s.mtime THEN 1 ELSE 0 END
@@ -425,6 +416,70 @@ impl NativeMemoryStore {
             .write()
             .with_context(|| format!("write-lock native memory at {}", self.root.display()))?;
         operation()
+    }
+
+    fn with_read_lock<T>(&self, operation: impl FnOnce() -> Result<T>) -> Result<T> {
+        fs::create_dir_all(&self.root)?;
+        let lock_path = self.root.join(".memory.lock");
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)?;
+        let mut lock = fd_lock::RwLock::new(lock_file);
+        let _guard = lock
+            .read()
+            .with_context(|| format!("read-lock native memory at {}", self.root.display()))?;
+        operation()
+    }
+
+    /// `true` when the Markdown tree differs from the index — a source file
+    /// was added, removed, or touched since the last reindex — so a reindex
+    /// would change index contents.
+    fn tree_changes_pending(&self, conn: &Connection) -> Result<bool> {
+        let mut files = Vec::new();
+        collect_markdown(&self.root, &mut files)?;
+        let indexed = conn
+            .prepare("SELECT path, mtime FROM memory_sources")?
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })?
+            .collect::<rusqlite::Result<HashMap<_, _>>>()?;
+        if indexed.len() != files.len() {
+            return Ok(true);
+        }
+        for path in files {
+            let key = path.to_string_lossy();
+            match indexed.get(key.as_ref()) {
+                Some(&indexed_mtime) if indexed_mtime == file_mtime(&path)? => {}
+                _ => return Ok(true),
+            }
+        }
+        Ok(false)
+    }
+
+    /// Run `operation` against a fresh index under the lightest lock the
+    /// tree allows. The freshness check itself runs under a shared read
+    /// lock, so reads on an unchanged tree never queue behind the exclusive
+    /// write lock (#5173); a real tree change escalates to the write-locked
+    /// reindex, keeping direct Markdown edits visible on the next read.
+    fn with_fresh_index<T>(&self, operation: impl Fn(&Connection) -> Result<T>) -> Result<T> {
+        let fresh = self.with_read_lock(|| {
+            let conn = self.connection_unlocked()?;
+            self.tree_changes_pending(&conn).map(|changed| !changed)
+        })?;
+        if fresh {
+            return self.with_read_lock(|| {
+                let conn = self.connection_unlocked()?;
+                operation(&conn)
+            });
+        }
+        self.with_write_lock(|| {
+            self.reindex_unlocked()?;
+            let conn = self.connection_unlocked()?;
+            operation(&conn)
+        })
     }
 
     fn connection_unlocked(&self) -> Result<Connection> {
@@ -803,6 +858,45 @@ mod tests {
         fs::write(&path, "- second value\n").unwrap();
         assert!(store.search("first", 10).unwrap().is_empty());
         assert_eq!(store.search("second", 10).unwrap().len(), 1);
+    }
+
+    /// #5173: the read-path freshness check is what decides between the
+    /// shared read lock and the write-locked reindex — pin exactly which
+    /// tree states escalate.
+    #[test]
+    fn freshness_check_escalates_only_on_real_tree_changes() {
+        let tmp = TempDir::new().unwrap();
+        let store = NativeMemoryStore::new(tmp.path());
+        store.remember(MemoryScope::Global, None, "alpha").unwrap();
+        let conn = store.connection_unlocked().unwrap();
+        assert!(
+            !store.tree_changes_pending(&conn).unwrap(),
+            "an unchanged tree must take the shared read path"
+        );
+
+        let global = store.global_path();
+        OpenOptions::new()
+            .append(true)
+            .open(&global)
+            .unwrap()
+            .write_all(b"\n- beta\n")
+            .unwrap();
+        assert!(
+            store.tree_changes_pending(&conn).unwrap(),
+            "a direct edit must escalate to the reindex path"
+        );
+
+        store.reindex().unwrap();
+        assert!(
+            !store.tree_changes_pending(&conn).unwrap(),
+            "a reindexed tree is fresh again"
+        );
+
+        fs::remove_file(&global).unwrap();
+        assert!(
+            store.tree_changes_pending(&conn).unwrap(),
+            "a removed source must escalate to the reindex path"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tools/tool_call_budget.rs
+++ b/crates/tui/src/tools/tool_call_budget.rs
@@ -1,10 +1,15 @@
 //! Hard per-turn tool-call admission budget (#4415).
 //!
 //! One counter per turn, built from the task's structured `max_tool_calls`
-//! constraint. Every proposed tool call is admitted through the same gate in
-//! proposal order, so a batch larger than the remaining budget is truncated
-//! to exactly the calls that still fit and the excess are rejected — never
+//! constraint. Every proposed tool call passes the same gate in proposal
+//! order, so a batch larger than the remaining budget is truncated to
+//! exactly the calls that still fit and the excess are rejected — never
 //! executed — with a typed reason carrying the remaining-call count.
+//!
+//! The cap counts *admitted* calls: a call that debits a slot but is then
+//! stopped by a later admission gate (deny-list, allow-list, sandbox,
+//! hooks, missing tool) is refunded before it would have executed (#5170),
+//! so blocked calls cannot burn the budget.
 
 use codewhale_tools::ToolError;
 
@@ -49,9 +54,11 @@ impl ToolCallBudget {
         }
     }
 
-    /// Admit one proposed tool call. Every proposed call counts: while budget
-    /// remains, the call is admitted and the remaining count decrements; once
-    /// exhausted, the call is rejected with [`ToolCallBudgetExceeded`].
+    /// Debit one proposed tool call at the admission gate. While budget
+    /// remains, the call is admitted and the remaining count decrements;
+    /// once exhausted, the call is rejected with [`ToolCallBudgetExceeded`].
+    /// A call stopped by a later gate before execution must be handed back
+    /// through [`refund`](Self::refund) so the cap counts admitted calls.
     pub(crate) fn admit(&mut self) -> Result<(), ToolCallBudgetExceeded> {
         let (Some(max), Some(remaining)) = (self.max, self.remaining.as_mut()) else {
             return Ok(());
@@ -61,5 +68,14 @@ impl ToolCallBudget {
         }
         *remaining -= 1;
         Ok(())
+    }
+
+    /// Hand back one debited slot when the call that took it is blocked by
+    /// a later admission gate and never executes (#5170). Clamped at the
+    /// declared maximum so a refund can never grow the budget.
+    pub(crate) fn refund(&mut self) {
+        if let (Some(max), Some(remaining)) = (self.max, self.remaining.as_mut()) {
+            *remaining = (*remaining + 1).min(max);
+        }
     }
 }

--- a/web/lib/install-platform.test.ts
+++ b/web/lib/install-platform.test.ts
@@ -23,4 +23,32 @@ describe("install platform detection", () => {
       "windows-arm64",
     );
   });
+
+  const frozenMacUa =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36";
+
+  it("detects Intel Macs through User-Agent Client Hints (#5168)", () => {
+    expect(
+      detectFromBrowserSignals(frozenMacUa, {
+        architecture: "x86",
+        bitness: "64",
+      }),
+    ).toBe("macos-x64");
+  });
+
+  it("detects Apple Silicon through User-Agent Client Hints", () => {
+    expect(
+      detectFromBrowserSignals(frozenMacUa, {
+        architecture: "arm",
+        bitness: "64",
+      }),
+    ).toBe("macos-arm64");
+  });
+
+  it("defaults to arm64 without hints because the frozen Mac UA cannot distinguish", () => {
+    // Since Big Sur the UA says "Intel Mac OS X" on Apple Silicon too, so
+    // UA parsing must not route anyone to x64. The install page's arch
+    // chooser is the honest fallback for Intel users without hints.
+    expect(detectFromBrowserSignals(frozenMacUa)).toBe("macos-arm64");
+  });
 });

--- a/web/lib/install-platform.ts
+++ b/web/lib/install-platform.ts
@@ -16,9 +16,9 @@ export function detectFromBrowserSignals(
   userAgentArchitecture?: UserAgentArchitecture,
 ): Arch {
   const ua = userAgent.toLowerCase();
+  const architecture = userAgentArchitecture?.architecture?.toLowerCase();
+  const bitness = userAgentArchitecture?.bitness;
   if (ua.includes("win")) {
-    const architecture = userAgentArchitecture?.architecture?.toLowerCase();
-    const bitness = userAgentArchitecture?.bitness;
     if (
       architecture === "arm64" ||
       (architecture === "arm" && bitness === "64") ||
@@ -33,5 +33,11 @@ export function detectFromBrowserSignals(
     if (ua.includes("aarch64") || ua.includes("arm64")) return "linux-arm64";
     return "linux-x64";
   }
+  // macOS. Since Big Sur the UA reports "Intel Mac OS X" on Apple Silicon
+  // too, so the UA string cannot distinguish architectures — only
+  // User-Agent Client Hints can (#5168). Without hints we default to arm64
+  // (every Mac sold since late 2020); the arch chooser on the install page
+  // stays the honest fallback for Intel users.
+  if (architecture === "x86") return "macos-x64";
   return "macos-arm64";
 }


### PR DESCRIPTION
Stack **R5** of the v0.9.4 program — lands on the release train (#5135). 9 commits, one concern each. Closes #5165–#5173 (security/correctness order).

## What's in it

- **#5166 (SECURITY)** — read-only secret store no longer falls back to a cwd-relative `.codewhale-secrets.json`; fails closed with a named fix. Pin test plants a cwd credential and proves non-read.
- **#5165 (HIGH)** — `StdoutHookSink` gated on HTTP transport; stdio JSON-RPC stdout is pure JSON-RPC again (desktop/IDE clients desynced on every hook fire before this).
- **#5167** — `config set providers.<custom>.<field>` writes typed values into the real `[providers.<id>]` table (was silently corrupting config into a junk extras key). Pin test walks the owner's Alibaba custom-provider flow end-to-end.
- **#5170** — `max_tool_calls` counts ADMITTED calls (per the field doc): `ToolCallBudget::refund()` on gate blocks; contradiction comments/docs killed.
- **#5171** — stdio resume/fork of a missing thread fails with named `-32004 thread not found`; hint cache untouched.
- **#5169** — constitution draft extraction iterates all balanced candidates until one parses (finding partially stale — honest residual fixed); drops log loudly.
- **#5172** — keyring `probe()` implemented on all 3 platforms (no-entry read); **verified live on this Mac's real Keychain** via opt-in test, no prompt. The by-design comment overstated prompt risk — corrected.
- **#5173** — memory freshness check moved off the exclusive write lock (shared read lock; escalation only on real changes). Unchanged-tree reads concurrent.
- **#5168** — Intel Macs get the x64 snippet via UA Client Hints; honest arch chooser remains the no-hints fallback (UA alone can't distinguish since Big Sur — documented).

## Gates

- `cargo fmt --all -- --check` exit=0; `cargo check --workspace --all-targets --locked` exit=0.
- Post-rebase full bin suite: **9615 pass / 3 fail** = the 2 `config::credential_scope_tests::*` (a LIVE regression predating this stack — stack R7 is re-landing the deleted fix, issue #5193) + `tui_and_api_listings_agree` (known parallel-load flake, passes solo).
- Pre-rebase agent receipts: secrets 56(+1 ignored)/hooks 7/app-server 78/config 482 ✓; live Keychain probe 1 ✓; web vitest 227 ✓.

No-Issue: v0.9.4 program stack PR. Closes #5165, Closes #5166, Closes #5167, Closes #5168, Closes #5169, Closes #5170, Closes #5171, Closes #5172, Closes #5173.