### PR TITLE
harvest: re-quote Windows OHOS linker arguments containing spaces (from @shenjackyuanjie, #5095)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,10 @@ terminal width, and Windows installation.
 - Shared CI now handles bot-authored issue-link checks, provisions cargo-deny's
   toolchain, and fetches the locked test graph before offline runtime-budget
   validation.
+- Re-quote each linker argument in the Windows OpenHarmony clang launcher so a
+  spaced SDK path (e.g. the default `D:\DevEco Studio\...` install) keeps its
+  `--sysroot` intact through the final Rust link, and extend the no-SDK release
+  guard to keep the re-quoting contract (PR #5095).
 
 ### Removed
 
@@ -133,6 +137,9 @@ terminal width, and Windows installation.
   multilingual, CRLF-heavy File-edit failure report in issue #5003.
 - [An Ziwu](https://github.com/MuRongMoQing) (`@MuRongMoQing`) reported the
   Windows PATH-overwrite defect in issue #4685.
+- [shenjackyuanjie](https://github.com/shenjackyuanjie) (`@shenjackyuanjie`)
+  fixed the Windows OpenHarmony linker re-quoting for spaced SDK paths in
+  PR #5095.
 
 ## [0.9.3] - 2026-07-31
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -113,6 +113,10 @@ terminal width, and Windows installation.
 - Shared CI now handles bot-authored issue-link checks, provisions cargo-deny's
   toolchain, and fetches the locked test graph before offline runtime-budget
   validation.
+- Re-quote each linker argument in the Windows OpenHarmony clang launcher so a
+  spaced SDK path (e.g. the default `D:\DevEco Studio\...` install) keeps its
+  `--sysroot` intact through the final Rust link, and extend the no-SDK release
+  guard to keep the re-quoting contract (PR #5095).
 
 ### Removed
 
@@ -133,6 +137,9 @@ terminal width, and Windows installation.
   multilingual, CRLF-heavy File-edit failure report in issue #5003.
 - [An Ziwu](https://github.com/MuRongMoQing) (`@MuRongMoQing`) reported the
   Windows PATH-overwrite defect in issue #4685.
+- [shenjackyuanjie](https://github.com/shenjackyuanjie) (`@shenjackyuanjie`)
+  fixed the Windows OpenHarmony linker re-quoting for spaced SDK paths in
+  PR #5095.
 
 ## [0.9.3] - 2026-07-31
 

--- a/docs/HarmonyOS.md
+++ b/docs/HarmonyOS.md
@@ -63,7 +63,10 @@ On Windows, `ohos-env.ps1` points Cargo at the repository's
 `ohos-clang.cmd` launcher. The launcher delegates to `ohos-clang.ps1`, so the
 final Rust link—not only C/C++ compilation and bindgen—always carries
 `-target aarch64-linux-ohos`, the SDK sysroot, and `-D__MUSL__` while preserving
-Cargo's linker arguments and exit status.
+Cargo's linker arguments and exit status. The launcher re-quotes every
+argument before forwarding, so an SDK path containing spaces (for example the
+default `D:\DevEco Studio\...` install) keeps its `--sysroot` intact through
+the final link.
 
 ## Compiler Wrappers
 

--- a/scripts/ohos/ohos-clang.cmd
+++ b/scripts/ohos/ohos-clang.cmd
@@ -7,5 +7,18 @@ if not exist "%OHOS_LINKER_SCRIPT%" (
     exit /b 1
 )
 
-"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "%OHOS_LINKER_SCRIPT%" %*
+rem Re-quote every argument before forwarding: cmd's %* expansion strips the
+rem quotes that rustc put around arguments containing spaces, so a sysroot like
+rem "D:\DevEco Studio\...\sysroot" would otherwise arrive at clang split on the
+rem space. %~1 strips the caller's quoting, then we wrap the argument in quotes
+rem again so PowerShell -File hands it to the script as one argument.
+set "ARGS="
+:argloop
+if "%~1"=="" goto run
+set "ARGS=%ARGS% "%~1""
+shift
+goto argloop
+
+:run
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "%OHOS_LINKER_SCRIPT%" %ARGS%
 exit /b %ERRORLEVEL%

--- a/scripts/release/check-ohos-deps.sh
+++ b/scripts/release/check-ohos-deps.sh
@@ -31,7 +31,11 @@ require_literal() {
 # Rust link receives the OHOS target, sysroot, and musl flags as reliably as C,
 # C++, and bindgen invocations do. This is a static, no-SDK contract check; the
 # launcher delegates to the PowerShell compiler wrapper that validates the SDK
-# and preserves Cargo's linker arguments and exit status.
+# and preserves Cargo's linker arguments and exit status. The launcher must
+# also re-quote each argument it forwards: cmd's %* expansion strips the quotes
+# rustc puts around arguments containing spaces, so a spaced SDK path (for
+# example the default "D:\DevEco Studio\..." install) would otherwise arrive at
+# clang with --sysroot split on the space.
 require_literal \
   scripts/ohos-env.ps1 \
   '$linker = [System.IO.Path]::Combine($PSScriptRoot, "ohos", "ohos-clang.cmd")' \
@@ -50,8 +54,12 @@ require_literal \
   "the cmd-to-PowerShell delegation"
 require_literal \
   scripts/ohos/ohos-clang.cmd \
-  '-File "%OHOS_LINKER_SCRIPT%" %*' \
+  '-File "%OHOS_LINKER_SCRIPT%" %ARGS%' \
   "linker argument forwarding"
+require_literal \
+  scripts/ohos/ohos-clang.cmd \
+  'set "ARGS=%ARGS% "%~1""' \
+  "argument re-quoting for space-containing paths"
 require_literal \
   scripts/ohos/ohos-clang.cmd \
   'exit /b %ERRORLEVEL%' \


### PR DESCRIPTION
## What

Harvests @shenjackyuanjie's OpenHarmony Windows link fix from #5095 onto the v0.9.4 release train, authorship intact (cherry-pick -x of 6a3837cd48dc937bfaff6288750ac79f7f9cd2fd and e27ebdb64095cb4a903c10989ebf8dc328a51b14).

## Problem

rustc passes Cargo's linker arguments as quoted strings when they contain spaces, but cmd's `%*` expansion strips that quoting, so an OpenHarmony SDK installed under a spaced path (e.g. the default `D:\DevEco Studio\...\native`) arrived at the clang launcher with `--sysroot` split on the space and the final Rust link failed.

## Fix

The `ohos-clang.cmd` launcher now walks every argument with `%~1` and re-wraps each in quotes before forwarding to `ohos-clang.ps1`, and the no-SDK release guard (`scripts/release/check-ohos-deps.sh`) asserts the re-quoting contract so it cannot regress. Docs updated in `docs/HarmonyOS.md`.

## Conflict handling

The PR was conflicting vs main (changelog churn only). The code commit applied cleanly; the changelog commit conflicted in `CHANGELOG.md` and `crates/tui/CHANGELOG.md` because the train restructured Unreleased into the v0.9.4 candidate section. Resolved by folding the PR's entry into the 0.9.4 `### Fixed` list in house style (`PR #5095`) and adding @shenjackyuanjie to the 0.9.4 `### Contributors` section. Final diff vs train tip: +42/−4, same as the original PR.

## Test evidence

`bash scripts/release/check-ohos-deps.sh` — all three guards pass (linker wrapper contract incl. the new re-quoting assertion, OHOS dependency graph, rquickjs bindgen feature edge). No Rust code touched, so no crate build affected. Author additionally verified a real `cargo build --target aarch64-unknown-linux-ohos -p codewhale-cli` on Windows with a spaced-path SDK (see #5095).

## Credit

All credit to @shenjackyuanjie. Closes #5095 on train merge.