### PR TITLE
stack R7: credential scope truth — re-land merge-deleted user-global writes, durable logout, shadow warnings

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1981,12 +1981,14 @@ fn run_login_command_with_secrets(
     secrets: &Secrets,
 ) -> Result<()> {
     let provider: ProviderKind = args.provider.unwrap_or(ProviderArg::Deepseek).into();
-    store.config.provider = provider;
-
     let api_key = match args.api_key {
         Some(v) => v,
         None => read_api_key_from_stdin()?,
     };
+    let mut credential_store = credential_metadata_store(store)?;
+    let store = credential_store.as_mut().unwrap_or(store);
+    store.config.provider = provider;
+
     let secret_store_saved = persist_provider_api_key(store, secrets, provider, &api_key)?;
     let destination = if secret_store_saved {
         secrets.backend_name().to_string()
@@ -2056,6 +2058,33 @@ fn provider_slot(provider: ProviderKind) -> &'static str {
         ProviderKind::SiliconflowCN => "siliconflow",
         _ => provider.provider().id(),
     }
+}
+
+/// Resolve the store for credential-adjacent writes: provider selection,
+/// `auth_mode` markers, and the plaintext-free metadata that accompanies a
+/// saved key.
+///
+/// Credentials and their metadata are user-global — a key saved while
+/// working in one repo must be visible from every other repo, and the secret
+/// store already is (#5045). When the ambient config path is a
+/// workspace-scoped document (`<repo>/.codewhale/config.toml`), login and
+/// `auth set` must not bind the provider or write auth markers there: the
+/// binding would be invisible from every other repo and would invite
+/// plaintext keys into a committable repo file (#5198). Returns a store
+/// loaded on the user-global document in that case, or `None` when the
+/// ambient store is already correctly scoped, so key + provider binding +
+/// auth markers share one user-global scope by default.
+fn credential_metadata_store(store: &ConfigStore) -> Result<Option<ConfigStore>> {
+    if !codewhale_config::config_path_is_workspace_scoped(store.path()) {
+        return Ok(None);
+    }
+    let global = codewhale_config::default_config_path()?;
+    eprintln!(
+        "ambient config {} is workspace-scoped; writing credential metadata to the user-global {} instead",
+        codewhale_config::quote_os_path(store.path()),
+        codewhale_config::quote_os_path(&global),
+    );
+    ConfigStore::load(Some(global)).map(Some)
 }
 
 #[cfg(test)]
@@ -3424,6 +3453,8 @@ fn run_auth_command_with_secrets_and_runtime(
                 (None, true) => read_api_key_from_stdin()?,
                 (None, false) => prompt_api_key(slot)?,
             };
+            let mut credential_store = credential_metadata_store(store)?;
+            let store = credential_store.as_mut().unwrap_or(store);
             let secret_store_saved = persist_provider_api_key(store, secrets, provider, &api_key)?;
             // Don't print the key. Don't echo length.
             if secret_store_saved {
@@ -5930,6 +5961,114 @@ model = "qwen-2.5-7b"
         assert_eq!(
             secrets.get("deepseek").expect("read secret").as_deref(),
             Some("sk-test")
+        );
+    }
+
+    /// #5198: with CODEWHALE_CONFIG_PATH pointing at a workspace-scoped
+    /// `<repo>/.codewhale/config.toml`, login must write the provider binding
+    /// and auth markers to the user-global document, never the repo file.
+    #[test]
+    fn login_with_repo_scoped_ambient_config_writes_user_global_metadata() {
+        let _lock = env_lock();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).expect("git marker");
+        let repo_config_dir = repo.join(".codewhale");
+        std::fs::create_dir_all(&repo_config_dir).expect("repo config dir");
+        let repo_config = repo_config_dir.join("config.toml");
+        std::fs::write(&repo_config, "approval_policy = \"never\"\n").expect("repo config");
+
+        let codewhale_home = dir.path().join("codewhale-home");
+        let _home = ScopedEnvVar::set("CODEWHALE_HOME", &codewhale_home.to_string_lossy());
+        let _config = ScopedEnvVar::set("CODEWHALE_CONFIG_PATH", &repo_config.to_string_lossy());
+        let _legacy_config = ScopedEnvVar::remove("DEEPSEEK_CONFIG_PATH");
+        let _backend = ScopedEnvVar::set("CODEWHALE_SECRET_BACKEND", "file");
+        let mut store = ConfigStore::load(None).expect("ambient store should load");
+        let secrets = Secrets::auto_detect();
+
+        run_login_command_with_secrets(
+            &mut store,
+            LoginArgs {
+                provider: Some(ProviderArg::Deepseek),
+                api_key: Some("sk-repo-scoped".to_string()),
+            },
+            &secrets,
+        )
+        .expect("login should persist credential");
+
+        assert_eq!(
+            secrets.get("deepseek").expect("read secret").as_deref(),
+            Some("sk-repo-scoped")
+        );
+        let global_config = codewhale_home.join("config.toml");
+        let global = std::fs::read_to_string(&global_config).expect("user-global config");
+        assert!(
+            global.contains("auth_mode = \"api_key\""),
+            "user-global config must carry the auth marker: {global}"
+        );
+        assert!(
+            global.contains("provider = \"deepseek\""),
+            "user-global config must carry the provider binding: {global}"
+        );
+        assert!(!global.contains("sk-repo-scoped"), "{global}");
+        let repo_after = std::fs::read_to_string(&repo_config).expect("repo config");
+        assert_eq!(
+            repo_after, "approval_policy = \"never\"\n",
+            "workspace config must stay untouched by credential metadata: {repo_after}"
+        );
+    }
+
+    /// #5198: `auth set` shares the login resolver — provider auth markers go
+    /// user-global even when the ambient config is workspace-scoped.
+    #[test]
+    fn auth_set_with_repo_scoped_ambient_config_writes_user_global_metadata() {
+        let _lock = env_lock();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).expect("git marker");
+        let repo_config_dir = repo.join(".codewhale");
+        std::fs::create_dir_all(&repo_config_dir).expect("repo config dir");
+        let repo_config = repo_config_dir.join("config.toml");
+        std::fs::write(&repo_config, "approval_policy = \"never\"\n").expect("repo config");
+
+        let codewhale_home = dir.path().join("codewhale-home");
+        let _home = ScopedEnvVar::set("CODEWHALE_HOME", &codewhale_home.to_string_lossy());
+        let _config = ScopedEnvVar::set("CODEWHALE_CONFIG_PATH", &repo_config.to_string_lossy());
+        let _legacy_config = ScopedEnvVar::remove("DEEPSEEK_CONFIG_PATH");
+        let _backend = ScopedEnvVar::set("CODEWHALE_SECRET_BACKEND", "file");
+        let mut store = ConfigStore::load(None).expect("ambient store should load");
+        let secrets = Secrets::auto_detect();
+
+        run_auth_command_with_secrets(
+            &mut store,
+            AuthCommand::Set {
+                provider: ProviderArg::Openrouter,
+                api_key: Some("sk-or-repo-scoped".to_string()),
+                api_key_stdin: false,
+            },
+            &secrets,
+        )
+        .expect("auth set should persist credential");
+
+        assert_eq!(
+            secrets.get("openrouter").expect("read secret").as_deref(),
+            Some("sk-or-repo-scoped")
+        );
+        let global = std::fs::read_to_string(codewhale_home.join("config.toml"))
+            .expect("user-global config");
+        assert!(
+            global.contains("auth_mode = \"api_key\""),
+            "user-global config must carry the auth markers: {global}"
+        );
+        assert!(
+            global.contains("openrouter"),
+            "user-global config must name the provider table: {global}"
+        );
+        assert!(!global.contains("sk-or-repo-scoped"), "{global}");
+        let repo_after = std::fs::read_to_string(&repo_config).expect("repo config");
+        assert_eq!(
+            repo_after, "approval_policy = \"never\"\n",
+            "workspace config must stay untouched by credential metadata: {repo_after}"
         );
     }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -4929,6 +4929,197 @@ pub fn resolve_config_path(explicit: Option<PathBuf>) -> Result<PathBuf> {
     default_config_path()
 }
 
+/// Whether `path` names a workspace-scoped config document —
+/// `<repo>/.codewhale/config.toml` (or the legacy `.deepseek` layout) inside a
+/// checkout — rather than a user-global config file.
+///
+/// Credential writes (api_key values, `auth_mode` markers, oauth/external
+/// credential pointers) must never target such a document: a key saved while
+/// working in one repo would be invisible from every other repo, and the repo
+/// file stores it in plaintext where it is easy to commit by accident (#5045,
+/// #5193).
+///
+/// A path is classified workspace-scoped only when its parent directory is a
+/// `.codewhale`/`.deepseek` app dir outside the user's home AND the document
+/// belongs to a workspace: it is relative (resolves against the process cwd),
+/// its base directory contains the process cwd, or its base directory is a
+/// checkout (has a `.git` entry). An explicit `$CODEWHALE_HOME` config is
+/// user-global wherever that home points, even when the directory itself
+/// happens to be named `.codewhale`; other custom locations (for example
+/// `CODEWHALE_CONFIG_PATH=~/team.toml` or an isolated test directory) stay
+/// honored as deliberate user-scoped choices.
+#[must_use]
+pub fn config_path_is_workspace_scoped(path: &Path) -> bool {
+    config_path_is_workspace_scoped_with_context(
+        path,
+        codewhale_paths::codewhale_home_override()
+            .ok()
+            .flatten()
+            .as_deref(),
+        codewhale_paths::user_home().as_deref(),
+        std::env::current_dir().ok().as_deref(),
+    )
+}
+
+/// Environment-free core of [`config_path_is_workspace_scoped`], split out so
+/// scope classification is testable without mutating process-global state.
+fn config_path_is_workspace_scoped_with_context(
+    path: &Path,
+    explicit_codewhale_home: Option<&Path>,
+    user_home: Option<&Path>,
+    current_dir: Option<&Path>,
+) -> bool {
+    if let Some(home) = explicit_codewhale_home
+        && same_lexical_or_canonical_path(path, &home.join(CONFIG_FILE_NAME))
+    {
+        return false;
+    }
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let parent_is_app_dir = parent
+        .file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| name == CODEWHALE_APP_DIR || name == LEGACY_APP_DIR);
+    if !parent_is_app_dir {
+        return false;
+    }
+    let Some(base) = parent.parent() else {
+        return true;
+    };
+    if let Some(home) = user_home
+        && same_lexical_or_canonical_path(base, home)
+    {
+        return false;
+    }
+    if path.is_relative() {
+        // Resolves against the process cwd: repo-scoped by construction.
+        return true;
+    }
+    // The document belongs to the workspace the process is sitting in…
+    if let Some(cwd) = current_dir
+        && canonicalize_or_keep(cwd).starts_with(canonicalize_or_keep(base))
+    {
+        return true;
+    }
+    // …or to some other checkout (a `.git` entry beside the app dir).
+    base.join(".git").exists()
+}
+
+/// Lexical equality first, canonical equality as a fallback so an existing
+/// path still matches through symlinked parents (e.g. `/tmp` on macOS).
+fn same_lexical_or_canonical_path(a: &Path, b: &Path) -> bool {
+    a == b || canonicalize_or_keep(a) == canonicalize_or_keep(b)
+}
+
+fn canonicalize_or_keep(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod credential_scope_tests {
+    use super::config_path_is_workspace_scoped_with_context;
+    use std::path::Path;
+
+    #[test]
+    fn config_inside_current_workspace_is_workspace_scoped() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let cwd = repo.join("nested/dir");
+        for app_dir in [".codewhale", ".deepseek"] {
+            let config = repo.join(app_dir).join("config.toml");
+            assert!(
+                config_path_is_workspace_scoped_with_context(
+                    &config,
+                    None,
+                    Some(Path::new("/home/user")),
+                    Some(&cwd),
+                ),
+                "{} should be workspace-scoped when cwd sits inside the repo",
+                config.display()
+            );
+        }
+    }
+
+    #[test]
+    fn relative_app_dir_config_is_workspace_scoped() {
+        assert!(config_path_is_workspace_scoped_with_context(
+            Path::new(".codewhale/config.toml"),
+            None,
+            Some(Path::new("/home/user")),
+            Some(Path::new("/somewhere/else")),
+        ));
+    }
+
+    #[test]
+    fn checkout_config_outside_cwd_is_workspace_scoped_via_git_marker() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).expect("git marker");
+        std::fs::create_dir_all(repo.join(".codewhale")).expect("app dir");
+        assert!(config_path_is_workspace_scoped_with_context(
+            &repo.join(".codewhale/config.toml"),
+            None,
+            Some(Path::new("/home/user")),
+            Some(Path::new("/somewhere/else")),
+        ));
+    }
+
+    #[test]
+    fn user_global_and_custom_locations_are_not_workspace_scoped() {
+        let home = Path::new("/home/user");
+        let elsewhere = Some(Path::new("/somewhere/else"));
+        for global_config in [
+            "/home/user/.codewhale/config.toml",
+            "/home/user/.deepseek/config.toml",
+            "/home/user/team-config.toml",
+            "/etc/codewhale/config.toml",
+        ] {
+            assert!(
+                !config_path_is_workspace_scoped_with_context(
+                    Path::new(global_config),
+                    None,
+                    Some(home),
+                    elsewhere,
+                ),
+                "{global_config} should stay user-global"
+            );
+        }
+        // An isolated app-dir-shaped location with no workspace relationship
+        // (no cwd ancestry, no checkout marker) stays honored: test harnesses
+        // and deliberate overrides point there.
+        let temp = tempfile::tempdir().expect("tempdir");
+        assert!(!config_path_is_workspace_scoped_with_context(
+            &temp.path().join(".codewhale/config.toml"),
+            None,
+            Some(home),
+            elsewhere,
+        ));
+    }
+
+    #[test]
+    fn explicit_codewhale_home_config_is_user_global_even_when_dir_is_app_named() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let explicit = repo.join(".codewhale");
+        // Even with cwd inside the repo, the explicit CODEWHALE_HOME config is
+        // the user-global scope by definition.
+        assert!(!config_path_is_workspace_scoped_with_context(
+            &explicit.join("config.toml"),
+            Some(&explicit),
+            Some(Path::new("/home/user")),
+            Some(&repo),
+        ));
+        // A different repo-scoped document is still workspace-scoped.
+        assert!(config_path_is_workspace_scoped_with_context(
+            &repo.join("other/.codewhale/config.toml"),
+            Some(&explicit),
+            Some(Path::new("/home/user")),
+            Some(&repo.join("other")),
+        ));
+    }
+}
+
 #[must_use]
 pub fn permissions_path_for_config_path(config_path: &Path) -> PathBuf {
     config_sibling_path_unchecked(config_path, OsStr::new(PERMISSIONS_FILE_NAME))

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -2350,10 +2350,13 @@ pub fn lsp_command(app: &mut App, arg: Option<&str>) -> CommandResult {
     }
 }
 
-/// Logout - clear all saved API keys and return to onboarding.
-/// This is NOT provider-scoped — it clears keys for every saved provider.
-/// For single-provider key replacement, use
-/// `codewhale auth clear --provider <id>` and
+/// Logout - clear the active provider's saved API key and return to
+/// onboarding. The on-disk scrub targets the user-global config document
+/// (#5193) and the provider's durable secret-store slot is deleted too, so
+/// the cleared key cannot reappear through the read chain (#5196). Exact
+/// named custom providers clear only their own table (cae14f4b9). For a
+/// full every-provider wipe, use `codewhale auth logout`; for single-provider
+/// key replacement, use `codewhale auth clear --provider <id>` and
 /// `codewhale auth set --provider <id>`.
 pub fn logout(app: &mut App) -> CommandResult {
     let provider_name = app.provider_identity_for_persistence().to_string();

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -9365,7 +9365,7 @@ fn save_root_api_key_for_secret_slot(
 
     let path = credential_config_path().context("Failed to resolve config path for API key.")?;
 
-    if let Some(secrets) = credential_secret_store_for_save() {
+    if let Some(secrets) = credential_secret_store() {
         let prior_secret = secrets.get(secret_slot);
         match prior_secret.as_ref() {
             Ok(prior) => match secrets.set(secret_slot, trimmed) {
@@ -9432,13 +9432,18 @@ fn plaintext_credential_fallback_refused(
     )
 }
 
+/// The durable secret store for credential saves and logout-time deletes.
+///
+/// Under `cfg(test)` the store is only exposed when the test set both an
+/// isolated `CODEWHALE_HOME` and an explicit backend, so unit tests can never
+/// touch the developer's real credential store.
 #[cfg(not(test))]
-fn credential_secret_store_for_save() -> Option<codewhale_secrets::Secrets> {
+fn credential_secret_store() -> Option<codewhale_secrets::Secrets> {
     Some(codewhale_secrets::Secrets::auto_detect())
 }
 
 #[cfg(test)]
-fn credential_secret_store_for_save() -> Option<codewhale_secrets::Secrets> {
+fn credential_secret_store() -> Option<codewhale_secrets::Secrets> {
     let isolated_home = codewhale_paths::codewhale_home_is_explicit();
     let explicit_backend = std::env::var_os("CODEWHALE_SECRET_BACKEND")
         .or_else(|| std::env::var_os("DEEPSEEK_SECRET_BACKEND"))
@@ -9984,7 +9989,7 @@ fn save_api_key_for_identity_unlocked(
             });
 
     if !route_config.should_skip_secret_store_for_provider(provider)
-        && let Some(secrets) = credential_secret_store_for_save()
+        && let Some(secrets) = credential_secret_store()
     {
         let secret_slot = provider_secret_store_slot(provider);
         let prior_secret = secrets.get(secret_slot);
@@ -10488,13 +10493,19 @@ fn missing_provider_api_key_message(provider: ApiProvider) -> Result<String> {
     ))
 }
 
-/// Clear the API key from config-file storage.
+/// Clear every saved API key from config-file storage AND the durable
+/// secret store.
 ///
-/// `/logout` calls this to wipe credentials so the next request can't
+/// The full-wipe logout path (`codewhale-tui --logout`, `auth logout`)
+/// calls this to remove credentials so the next request can't
 /// silently use a stale config key (#343). The function removes the legacy
 /// root `api_key` entry *and* every `api_key` entry nested in a
 /// `[providers.<name>]` table, leaving keys like `api_key_env`, comments,
-/// and formatting untouched.
+/// and formatting untouched, then deletes every provider's secret-store
+/// slot — symmetric with CLI logout (#5159) — so a stored credential cannot
+/// survive logout and reappear through the read chain (#5196). The TUI
+/// `/logout` command stays single-provider and goes through
+/// [`clear_active_provider_api_key`] instead.
 ///
 /// Environment variables (`DEEPSEEK_API_KEY`, etc.) are intentionally
 /// **not** unset — they are managed by the user's shell and outside the
@@ -10513,37 +10524,88 @@ fn clear_api_key_unlocked() -> Result<()> {
     let config_path = credential_config_path()
         .context("Failed to resolve config path while clearing API keys.")?;
 
-    if !config_path.exists() {
-        return Ok(());
+    if config_path.exists() {
+        crate::config_persistence::mutate_config_document(&config_path, |doc| {
+            crate::config_persistence::remove_document_key_recursive(doc.as_table_mut(), "api_key");
+            crate::config_persistence::unset_document_value(
+                doc,
+                &["providers", "xai", "oauth_credential_generation"],
+            )?;
+            crate::config_persistence::unset_document_value(
+                doc,
+                &["providers", "xai", "auth_mode"],
+            )?;
+            crate::config_persistence::unset_document_value(
+                doc,
+                &["providers", "xai", "external_credentials"],
+            )?;
+            Ok(())
+        })
+        .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
+        log_sensitive_event(
+            "credential.clear",
+            json!({
+                "backend": "config_file",
+                "config_path": config_path.display().to_string(),
+                "scope": "root_and_provider_keys",
+            }),
+        );
     }
 
-    crate::config_persistence::mutate_config_document(&config_path, |doc| {
-        crate::config_persistence::remove_document_key_recursive(doc.as_table_mut(), "api_key");
-        crate::config_persistence::unset_document_value(
-            doc,
-            &["providers", "xai", "oauth_credential_generation"],
-        )?;
-        crate::config_persistence::unset_document_value(doc, &["providers", "xai", "auth_mode"])?;
-        crate::config_persistence::unset_document_value(
-            doc,
-            &["providers", "xai", "external_credentials"],
-        )?;
-        Ok(())
-    })
-    .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
-    log_sensitive_event(
-        "credential.clear",
-        json!({
-            "backend": "config_file",
-            "config_path": config_path.display().to_string(),
-            "scope": "root_and_provider_keys",
-        }),
-    );
+    // The config scrub alone leaves the durable secret-store credential
+    // alive, and the read chain prefers the secret store over the file, so a
+    // "cleared" key silently came back on the next launch (#5196). Delete
+    // every provider slot too, symmetric with CLI logout (#5159). This runs
+    // even when the config file is absent: the slot survives independently
+    // of the file.
+    if let Some(secrets) = credential_secret_store() {
+        let failures = clear_all_provider_api_keys_from_secret_store(&secrets);
+        if !failures.is_empty() {
+            anyhow::bail!(
+                "failed to delete stored credentials for: {}",
+                failures.join(", ")
+            );
+        }
+    }
 
     Ok(())
 }
 
-/// Clear only the active provider's API key from the config file.
+/// Delete the credential slot of every provider that has one stored.
+///
+/// Mirrors the CLI logout helper (#5159): each slot is probed first so
+/// backends that error on deleting a missing item stay quiet, slots shared
+/// by several providers (e.g. the historical `siliconflow` slot) are deleted
+/// once, and every deletion failure is returned as a human-readable entry so
+/// the caller can fail loudly instead of claiming a clean logout while
+/// credentials linger in the store (#5196).
+fn clear_all_provider_api_keys_from_secret_store(
+    secrets: &codewhale_secrets::Secrets,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    let mut cleared_slots = std::collections::HashSet::new();
+    for provider in ApiProvider::all() {
+        let slot = provider_secret_store_slot(*provider);
+        if !cleared_slots.insert(slot) {
+            continue;
+        }
+        let has_value = secrets
+            .get(slot)
+            .ok()
+            .flatten()
+            .is_some_and(|value| !value.trim().is_empty());
+        if !has_value {
+            continue;
+        }
+        if let Err(error) = secrets.delete(slot) {
+            failures.push(format!("{slot}: {error}"));
+        }
+    }
+    failures
+}
+
+/// Clear only the active provider's API key from the config file and delete
+/// that provider's durable secret-store slot (#5196).
 /// Unlike `clear_api_key()` which strips ALL api_key entries, this
 /// removes only the key for the specified provider section (plus the
 /// legacy root `api_key` when the provider is DeepSeek).
@@ -10560,71 +10622,92 @@ fn clear_active_provider_api_key_unlocked(provider: &str) -> Result<()> {
     let config_path = credential_config_path()
         .context("Failed to resolve config path while clearing API keys.")?;
 
-    if !config_path.exists() {
-        return Ok(());
+    if config_path.exists() {
+        // `custom` is both the legacy root-shaped route id and a valid exact
+        // `[providers.custom]` table key. Inspect the persisted shape before the
+        // mutation so logout clears exactly one credential scope.
+        let persisted = fs::read_to_string(&config_path)
+            .with_context(|| format!("Failed to read config from {}", config_path.display()))?;
+        let persisted_config: Config = toml::from_str(&persisted).map_err(|_| {
+            anyhow::anyhow!(
+                "Failed to parse config from {}; file contents were omitted",
+                codewhale_config::quote_os_path(&config_path)
+            )
+        })?;
+        let exact_literal_custom_table = provider == ApiProvider::Custom.as_str()
+            && persisted_config
+                .providers
+                .as_ref()
+                .and_then(|providers| providers.custom_provider_config(provider))
+                .is_some();
+
+        crate::config_persistence::mutate_config_document(&config_path, |doc| {
+            // The root-level api_key is shared by the legacy DeepSeek and released
+            // literal-custom config shapes. Exact named custom ids remain scoped
+            // to their own table.
+            if matches!(
+                provider,
+                value if value == ApiProvider::Deepseek.as_str()
+                    || value == ApiProvider::DeepseekCN.as_str()
+            ) || (provider == ApiProvider::Custom.as_str() && !exact_literal_custom_table)
+            {
+                crate::config_persistence::unset_document_value(doc, &["api_key"])?;
+            }
+            if provider != ApiProvider::Custom.as_str() || exact_literal_custom_table {
+                crate::config_persistence::unset_document_value(
+                    doc,
+                    &["providers", provider, "api_key"],
+                )?;
+            }
+            if provider == ApiProvider::Xai.as_str() {
+                crate::config_persistence::unset_document_value(
+                    doc,
+                    &["providers", "xai", "oauth_credential_generation"],
+                )?;
+                crate::config_persistence::unset_document_value(
+                    doc,
+                    &["providers", "xai", "auth_mode"],
+                )?;
+                crate::config_persistence::unset_document_value(
+                    doc,
+                    &["providers", "xai", "external_credentials"],
+                )?;
+            }
+            Ok(())
+        })
+        .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
+        log_sensitive_event(
+            "credential.clear",
+            json!({
+                "backend": "config_file",
+                "config_path": config_path.display().to_string(),
+                "scope": provider,
+            }),
+        );
     }
 
-    // `custom` is both the legacy root-shaped route id and a valid exact
-    // `[providers.custom]` table key. Inspect the persisted shape before the
-    // mutation so logout clears exactly one credential scope.
-    let persisted = fs::read_to_string(&config_path)
-        .with_context(|| format!("Failed to read config from {}", config_path.display()))?;
-    let persisted_config: Config = toml::from_str(&persisted).map_err(|_| {
-        anyhow::anyhow!(
-            "Failed to parse config from {}; file contents were omitted",
-            codewhale_config::quote_os_path(&config_path)
-        )
-    })?;
-    let exact_literal_custom_table = provider == ApiProvider::Custom.as_str()
-        && persisted_config
-            .providers
-            .as_ref()
-            .and_then(|providers| providers.custom_provider_config(provider))
-            .is_some();
-
-    crate::config_persistence::mutate_config_document(&config_path, |doc| {
-        // The root-level api_key is shared by the legacy DeepSeek and released
-        // literal-custom config shapes. Exact named custom ids remain scoped
-        // to their own table.
-        if matches!(
-            provider,
-            value if value == ApiProvider::Deepseek.as_str()
-                || value == ApiProvider::DeepseekCN.as_str()
-        ) || (provider == ApiProvider::Custom.as_str() && !exact_literal_custom_table)
-        {
-            crate::config_persistence::unset_document_value(doc, &["api_key"])?;
+    // The durable secret-store slot survives a config-file scrub and the
+    // read chain prefers it, so the cleared key would silently come back
+    // (#5196). Delete the provider's slot too — even when the config file
+    // itself is absent. Exact named custom providers have no secret-store
+    // slot, so an unmatched provider string skips this step.
+    if let Some(secrets) = credential_secret_store()
+        && let Some(slot) = ApiProvider::all()
+            .iter()
+            .find(|candidate| candidate.as_str() == provider)
+            .map(|candidate| provider_secret_store_slot(*candidate))
+    {
+        let has_value = secrets
+            .get(slot)
+            .ok()
+            .flatten()
+            .is_some_and(|value| !value.trim().is_empty());
+        if has_value {
+            secrets
+                .delete(slot)
+                .with_context(|| format!("failed to delete stored credential for {slot}"))?;
         }
-        if provider != ApiProvider::Custom.as_str() || exact_literal_custom_table {
-            crate::config_persistence::unset_document_value(
-                doc,
-                &["providers", provider, "api_key"],
-            )?;
-        }
-        if provider == ApiProvider::Xai.as_str() {
-            crate::config_persistence::unset_document_value(
-                doc,
-                &["providers", "xai", "oauth_credential_generation"],
-            )?;
-            crate::config_persistence::unset_document_value(
-                doc,
-                &["providers", "xai", "auth_mode"],
-            )?;
-            crate::config_persistence::unset_document_value(
-                doc,
-                &["providers", "xai", "external_credentials"],
-            )?;
-        }
-        Ok(())
-    })
-    .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
-    log_sensitive_event(
-        "credential.clear",
-        json!({
-            "backend": "config_file",
-            "config_path": config_path.display().to_string(),
-            "scope": provider,
-        }),
-    );
+    }
 
     Ok(())
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -6448,7 +6448,7 @@ mod paths;
 use paths::{
     canonicalize_or_keep, codewhale_home_dir, default_config_path, default_managed_config_path,
     default_mcp_config_path, default_memory_path, default_notes_path, default_requirements_path,
-    default_skills_dir, env_config_path, expand_pathbuf, try_default_config_path,
+    default_skills_dir, env_config_path, expand_pathbuf, home_config_path, try_default_config_path,
     workspace_config_key,
 };
 pub(crate) use paths::{effective_home_dir, expand_path};
@@ -9311,6 +9311,33 @@ impl SavedCredential {
     }
 }
 
+/// Resolve the config document for CREDENTIAL writes: api_key values,
+/// `auth_mode` markers, and oauth/external-credential pointers.
+///
+/// Credentials are user-global — a key saved while working in one repo must be
+/// visible from every other repo (#5045, #5193). The ambient
+/// `CODEWHALE_CONFIG_PATH`/`DEEPSEEK_CONFIG_PATH` override can point at a
+/// workspace-scoped document (`<repo>/.codewhale/config.toml`, plaintext and
+/// easy to commit by accident), so credential writes that would land there are
+/// rescoped to the user-global config instead. Non-credential settings keep
+/// the ambient scoping, and callers that pass an explicit config path never
+/// consult this resolver; a per-workspace destination stays possible only as
+/// that kind of explicit opt-in.
+fn credential_config_path() -> anyhow::Result<PathBuf> {
+    let resolved = try_default_config_path()?;
+    if !codewhale_config::config_path_is_workspace_scoped(&resolved) {
+        return Ok(resolved);
+    }
+    let global = home_config_path()
+        .context("Failed to resolve user-global config path: home directory not found.")?;
+    tracing::info!(
+        ambient = %resolved.display(),
+        global = %global.display(),
+        "rescoping credential write from workspace config to user-global config"
+    );
+    Ok(global)
+}
+
 /// Save the active provider's API key.
 ///
 /// The selected durable secret backend is attempted first. On success the
@@ -9336,7 +9363,7 @@ fn save_root_api_key_for_secret_slot(
         anyhow::bail!("Refusing to save an empty API key.");
     }
 
-    let path = try_default_config_path().context("Failed to resolve config path for API key.")?;
+    let path = credential_config_path().context("Failed to resolve config path for API key.")?;
 
     if let Some(secrets) = credential_secret_store_for_save() {
         let prior_secret = secrets.get(secret_slot);
@@ -9455,7 +9482,7 @@ fn save_root_api_key_metadata_without_plaintext(
 /// Write the `api_key` slot directly to `config.toml`.
 fn save_api_key_to_config_file(api_key: &str) -> Result<PathBuf> {
     let config_path =
-        try_default_config_path().context("Failed to resolve config path for API key.")?;
+        credential_config_path().context("Failed to resolve config path for API key.")?;
 
     ensure_parent_dir(&config_path)?;
 
@@ -9930,7 +9957,7 @@ fn save_api_key_for_identity_unlocked(
     anyhow::ensure!(!api_key.is_empty(), "Refusing to save an empty API key.");
 
     let config_path =
-        try_default_config_path().context("Failed to resolve config path for provider API key.")?;
+        credential_config_path().context("Failed to resolve config path for provider API key.")?;
     ensure_parent_dir(&config_path)?;
 
     let key_inside = if provider == ApiProvider::Custom {
@@ -10237,7 +10264,7 @@ pub(crate) fn persist_external_credential_consent_for_at(
     )?;
     let config_path = match config_path {
         Some(path) => path.to_path_buf(),
-        None => try_default_config_path()
+        None => credential_config_path()
             .context("Failed to resolve config path for external credential consent.")?,
     };
     ensure_parent_dir(&config_path)?;
@@ -10307,7 +10334,7 @@ pub(crate) fn revoke_external_credential_consent_for_at(
     );
     let config_path = match config_path {
         Some(path) => path.to_path_buf(),
-        None => try_default_config_path()
+        None => credential_config_path()
             .context("Failed to resolve config path for external credential consent.")?,
     };
     ensure_parent_dir(&config_path)?;
@@ -10481,8 +10508,9 @@ pub fn clear_api_key() -> Result<()> {
 fn clear_api_key_unlocked() -> Result<()> {
     // Strip api_key entries from config.toml, including provider-scoped
     // nested entries. Clearing a config file must not trigger platform
-    // credential prompts.
-    let config_path = try_default_config_path()
+    // credential prompts. Clears target the same user-global document that
+    // credential saves write, so logout removes what login stored (#5045).
+    let config_path = credential_config_path()
         .context("Failed to resolve config path while clearing API keys.")?;
 
     if !config_path.exists() {
@@ -10529,7 +10557,7 @@ pub fn clear_active_provider_api_key(provider: &str) -> Result<()> {
 }
 
 fn clear_active_provider_api_key_unlocked(provider: &str) -> Result<()> {
-    let config_path = try_default_config_path()
+    let config_path = credential_config_path()
         .context("Failed to resolve config path while clearing API keys.")?;
 
     if !config_path.exists() {
@@ -10641,9 +10669,18 @@ mod credential_scope_tests {
         let saved = save_api_key("workspace-rescope-test-key")?;
 
         let global_config = user_home.join("config.toml");
+        // Compare canonicalized paths: the resolved config path runs through
+        // `normalize_config_file_path`, which canonicalizes the parent, so on
+        // macOS the lexical `/var/folders/…` tempdir and its canonical
+        // `/private/var/folders/…` form are the same file. A lexical compare
+        // both false-fails and false-passes on that symlink.
+        let saved_path = match saved {
+            SavedCredential::ConfigFile(path) => path,
+            other => panic!("expected a config-file save, got {}", other.describe()),
+        };
         assert_eq!(
-            saved,
-            SavedCredential::ConfigFile(global_config.clone()),
+            canonicalize_or_keep(&saved_path),
+            canonicalize_or_keep(&global_config),
             "credential save must surface the user-global destination"
         );
         let global = fs::read_to_string(&global_config)?;
@@ -10686,9 +10723,10 @@ mod credential_scope_tests {
 
         let path = save_api_key_for(ApiProvider::Openrouter, "workspace-rescope-openrouter-key")?;
 
+        // Canonicalized comparison: see the root-key test above.
         assert_eq!(
-            path,
-            user_home.join("config.toml"),
+            canonicalize_or_keep(&path),
+            canonicalize_or_keep(&user_home.join("config.toml")),
             "provider save must report the user-global destination"
         );
         let global = fs::read_to_string(&path)?;

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -5558,6 +5558,7 @@ impl Config {
             && let Some(configured) = self.api_key.as_ref()
             && classify_config_api_key_value(configured) == ConfigApiKeyValueKind::Literal
         {
+            warn_on_config_api_key_shadowing(self, provider, "the root api_key");
             return Ok(configured.clone());
         }
 
@@ -5623,6 +5624,11 @@ impl Config {
                 })
             && classify_config_api_key_value(&configured) == ConfigApiKeyValueKind::Literal
         {
+            let config_source = match provider_config_table_name(provider) {
+                Ok(table) => format!("`{table}` api_key"),
+                Err(_) => "the provider config-table api_key".to_string(),
+            };
+            warn_on_config_api_key_shadowing(self, provider, &config_source);
             return Ok(configured);
         }
         if provider == ApiProvider::Custom
@@ -5631,6 +5637,7 @@ impl Config {
             && let Some(configured) = self.api_key.as_ref()
             && classify_config_api_key_value(configured) == ConfigApiKeyValueKind::Literal
         {
+            warn_on_config_api_key_shadowing(self, provider, "the root api_key");
             return Ok(configured.clone());
         }
 
@@ -10450,6 +10457,58 @@ fn provider_secret_store_api_key_with_mode(
         .ok()
         .flatten()
         .filter(|value| !value.trim().is_empty())
+}
+
+/// The shadowing warning for a config-file `api_key` that wins over a live
+/// secret-store credential, if both exist (#5194).
+///
+/// The config file intentionally outranks the secret store in the read
+/// chain, but a shadowed slot is invisible: the user rotates the key with
+/// `codewhale auth set` and nothing changes, because the stale plaintext
+/// copy still wins. Mirror the fleet-roster shadowing rule (#5098):
+/// precedence is normal, but it must be VISIBLE. The message names both
+/// sources, which one won, and the command that resolves the shadow.
+/// Split from [`warn_on_config_api_key_shadowing`] so the decision is
+/// testable without capturing tracing output.
+fn config_api_key_shadow_warning(
+    config: &Config,
+    provider: ApiProvider,
+    config_source: &str,
+) -> Option<String> {
+    if config.should_skip_secret_store_for_provider(provider) {
+        return None;
+    }
+    provider_secret_store_api_key_with_mode(config, provider, true).map(|_| {
+        let slot = provider_secret_store_slot(provider);
+        let id = provider.as_str();
+        format!(
+            "both {config_source} in the config file and secret-store slot \"{slot}\" \
+             hold a credential for provider {id}; the config-file key won. Run \
+             `codewhale auth set --provider {id}` to move the key into the secret store \
+             and strip the plaintext copy, or remove the config-file api_key."
+        )
+    })
+}
+
+/// Emit the #5194 shadowing warning at most once per provider slot per
+/// process: credential resolution runs on every request, and a repeating
+/// warning is noise, not signal.
+fn warn_on_config_api_key_shadowing(config: &Config, provider: ApiProvider, config_source: &str) {
+    let Some(message) = config_api_key_shadow_warning(config, provider, config_source) else {
+        return;
+    };
+    static WARNED_SLOTS: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashSet<&'static str>>,
+    > = std::sync::OnceLock::new();
+    let mut warned = WARNED_SLOTS
+        .get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if !warned.insert(provider_secret_store_slot(provider)) {
+        return;
+    }
+    drop(warned);
+    tracing::warn!("{message}");
 }
 
 /// The model this launch was explicitly asked for, if any.

--- a/crates/tui/src/config/paths.rs
+++ b/crates/tui/src/config/paths.rs
@@ -48,6 +48,39 @@ pub(crate) fn codewhale_home_dir() -> Result<Option<PathBuf>, codewhale_paths::P
     codewhale_paths::codewhale_home_override()
 }
 
+/// The user-global config document: `$CODEWHALE_HOME/config.toml` when an
+/// explicit home is set, otherwise `~/.codewhale/config.toml` (falling back to
+/// the legacy `~/.deepseek/config.toml` only when that file already exists).
+///
+/// Credential writes are rerouted here when the ambient config path resolves
+/// to a workspace-scoped document (#5045, #5193); non-credential settings keep
+/// the ambient scoping.
+pub(crate) fn home_config_path() -> Option<PathBuf> {
+    match codewhale_home_dir() {
+        Ok(Some(home)) => return Some(home.join(codewhale_config::CONFIG_FILE_NAME)),
+        Ok(None) => {}
+        Err(error) => {
+            tracing::error!(
+                error = %error,
+                "invalid Codewhale home override; refusing to substitute a different config path"
+            );
+            return None;
+        }
+    }
+
+    effective_home_dir().map(|home| {
+        let primary = home.join(".codewhale").join("config.toml");
+        if primary.exists() {
+            return primary;
+        }
+        let legacy = home.join(".deepseek").join("config.toml");
+        if legacy.exists() {
+            return legacy;
+        }
+        primary
+    })
+}
+
 pub(crate) fn workspace_config_key(workspace: &Path) -> String {
     canonicalize_or_keep(workspace)
         .to_string_lossy()

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -2770,6 +2770,91 @@ fn save_deepseek_key_uses_isolated_file_store_without_plaintext_config() -> Resu
     Ok(())
 }
 
+/// #5196: logout must remove the durable credential, not just the config
+/// file entry. After save + `clear_api_key()`, the whole read chain —
+/// secret-store slot first, config file second — must find nothing.
+#[test]
+fn full_logout_clears_secret_store_slot_and_config_document() -> Result<()> {
+    let _lock = lock_test_env();
+    let temp_root = tempfile::tempdir()?;
+    // Canonicalize: the xAI credential walker opens each path component with
+    // O_NOFOLLOW, so the lexical `/var` symlink in macOS tempdirs fails.
+    let temp_root = temp_root.path().canonicalize()?;
+    let _guard = EnvGuard::new(&temp_root);
+    let codewhale_home = temp_root.join("codewhale-home");
+    let config_path = codewhale_home.join("config.toml");
+    let _codewhale_home = EnvVarGuard::set("CODEWHALE_HOME", codewhale_home.as_os_str());
+    let _config_path = EnvVarGuard::set("CODEWHALE_CONFIG_PATH", config_path.as_os_str());
+    let _backend = EnvVarGuard::set("CODEWHALE_SECRET_BACKEND", "file");
+
+    let saved = save_api_key("logout-credential")?;
+    assert!(matches!(
+        saved,
+        SavedCredential::KeyringAndConfigFile { .. }
+    ));
+    assert_eq!(
+        codewhale_secrets::Secrets::auto_detect().get("deepseek")?,
+        Some("logout-credential".to_string())
+    );
+
+    clear_api_key()?;
+
+    assert_eq!(
+        codewhale_secrets::Secrets::auto_detect().get("deepseek")?,
+        None,
+        "logout must delete the durable secret-store slot"
+    );
+    assert_eq!(
+        provider_secret_store_api_key(&Config::default(), ApiProvider::Deepseek),
+        None,
+        "the read chain must not find a cleared credential"
+    );
+    let config = fs::read_to_string(&config_path)?;
+    assert!(!config.contains("logout-credential"), "{config}");
+    assert!(
+        !config
+            .lines()
+            .any(|line| line.trim_start().starts_with("api_key =")),
+        "{config}"
+    );
+    Ok(())
+}
+
+/// #5196: the single-provider clear used by TUI `/logout` must delete that
+/// provider's secret-store slot as well as its config-file entry.
+#[test]
+fn single_provider_logout_clears_secret_store_slot() -> Result<()> {
+    let _lock = lock_test_env();
+    let temp_root = tempfile::tempdir()?;
+    let temp_root = temp_root.path().canonicalize()?;
+    let _guard = EnvGuard::new(&temp_root);
+    let codewhale_home = temp_root.join("codewhale-home");
+    let config_path = codewhale_home.join("config.toml");
+    let _codewhale_home = EnvVarGuard::set("CODEWHALE_HOME", codewhale_home.as_os_str());
+    let _config_path = EnvVarGuard::set("CODEWHALE_CONFIG_PATH", config_path.as_os_str());
+    let _backend = EnvVarGuard::set("CODEWHALE_SECRET_BACKEND", "file");
+
+    save_api_key_for(ApiProvider::Openrouter, "openrouter-logout-credential")?;
+    assert_eq!(
+        codewhale_secrets::Secrets::auto_detect().get("openrouter")?,
+        Some("openrouter-logout-credential".to_string())
+    );
+
+    clear_active_provider_api_key("openrouter")?;
+
+    assert_eq!(
+        codewhale_secrets::Secrets::auto_detect().get("openrouter")?,
+        None,
+        "single-provider logout must delete the durable secret-store slot"
+    );
+    assert_eq!(
+        provider_secret_store_api_key(&Config::default(), ApiProvider::Openrouter),
+        None,
+        "the read chain must not find a cleared credential"
+    );
+    Ok(())
+}
+
 #[test]
 fn whitespace_codewhale_home_never_opens_ambient_file_secret_store() -> Result<()> {
     let _lock = lock_test_env();

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -2855,6 +2855,80 @@ fn single_provider_logout_clears_secret_store_slot() -> Result<()> {
     Ok(())
 }
 
+/// #5194: when both a config-file api_key and the provider's secret-store
+/// slot hold a credential, the shadowing warning names both sources, says
+/// which won, and hands over the resolve command.
+#[test]
+fn config_api_key_shadow_warning_names_sources_winner_and_resolution() -> Result<()> {
+    let _lock = lock_test_env();
+    let temp_root = tempfile::tempdir()?;
+    let _guard = EnvGuard::new(temp_root.path());
+    let codewhale_home = temp_root.path().join("codewhale-home");
+    let config_path = codewhale_home.join("config.toml");
+    let _codewhale_home = EnvVarGuard::set("CODEWHALE_HOME", codewhale_home.as_os_str());
+    let _config_path = EnvVarGuard::set("CODEWHALE_CONFIG_PATH", config_path.as_os_str());
+    let _backend = EnvVarGuard::set("CODEWHALE_SECRET_BACKEND", "file");
+    codewhale_secrets::Secrets::auto_detect().set("openrouter", "store-key")?;
+
+    let mut config = Config::default();
+    config
+        .provider_config_for_mut(ApiProvider::Openrouter)
+        .api_key = Some("plaintext-config-key".to_string());
+
+    let warning = config_api_key_shadow_warning(
+        &config,
+        ApiProvider::Openrouter,
+        "`providers.openrouter` api_key",
+    )
+    .expect("a live secret-store slot shadowed by a config key must warn");
+    assert!(
+        warning.contains("`providers.openrouter` api_key"),
+        "warning must name the config-file source: {warning}"
+    );
+    assert!(
+        warning.contains("secret-store slot \"openrouter\""),
+        "warning must name the secret-store source: {warning}"
+    );
+    assert!(
+        warning.contains("the config-file key won"),
+        "warning must say which source won: {warning}"
+    );
+    assert!(
+        warning.contains("codewhale auth set --provider openrouter"),
+        "warning must name the resolve command: {warning}"
+    );
+    Ok(())
+}
+
+/// #5194: no secret-store credential, no shadow, no warning.
+#[test]
+fn config_api_key_shadow_warning_stays_quiet_without_a_store_slot() -> Result<()> {
+    let _lock = lock_test_env();
+    let temp_root = tempfile::tempdir()?;
+    let _guard = EnvGuard::new(temp_root.path());
+    let codewhale_home = temp_root.path().join("codewhale-home");
+    let config_path = codewhale_home.join("config.toml");
+    let _codewhale_home = EnvVarGuard::set("CODEWHALE_HOME", codewhale_home.as_os_str());
+    let _config_path = EnvVarGuard::set("CODEWHALE_CONFIG_PATH", config_path.as_os_str());
+    let _backend = EnvVarGuard::set("CODEWHALE_SECRET_BACKEND", "file");
+
+    let mut config = Config::default();
+    config
+        .provider_config_for_mut(ApiProvider::Openrouter)
+        .api_key = Some("plaintext-config-key".to_string());
+
+    assert_eq!(
+        config_api_key_shadow_warning(
+            &config,
+            ApiProvider::Openrouter,
+            "`providers.openrouter` api_key"
+        ),
+        None,
+        "a config key with no secret-store slot behind it is not a shadow"
+    );
+    Ok(())
+}
+
 #[test]
 fn whitespace_codewhale_home_never_opens_ambient_file_secret_store() -> Result<()> {
     let _lock = lock_test_env();


### PR DESCRIPTION
Stack **R7** — closes the owner's 'keys don't persist between sessions/folders' pain at the root. **Headline: the full bin suite is 0-fail for the first time this cycle** (the two `config::credential_scope_tests::*` failures waived all month as 'macOS symlink noise' were a LIVE regression).

## Root cause (from the credential-storage audit)

`fb1b05c7c` (#5045) added `config_path_is_workspace_scoped` + `credential_config_path()` so credential writes default to the user-global document. Merge `6860a40eb` resolved conflicts by deleting the entire fix while keeping its tests — credential writes have been landing in repo-scoped configs again ever since: key material written in folder A, invisible in folder B.

## What's in it (one commit per issue)

- **#5193** — re-land the classifier + resolver: every credential write defaults to the user-global document; per-workspace destination is explicit opt-in only. Test expectations compare canonicalized paths so the `/private` symlink stops masking real failures. **credential_scope tests: 2/2 pass.**
- **#5196** — TUI `/logout` now deletes the provider's durable secret-store slot (previously only stripped the ambient config — 'logged out' was false). Symmetric with the R4 CLI fix.
- **#5198** — `auth set`/login metadata (provider binding, `auth_mode` markers) routes to the same user-global document — the provider no longer 'un-switches' when changing folders.
- **#5194** — a config-file `api_key` that shadows the secret-store slot now warns, naming both sources and which won (same class as the fleet roster shadowing badge).

## Gates

- `cargo fmt --all -- --check` exit=0.
- Full bin suite post-rebase: **9634 passed, 0 failed, 9 ignored** (99.5s) — the suite's first fully green run this cycle; the waived-failure baseline is gone.

No-Issue: v0.9.4 program stack PR. Closes #5193, Closes #5194, Closes #5196, Closes #5198. Refs #5195, #5197 (remaining credential-truth items).