### PR TITLE
fix(tui): retry sub-agent API timeouts with backoff; raise default timeout to 600s

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -311,7 +311,7 @@ max_subagents = 10 # optional (1-20)
 # Optional sub-agent tuning. max_concurrent overrides top-level max_subagents.
 # [subagents]
 # max_concurrent = 10
-# api_timeout_secs = 120 # per-step API timeout, clamped to 1..=1800
+# api_timeout_secs = 600 # per-step API timeout, clamped to 1..=3600
 #
 # How many levels of nested sub-agents the `agent` tool may spawn:
 #   max_depth = 0   # opt out completely — the agent never spawns sub-agents

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -3539,11 +3539,11 @@ heartbeat_timeout_secs = 1
         );
         assert!(
             msg.contains(
-                "subagents.api_timeout_secs = 0 (resolved global 120; active provider 120)"
+                "subagents.api_timeout_secs = 0 (resolved global 600; active provider 600)"
             )
         );
         assert!(msg.contains(
-            "subagents.heartbeat_timeout_secs = 1 (resolved global 150; active provider 150)"
+            "subagents.heartbeat_timeout_secs = 1 (resolved global 630; active provider 630)"
         ));
         assert!(msg.contains("subagents.providers.deepseek = inherits global"));
     }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2172,9 +2172,9 @@ pub struct SubagentsConfig {
     /// Per-step DeepSeek API timeout for sub-agent requests, in seconds. The
     /// timeout wraps `client.create_message` so a stuck single step cannot
     /// pin the parent's parent-completion wakeup channel indefinitely.
-    /// Defaults to `DEFAULT_SUBAGENT_API_TIMEOUT_SECS` (120) and is clamped
+    /// Defaults to `DEFAULT_SUBAGENT_API_TIMEOUT_SECS` (600) and is clamped
     /// to `MIN_SUBAGENT_API_TIMEOUT_SECS..=MAX_SUBAGENT_API_TIMEOUT_SECS`
-    /// (1..=1800). Zero or unset uses the legacy 120s default (#1806, #1808).
+    /// (1..=3600). Zero or unset uses the 600s default (#1806, #1808).
     #[serde(default)]
     pub api_timeout_secs: Option<u64>,
     /// Wall-clock timeout for a running sub-agent that stops making
@@ -6222,10 +6222,9 @@ impl Config {
     ///
     /// Reads `[subagents] api_timeout_secs` and clamps to
     /// `[MIN_SUBAGENT_API_TIMEOUT_SECS, MAX_SUBAGENT_API_TIMEOUT_SECS]`
-    /// (1..=1800). `None` or `0` resolve to the legacy
-    /// `DEFAULT_SUBAGENT_API_TIMEOUT_SECS` (120) so existing configs keep
-    /// their old behavior; explicit `1` is honored, useful only in fast
-    /// fail-fast tests, not production (#1806, #1808).
+    /// (1..=3600). `None` or `0` resolve to
+    /// `DEFAULT_SUBAGENT_API_TIMEOUT_SECS` (600); explicit `1` is honored,
+    /// useful only in fast fail-fast tests, not production (#1806, #1808).
     #[must_use]
     pub fn subagent_api_timeout_secs(&self) -> u64 {
         resolve_subagent_api_timeout_secs(

--- a/crates/tui/src/config/subagent_limits.rs
+++ b/crates/tui/src/config/subagent_limits.rs
@@ -20,17 +20,20 @@ pub const MAX_SUBAGENTS: usize = 128;
 /// opt into large bounded populations without unbounded queue growth.
 pub const MAX_SUBAGENT_ADMISSION: usize = 1024;
 /// Default per-step DeepSeek API timeout for sub-agent requests, in seconds.
-/// Matches the legacy hardcoded value so existing configs keep their old
-/// behavior when `[subagents] api_timeout_secs` is unset (#1806, #1808).
-pub const DEFAULT_SUBAGENT_API_TIMEOUT_SECS: u64 = 120;
+/// Raised from the legacy 120s: a live-but-slow reasoning call routinely
+/// outlasts two minutes, and a timed-out attempt is now retried with backoff
+/// before the step interrupts, so the default should only trip on genuinely
+/// stuck calls (FINISH-0.9.4 entry #40). Applies when `[subagents]
+/// api_timeout_secs` is unset (#1806, #1808).
+pub const DEFAULT_SUBAGENT_API_TIMEOUT_SECS: u64 = 600;
 /// Minimum accepted `[subagents] api_timeout_secs`. Anything lower (including
 /// `0`, which would otherwise produce an immediate timeout footgun) clamps
 /// up to this value before the runtime sees it.
 pub const MIN_SUBAGENT_API_TIMEOUT_SECS: u64 = 1;
-/// Maximum accepted `[subagents] api_timeout_secs` (30 minutes). The cap
+/// Maximum accepted `[subagents] api_timeout_secs` (60 minutes). The cap
 /// keeps a misconfigured per-step timeout from masking real model/network
 /// hangs forever.
-pub const MAX_SUBAGENT_API_TIMEOUT_SECS: u64 = 1800;
+pub const MAX_SUBAGENT_API_TIMEOUT_SECS: u64 = 3600;
 /// Default wall-clock interval without manager-visible sub-agent progress
 /// before a running child can be auto-cancelled to release its slot (#2614).
 pub const DEFAULT_SUBAGENT_HEARTBEAT_TIMEOUT_SECS: u64 = 300;

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -2302,6 +2302,7 @@ fn subagent_api_timeout_defaults_and_clamps() {
         Config::default().subagent_api_timeout_secs(),
         DEFAULT_SUBAGENT_API_TIMEOUT_SECS
     );
+    assert_eq!(DEFAULT_SUBAGENT_API_TIMEOUT_SECS, 600);
 
     let zero = Config {
         subagents: Some(SubagentsConfig {
@@ -2324,6 +2325,24 @@ fn subagent_api_timeout_defaults_and_clamps() {
     };
     assert_eq!(explicit_min.subagent_api_timeout_secs(), 1);
 
+    let explicit_max = Config {
+        subagents: Some(SubagentsConfig {
+            api_timeout_secs: Some(3600),
+            ..SubagentsConfig::default()
+        }),
+        ..Config::default()
+    };
+    assert_eq!(explicit_max.subagent_api_timeout_secs(), 3600);
+
+    let beyond_max = Config {
+        subagents: Some(SubagentsConfig {
+            api_timeout_secs: Some(3601),
+            ..SubagentsConfig::default()
+        }),
+        ..Config::default()
+    };
+    assert_eq!(beyond_max.subagent_api_timeout_secs(), 3600);
+
     let high = Config {
         subagents: Some(SubagentsConfig {
             api_timeout_secs: Some(MAX_SUBAGENT_API_TIMEOUT_SECS + 60),
@@ -2339,9 +2358,13 @@ fn subagent_api_timeout_defaults_and_clamps() {
 
 #[test]
 fn subagent_heartbeat_timeout_defaults_clamps_and_respects_api_timeout() {
+    // With the 600s default API timeout, the heartbeat floor (api + 30s)
+    // lifts the resolved default above the raw 300s constant.
+    let resolved_default =
+        DEFAULT_SUBAGENT_HEARTBEAT_TIMEOUT_SECS.max(DEFAULT_SUBAGENT_API_TIMEOUT_SECS + 30);
     assert_eq!(
         Config::default().subagent_heartbeat_timeout_secs(),
-        DEFAULT_SUBAGENT_HEARTBEAT_TIMEOUT_SECS
+        resolved_default
     );
 
     let zero = Config {
@@ -2351,10 +2374,7 @@ fn subagent_heartbeat_timeout_defaults_clamps_and_respects_api_timeout() {
         }),
         ..Config::default()
     };
-    assert_eq!(
-        zero.subagent_heartbeat_timeout_secs(),
-        DEFAULT_SUBAGENT_HEARTBEAT_TIMEOUT_SECS
-    );
+    assert_eq!(zero.subagent_heartbeat_timeout_secs(), resolved_default);
 
     let low = Config {
         subagents: Some(SubagentsConfig {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -362,7 +362,7 @@ pub struct EngineConfig {
     /// Optional DuckDuckGo-compatible HTML endpoint override.
     pub search_base_url: Option<String>,
     /// Per-step DeepSeek API timeout for sub-agent `create_message` requests.
-    /// Resolved from `[subagents] api_timeout_secs` (clamped to 1..=1800)
+    /// Resolved from `[subagents] api_timeout_secs` (clamped to 1..=3600)
     /// once at engine construction, then threaded onto every
     /// `SubAgentRuntime` the engine builds (#1806, #1808).
     pub subagent_api_timeout: Duration,

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -270,12 +270,30 @@ const SUBAGENT_RESPONSE_MAX_TOKENS: u32 = 16_384;
 const MAX_CONSECUTIVE_TRUNCATED_SUBAGENT_RESPONSES: u32 = 5;
 const SUBAGENT_TRANSIENT_PROVIDER_MAX_RETRIES: u32 = 2;
 const SUBAGENT_TRANSIENT_PROVIDER_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
+/// Per-step API-call timeout retry budget. A `create_message` call that
+/// exceeds `step_api_timeout` is re-issued up to this many times (with
+/// exponential backoff) before the step is interrupted with a preserved
+/// checkpoint. Dogfooding showed a single 120s stall wiping out every child
+/// in a fan-out one by one even though the provider call was live-but-slow,
+/// so a timeout now gets the same retry dignity as a transient provider
+/// error (kimi-code comparison, FINISH-0.9.4 entry #40).
+const SUBAGENT_API_TIMEOUT_MAX_RETRIES: u32 = 5;
+/// Initial backoff for a timed-out per-step API call; doubles per retry and
+/// is capped at [`SUBAGENT_API_TIMEOUT_MAX_BACKOFF`].
+const SUBAGENT_API_TIMEOUT_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+/// Cap for the per-step API-call timeout backoff.
+const SUBAGENT_API_TIMEOUT_MAX_BACKOFF: Duration = Duration::from_secs(30);
+/// Jitter applied to the timeout backoff (0.2 = ±20%) so a fan-out of
+/// children that all time out together does not re-fire in lockstep.
+const SUBAGENT_API_TIMEOUT_BACKOFF_JITTER_FACTOR: f64 = 0.2;
 /// Per-step LLM API call timeout. Each `create_message` request must complete
-/// within this window or the step is treated as timed out. Prevents a single
-/// stuck API call from blocking the sub-agent indefinitely.
+/// within this window or the attempt is treated as timed out (and retried up
+/// to [`SUBAGENT_API_TIMEOUT_MAX_RETRIES`] times before interrupting the
+/// step). Prevents a single stuck API call from blocking the sub-agent
+/// indefinitely.
 /// Legacy fallback for the per-step DeepSeek API timeout. The active timeout
 /// now travels on `SubAgentRuntime::step_api_timeout` so users can override
-/// it via `[subagents] api_timeout_secs` in `~/.deepseek/config.toml`. The
+/// it via `[subagents] api_timeout_secs` in `~/.codewhale/config.toml`. The
 /// constant only exists for tests/stub runtimes that need a hard-coded
 /// default; production runtimes set the field explicitly (#1806, #1808).
 const DEFAULT_STEP_API_TIMEOUT: Duration =
@@ -2082,11 +2100,16 @@ pub struct SubAgentRuntime {
     /// The parent's MCP pool if available.
     pub mcp_pool: Option<std::sync::Arc<tokio::sync::Mutex<crate::mcp::McpPool>>>,
     /// Per-step DeepSeek API timeout for the child's `create_message` call.
-    /// Resolved from `[subagents] api_timeout_secs` (clamped to 1..=1800) at
+    /// Resolved from `[subagents] api_timeout_secs` (clamped to 1..=3600) at
     /// engine construction so a slow but legitimate model turn does not
     /// false-timeout the child mid-thinking. `child_runtime()` and
     /// `background_runtime()` preserve the parent's value (#1806, #1808).
     pub step_api_timeout: Duration,
+    /// Initial backoff between timed-out `create_message` retries. Defaults
+    /// to [`SUBAGENT_API_TIMEOUT_INITIAL_BACKOFF`]; tests shrink it so the
+    /// timeout-retry path runs in milliseconds. `child_runtime()` preserves
+    /// the parent's value.
+    pub(crate) api_timeout_retry_base_backoff: Duration,
     /// Wall-clock budget for a single tool execution within a sub-agent step.
     /// Defaults to `DEFAULT_TOOL_TIMEOUT`; the engine may override it so a long
     /// but legitimate tool run is not killed mid-flight. `child_runtime()`
@@ -2158,6 +2181,7 @@ impl SubAgentRuntime {
             fork_context: None,
             mcp_pool: None,
             step_api_timeout: DEFAULT_STEP_API_TIMEOUT,
+            api_timeout_retry_base_backoff: SUBAGENT_API_TIMEOUT_INITIAL_BACKOFF,
             tool_timeout: DEFAULT_TOOL_TIMEOUT,
             speech_output_dir: None,
             todos: crate::tools::todo::new_shared_todo_list(),
@@ -2210,10 +2234,19 @@ impl SubAgentRuntime {
     /// Override the per-step DeepSeek API timeout (default
     /// `DEFAULT_STEP_API_TIMEOUT`). Called by the engine after reading
     /// `[subagents] api_timeout_secs`. Tests may use this to fail fast
-    /// without waiting the legacy 120 seconds (#1806, #1808).
+    /// without waiting the default 600 seconds (#1806, #1808).
     #[must_use]
     pub fn with_step_api_timeout(mut self, timeout: Duration) -> Self {
         self.step_api_timeout = timeout;
+        self
+    }
+
+    /// Shrink the timeout-retry backoff so tests covering the retry path do
+    /// not wait out the production 1s..=30s backoff sequence.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn with_api_timeout_retry_base_backoff(mut self, backoff: Duration) -> Self {
+        self.api_timeout_retry_base_backoff = backoff;
         self
     }
 
@@ -2428,6 +2461,7 @@ impl SubAgentRuntime {
             fork_context: self.fork_context.clone(),
             mcp_pool: self.mcp_pool.clone(),
             step_api_timeout: self.step_api_timeout,
+            api_timeout_retry_base_backoff: self.api_timeout_retry_base_backoff,
             tool_timeout: self.tool_timeout,
             speech_output_dir: self.speech_output_dir.clone(),
             // #4810: every spawned agent owns its todo list. Cloning the
@@ -8814,6 +8848,32 @@ fn subagent_transient_provider_retry_delay(retry_number: u32) -> Duration {
     SUBAGENT_TRANSIENT_PROVIDER_INITIAL_BACKOFF.saturating_mul(multiplier.min(4))
 }
 
+/// Deterministic exponential backoff for a timed-out per-step API call
+/// (`retry_number` is 1-based): `initial_backoff`, ×2, ×4, …, capped at
+/// [`SUBAGENT_API_TIMEOUT_MAX_BACKOFF`].
+fn subagent_api_timeout_retry_base_delay(retry_number: u32, initial_backoff: Duration) -> Duration {
+    let multiplier = 1u32
+        .checked_shl(retry_number.saturating_sub(1))
+        .unwrap_or(u32::MAX);
+    initial_backoff
+        .saturating_mul(multiplier)
+        .min(SUBAGENT_API_TIMEOUT_MAX_BACKOFF)
+}
+
+/// Timeout retry backoff with ±20% jitter (UUID v4 entropy, the same idiom
+/// as `llm_client::RetryConfig::delay_for_attempt`) so a fan-out of children
+/// whose calls all time out together does not re-fire in lockstep.
+fn subagent_api_timeout_retry_delay(retry_number: u32, initial_backoff: Duration) -> Duration {
+    let base = subagent_api_timeout_retry_base_delay(retry_number, initial_backoff);
+    let bytes = *Uuid::new_v4().as_bytes();
+    let sample = u16::from_le_bytes([bytes[0], bytes[1]]);
+    let random_factor = f64::from(sample) / f64::from(u16::MAX); // 0.0 to 1.0
+    let jitter = base.as_secs_f64()
+        * SUBAGENT_API_TIMEOUT_BACKOFF_JITTER_FACTOR
+        * (2.0 * random_factor - 1.0); // -20% to +20%
+    Duration::from_secs_f64((base.as_secs_f64() + jitter).max(0.0))
+}
+
 #[derive(Debug, Clone, Copy)]
 struct RetryableSubAgentProviderFailure {
     label: &'static str,
@@ -8898,6 +8958,7 @@ async fn request_subagent_model_response_with_retries(
     SubAgentApiRequestFailure,
 > {
     let mut transient_failures = 0u32;
+    let mut timeout_failures = 0u32;
 
     loop {
         // Billing time is the immutable wire-dispatch boundary, not worker
@@ -8948,13 +9009,39 @@ async fn request_subagent_model_response_with_retries(
                 tokio::time::sleep(delay).await;
             }
             Err(_) => {
-                return Err(SubAgentApiRequestFailure::Interrupted {
-                    reason: format!(
-                        "API call timed out after {}ms; checkpoint preserved for continuation",
-                        runtime.step_api_timeout.as_millis()
+                // A wall-clock timeout is usually a live-but-slow provider
+                // call, not a dead one: retry with backoff like the transient
+                // path before giving up the step (FINISH-0.9.4 entry #40).
+                if timeout_failures >= SUBAGENT_API_TIMEOUT_MAX_RETRIES {
+                    let attempts = timeout_failures.saturating_add(1);
+                    return Err(SubAgentApiRequestFailure::Interrupted {
+                        reason: format!(
+                            "API call timed out after {}ms on {attempts} API attempt(s); checkpoint preserved for continuation",
+                            runtime.step_api_timeout.as_millis()
+                        ),
+                        checkpoint_reason: "api_timeout",
+                    });
+                }
+
+                timeout_failures = timeout_failures.saturating_add(1);
+                let delay = subagent_api_timeout_retry_delay(
+                    timeout_failures,
+                    runtime.api_timeout_retry_base_backoff,
+                );
+                record_agent_progress(
+                    runtime,
+                    agent_id,
+                    AgentProgressEventMeta::new(AgentWorkerStatus::ModelWait).with_step(steps),
+                    format!(
+                        "{}: API call timed out after {}ms; retrying API request {}/{} in {}ms",
+                        format_step_counter(steps, max_steps),
+                        runtime.step_api_timeout.as_millis(),
+                        timeout_failures,
+                        SUBAGENT_API_TIMEOUT_MAX_RETRIES,
+                        delay.as_millis(),
                     ),
-                    checkpoint_reason: "api_timeout",
-                });
+                );
+                tokio::time::sleep(delay).await;
             }
         }
     }

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1646,6 +1646,64 @@ async fn delayed_chat_client(
     (client, calls, bodies)
 }
 
+/// Like [`delayed_chat_client`] but delays *every* attempt, so the per-step
+/// API timeout fires on the first call and on every retry — the shape needed
+/// to drive the timeout-retry budget to exhaustion.
+async fn always_delayed_chat_client(
+    delay: Duration,
+    response_text: &str,
+) -> (DeepSeekClient, Arc<AtomicUsize>) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let response_text = response_text.to_string();
+    let app = Router::new().route(
+        "/{*path}",
+        post({
+            let calls = Arc::clone(&calls);
+            move |Json(_body): Json<Value>| {
+                let calls = Arc::clone(&calls);
+                let response_text = response_text.clone();
+                async move {
+                    let attempt = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                    tokio::time::sleep(delay).await;
+                    Json(json!({
+                        "id": format!("chatcmpl-test-{attempt}"),
+                        "model": "deepseek-v4-flash",
+                        "choices": [{
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": response_text
+                            },
+                            "finish_reason": "stop"
+                        }],
+                        "usage": {
+                            "prompt_tokens": 1,
+                            "completion_tokens": 1,
+                            "total_tokens": 2
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake always-slow chat server");
+    let addr = listener.local_addr().expect("fake chat server addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let config = crate::config::Config {
+        api_key: Some("test-key".to_string()),
+        base_url: Some(format!("http://{addr}/v1")),
+        ..crate::config::Config::default()
+    };
+    let client = DeepSeekClient::new(&config).expect("fake always-slow chat client");
+    (client, calls)
+}
+
 #[tokio::test]
 async fn tool_free_subagent_omits_chat_tools_and_tool_choice() {
     let tmp = tempdir().expect("tempdir");
@@ -5630,9 +5688,15 @@ async fn api_timeout_preserves_checkpoint_and_returns_needs_input_without_parkin
         manager.register_worker(make_worker_spec(&agent_id, tmp.path().to_path_buf()));
     }
 
-    let (client, calls, _bodies) =
-        delayed_chat_client(Duration::from_millis(80), "resumed answer").await;
-    let mut runtime = stub_runtime().with_step_api_timeout(Duration::from_millis(50));
+    // Every attempt outlasts the 50ms step timeout, so the timeout-retry
+    // budget (SUBAGENT_API_TIMEOUT_MAX_RETRIES) is driven to exhaustion
+    // before the step interrupts. The backoff base is shrunk to 1ms so the
+    // test does not wait out the production backoff sequence.
+    let (client, calls) =
+        always_delayed_chat_client(Duration::from_millis(150), "resumed answer").await;
+    let mut runtime = stub_runtime()
+        .with_step_api_timeout(Duration::from_millis(50))
+        .with_api_timeout_retry_base_backoff(Duration::from_millis(1));
     runtime.client = client;
     runtime.manager = Arc::clone(&manager);
     runtime.context = ToolContext::new(tmp.path());
@@ -5698,8 +5762,9 @@ async fn api_timeout_preserves_checkpoint_and_returns_needs_input_without_parkin
         .expect("sub-agent task should finish");
     assert_eq!(
         calls.load(Ordering::SeqCst),
-        1,
-        "needs-input interruption must not park for continuation or issue a second API request"
+        SUBAGENT_API_TIMEOUT_MAX_RETRIES.saturating_add(1) as usize,
+        "needs-input interruption must not park for continuation; the API call \
+         is retried up to the timeout-retry budget, then stops"
     );
 
     let interrupted = {
@@ -5713,6 +5778,7 @@ async fn api_timeout_preserves_checkpoint_and_returns_needs_input_without_parkin
         .checkpoint
         .as_ref()
         .expect("timeout should preserve checkpoint");
+    assert_eq!(checkpoint.reason, "api_timeout");
     assert!(checkpoint.continuable);
     assert_eq!(checkpoint.steps_taken, 1);
     assert!(
@@ -5764,9 +5830,122 @@ async fn api_timeout_preserves_checkpoint_and_returns_needs_input_without_parkin
     );
     assert_eq!(
         calls.load(Ordering::SeqCst),
-        1,
+        SUBAGENT_API_TIMEOUT_MAX_RETRIES.saturating_add(1) as usize,
         "projection inspection must not respawn the child implicitly"
     );
+}
+
+#[tokio::test]
+async fn subagent_retries_api_timeout_before_succeeding() {
+    let tmp = tempdir().expect("tempdir");
+    let manager = Arc::new(RwLock::new(SubAgentManager::new(
+        tmp.path().to_path_buf(),
+        2,
+    )));
+    let agent_id = "agent_api_timeout_retry".to_string();
+    let (task_input_tx, task_input_rx) = mpsc::unbounded_channel();
+    let agent = SubAgent::new(
+        agent_id.clone(),
+        FleetRole::Worker,
+        "Inspect API timeout recovery".to_string(),
+        make_assignment(),
+        "deepseek-v4-flash".to_string(),
+        Some("Blue".to_string()),
+        Some(vec![]),
+        task_input_tx,
+        tmp.path().to_path_buf(),
+        "boot_test".to_string(),
+    );
+    {
+        let mut manager = manager.write().await;
+        manager.agents.insert(agent_id.clone(), agent);
+        manager.register_worker(make_worker_spec(&agent_id, tmp.path().to_path_buf()));
+    }
+
+    // Only the first attempt outlasts the 50ms step timeout; the retry
+    // answers immediately, so a single timed-out attempt must be retried
+    // exactly once and then complete.
+    let (client, calls, _bodies) =
+        delayed_chat_client(Duration::from_millis(150), "recovered answer").await;
+    let mut runtime = stub_runtime()
+        .with_step_api_timeout(Duration::from_millis(50))
+        .with_api_timeout_retry_base_backoff(Duration::from_millis(1));
+    runtime.client = client;
+    runtime.manager = Arc::clone(&manager);
+    runtime.context = ToolContext::new(tmp.path());
+
+    let task = SubAgentTask {
+        manager_handle: Arc::clone(&manager),
+        runtime,
+        agent_id: agent_id.clone(),
+        agent_type: FleetRole::Worker,
+        prompt: "Inspect API timeout recovery".to_string(),
+        assignment: make_assignment(),
+        allowed_tools: Some(vec![]),
+        fork_context: false,
+        started_at: Instant::now(),
+        max_steps: 3,
+        token_budget: None,
+        wall_time: DEFAULT_CHILD_WALL_TIME,
+        input_rx: task_input_rx,
+        launch_gate: None,
+    };
+
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        tokio::spawn(run_subagent_task(task)),
+    )
+    .await
+    .expect("sub-agent task should finish")
+    .expect("sub-agent join should succeed");
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "one timed-out API attempt should be retried exactly once"
+    );
+    let snapshot = {
+        let manager = manager.read().await;
+        manager
+            .get_result(&agent_id)
+            .expect("agent should stay registered")
+    };
+    assert_eq!(snapshot.status, SubAgentStatus::Completed);
+    assert_eq!(snapshot.result.as_deref(), Some("recovered answer"));
+}
+
+#[test]
+fn api_timeout_retry_backoff_doubles_and_caps() {
+    let base = SUBAGENT_API_TIMEOUT_INITIAL_BACKOFF;
+    let expected = [1, 2, 4, 8, 16, 30, 30];
+    for (index, expected_secs) in expected.iter().enumerate() {
+        let retry_number = (index as u32).saturating_add(1);
+        assert_eq!(
+            subagent_api_timeout_retry_base_delay(retry_number, base),
+            Duration::from_secs(*expected_secs),
+            "retry {retry_number} backoff"
+        );
+    }
+}
+
+#[test]
+fn api_timeout_retry_delay_stays_within_jitter_bounds() {
+    let base = SUBAGENT_API_TIMEOUT_INITIAL_BACKOFF;
+    for retry_number in 1..=SUBAGENT_API_TIMEOUT_MAX_RETRIES {
+        let deterministic = subagent_api_timeout_retry_base_delay(retry_number, base);
+        let lower =
+            deterministic.as_secs_f64() * (1.0 - SUBAGENT_API_TIMEOUT_BACKOFF_JITTER_FACTOR);
+        let upper =
+            deterministic.as_secs_f64() * (1.0 + SUBAGENT_API_TIMEOUT_BACKOFF_JITTER_FACTOR);
+        for _ in 0..32 {
+            let sample = subagent_api_timeout_retry_delay(retry_number, base).as_secs_f64();
+            assert!(
+                (lower..=upper).contains(&sample),
+                "retry {retry_number} delay {sample}s outside ±20% of {}s",
+                deterministic.as_secs_f64()
+            );
+        }
+    }
 }
 
 #[test]
@@ -8299,13 +8478,18 @@ async fn child_work_tail_never_leaks_across_siblings_or_to_the_parent() {
 #[test]
 fn child_and_background_runtimes_preserve_step_api_timeout() {
     let timeout = Duration::from_secs(7);
-    let parent = stub_runtime().with_step_api_timeout(timeout);
+    let backoff = Duration::from_millis(3);
+    let parent = stub_runtime()
+        .with_step_api_timeout(timeout)
+        .with_api_timeout_retry_base_backoff(backoff);
 
     let child = parent.child_runtime();
     assert_eq!(child.step_api_timeout, timeout);
+    assert_eq!(child.api_timeout_retry_base_backoff, backoff);
 
     let background = parent.background_runtime();
     assert_eq!(background.step_api_timeout, timeout);
+    assert_eq!(background.api_timeout_retry_base_backoff, backoff);
 }
 
 #[tokio::test]
@@ -9516,6 +9700,7 @@ fn stub_runtime() -> SubAgentRuntime {
         parent_mode: crate::tui::app::AppMode::Agent,
         mcp_pool: None,
         step_api_timeout: DEFAULT_STEP_API_TIMEOUT,
+        api_timeout_retry_base_backoff: SUBAGENT_API_TIMEOUT_INITIAL_BACKOFF,
         tool_timeout: DEFAULT_TOOL_TIMEOUT,
         speech_output_dir: None,
         todos: crate::tools::todo::new_shared_todo_list(),
@@ -11222,15 +11407,19 @@ fn child_completion_runtime_message_preserves_agent_and_provenance_guidance() {
 }
 
 #[test]
-fn subagent_runtime_default_step_api_timeout_is_legacy_120s() {
-    // The legacy hardcoded constant is now the default field value so existing
-    // call sites and tests that construct a runtime without explicit timeout
-    // wiring keep their old behavior (#1806, #1808).
+fn subagent_runtime_default_step_api_timeout_matches_config_default() {
+    // The runtime default is derived from the config default so call sites
+    // and tests that construct a runtime without explicit timeout wiring get
+    // the configured behavior (#1806, #1808).
     let runtime = stub_runtime();
     assert_eq!(runtime.step_api_timeout, DEFAULT_STEP_API_TIMEOUT);
     assert_eq!(
         DEFAULT_STEP_API_TIMEOUT,
         std::time::Duration::from_secs(crate::config::DEFAULT_SUBAGENT_API_TIMEOUT_SECS)
+    );
+    assert_eq!(
+        DEFAULT_STEP_API_TIMEOUT,
+        std::time::Duration::from_secs(600)
     );
 }
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1599,7 +1599,9 @@ If you are upgrading from older releases:
   aggregate token ceiling for each root `agent` run and its descendants; unset
   or `0` preserves unlimited legacy behavior. `[subagents] api_timeout_secs`
   controls the per-step API timeout for sub-agent model calls and is clamped to
-  `1..=1800`, with `0` or unset preserving the legacy 120 second default.
+  `1..=3600`, with `0` or unset preserving the 600 second default; a timed-out
+  attempt is retried with exponential backoff (up to 5 retries) before the
+  step interrupts with a preserved checkpoint.
   `[subagents] heartbeat_timeout_secs` controls stale running agent cleanup,
   defaults to `300`, and is clamped to `30..=3600` while staying above the
   resolved API timeout. `[subagents.providers.<provider>]` accepts the same

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -432,25 +432,29 @@ spawn rather than silently falling back to the parent provider.
 
 Each sub-agent step wraps its DeepSeek `create_message` call in a
 per-step timeout so a single stuck request can't pin the parent's
-completion wakeup channel indefinitely. The default is `120` seconds,
-which matches the legacy hardcoded value. Long-thinking children that
-legitimately exceed that, for example heavy plan or review work behind
-`agent`, can extend the timeout in `~/.codewhale/config.toml`:
+completion wakeup channel indefinitely. The default is `600` seconds.
+A timed-out attempt is retried with exponential backoff (up to 5
+retries) before the step interrupts with a preserved checkpoint.
+Long-thinking children that legitimately exceed that, for example
+heavy plan or review work behind `agent`, can extend the timeout in
+`~/.codewhale/config.toml`:
 
 ```toml
 [subagents]
-api_timeout_secs = 900  # 15 minutes; clamped to 1..=1800
+api_timeout_secs = 900  # 15 minutes; clamped to 1..=3600
 ```
 
-Values are clamped to `1..=1800`. `0` and `unset` keep the legacy
-`120` second default, so existing installs see no behavior change.
+Values are clamped to `1..=3600`. `0` and `unset` keep the `600`
+second default.
 
 ## Stale-agent heartbeat (#2614)
 
 Running agents also track manager-visible progress. If a child stops emitting
 progress for the heartbeat window, the manager auto-cancels it, releases its
 sub-agent slot, and keeps the cancelled record inspectable through the returned
-transcript handle and persisted worker record. The default is 5 minutes:
+transcript handle and persisted worker record. The default is 5 minutes
+(resolved to at least 30 seconds above `api_timeout_secs`, so 630 seconds
+with the 600-second default API timeout):
 
 ```toml
 [subagents]


### PR DESCRIPTION
## Problem

Dogfood-confirmed 2026-08-03: a 6-agent fan-out was wiped out one by one — every sub-agent died with `Sub-agent interrupted before completion (API call timed out after 120000ms; checkpoint preserved for continuation)`.

Root cause: in `crates/tui/src/tools/subagent/mod.rs`, the per-step `create_message` call is wrapped in `tokio::time::timeout(step_api_timeout, …)`, and the timeout arm returned `Interrupted` with **zero retries**. Transient provider *errors* already retry (`SUBAGENT_TRANSIENT_PROVIDER_MAX_RETRIES`), but timeouts did not — so one live-but-slow provider call killed an entire child. Full findings: `codewhale-ops/FINISH-0.9.4.md` entries #39/#40.

## kimi-code comparison

A scout compared against kimi-code (`packages/agent-core`): it retries every provider step up to 10 attempts with exponential backoff 0.5s→32s + 25% jitter, honors `Retry-After`, classifies timeouts as retryable, uses streaming so live-but-slow calls never hit a wall-clock cap, and has first-class resume. Owner directive: "learn from kimicode."

## What this PR does

**(a) Timeout arm is now retryable.** A per-step API timeout folds into the retry machinery:

- New budget `SUBAGENT_API_TIMEOUT_MAX_RETRIES = 5` per step.
- Exponential backoff: base 1s, ×2 per retry, capped at 30s, ±20% jitter (UUID-entropy idiom shared with `llm_client::RetryConfig`) so a fan-out that times out together doesn't re-fire in lockstep.
- Emits the same style of `ModelWait` progress event as the existing "retrying API request" transient path, so the TUI shows the retry (`…: API call timed out after Nms; retrying API request k/5 in Xms`).
- After exhaustion, behavior is unchanged: `Interrupted` with `checkpoint_reason: "api_timeout"` and the checkpoint preserved for continuation.

**(c) Config limits** (`crates/tui/src/config/subagent_limits.rs`):

- `DEFAULT_SUBAGENT_API_TIMEOUT_SECS`: 120 → **600** (matches the mitigation operators already applied by hand).
- Clamp ceiling `MAX_SUBAGENT_API_TIMEOUT_SECS`: 1800 → **3600**.
- Doc comments updated, including the stale `~/.deepseek/config.toml` reference (product home is `~/.codewhale`); `docs/SUBAGENTS.md`, `docs/CONFIGURATION.md`, and `config.example.toml` updated to match.
- Knock-on effect (test updated, no code change): with the 600s API default, the heartbeat resolver's "at least api_timeout + 30s" floor lifts the *resolved* default heartbeat from 300s to 630s (`subagent_heartbeat_timeout_defaults_clamps_and_respects_api_timeout` now asserts the resolved value; docs updated).

## Tests

- Backoff sequence is deterministic and bounded: 1s/2s/4s/8s/16s then capped at 30s; jittered delay stays within ±20% of the base (32 samples per retry level).
- Integration: server slow on attempt 1 only → retried exactly once, then `Completed` (`subagent_retries_api_timeout_before_succeeding`).
- Integration: server slow on every attempt → exactly `1 + SUBAGENT_API_TIMEOUT_MAX_RETRIES` calls, then `Interrupted` with `api_timeout` checkpoint, `waiting_for_user` projection, no parking (updated `api_timeout_preserves_checkpoint_and_returns_needs_input_without_parking`; new `always_delayed_chat_client` helper mirrors the existing fake-server pattern; production backoff is shrunk via a `#[cfg(test)]` runtime knob so the test runs in milliseconds).
- Config: default is 600, `3600` accepted, `3601` clamps to 3600 (added literal assertions to `subagent_api_timeout_defaults_and_clamps`).
- `child_runtime()`/`background_runtime()` preserve the new backoff field (extended `child_and_background_runtimes_preserve_step_api_timeout`).
- Gates: `cargo fmt --all` clean; `cargo test -p codewhale-tui` — 9621 passed; the only 19 failures are pre-existing environment-dependent tests (missing DeepSeek/MiniMax/Anthropic keys, provider-catalog fixtures) verified to fail identically on base `d53f4f998`.

Not covered at unit level: the exact wall-clock interleaving of timeout → progress event → sleep inside `request_subagent_model_response_with_retries` (exercised end-to-end by the two integration tests instead); the TUI rendering of the progress event (same event path as the existing transient retry).

## Follow-ups (NOT in this PR)

- **(b)** Idle-based streaming keepalive for sub-agent calls, reusing the engine's `stream_chunk_timeout` (`crates/tui/src/core/engine.rs:467`), so a live-but-slow streaming call never trips a wall-clock cap at all (kimi's actual defense-in-depth).
- **(d)** Automated checkpoint resume on re-dispatch (kimi's `resume=<agent_id>` semantics) instead of relying on the parent to re-dispatch manually.
