### PR TITLE
fix(tools): remove fim_edit read-only capability

### DIFF
--- a/crates/tui/src/tools/fim.rs
+++ b/crates/tui/src/tools/fim.rs
@@ -95,7 +95,6 @@ impl ToolSpec for FimEditTool {
 
     fn capabilities(&self) -> Vec<ToolCapability> {
         vec![
-            ToolCapability::ReadOnly,
             ToolCapability::WritesFiles,
             ToolCapability::RequiresApproval,
         ]
@@ -178,5 +177,20 @@ impl ToolSpec for FimEditTool {
         };
 
         ToolResult::json(&result).map_err(|e| ToolError::execution_failed(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fim_edit_is_write_capable_but_not_read_only() {
+        let tool = FimEditTool::new(None, "fim-model".to_string());
+        let capabilities = tool.capabilities();
+
+        assert!(capabilities.contains(&ToolCapability::WritesFiles));
+        assert!(!capabilities.contains(&ToolCapability::ReadOnly));
+        assert!(!tool.is_read_only());
     }
 }


### PR DESCRIPTION
## Summary

- remove the contradictory `ReadOnly` capability from `fim_edit`
- retain `WritesFiles`, `RequiresApproval`, and the explicit approval policy
- add a focused capability regression test

The tool atomically writes its target file, so the old `ReadOnly + WritesFiles` pair described mutually exclusive behavior.

Adapted from [Pinvou/CodeWhale#5](https://github.com/Pinvou/CodeWhale/pull/5) by @asto18089 with numeric-noreply co-author credit.

No-Issue: narrow contract correction adapted from an external fork audit.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked fim_edit_is_write_capable_but_not_read_only`
- [ ] full workspace clippy/test gates (CI)

Known base failure: the Web Frontend workflow already fails on current `main` at `e32119564` in the same two release-copy tests ([base run](https://github.com/Hmbown/CodeWhale/actions/runs/30780343724)); these PRs do not touch `web/` or `CHANGELOG.md`.

## Checklist

- [x] Updated comments as needed
- [x] Added a regression test
- [x] TUI manual QA not applicable
- [x] Co-author credit uses a GitHub numeric noreply address