### PR TITLE
fix(rlm): document the runtime content variable

### DIFF
--- a/crates/tui/src/tools/rlm.rs
+++ b/crates/tui/src/tools/rlm.rs
@@ -232,7 +232,7 @@ impl ToolSpec for RlmTool {
                 },
                 "code": {
                     "type": "string",
-                    "description": "Raw Python executed against the context (no markdown fences). The loaded source is in scope; call FINAL(value)/finalize(...) to return a result handle. Example: print(len(SOURCE)). (action=eval)"
+                    "description": "Raw Python executed against the context (no markdown fences). The loaded source is in scope as `content`; call FINAL(value)/finalize(...) to return a result handle. Example: print(len(content)). (action=eval)"
                 },
                 "output_feedback": {
                     "type": "string",
@@ -427,7 +427,7 @@ impl RlmTool {
         let code = required_non_empty_str(input, "code").map_err(|_| {
             ToolError::invalid_input(
                 "rlm_eval: `code` is required and runs raw Python against the RLM context (no markdown fences). \
-                 Example: {\"name\": \"<ctx>\", \"code\": \"print(len(SOURCE))\"}; call FINAL(value) to return a result handle.",
+                 Example: {\"name\": \"<ctx>\", \"code\": \"print(len(content))\"}; call FINAL(value) to return a result handle.",
             )
         })?;
         let session = get_session(context, name).await?;
@@ -696,7 +696,7 @@ fn legacy_action_schema(action: &str) -> Value {
             "required": ["name", "code"],
             "properties": {
                 "name": { "type": "string", "description": "RLM context name returned by rlm_open." },
-                "code": { "type": "string", "description": "Raw Python executed against the context (no markdown fences). The loaded source is in scope; call FINAL(value)/finalize(...) to return a result handle. Example: print(len(SOURCE))." }
+                "code": { "type": "string", "description": "Raw Python executed against the context (no markdown fences). The loaded source is in scope as `content`; call FINAL(value)/finalize(...) to return a result handle. Example: print(len(content))." }
             }
         }),
         "configure" => json!({
@@ -1158,9 +1158,21 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("raw Python"), "explains it runs Python: {msg}");
         assert!(
-            msg.contains("print(len(SOURCE))") || msg.contains("FINAL"),
+            msg.contains("print(len(content))") || msg.contains("FINAL"),
             "includes an example: {msg}"
         );
+    }
+
+    #[test]
+    fn rlm_eval_schema_names_the_runtime_content_variable() {
+        let schema = RlmTool::alias("rlm_eval", "eval", None).input_schema();
+        let description = schema["properties"]["code"]["description"]
+            .as_str()
+            .expect("rlm_eval code description");
+
+        assert!(description.contains("`content`"));
+        assert!(description.contains("print(len(content))"));
+        assert!(!description.contains("SOURCE"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- replace the undefined `SOURCE` name in every `rlm_eval` example with the actual `content` runtime variable
- update the missing-code diagnostic and both unified/alias schemas
- add schema and diagnostic regression coverage

Adapted from [Pinvou/CodeWhale#4](https://github.com/Pinvou/CodeWhale/pull/4) by @asto18089 with numeric-noreply co-author credit.

No-Issue: narrow contract correction adapted from an external fork audit.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked rlm_eval_`
- [ ] full workspace clippy/test gates (CI)

Known base failure: the Web Frontend workflow already fails on current `main` at `e32119564` in the same two release-copy tests ([base run](https://github.com/Hmbown/CodeWhale/actions/runs/30780343724)); these PRs do not touch `web/` or `CHANGELOG.md`.

## Checklist

- [x] Updated tool documentation
- [x] Added or updated tests
- [x] TUI manual QA not applicable
- [x] Co-author credit uses a GitHub numeric noreply address