### PR TITLE
stack R6: k3 pleasantness F1+F2 — in-workspace write carve-out, ungated read-only spawns (posture redefinition)

### DIFF
--- a/crates/tui/src/core/authority.rs
+++ b/crates/tui/src/core/authority.rs
@@ -4,10 +4,11 @@
 //! in one place so prompt metadata, tool catalogs, and runtime gates cannot
 //! drift independently.
 
-use std::path::Path;
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
 
 use crate::sandbox::SandboxPolicy;
-use crate::tools::spec::ApprovalRequirement;
+use crate::tools::spec::{ApprovalRequirement, normalize_path};
 use crate::tui::app::AppMode;
 use crate::tui::approval::ApprovalMode;
 use crate::worker_profile::ShellPolicy;
@@ -444,6 +445,158 @@ pub(crate) fn resolve_tool_permission(
     }
 }
 
+/// Whether the session posture is the one the in-workspace write carve-out
+/// (#5185) relaxes: the default Ask posture (`Suggest` approvals, no
+/// auto-approve) in an Agent-family mode.
+///
+/// Every other posture keeps its exact prior meaning: Full Access already
+/// runs these calls, `Never` still denies them, Auto-Review still fails
+/// unresolved holds closed, and Plan is read-only by mode.
+#[must_use]
+pub(crate) fn write_carve_out_posture(
+    mode: AppMode,
+    approval_mode: ApprovalMode,
+    auto_approve: bool,
+) -> bool {
+    !auto_approve
+        && matches!(mode, AppMode::Agent | AppMode::Auto | AppMode::Operate)
+        && approval_mode == ApprovalMode::Suggest
+}
+
+/// Whether every target path of a file-write call qualifies for the
+/// in-workspace write carve-out (#5185): the workspace is a git work tree,
+/// each path resolves inside it, and none touches `.git` internals, runtime
+/// state, or a sensitive file.
+///
+/// The git work-tree marker is deliberate (the same shape as kimi-code's
+/// `git-cwd-write-approve` policy): the carve-out exists because
+/// version-controlled edits stay reviewable and recoverable, so a workspace
+/// without git keeps the modal.
+#[must_use]
+pub(crate) fn paths_within_workspace_write_carve_out(workspace: &Path, paths: &[String]) -> bool {
+    if paths.is_empty() {
+        return false;
+    }
+    // `.git` may be a directory (normal checkout) or a file (worktree or
+    // submodule); either marks a git work tree.
+    if workspace.join(".git").symlink_metadata().is_err() {
+        return false;
+    }
+    let Ok(workspace_canonical) = workspace.canonicalize() else {
+        return false;
+    };
+    paths
+        .iter()
+        .all(|raw| carve_out_target_allowed(workspace, &workspace_canonical, raw))
+}
+
+fn carve_out_target_allowed(workspace: &Path, workspace_canonical: &Path, raw: &str) -> bool {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return false;
+    }
+    let raw_path = Path::new(raw);
+    let candidate = if raw_path.is_absolute() {
+        raw_path.to_path_buf()
+    } else {
+        workspace.join(raw_path)
+    };
+    // Lexical containment first: `..` escapes and absolute out-of-tree paths
+    // fail here without touching the filesystem.
+    let lexical = normalize_path(&candidate);
+    let workspace_lexical = normalize_path(workspace);
+    let workspace_canonical_lexical = normalize_path(workspace_canonical);
+    let Ok(relative) = lexical
+        .strip_prefix(&workspace_lexical)
+        .or_else(|_| lexical.strip_prefix(&workspace_canonical_lexical))
+    else {
+        return false;
+    };
+    if !carve_out_relative_path_allowed(relative) {
+        return false;
+    }
+    // Then symlink reality: resolve the deepest existing ancestor and
+    // require the real path to stay inside the real workspace and off the
+    // same exclusions (a symlink hop into `.git` or out of the tree fails).
+    let Some(resolved) = resolve_deepest_existing(&candidate) else {
+        return false;
+    };
+    let Ok(resolved_relative) = resolved.strip_prefix(workspace_canonical) else {
+        return false;
+    };
+    carve_out_relative_path_allowed(resolved_relative)
+}
+
+/// Canonicalize the deepest existing ancestor of `candidate` and re-append
+/// the not-yet-existing tail, so write targets that do not exist yet still
+/// get a real-path check.
+fn resolve_deepest_existing(candidate: &Path) -> Option<PathBuf> {
+    let mut ancestor = candidate;
+    let mut suffix: Vec<&OsStr> = Vec::new();
+    loop {
+        if let Ok(canonical) = ancestor.canonicalize() {
+            let mut resolved = canonical;
+            for part in suffix.iter().rev() {
+                resolved.push(part);
+            }
+            return Some(resolved);
+        }
+        suffix.push(ancestor.file_name()?);
+        ancestor = ancestor.parent()?;
+    }
+}
+
+fn carve_out_relative_path_allowed(relative: &Path) -> bool {
+    relative.components().all(|component| {
+        let Component::Normal(part) = component else {
+            return true;
+        };
+        !is_carve_out_excluded_name(&part.to_string_lossy().to_ascii_lowercase())
+    })
+}
+
+/// Names the carve-out never auto-allows, matched per path component:
+/// `.git` internals, runtime/project state, credential-bearing directories
+/// and files, and key material.
+fn is_carve_out_excluded_name(name: &str) -> bool {
+    if name == ".git" {
+        return true;
+    }
+    // Runtime/project state and credential-bearing directories. `.codewhale`
+    // holds session state plus MCP/hook configuration — editing it changes
+    // what runs, so it keeps the modal.
+    if matches!(
+        name,
+        ".codewhale" | ".ssh" | ".aws" | ".gnupg" | ".kube" | ".docker"
+    ) {
+        return true;
+    }
+    // Environment files and well-known credential stores.
+    if name.starts_with(".env")
+        || name == ".netrc"
+        || name == ".npmrc"
+        || name == ".pypirc"
+        || name == ".git-credentials"
+        || name == "credentials"
+        || name.starts_with("credentials.")
+    {
+        return true;
+    }
+    // SSH private (and public) key material.
+    if name.starts_with("id_rsa")
+        || name.starts_with("id_dsa")
+        || name.starts_with("id_ecdsa")
+        || name.starts_with("id_ed25519")
+    {
+        return true;
+    }
+    // Key/certificate containers by extension.
+    matches!(
+        Path::new(name).extension().and_then(|ext| ext.to_str()),
+        Some("pem" | "key" | "p12" | "pfx" | "jks" | "keystore")
+    )
+}
+
 /// Disposition for an approval request that reached the UI (#4412).
 ///
 /// The engine emits `ApprovalRequired` whenever its resolver answer was
@@ -509,6 +662,137 @@ mod tests {
 
     fn authority(mode: AppMode, auto_approve: bool, approval_mode: ApprovalMode) -> TurnAuthority {
         TurnAuthority::from_effective_fields(mode, true, false, auto_approve, approval_mode)
+    }
+
+    #[test]
+    fn write_carve_out_posture_is_exactly_the_default_ask_posture() {
+        assert!(write_carve_out_posture(
+            AppMode::Agent,
+            ApprovalMode::Suggest,
+            false
+        ));
+        assert!(write_carve_out_posture(
+            AppMode::Operate,
+            ApprovalMode::Suggest,
+            false
+        ));
+        // Full Access already runs these calls; the carve-out must not be
+        // what allows them.
+        assert!(!write_carve_out_posture(
+            AppMode::Agent,
+            ApprovalMode::Bypass,
+            true
+        ));
+        assert!(!write_carve_out_posture(
+            AppMode::Yolo,
+            ApprovalMode::Bypass,
+            true
+        ));
+        // Never still denies; Auto-Review still fails unresolved holds closed;
+        // Plan is read-only by mode.
+        assert!(!write_carve_out_posture(
+            AppMode::Agent,
+            ApprovalMode::Never,
+            false
+        ));
+        assert!(!write_carve_out_posture(
+            AppMode::Agent,
+            ApprovalMode::Auto,
+            false
+        ));
+        assert!(!write_carve_out_posture(
+            AppMode::Plan,
+            ApprovalMode::Suggest,
+            false
+        ));
+    }
+
+    fn carve_out_workspace() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(tmp.path().join(".git")).expect("git marker");
+        std::fs::create_dir_all(tmp.path().join("src")).expect("src dir");
+        std::fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").expect("source file");
+        tmp
+    }
+
+    #[test]
+    fn carve_out_allows_in_workspace_write_targets() {
+        let tmp = carve_out_workspace();
+        let workspace = tmp.path();
+        for paths in [
+            vec!["src/main.rs".to_string()],
+            vec!["src/new_file.rs".to_string()],
+            vec!["deeply/nested/not-yet-created.rs".to_string()],
+            vec!["./src/main.rs".to_string()],
+            vec![workspace.join("src/main.rs").to_string_lossy().into_owned()],
+            vec!["src/main.rs".to_string(), "src/other.rs".to_string()],
+        ] {
+            assert!(
+                paths_within_workspace_write_carve_out(workspace, &paths),
+                "{paths:?} should qualify"
+            );
+        }
+    }
+
+    #[test]
+    fn carve_out_rejects_out_of_tree_sensitive_and_git_paths() {
+        let tmp = carve_out_workspace();
+        let workspace = tmp.path();
+        for paths in [
+            vec!["../outside.rs".to_string()],
+            vec!["src/../../outside.rs".to_string()],
+            vec!["/etc/passwd".to_string()],
+            vec![".git/config".to_string()],
+            vec!["nested/.git/hooks/pre-commit".to_string()],
+            vec![".env".to_string()],
+            vec!["config/.env.production".to_string()],
+            vec![".ssh/config".to_string()],
+            vec!["deploy/id_rsa".to_string()],
+            vec!["certs/server.pem".to_string()],
+            vec![".codewhale/mcp.json".to_string()],
+            vec!["aws/credentials".to_string()],
+            // One bad target poisons the whole call.
+            vec!["src/main.rs".to_string(), ".env".to_string()],
+        ] {
+            assert!(
+                !paths_within_workspace_write_carve_out(workspace, &paths),
+                "{paths:?} must keep the modal"
+            );
+        }
+    }
+
+    #[test]
+    fn carve_out_requires_a_git_work_tree() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!paths_within_workspace_write_carve_out(
+            tmp.path(),
+            &["src/main.rs".to_string()]
+        ));
+    }
+
+    #[test]
+    fn carve_out_rejects_empty_target_list() {
+        let tmp = carve_out_workspace();
+        assert!(!paths_within_workspace_write_carve_out(tmp.path(), &[]));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn carve_out_rejects_symlink_escapes() {
+        let tmp = carve_out_workspace();
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        std::os::unix::fs::symlink(outside.path(), tmp.path().join("link")).expect("symlink");
+        assert!(!paths_within_workspace_write_carve_out(
+            tmp.path(),
+            &["link/evil.rs".to_string()]
+        ));
+        // A symlink that stays inside the workspace is fine.
+        std::os::unix::fs::symlink(tmp.path().join("src"), tmp.path().join("src-link"))
+            .expect("inner symlink");
+        assert!(paths_within_workspace_write_carve_out(
+            tmp.path(),
+            &["src-link/main.rs".to_string()]
+        ));
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -5562,6 +5562,17 @@ fn file_tool_permission_paths(tool_name: &str, input: &Value) -> Option<Vec<Stri
     }
 }
 
+/// Target paths when a call is one of the canonical workspace file-write
+/// tools (`write_file` / `edit_file` / `apply_patch`), `None` for any other
+/// tool. Feeds the in-workspace write carve-out (#5185).
+fn file_write_tool_target_paths(tool_name: &str, input: &Value) -> Option<Vec<String>> {
+    let canonical = crate::tools::canonical_action::canonical_action_alias(tool_name, input);
+    if !matches!(canonical, "write_file" | "edit_file" | "apply_patch") {
+        return None;
+    }
+    file_tool_permission_paths(canonical, input)
+}
+
 fn string_field(input: &Value, key: &str) -> Option<String> {
     input
         .get(key)

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -5,6 +5,7 @@ use super::streaming::{TOOL_CALL_END_MARKERS, TOOL_CALL_MARKER_PAIRS};
 use super::turn_loop::{
     registered_tool_approval_required, registered_tool_blocked_in_full_access,
     registered_tool_forces_prompt, tool_error_degradation_runtime_hint,
+    workspace_write_carve_out_applies,
 };
 use crate::config::ApiProvider;
 use crate::models::{SystemBlock, Usage};
@@ -4723,6 +4724,105 @@ fn generic_required_tools_keep_auto_approve_behavior() {
         "exec_shell",
         ApprovalRequirement::Required,
         false
+    ));
+}
+
+#[test]
+fn workspace_write_carve_out_covers_the_default_ask_posture_only() {
+    // #5185: an in-workspace edit under the default posture does not prompt;
+    // out-of-tree, sensitive, and `.git` targets keep the modal; shell and
+    // non-write tools never qualify.
+    let tmp = tempdir().expect("tempdir");
+    std::fs::create_dir(tmp.path().join(".git")).expect("git marker");
+    let workspace = tmp.path();
+    let ask = (
+        crate::tui::app::AppMode::Agent,
+        crate::tui::approval::ApprovalMode::Suggest,
+        false,
+    );
+    let carve_out = |tool: &str, input: &serde_json::Value| {
+        workspace_write_carve_out_applies(
+            ask.0,
+            ask.1,
+            ask.2,
+            workspace,
+            tool,
+            input,
+            ApprovalRequirement::Suggest,
+        )
+    };
+
+    // In-workspace edits and patches qualify, in legacy and canonical form.
+    assert!(carve_out("write_file", &json!({"path": "src/main.rs"})));
+    assert!(carve_out("edit_file", &json!({"path": "src/main.rs"})));
+    assert!(carve_out(
+        "File",
+        &json!({"action": "edit", "path": "src/main.rs"})
+    ));
+    assert!(carve_out(
+        "apply_patch",
+        &json!({"replace": [{"path": "src/main.rs", "content": "fn main() {}"}]})
+    ));
+
+    // Out-of-tree, sensitive, and `.git` targets keep the modal.
+    assert!(!carve_out("write_file", &json!({"path": "../outside.rs"})));
+    assert!(!carve_out("write_file", &json!({"path": "/etc/hostname"})));
+    assert!(!carve_out("write_file", &json!({"path": ".env"})));
+    assert!(!carve_out("write_file", &json!({"path": ".git/config"})));
+
+    // Shell, destructive commands, and read tools never qualify here.
+    assert!(!carve_out("exec_shell", &json!({"command": "rm -rf /"})));
+    assert!(!carve_out(
+        "File",
+        &json!({"action": "read", "path": "src/main.rs"})
+    ));
+
+    // Full Access, Auto-Review, Never, and Plan are untouched by the carve-out.
+    for (mode, approval_mode, auto_approve) in [
+        (
+            crate::tui::app::AppMode::Agent,
+            crate::tui::approval::ApprovalMode::Bypass,
+            true,
+        ),
+        (
+            crate::tui::app::AppMode::Agent,
+            crate::tui::approval::ApprovalMode::Auto,
+            false,
+        ),
+        (
+            crate::tui::app::AppMode::Agent,
+            crate::tui::approval::ApprovalMode::Never,
+            false,
+        ),
+        (
+            crate::tui::app::AppMode::Plan,
+            crate::tui::approval::ApprovalMode::Suggest,
+            false,
+        ),
+    ] {
+        assert!(
+            !workspace_write_carve_out_applies(
+                mode,
+                approval_mode,
+                auto_approve,
+                workspace,
+                "write_file",
+                &json!({"path": "src/main.rs"}),
+                ApprovalRequirement::Suggest,
+            ),
+            "{mode:?}/{approval_mode:?} must not take the carve-out"
+        );
+    }
+
+    // Only `Suggest`-tier calls qualify; `Required` keeps its gate.
+    assert!(!workspace_write_carve_out_applies(
+        ask.0,
+        ask.1,
+        ask.2,
+        workspace,
+        "write_file",
+        &json!({"path": "src/main.rs"}),
+        ApprovalRequirement::Required,
     ));
 }
 

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -69,6 +69,32 @@ pub(super) fn registered_tool_blocked_in_full_access(
     auto_approve && registered_tool_forces_prompt(tool_name, requirement)
 }
 
+/// The engine-side half of the in-workspace write carve-out (#5185): true
+/// when a `Suggest`-tier call is a canonical file-write tool whose targets
+/// all qualify under the default Ask posture. Callers still honor
+/// `approval_force_prompt`, typed ask-rules, the built-in safety floor, and
+/// repo law after this answer.
+#[must_use]
+pub(super) fn workspace_write_carve_out_applies(
+    mode: AppMode,
+    approval_mode: crate::tui::approval::ApprovalMode,
+    auto_approve: bool,
+    workspace: &std::path::Path,
+    tool_name: &str,
+    input: &serde_json::Value,
+    approval: ApprovalRequirement,
+) -> bool {
+    if approval != ApprovalRequirement::Suggest
+        || !crate::core::authority::write_carve_out_posture(mode, approval_mode, auto_approve)
+    {
+        return false;
+    }
+    let Some(paths) = file_write_tool_target_paths(tool_name, input) else {
+        return false;
+    };
+    crate::core::authority::paths_within_workspace_write_carve_out(workspace, &paths)
+}
+
 pub(super) fn registered_tool_forces_prompt(
     tool_name: &str,
     requirement: ApprovalRequirement,
@@ -2103,6 +2129,32 @@ impl Engine {
                     detached_start = prepared.call.starts_detached;
                     tool_input = prepared.call.input;
                     resources = prepared.call.resources;
+
+                    // #5185: in the default Ask posture, a file write whose
+                    // every target stays inside the workspace git work tree —
+                    // off `.git` internals, runtime state, and sensitive files
+                    // — runs without a modal. Everything evaluated after this
+                    // point (typed ask-rules, the built-in safety floor, repo
+                    // law) can still force a prompt; none of them is weakened.
+                    if approval_required
+                        && !approval_force_prompt
+                        && workspace_write_carve_out_applies(
+                            mode,
+                            self.session.approval_mode,
+                            self.session.auto_approve,
+                            &self.session.workspace,
+                            &tool_name,
+                            &tool_input,
+                            prepared.call.approval,
+                        )
+                    {
+                        approval_required = false;
+                        emit_tool_audit(json!({
+                            "event": "tool.workspace_write_carve_out",
+                            "tool_id": tool_id.clone(),
+                            "tool_name": tool_name.clone(),
+                        }));
+                    }
 
                     let approval = match prepared.call.approval {
                         ApprovalRequirement::Auto => "auto",

--- a/crates/tui/src/prompts/text.rs
+++ b/crates/tui/src/prompts/text.rs
@@ -332,7 +332,7 @@ Execute rather than narrate. Verification still applies — check your work even
 /// Tool calls require confirmation.
 pub const SUGGEST_APPROVAL: &str = r#"##### Approval Policy: Suggest
 
-Read-only operations run silently. Write operations (file edits, patches, shell execution, sub-agent spawns, CSV batches) require user approval before executing.
+Read-only operations run silently. File edits and patches whose targets all stay inside this workspace also run without approval, because version control keeps them reviewable — but only when they steer clear of `.git` internals, runtime state (`.codewhale`), and sensitive files (`.env`, credentials, key material). Every other write requires user approval before executing: paths outside the workspace, those excluded paths, shell execution, sub-agent spawns, CSV batches.
 
 When you need approval:
 1. For multi-step changes, use `work_update` when it is present; otherwise state the approach briefly.

--- a/crates/tui/src/prompts/text.rs
+++ b/crates/tui/src/prompts/text.rs
@@ -332,7 +332,7 @@ Execute rather than narrate. Verification still applies — check your work even
 /// Tool calls require confirmation.
 pub const SUGGEST_APPROVAL: &str = r#"##### Approval Policy: Suggest
 
-Read-only operations run silently. File edits and patches whose targets all stay inside this workspace also run without approval, because version control keeps them reviewable — but only when they steer clear of `.git` internals, runtime state (`.codewhale`), and sensitive files (`.env`, credentials, key material). Every other write requires user approval before executing: paths outside the workspace, those excluded paths, shell execution, sub-agent spawns, CSV batches.
+Read-only operations run silently. File edits and patches whose targets all stay inside this workspace also run without approval, because version control keeps them reviewable — but only when they steer clear of `.git` internals, runtime state (`.codewhale`), and sensitive files (`.env`, credentials, key material). Spawning a read-only sub-agent role (scout, planner, reviewer, verifier, consultant) runs without approval too; the child's own gates keep it read-only. Every other write requires user approval before executing: paths outside the workspace, those excluded paths, shell execution, write-capable sub-agent spawns, CSV batches.
 
 When you need approval:
 1. For multi-step changes, use `work_update` when it is present; otherwise state the approach briefly.

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -1111,7 +1111,7 @@ pub async fn lsp_diagnostics_for_paths(context: &ToolContext, paths: &[PathBuf])
     render_blocks(&blocks)
 }
 
-fn normalize_path(path: &Path) -> PathBuf {
+pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     let mut prefix: Option<std::ffi::OsString> = None;
     let mut is_root = false;
     let mut stack: Vec<std::ffi::OsString> = Vec::new();

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -6534,6 +6534,46 @@ fn parse_agent_ref(input: &Value) -> Option<String> {
         .map(str::to_string)
 }
 
+/// #5186: whether an `agent action=start` call asks for exactly a canonical
+/// read-only Fleet role and nothing that could widen it. Those spawns run
+/// without an approval modal in the default posture because the child's own
+/// posture gates (`role_posture_permits`, `SubAgentToolRegistry`) enforce
+/// read-only behavior from the inside.
+///
+/// Anything this parser cannot prove read-only stays gated: no role token
+/// (defaults to `worker`), an unparseable or roster role, a `profile`
+/// reference, a conflicting type/role pair, or an explicit write authority.
+fn start_requests_read_only_role(input: &Value) -> bool {
+    if optional_input_str(input, &["profile", "fleet_profile", "roster_profile"]).is_some() {
+        return false;
+    }
+    let type_input = optional_input_str(input, &["type", "agent_type", "agent_name"]);
+    let role_input = optional_input_str(input, &["role", "agent_role"]);
+    let parsed_type = type_input.and_then(FleetRole::from_str);
+    let parsed_role = role_input.and_then(FleetRole::from_str);
+    let role = match (parsed_type, parsed_role) {
+        (Some(from_type), Some(from_role)) if from_type == from_role => from_type,
+        // A second token that does not parse as a canonical role may be a
+        // roster id resolved later — fail closed like `profile`.
+        (Some(from_type), None) if role_input.is_none() => from_type,
+        (None, Some(from_role)) if type_input.is_none() => from_role,
+        _ => return false,
+    };
+    if optional_input_str(input, &["write_authority", "writeAuthority"])
+        .is_some_and(|authority| !authority.trim().eq_ignore_ascii_case("read_only"))
+    {
+        return false;
+    }
+    matches!(
+        role,
+        FleetRole::Scout
+            | FleetRole::Planner
+            | FleetRole::Reviewer
+            | FleetRole::Verifier
+            | FleetRole::Consultant
+    )
+}
+
 #[async_trait]
 impl ToolSpec for AgentTool {
     fn name(&self) -> &'static str {
@@ -6718,9 +6758,15 @@ impl ToolSpec for AgentTool {
 
     /// #3801: status and peek are read-only queries — no approval needed.
     /// #4097: wait passively observes children — also read-only.
+    /// #5186: starting an explicitly read-only role no longer modals in the
+    /// default posture; the child's own posture gates keep it read-only from
+    /// the inside. Write-capable spawns keep their gate.
     fn approval_requirement_for(&self, input: &Value) -> ApprovalRequirement {
         match parse_agent_tool_action(input) {
             Ok(AgentToolAction::Status | AgentToolAction::Peek | AgentToolAction::Wait) => {
+                ApprovalRequirement::Auto
+            }
+            Ok(AgentToolAction::Start) if start_requests_read_only_role(input) => {
                 ApprovalRequirement::Auto
             }
             _ => ApprovalRequirement::Required,
@@ -11580,10 +11626,11 @@ fn routine_agent_progress_can_preserve_event_headroom(status: AgentWorkerStatus)
 /// - **Full inheritance** (`allowed_tools = None`): the child sees the same
 ///   tool surface as the parent's Agent mode, except legacy sub-agent lifecycle
 ///   tools are removed. The single `agent` launcher remains visible only while
-///   the configured depth budget allows another child. Approval-gated tools are
-///   callable only when the parent runtime is auto-approved or, for explicit
-///   write-capable roles (`implementer`, `custom`), when the tool's approval
-///   requirement is `Suggest`.
+///   the configured depth budget allows another child. Approval-gated tools
+///   are callable when the parent runtime is auto-approved; otherwise a
+///   `Suggest`-level call needs a write-capable role (`implementer`, `custom`)
+///   or the in-workspace write carve-out (#5186), and a `Required`-level call
+///   must be the bounded built-in verification surface.
 /// - **Explicit narrow** (`allowed_tools = Some(list)`): legacy / Custom
 ///   path. The registry still builds the full surface, but only the listed
 ///   tool names are visible to the model and callable.
@@ -11679,8 +11726,11 @@ struct SubAgentToolRegistry {
     auto_approve: bool,
     /// Workflow-spawned children auto-accept Suggest-level file edits.
     accept_edits: bool,
-    /// Root Operate workers may run only the built-in verifier surfaces after
-    /// their parent-approved `agent` start. This never delegates raw shell or
+    /// Root Operate verification lease: provenance for the work graph
+    /// (`SubAgentWorkLifecycle::register`). Since #5186 the bounded built-in
+    /// verification surface is delegated to every shell-capable child rather
+    /// than keyed off this bit; the bit now only records *why* an Operate
+    /// child was allowed to run it. It never delegates raw shell or
     /// user-supplied verifier commands.
     accept_verification: bool,
     /// The role/type of the sub-agent that this registry belongs to. Used to
@@ -11807,6 +11857,24 @@ impl SubAgentToolRegistry {
     /// regardless of role (#1828, #1833).
     fn role_can_delegate_writes(agent_type: &FleetRole) -> bool {
         matches!(agent_type, FleetRole::Builder | FleetRole::Custom)
+    }
+
+    /// #5186: the child-side half of the in-workspace write carve-out
+    /// (#5185). A child whose posture permits writes at all
+    /// (`permissions.write`) may run a `Suggest`-tier write call without
+    /// parent auto-approve when every target path qualifies under the same
+    /// rule the parent session uses: inside the workspace git work tree,
+    /// off `.git` internals, runtime state, and sensitive files. Read-only
+    /// roles never reach this (their posture already bounced the call), and
+    /// out-of-tree or sensitive targets keep the delegation error.
+    fn workspace_write_carve_out_permits(&self, name: &str, input: &Value) -> bool {
+        if !self.runtime_profile.permissions.write {
+            return false;
+        }
+        crate::core::authority::paths_within_workspace_write_carve_out(
+            &self.registry.context().workspace,
+            &raw_mutation_target_paths(name, input),
+        )
     }
 
     /// Whether a `Required`-level call is the delegated built-in verification
@@ -12149,9 +12217,13 @@ impl SubAgentToolRegistry {
                     // without parent auto-approve (#1828, #1833). Workflow-spawned
                     // children also accept Suggest edits for any write-capable
                     // posture (including general). Read-only roles still bounce.
+                    // #5186: children also inherit the session's in-workspace
+                    // write carve-out (#5185) — a write-capable-posture child
+                    // may edit in-workspace, non-sensitive, non-`.git` paths
+                    // without the parent being auto-approved.
                     let may_write = self.runtime_profile.permissions.write
                         && (self.accept_edits || Self::role_can_delegate_writes(&self.agent_type));
-                    if !may_write {
+                    if !may_write && !self.workspace_write_carve_out_permits(name, &input) {
                         return Err(anyhow!(
                             "Tool {name} requires approval and is not delegated to {role} sub-agents; rerun the parent with auto approval or pick a write-capable role",
                             role = self.agent_type.as_str()
@@ -12159,9 +12231,14 @@ impl SubAgentToolRegistry {
                     }
                 }
                 ApprovalRequirement::Required => {
-                    if !(self.accept_verification
-                        && Self::is_delegated_builtin_verification(name, &input))
-                    {
+                    // #5186: the bounded built-in verification surface (the
+                    // fixed workspace-root command or a pure test selection,
+                    // per the one classifier the execution envelope also
+                    // reads) is delegated to any child whose posture reached
+                    // this branch — shell-capable by construction — instead
+                    // of keying everything off parent auto-approve. Arbitrary
+                    // shell and every other Required tool stay gated.
+                    if !Self::is_delegated_builtin_verification(name, &input) {
                         return Err(anyhow!(
                             "Tool {name} requires approval and cannot run inside this sub-agent unless the parent session is auto-approved"
                         ));
@@ -12415,6 +12492,30 @@ fn is_internal_coordination_state_tool(name: &str) -> bool {
             | "todo_update"
             | "todo_write"
     )
+}
+
+/// Raw target paths of a write-capable call, before claim normalization:
+/// the patch preflight's touched files for `apply_patch`/`File.patch`, else
+/// the `path`/`output_path` field. Feeds the child write carve-out (#5186);
+/// claim enforcement keeps using the normalized [`mutation_paths`].
+fn raw_mutation_target_paths(name: &str, input: &Value) -> Vec<String> {
+    if name == "apply_patch"
+        || (name == "File" && input.get("action").and_then(Value::as_str) == Some("patch"))
+    {
+        let mut patch_input = input.clone();
+        if let Some(object) = patch_input.as_object_mut() {
+            object.remove("action");
+        }
+        return crate::tools::apply_patch::preflight_apply_patch(&patch_input)
+            .map(|preflight| preflight.touched_files)
+            .unwrap_or_default();
+    }
+    input
+        .get("path")
+        .or_else(|| input.get("output_path"))
+        .and_then(Value::as_str)
+        .map(|path| vec![path.to_string()])
+        .unwrap_or_default()
 }
 
 fn mutation_paths(name: &str, input: &Value) -> Result<Vec<String>> {

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -8886,6 +8886,223 @@ async fn delegated_write_role_still_blocks_required_tools() {
     );
 }
 
+#[test]
+fn read_only_role_starts_do_not_require_approval() {
+    // #5186: an explicit canonical read-only role spawns without a modal in
+    // the default posture; the child's posture gates keep it read-only.
+    let tmp = tempdir().expect("tempdir");
+    let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 1);
+    let tool = AgentTool::new(manager, stub_runtime());
+
+    for role in [
+        "scout",
+        "explore",
+        "planner",
+        "plan",
+        "reviewer",
+        "review",
+        "verifier",
+        "verify",
+        "consultant",
+    ] {
+        assert_eq!(
+            tool.approval_requirement_for(
+                &json!({"action": "start", "type": role, "prompt": "look around"})
+            ),
+            ApprovalRequirement::Auto,
+            "{role} start should not open an approval modal"
+        );
+    }
+    // The `role` field form and an explicit read_only write authority keep
+    // the demotion.
+    assert_eq!(
+        tool.approval_requirement_for(&json!({"action": "start", "role": "scout", "prompt": "x"})),
+        ApprovalRequirement::Auto
+    );
+    assert_eq!(
+        tool.approval_requirement_for(
+            &json!({"action": "start", "type": "scout", "write_authority": "read_only", "prompt": "x"})
+        ),
+        ApprovalRequirement::Auto
+    );
+}
+
+#[test]
+fn write_capable_or_unproven_starts_keep_the_approval_gate() {
+    // #5186: anything the parser cannot prove read-only keeps the modal.
+    let tmp = tempdir().expect("tempdir");
+    let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 1);
+    let tool = AgentTool::new(manager, stub_runtime());
+
+    for input in [
+        json!({"action": "start", "prompt": "x"}), // defaults to worker
+        json!({"action": "start", "type": "worker", "prompt": "x"}),
+        json!({"action": "start", "type": "builder", "prompt": "x"}),
+        json!({"action": "start", "type": "implementer", "prompt": "x"}),
+        json!({"action": "start", "type": "custom", "prompt": "x"}),
+        json!({"action": "start", "type": "scout", "write_authority": "workspace_write", "prompt": "x"}),
+        json!({"action": "start", "type": "scout", "profile": "release_lead", "prompt": "x"}),
+        json!({"action": "start", "type": "scout", "role": "builder", "prompt": "x"}),
+        json!({"action": "start", "role": "release_lead", "prompt": "x"}), // roster token
+        json!({"action": "start", "type": "bogus", "prompt": "x"}),
+    ] {
+        assert_eq!(
+            tool.approval_requirement_for(&input),
+            ApprovalRequirement::Required,
+            "{input} must keep the approval gate"
+        );
+    }
+    // Non-start actions are untouched: cancel stays gated, status stays free.
+    assert_eq!(
+        tool.approval_requirement_for(&json!({"action": "cancel", "agent_id": "a"})),
+        ApprovalRequirement::Required
+    );
+    assert_eq!(
+        tool.approval_requirement_for(&json!({"action": "status"})),
+        ApprovalRequirement::Auto
+    );
+}
+
+#[tokio::test]
+async fn worker_child_inherits_workspace_write_carve_out_without_parent_auto_approve() {
+    // #5186: a write-posture child that is NOT an explicit write-delegated
+    // role (worker is not in `role_can_delegate_writes`) may still edit
+    // in-workspace, non-sensitive, non-`.git` paths — the child inherits the
+    // #5185 carve-out instead of keying off parent auto-approve.
+    let tmp = tempdir().expect("tempdir");
+    std::fs::create_dir(tmp.path().join(".git")).expect("git marker");
+    let workspace = tmp.path().to_path_buf();
+    let mut runtime = stub_runtime();
+    runtime.context = ToolContext::new(workspace.clone());
+    runtime.context.auto_approve = false;
+    let registry = SubAgentToolRegistry::new(
+        runtime,
+        FleetRole::Worker,
+        None,
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    );
+
+    registry
+        .execute(
+            "agent_test",
+            "File",
+            json!({"action": "write", "path": "carveout.txt", "content": "hi"}),
+        )
+        .await
+        .expect("in-workspace write should take the carve-out");
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("carveout.txt")).expect("written file"),
+        "hi"
+    );
+
+    // Sensitive files, `.git` internals, and out-of-tree paths keep the
+    // delegation error.
+    for input in [
+        json!({"action": "write", "path": ".env", "content": "x"}),
+        json!({"action": "write", "path": ".git/config", "content": "x"}),
+        json!({"action": "write", "path": "../escape.txt", "content": "x"}),
+    ] {
+        let err = registry
+            .execute("agent_test", "File", input.clone())
+            .await
+            .expect_err("excluded targets must stay gated");
+        assert!(
+            err.to_string().contains("is not delegated to"),
+            "{input}: unexpected error {err}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn worker_child_write_carve_out_requires_a_git_work_tree() {
+    // #5186: without a `.git` marker the child keeps the old delegation
+    // error, mirroring the parent-side carve-out.
+    let tmp = tempdir().expect("tempdir");
+    let mut runtime = stub_runtime();
+    runtime.context = ToolContext::new(tmp.path().to_path_buf());
+    runtime.context.auto_approve = false;
+    let registry = SubAgentToolRegistry::new(
+        runtime,
+        FleetRole::Worker,
+        None,
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    );
+
+    let err = registry
+        .execute(
+            "agent_test",
+            "File",
+            json!({"action": "write", "path": "nope.txt", "content": "x"}),
+        )
+        .await
+        .expect_err("non-git workspace keeps the delegation gate");
+    assert!(
+        err.to_string().contains("is not delegated to"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn builder_child_runs_bounded_verification_but_not_shell_without_parent_auto_approve() {
+    // #5186: the bounded built-in verification surface is delegated to
+    // shell-capable children of non-auto parents; arbitrary shell and
+    // unbounded verification argv stay gated.
+    let tmp = tempdir().expect("tempdir");
+    let mut runtime = stub_runtime();
+    runtime.context = ToolContext::new(tmp.path().to_path_buf());
+    runtime.context.auto_approve = false;
+    let registry = SubAgentToolRegistry::new(
+        runtime,
+        FleetRole::Builder,
+        None,
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    );
+
+    // No Cargo.toml here, so execution itself may fail — what must NOT
+    // appear is the approval-gate error.
+    match registry
+        .execute("agent_test", "Run", json!({"action": "tests"}))
+        .await
+    {
+        Ok(_) => {}
+        Err(err) => assert!(
+            !err.to_string().contains("requires approval"),
+            "bounded verification must pass the approval gate: {err}"
+        ),
+    }
+
+    let shell_err = registry
+        .execute(
+            "agent_test",
+            "Bash",
+            json!({"action": "run", "command": "echo nope"}),
+        )
+        .await
+        .expect_err("arbitrary shell stays gated for children of non-auto parents");
+    assert!(
+        shell_err.to_string().contains(
+            "cannot run inside this sub-agent unless the parent session is auto-approved"
+        ),
+        "unexpected error: {shell_err}"
+    );
+
+    let argv_err = registry
+        .execute(
+            "agent_test",
+            "Run",
+            json!({"action": "tests", "args": "--manifest-path ../outside/Cargo.toml"}),
+        )
+        .await
+        .expect_err("unbounded verification argv stays gated");
+    assert!(
+        argv_err.to_string().contains("requires approval"),
+        "unexpected error: {argv_err}"
+    );
+}
+
 #[tokio::test]
 async fn auto_approved_parent_runs_required_tools_in_subagent() {
     // Baseline: when the parent runtime IS auto-approved, every approval


### PR DESCRIPTION
Stack **R6** — the two release-blocking k3-gap fixes (#5185, #5186). **This redefines what the default approval posture means — read "Behavior changes" before merging.** Evidence: the k3-vs-kimi-code harness audit (findings F1/F2).

## What changes for users

**F1 (#5185) — in-workspace write carve-out.** Under the default Ask session, a file write/edit/patch runs WITHOUT a modal when every target path resolves inside the workspace git work tree. The carve-out refuses: workspaces without a `.git` marker (recoverability is the rationale), out-of-tree paths incl. `..` escapes and symlink hops (canonicalized + re-checked), `.git` internals, `.codewhale` runtime state (hooks/MCP config = code execution), and sensitive files (`.env*`, rc files, `credentials*`, `.ssh` / `.aws` / `.gnupg` / `.kube` / `.docker`, key-material names and extensions). Typed ask-rules, ToolCallBefore hooks, the safety floor, and repo law evaluate AFTER the carve-out and can still force a prompt — user-configured policy overrides it. Scope: only Suggest-tier file writes — `Never` still denies, Auto-Review still fails holds closed, Plan stays read-only, Full Access unchanged.

**F2 (#5186) — ungated read-only spawns + children inherit capability.** Starting an explicitly read-only role (scout, planner, reviewer, verifier, consultant, legacy `explore`) no longer modals; anything the parser can't prove read-only keeps the Required gate. Children of non-auto parents inherit the F1 carve-out (write-posture children incl. `worker` may edit in-workspace) and may run the bounded built-in verification surface at any depth (fixed-root `cargo test` / pure test selection via `classify_verification`). Arbitrary shell and unbounded verification argv stay gated.

## Behavior changes to consciously approve (from the implementer's report)

1. Routine in-workspace edits no longer interrupt in the default posture (the `.codewhale` exclusion goes slightly beyond the issue's literal list — hooks/MCP config is code execution).
2. `worker`-role children of Ask parents can now edit in-workspace files (previously builder/custom/workflow only).
3. Bounded verification is delegated at any spawn depth (the old root-Operate-only lease is now work-graph provenance only, not a gate).
4. Verifier starts are ungated although verifier holds `ShellPolicy::Full` — safe because the Required branch still blocks everything except bounded verification, but worth a conscious nod.

The shipped approval-guidance prose is updated to match the new policy exactly (capability honesty); tool schemas and the first-turn tool-catalog head are byte-stable.

## Gates

- `cargo fmt --all -- --check` exit=0; `cargo check --workspace --all-targets --locked` exit=0.
- Targeted: authority 67 ✓ · approval 236 ✓ · carve_out 7 ✓ · subagent 528 ✓.
- Full bin suite post-rebase: **9625 pass / 3 fail** = 2 `config::credential_scope_tests::*` (live regression — stack R7 re-lands the deleted fix, #5193) + `cache_is_scoped_by_session_and_accept_header` (parallel-load flake — passes solo on both this branch and the train; same family as `tui_and_api_listings_agree`).

No-Issue: v0.9.4 program stack PR. Closes #5185, Closes #5186. Refs #5191 (user-typed `!` commands — follow-up in the same posture family).