### PR TITLE
stack: Model Studio truth pack — catalog + one-key family + per-model vision

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2053,11 +2053,9 @@ fn run_logout_command_with_secrets_unlocked(
 
 /// Map [`ProviderKind`] to the canonical provider credential slot.
 fn provider_slot(provider: ProviderKind) -> &'static str {
-    match provider {
-        // Keep the historical shared credential slot for the China endpoint.
-        ProviderKind::SiliconflowCN => "siliconflow",
-        _ => provider.provider().id(),
-    }
+    // Shared-account families (SiliconFlow China, the four Model Studio
+    // variants) collapse onto one slot; see ProviderKind::secret_store_slot.
+    provider.secret_store_slot()
 }
 
 /// Resolve the store for credential-adjacent writes: provider selection,
@@ -7933,10 +7931,29 @@ model = "qwen-2.5-7b"
 
         for provider in ProviderKind::ALL {
             assert_eq!(provider_env_vars(provider), provider.provider().env_vars());
+            // Shared-account families collapse onto one durable slot (see
+            // ProviderKind::secret_store_slot); everything else uses its own id.
+            assert_eq!(
+                provider_slot(provider),
+                provider.secret_store_slot(),
+                "{provider:?} slot must match ProviderKind::secret_store_slot"
+            );
             if provider == ProviderKind::SiliconflowCN {
                 assert_eq!(
                     provider_slot(provider),
                     provider_slot(ProviderKind::Siliconflow)
+                );
+            } else if matches!(
+                provider,
+                ProviderKind::ModelstudioTokenPlan
+                    | ProviderKind::ModelstudioTokenPlanAnthropic
+                    | ProviderKind::ModelstudioCodingPlan
+                    | ProviderKind::ModelstudioCodingPlanAnthropic
+            ) {
+                assert_eq!(
+                    provider_slot(provider),
+                    "modelstudio-token-plan",
+                    "{provider:?} must share the Model Studio family slot"
                 );
             } else {
                 assert_eq!(provider_slot(provider), provider.provider().id());

--- a/crates/config/assets/models_dev.bundled.json
+++ b/crates/config/assets/models_dev.bundled.json
@@ -4,9 +4,10 @@
     "schema": "Matches crates/config/src/models_dev.rs ModelsDevCatalog ({ models, providers }).",
     "role": "NOT a competing source of truth. Preferred metadata is the live Models.dev catalog published into ProviderLake (#4187). This asset is used only when live/cache rows are unavailable (offline startup, failed refresh, or empty cache).",
     "source": "Compact offline seed of verified in-repo defaults (context/output from crates/tui/src/models.rs; USD pricing from crates/tui/src/pricing.rs) for providers Codewhale ships with. It is intentionally smaller than a full Models.dev dump; live refresh supersedes these rows on (provider, wire_model_id) identity.",
-    "honesty": "Pricing is intentionally OMITTED where the repo does not publish a trustworthy per-token rate: DeepSeek-native rows (priced via the time-aware DeepSeek table elsewhere, kept UnknownOrStale at the route layer), aggregator-hosted DeepSeek rows (aggregator account terms, not DeepSeek Platform pricing), and Xiaomi MiMo rows (published PAYG rates apply only to sk- pay-as-you-go keys; the catalog cannot distinguish that billing surface from credit/quota Token Plan keys, so MiMo stays unpriced). Absent pricing surfaces as PricingSku::UnknownOrStale, never a fabricated zero.",
+    "honesty": "Pricing is intentionally OMITTED where the repo does not publish a trustworthy per-token rate: DeepSeek-native rows (priced via the time-aware DeepSeek table elsewhere, kept UnknownOrStale at the route layer), aggregator-hosted DeepSeek rows (aggregator account terms, not DeepSeek Platform pricing), Xiaomi MiMo rows (published PAYG rates apply only to sk- pay-as-you-go keys; the catalog cannot distinguish that billing surface from credit/quota Token Plan keys, so MiMo stays unpriced), and Alibaba Model Studio Token/Coding Plan rows (upstream lists zero per-token cost because usage draws on plan quota, not per-token billing; a zero here would read as 'free'). Absent pricing surfaces as PricingSku::UnknownOrStale, never a fabricated zero.",
     "default_rows": "Each provider's `default: true` wire id equals that provider's built-in DEFAULT_*_MODEL so RouteResolver::new() and the descriptor stay in agreement when offline.",
-    "coverage": "15 providers, 45 chat offerings (offline seed only)."
+    "curated": "qwen3.8-max (GA) is curated ahead of upstream Models.dev, which as of 2026-08-03 lists only qwen3.8-max-preview; facts verified against the owner's Token Plan console (2026-08-03): ~1M context, 128K output, image understanding, always-on reasoning. deepseek-v4-flash-0731 keeps the console/in-repo wire id for the row upstream serves as deepseek-v4-flash. Coding Plan rows for qwen3.8-max-preview, deepseek-v4-pro, deepseek-v4-flash-0731, and glm-5.2 are curated from the Token Plan upstream entries (upstream alibaba-coding-plan does not list them yet); the in-repo route layer already offers the same model set on both plans. Upstream provider ids alibaba-token-plan(-cn) / alibaba-coding-plan(-cn) were merged onto the CodeWhale provider ids (live refresh normalizes them via ProviderKind aliases; the -cn regional variants stay upstream-id browse rows until Codewhale ships China endpoints).",
+    "coverage": "20 providers, 78 chat offerings (offline seed only)."
   },
   "models": {
     "deepseek-v4-pro": {
@@ -210,6 +211,502 @@
           "modalities": { "input": ["text"], "output": ["text"] },
           "limit": { "context": 204800, "output": 204800 },
           "cost": { "input": 0.30, "output": 1.20, "cache_read": 0.06, "cache_write": 0.375 }
+        }
+      }
+    },
+    "modelstudio-token-plan": {
+      "id": "modelstudio-token-plan",
+      "name": "Alibaba Cloud Model Studio (Token Plan)",
+      "api": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+      "npm": "@ai-sdk/openai-compatible",
+      "env": ["MODELSTUDIO_API_KEY", "DASHSCOPE_API_KEY"],
+      "models": {
+        "qwen3.8-max": {
+          "id": "qwen3.8-max",
+          "name": "Qwen3.8 Max",
+          "family": "qwen",
+          "default": true,
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "thinking", "values": ["always_on"], "default": "always_on"}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        },
+        "qwen3.8-max-preview": {
+          "id": "qwen3.8-max-preview",
+          "name": "Qwen3.8 Max Preview",
+          "family": "qwen",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "effort", "values": ["low", "medium", "xhigh"]},
+            {"type": "budget_tokens", "min": 0, "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        },
+        "qwen3.7-plus": {
+          "id": "qwen3.7-plus",
+          "name": "Qwen3.7 Plus",
+          "family": "qwen",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 65536 }
+        },
+        "qwen3.7-max": {
+          "id": "qwen3.7-max",
+          "name": "Qwen3.7 Max",
+          "family": "qwen",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        },
+        "qwen3.6-flash": {
+          "id": "qwen3.6-flash",
+          "name": "Qwen3.6 Flash",
+          "family": "qwen3.6",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 131072}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 65536 }
+        },
+        "deepseek-v4-pro": {
+          "id": "deepseek-v4-pro",
+          "name": "DeepSeek V4 Pro",
+          "family": "deepseek-thinking",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 384000 }
+        },
+        "deepseek-v4-flash-0731": {
+          "id": "deepseek-v4-flash-0731",
+          "name": "DeepSeek V4 Flash (0731)",
+          "family": "deepseek-flash",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 384000 }
+        },
+        "glm-5.2": {
+          "id": "glm-5.2",
+          "name": "GLM-5.2",
+          "family": "glm",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        }
+      }
+    },
+    "modelstudio-token-plan-anthropic": {
+      "id": "modelstudio-token-plan-anthropic",
+      "name": "Alibaba Cloud Model Studio (Token Plan, Anthropic-compatible)",
+      "api": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic",
+      "npm": "@ai-sdk/anthropic",
+      "env": ["MODELSTUDIO_API_KEY", "DASHSCOPE_API_KEY"],
+      "models": {
+        "qwen3.8-max": {
+          "id": "qwen3.8-max",
+          "name": "Qwen3.8 Max",
+          "family": "qwen",
+          "default": true,
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "thinking", "values": ["always_on"], "default": "always_on"}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        },
+        "qwen3.8-max-preview": {
+          "id": "qwen3.8-max-preview",
+          "name": "Qwen3.8 Max Preview",
+          "family": "qwen",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "effort", "values": ["low", "medium", "xhigh"]},
+            {"type": "budget_tokens", "min": 0, "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        },
+        "qwen3.7-plus": {
+          "id": "qwen3.7-plus",
+          "name": "Qwen3.7 Plus",
+          "family": "qwen",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 65536 }
+        },
+        "qwen3.7-max": {
+          "id": "qwen3.7-max",
+          "name": "Qwen3.7 Max",
+          "family": "qwen",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        },
+        "qwen3.6-flash": {
+          "id": "qwen3.6-flash",
+          "name": "Qwen3.6 Flash",
+          "family": "qwen3.6",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 131072}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 65536 }
+        },
+        "deepseek-v4-pro": {
+          "id": "deepseek-v4-pro",
+          "name": "DeepSeek V4 Pro",
+          "family": "deepseek-thinking",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 384000 }
+        },
+        "deepseek-v4-flash-0731": {
+          "id": "deepseek-v4-flash-0731",
+          "name": "DeepSeek V4 Flash (0731)",
+          "family": "deepseek-flash",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 384000 }
+        },
+        "glm-5.2": {
+          "id": "glm-5.2",
+          "name": "GLM-5.2",
+          "family": "glm",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        }
+      }
+    },
+    "modelstudio-coding-plan": {
+      "id": "modelstudio-coding-plan",
+      "name": "Alibaba Cloud Model Studio (Coding Plan)",
+      "api": "https://coding-intl.dashscope.aliyuncs.com/v1",
+      "npm": "@ai-sdk/openai-compatible",
+      "env": ["MODELSTUDIO_API_KEY", "DASHSCOPE_API_KEY"],
+      "models": {
+        "qwen3.8-max": {
+          "id": "qwen3.8-max",
+          "name": "Qwen3.8 Max",
+          "family": "qwen",
+          "default": true,
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "thinking", "values": ["always_on"], "default": "always_on"}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        },
+        "qwen3.8-max-preview": {
+          "id": "qwen3.8-max-preview",
+          "name": "Qwen3.8 Max Preview",
+          "family": "qwen",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "effort", "values": ["low", "medium", "xhigh"]},
+            {"type": "budget_tokens", "min": 0, "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        },
+        "qwen3.7-plus": {
+          "id": "qwen3.7-plus",
+          "name": "Qwen3.7 Plus",
+          "family": "qwen",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 64000 }
+        },
+        "qwen3.7-max": {
+          "id": "qwen3.7-max",
+          "name": "Qwen3.7 Max",
+          "family": "qwen",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 65536 }
+        },
+        "qwen3.6-flash": {
+          "id": "qwen3.6-flash",
+          "name": "Qwen3.6 Flash",
+          "family": "qwen3.6",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 131072}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 65536 }
+        },
+        "deepseek-v4-pro": {
+          "id": "deepseek-v4-pro",
+          "name": "DeepSeek V4 Pro",
+          "family": "deepseek-thinking",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 384000 }
+        },
+        "deepseek-v4-flash-0731": {
+          "id": "deepseek-v4-flash-0731",
+          "name": "DeepSeek V4 Flash (0731)",
+          "family": "deepseek-flash",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 384000 }
+        },
+        "glm-5.2": {
+          "id": "glm-5.2",
+          "name": "GLM-5.2",
+          "family": "glm",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        }
+      }
+    },
+    "modelstudio-coding-plan-anthropic": {
+      "id": "modelstudio-coding-plan-anthropic",
+      "name": "Alibaba Cloud Model Studio (Coding Plan, Anthropic-compatible)",
+      "api": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic",
+      "npm": "@ai-sdk/anthropic",
+      "env": ["MODELSTUDIO_API_KEY", "DASHSCOPE_API_KEY"],
+      "models": {
+        "qwen3.8-max": {
+          "id": "qwen3.8-max",
+          "name": "Qwen3.8 Max",
+          "family": "qwen",
+          "default": true,
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "thinking", "values": ["always_on"], "default": "always_on"}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        },
+        "qwen3.8-max-preview": {
+          "id": "qwen3.8-max-preview",
+          "name": "Qwen3.8 Max Preview",
+          "family": "qwen",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "effort", "values": ["low", "medium", "xhigh"]},
+            {"type": "budget_tokens", "min": 0, "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
+        },
+        "qwen3.7-plus": {
+          "id": "qwen3.7-plus",
+          "name": "Qwen3.7 Plus",
+          "family": "qwen",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 64000 }
+        },
+        "qwen3.7-max": {
+          "id": "qwen3.7-max",
+          "name": "Qwen3.7 Max",
+          "family": "qwen",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 262144}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 65536 }
+        },
+        "qwen3.6-flash": {
+          "id": "qwen3.6-flash",
+          "name": "Qwen3.6 Flash",
+          "family": "qwen3.6",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "budget_tokens", "max": 131072}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 65536 }
+        },
+        "deepseek-v4-pro": {
+          "id": "deepseek-v4-pro",
+          "name": "DeepSeek V4 Pro",
+          "family": "deepseek-thinking",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 384000 }
+        },
+        "deepseek-v4-flash-0731": {
+          "id": "deepseek-v4-flash-0731",
+          "name": "DeepSeek V4 Flash (0731)",
+          "family": "deepseek-flash",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "toggle"},
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 384000 }
+        },
+        "glm-5.2": {
+          "id": "glm-5.2",
+          "name": "GLM-5.2",
+          "family": "glm",
+          "reasoning": true,
+          "reasoning_options": [
+            {"type": "effort", "values": ["high", "max"]}
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": {"input": ["text"], "output": ["text"]},
+          "limit": { "context": 1000000, "output": 131072 }
         }
       }
     },

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2832,7 +2832,7 @@ impl ConfigToml {
                 None => (None, None),
             }
         } else {
-            match secrets.resolve_with_source(provider.as_str()) {
+            match secrets.resolve_with_source(provider.secret_store_slot()) {
                 Some((value, source)) => {
                     let source = match source {
                         SecretSource::Keyring => RuntimeApiKeySource::Keyring,

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -269,6 +269,31 @@ impl ProviderKind {
         matches!(self, Self::Siliconflow | Self::SiliconflowCN)
     }
 
+    /// Canonical durable-credential slot in the local secret store.
+    ///
+    /// Most providers own a slot named after their id. Variants authenticated
+    /// by the SAME account share one slot so a single saved key (or logout)
+    /// applies to the whole family:
+    ///
+    /// - `SiliconflowCN` shares `siliconflow` (historical China-endpoint slot,
+    ///   already the TUI/CLI convention).
+    /// - The four Alibaba Cloud Model Studio variants share
+    ///   `modelstudio-token-plan`: one Model Studio account/key authenticates
+    ///   the Token Plan and Coding Plan endpoints in both wire dialects, so
+    ///   per-variant slots produced three bogus "missing key" rows whenever
+    ///   one variant held the key.
+    #[must_use]
+    pub fn secret_store_slot(self) -> &'static str {
+        match self {
+            Self::SiliconflowCN => "siliconflow",
+            Self::ModelstudioTokenPlan
+            | Self::ModelstudioTokenPlanAnthropic
+            | Self::ModelstudioCodingPlan
+            | Self::ModelstudioCodingPlanAnthropic => "modelstudio-token-plan",
+            _ => self.as_str(),
+        }
+    }
+
     /// Return the built-in metadata entry for this provider.
     ///
     /// This is a metadata foundation only; runtime routing still resolves

--- a/crates/config/src/route/conformance_tests.rs
+++ b/crates/config/src/route/conformance_tests.rs
@@ -138,3 +138,52 @@ fn every_provider_kind_resolves_the_auto_selector() {
         );
     }
 }
+
+#[test]
+fn modelstudio_image_input_capability_is_per_model() {
+    use super::capabilities::CapabilityState;
+
+    // Owner's Token Plan console (verified 2026-08-03) lists Visual
+    // Understanding for exactly these four models; upstream Models.dev
+    // modalities agree (image/video input) and mark the rest text-only.
+    const VISION: &[&str] = &[
+        "qwen3.8-max",
+        "qwen3.8-max-preview",
+        "qwen3.7-plus",
+        "qwen3.6-flash",
+    ];
+    const TEXT_ONLY: &[&str] = &[
+        "qwen3.7-max",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
+        "glm-5.2",
+    ];
+    const PROVIDERS: &[&str] = &[
+        "modelstudio-token-plan",
+        "modelstudio-coding-plan",
+        "modelstudio-token-plan-anthropic",
+        "modelstudio-coding-plan-anthropic",
+    ];
+
+    let offerings = bundled_offerings();
+    for provider in PROVIDERS {
+        for (models, expected) in [
+            (VISION, CapabilityState::Supported),
+            (TEXT_ONLY, CapabilityState::Unsupported),
+        ] {
+            for model in models {
+                let offering = offerings
+                    .iter()
+                    .find(|offering| {
+                        offering.provider.as_str() == *provider
+                            && offering.wire_model_id.as_str() == *model
+                    })
+                    .unwrap_or_else(|| panic!("{provider}/{model}: missing bundled offering"));
+                assert_eq!(
+                    offering.capabilities.image_input, expected,
+                    "{provider}/{model}: image_input drifted from the console-verified capability"
+                );
+            }
+        }
+    }
+}

--- a/crates/config/src/route/offering.rs
+++ b/crates/config/src/route/offering.rs
@@ -235,16 +235,27 @@ pub fn bundled_offerings() -> Vec<ProviderModelOffering> {
     // Alibaba Cloud Model Studio — Token Plan and Coding Plan.
     // All models below are classified as Text Generation / Reasoning on the
     // Model Studio catalog; reasoning and tool-call capabilities are marked
-    // Supported conservatively. Visual Understanding flag is not listed here
-    // because Codewhale's image-input routing for these models is unverified.
-    let ms_capabilities = RouteCapabilities {
-        reasoning: CapabilityState::Supported,
-        native_tool_calls: CapabilityState::Supported,
-        structured_output: CapabilityState::Supported,
-        streaming: CapabilityState::Supported,
-        image_input: CapabilityState::Unknown,
-        ..RouteCapabilities::default()
-    };
+    // Supported conservatively. Image input is per model: the owner's Token
+    // Plan console (verified 2026-08-03) lists Visual Understanding for
+    // qwen3.8-max, qwen3.8-max-preview, qwen3.7-plus, and qwen3.6-flash —
+    // corroborated by upstream Models.dev modalities — while qwen3.7-max,
+    // the DeepSeek rows, and glm-5.2 are text-only on both sources.
+    fn ms_capabilities(model: &str) -> RouteCapabilities {
+        let image_input = match model {
+            "qwen3.8-max" | "qwen3.8-max-preview" | "qwen3.7-plus" | "qwen3.6-flash" => {
+                CapabilityState::Supported
+            }
+            _ => CapabilityState::Unsupported,
+        };
+        RouteCapabilities {
+            reasoning: CapabilityState::Supported,
+            native_tool_calls: CapabilityState::Supported,
+            structured_output: CapabilityState::Supported,
+            streaming: CapabilityState::Supported,
+            image_input,
+            ..RouteCapabilities::default()
+        }
+    }
     for plan_provider_id in &["modelstudio-token-plan", "modelstudio-coding-plan"] {
         let plan = ProviderId::from(*plan_provider_id);
         offerings.extend(
@@ -258,7 +269,7 @@ pub fn bundled_offerings() -> Vec<ProviderModelOffering> {
                     endpoint_key: "chat".to_string(),
                     default_for_provider: i == 0,
                     limits: RouteLimits::default(),
-                    capabilities: ms_capabilities,
+                    capabilities: ms_capabilities(model),
                     pricing: PricingSku::UnknownOrStale,
                 }),
         );
@@ -280,7 +291,7 @@ pub fn bundled_offerings() -> Vec<ProviderModelOffering> {
                     endpoint_key: "messages".to_string(),
                     default_for_provider: i == 0,
                     limits: RouteLimits::default(),
-                    capabilities: ms_capabilities,
+                    capabilities: ms_capabilities(model),
                     pricing: PricingSku::UnknownOrStale,
                 }),
         );

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -5650,6 +5650,45 @@ fn moonshot_api_key_mode_can_use_secret_store_by_default() {
 }
 
 #[test]
+fn modelstudio_variants_resolve_one_shared_secret_store_slot() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+    let store = Arc::new(RecordingSecretsStore::with_value("secret-store-key"));
+    let secrets = Secrets::new(store.clone());
+
+    // One Alibaba Cloud Model Studio account authenticates every plan/dialect
+    // variant, so all four resolve the family's single canonical slot.
+    for provider in [
+        ProviderKind::ModelstudioTokenPlan,
+        ProviderKind::ModelstudioTokenPlanAnthropic,
+        ProviderKind::ModelstudioCodingPlan,
+        ProviderKind::ModelstudioCodingPlanAnthropic,
+    ] {
+        let config = ConfigToml {
+            provider,
+            ..ConfigToml::default()
+        };
+
+        let resolved =
+            config.resolve_runtime_options_with_secrets(&CliRuntimeOverrides::default(), &secrets);
+
+        assert_eq!(resolved.provider, provider);
+        assert_eq!(resolved.api_key.as_deref(), Some("secret-store-key"));
+        assert_eq!(resolved.api_key_source, Some(RuntimeApiKeySource::Keyring));
+    }
+
+    assert_eq!(
+        store.gets.lock().unwrap().as_slice(),
+        [
+            "modelstudio-token-plan",
+            "modelstudio-token-plan",
+            "modelstudio-token-plan",
+            "modelstudio-token-plan"
+        ]
+    );
+}
+
+#[test]
 fn loopback_custom_deepseek_base_url_does_not_probe_secret_store_by_default() {
     let _lock = env_lock();
     let _env = EnvGuard::without_deepseek_runtime_overrides();

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -1217,6 +1217,20 @@ pub fn env_for(name: &str) -> Option<String> {
         "telecomjs" | "telecom-js" | "telecom_js" | "telecomjs-cn" | "tokenhub" => {
             &["TELECOMJS_API_KEY"]
         }
+        // One Alibaba Cloud Model Studio account authenticates every plan /
+        // dialect variant; all four names share one env convention.
+        "modelstudio-token-plan"
+        | "modelstudio_token_plan"
+        | "modelstudio-token-plan-anthropic"
+        | "modelstudio_token_plan_anthropic"
+        | "modelstudio-coding-plan"
+        | "modelstudio_coding_plan"
+        | "modelstudio-coding-plan-anthropic"
+        | "modelstudio_coding_plan_anthropic"
+        | "modelstudio"
+        | "dashscope"
+        | "alibaba-token-plan"
+        | "alibaba-coding-plan" => &["MODELSTUDIO_API_KEY", "DASHSCOPE_API_KEY"],
         _ => return None,
     };
     for var in candidates {
@@ -1278,6 +1292,8 @@ mod tests {
             "MODEL_API_KEY",
             "XAI_API_KEY",
             "TELECOMJS_API_KEY",
+            "MODELSTUDIO_API_KEY",
+            "DASHSCOPE_API_KEY",
             SECRET_BACKEND_ENV,
             LEGACY_SECRET_BACKEND_ENV,
         ] {
@@ -1841,6 +1857,36 @@ mod tests {
         for alias in ["opencode-go", "opencode_go", "opencodego"] {
             assert_eq!(env_for(alias).as_deref(), Some("go-key"), "{alias}");
         }
+
+        clear_known_envs();
+    }
+
+    #[test]
+    fn modelstudio_variants_share_one_env_convention() {
+        let _guard = env_lock();
+        clear_known_envs();
+        unsafe { std::env::set_var("MODELSTUDIO_API_KEY", "ms-key") };
+
+        for alias in [
+            "modelstudio-token-plan",
+            "modelstudio-token-plan-anthropic",
+            "modelstudio-coding-plan",
+            "modelstudio-coding-plan-anthropic",
+            "modelstudio",
+            "dashscope",
+            "alibaba-token-plan",
+            "alibaba-coding-plan",
+        ] {
+            assert_eq!(env_for(alias).as_deref(), Some("ms-key"), "{alias}");
+        }
+
+        clear_known_envs();
+        unsafe { std::env::set_var("DASHSCOPE_API_KEY", "dashscope-key") };
+        assert_eq!(
+            env_for("modelstudio-token-plan").as_deref(),
+            Some("dashscope-key"),
+            "DASHSCOPE_API_KEY is the fallback for the same account"
+        );
 
         clear_known_envs();
     }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -9751,17 +9751,19 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
     // path itself writes (an api-key auth mode with no config literal). A
     // configured-but-inactive provider must not render as unconfigured just
     // because the operator switched providers after saving its key (#5033).
-    // The probe stays bounded to explicitly configured providers, and the
-    // non-active case is strictly read-only so rendering the catalog never
-    // migrates a legacy store or opens a write-capable backend.
+    // Shared-slot families (one account, several provider variants — e.g.
+    // Model Studio Token/Coding Plan × OpenAI/Anthropic dialects) honor the
+    // marker written by ANY sibling variant, since the save path stores one
+    // key under the family's canonical slot. The probe stays bounded to
+    // explicitly configured providers, and the non-active case is strictly
+    // read-only so rendering the catalog never migrates a legacy store or
+    // opens a write-capable backend.
     if !config.should_skip_secret_store_for_provider(provider) {
         if provider == config.api_provider() {
             if provider_secret_store_api_key(config, provider).is_some() {
                 return true;
             }
-        } else if config
-            .provider_config_for(provider)
-            .is_some_and(|entry| auth_mode_requires_api_key(entry.auth_mode.as_deref()))
+        } else if secret_slot_save_marker_on_shared_slot(config, provider)
             && provider_secret_store_api_key_with_mode(config, provider, true).is_some()
         {
             return true;
@@ -10408,9 +10410,33 @@ fn provider_secret_store_slot(provider: ApiProvider) -> &'static str {
     match provider {
         // TUI compatibility variants share the canonical CLI provider slots.
         ApiProvider::DeepseekCN => "deepseek",
-        ApiProvider::SiliconflowCn => "siliconflow",
-        _ => provider.as_str(),
+        // Shared-account families (SiliconFlow China, the four Model Studio
+        // variants) collapse onto one slot via ProviderKind::secret_store_slot.
+        _ => provider
+            .kind()
+            .map_or_else(|| provider.as_str(), |kind| kind.secret_store_slot()),
     }
+}
+
+/// Whether the secret-store save marker (`auth_mode = "api_key"` with no
+/// config literal, written by the save path) exists for `provider` or for any
+/// provider sharing its durable credential slot.
+///
+/// One Model Studio account authenticates all four plan/dialect variants, so
+/// saving a key on `modelstudio-token-plan` marks only that variant's config
+/// table; the sibling variants must still treat the family slot as saved.
+fn secret_slot_save_marker_on_shared_slot(config: &Config, provider: ApiProvider) -> bool {
+    let slot = provider_secret_store_slot(provider);
+    ApiProvider::all()
+        .iter()
+        .copied()
+        .chain(std::iter::once(ApiProvider::DeepseekCN))
+        .filter(|candidate| provider_secret_store_slot(*candidate) == slot)
+        .any(|candidate| {
+            config
+                .provider_config_for(candidate)
+                .is_some_and(|entry| auth_mode_requires_api_key(entry.auth_mode.as_deref()))
+        })
 }
 
 /// Read only the durable secret-store layer (no environment fallback).

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -9409,6 +9409,80 @@ fn save_api_key_for_deepseek_cn_uses_root_deepseek_storage() -> Result<()> {
 }
 
 #[test]
+fn modelstudio_variants_share_one_secret_slot_and_key_availability() -> Result<()> {
+    let _lock = lock_test_env();
+    let temp_root = tempfile::tempdir()?;
+    let _guard = EnvGuard::new(temp_root.path());
+    let codewhale_home = temp_root.path().join("codewhale-home");
+    let config_path = codewhale_home.join("config.toml");
+    let _codewhale_home = EnvVarGuard::set("CODEWHALE_HOME", codewhale_home.as_os_str());
+    let _config_path = EnvVarGuard::set("CODEWHALE_CONFIG_PATH", config_path.as_os_str());
+    let _backend = EnvVarGuard::set("CODEWHALE_SECRET_BACKEND", "file");
+    let _ms_env = EnvVarGuard::remove("MODELSTUDIO_API_KEY");
+    let _dashscope_env = EnvVarGuard::remove("DASHSCOPE_API_KEY");
+    let _cli_source = EnvVarGuard::remove("DEEPSEEK_API_KEY_SOURCE");
+    let _cli_key = EnvVarGuard::remove("CODEWHALE_CLI_API_KEY");
+
+    let variants = [
+        ApiProvider::ModelstudioTokenPlan,
+        ApiProvider::ModelstudioTokenPlanAnthropic,
+        ApiProvider::ModelstudioCodingPlan,
+        ApiProvider::ModelstudioCodingPlanAnthropic,
+    ];
+    for variant in variants {
+        assert_eq!(
+            provider_secret_store_slot(variant),
+            "modelstudio-token-plan",
+            "{variant:?} must share the family's one credential slot"
+        );
+    }
+
+    // Saving on the Token Plan variant writes the single family slot only.
+    save_api_key_for(ApiProvider::ModelstudioTokenPlan, "ms-family-key")?;
+    let secrets = codewhale_secrets::Secrets::auto_detect();
+    assert_eq!(
+        secrets.get("modelstudio-token-plan")?,
+        Some("ms-family-key".to_string())
+    );
+    assert_eq!(secrets.get("modelstudio-coding-plan")?, None);
+
+    // Every variant — active or not — resolves the family key, so the picker
+    // badge stops showing three bogus "missing key" rows after one save.
+    let inactive_variants = Config::load(Some(config_path.clone()), None)?;
+    for variant in variants {
+        assert_eq!(
+            provider_secret_store_api_key(&inactive_variants, variant).as_deref(),
+            Some("ms-family-key"),
+            "{variant:?} must read the family slot"
+        );
+        assert!(
+            has_api_key_for(&inactive_variants, variant),
+            "{variant:?} key-availability badge must resolve the family key"
+        );
+    }
+
+    // Saving on any sibling variant overwrites the same shared slot.
+    save_api_key_for(
+        ApiProvider::ModelstudioCodingPlanAnthropic,
+        "ms-family-key-v2",
+    )?;
+    assert_eq!(
+        secrets.get("modelstudio-token-plan")?,
+        Some("ms-family-key-v2".to_string())
+    );
+    assert_eq!(secrets.get("modelstudio-coding-plan-anthropic")?, None);
+    let reloaded = Config::load(Some(config_path), None)?;
+    for variant in variants {
+        assert_eq!(
+            provider_secret_store_api_key(&reloaded, variant).as_deref(),
+            Some("ms-family-key-v2"),
+            "{variant:?} must follow the family slot across saves"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn nvidia_nim_reads_facade_provider_table() -> Result<()> {
     let _lock = lock_test_env();
     let nanos = SystemTime::now()

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -5352,6 +5352,50 @@ mod tests {
     }
 
     #[test]
+    fn modelstudio_family_key_marks_all_variants_configured() {
+        let _guard = crate::test_support::lock_test_env();
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let _home = crate::test_support::EnvVarGuard::set("HOME", tmp.path());
+        let _userprofile = crate::test_support::EnvVarGuard::set("USERPROFILE", tmp.path());
+        let _codewhale_home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", tmp.path());
+        let _backend = crate::test_support::EnvVarGuard::set("CODEWHALE_SECRET_BACKEND", "file");
+        let _ms_key = crate::test_support::EnvVarGuard::remove("MODELSTUDIO_API_KEY");
+        let _dashscope_key = crate::test_support::EnvVarGuard::remove("DASHSCOPE_API_KEY");
+        let _cli_source = crate::test_support::EnvVarGuard::remove("DEEPSEEK_API_KEY_SOURCE");
+        let _cli_key = crate::test_support::EnvVarGuard::remove("CODEWHALE_CLI_API_KEY");
+
+        // One saved key on the Token Plan variant, marked by the save path.
+        codewhale_secrets::Secrets::auto_detect()
+            .set("modelstudio-token-plan", "ms-family-key")
+            .expect("seed family slot");
+        let config = Config {
+            provider: Some("deepseek".to_string()),
+            providers: Some(crate::config::ProvidersConfig {
+                modelstudio_token_plan: crate::config::ProviderConfig {
+                    auth_mode: Some("api_key".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+
+        for variant in [
+            ApiProvider::ModelstudioTokenPlan,
+            ApiProvider::ModelstudioTokenPlanAnthropic,
+            ApiProvider::ModelstudioCodingPlan,
+            ApiProvider::ModelstudioCodingPlanAnthropic,
+        ] {
+            let row = ProviderDashboardRow::from_config(variant, ApiProvider::Deepseek, &config);
+            assert_eq!(
+                row.auth_status,
+                ProviderAuthStatus::Configured,
+                "{variant:?} must resolve the family's one saved key"
+            );
+        }
+    }
+
+    #[test]
     fn provider_dashboard_row_marks_route_resolver_errors_as_invalid() {
         let config = Config {
             api_key: Some("deepseek-key".to_string()),


### PR DESCRIPTION
## Summary

Lands the Model Studio dogfood-readiness pack on the v0.9.4 release train after #5175:

1. **Bundled catalog** — Models.dev alibaba-*-plan rows for the four Codewhale provider ids + curated `qwen3.8-max` GA (upstream still only lists `-preview`).
2. **One key for all four variants** — Token/Coding Plan × OpenAI/Anthropic share `modelstudio-token-plan` secret slot + `MODELSTUDIO_API_KEY`/`DASHSCOPE_API_KEY` env. Picker badges stop lying after one save.
3. **Per-model vision** — console-verified Visual Understanding on qwen3.8-max / -preview / qwen3.7-plus / qwen3.6-flash; text-only on the rest.

## Receipts

- `cargo test -p codewhale-config modelstudio_` → 2 pass
- `cargo test -p codewhale-secrets modelstudio_` → 1 pass
- `cargo test -p codewhale-tui --bin codewhale-tui modelstudio_` → 2 pass
- `cargo test -p codewhale-cli cli_provider_helpers_follow_config_metadata` → 1 pass

Full bin suite running on the branch before merge.

## Test plan

- [x] Targeted gates above
- [ ] Full `cargo test -p codewhale-tui --bin codewhale-tui` on this tip
- [ ] Rebuild + install for owner dogfood of qwen3.8-max