### PR TITLE
fix(search): describe the actual default exclusions

### DIFF
--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -53,7 +53,7 @@ impl ToolSpec for GrepFilesTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search for a regex pattern in workspace files. Use this instead of `grep -r`, `rg`, or `find ... -exec grep` in `exec_shell` — pure-Rust, faster, and respects `.gitignore`. Returns matching lines with context (default: 2 lines before/after each match)."
+        "Search for a regex pattern in workspace files. Use this instead of `grep -r`, `rg`, or `find ... -exec grep` in `exec_shell` — pure-Rust, faster, and skips common non-code directories (node_modules, .git, target, ...) by default. Returns matching lines with context (default: 2 lines before/after each match)."
     }
 
     fn input_schema(&self) -> Value {
@@ -667,6 +667,14 @@ mod tests {
     use crate::tools::spec::{ApprovalRequirement, ToolContext, ToolSpec};
 
     use super::{GrepFilesTool, matches_glob};
+
+    #[test]
+    fn grep_description_matches_default_exclusion_behavior() {
+        let description = GrepFilesTool.description();
+
+        assert!(description.contains("skips common non-code directories"));
+        assert!(!description.contains("respects `.gitignore`"));
+    }
 
     #[test]
     fn test_matches_glob_star() {


### PR DESCRIPTION
## Summary

- stop claiming that `grep_files` parses or respects `.gitignore`
- describe the fixed default exclusions implemented by the walker
- add a regression assertion for the model-facing description

Adapted from [Pinvou/CodeWhale#4](https://github.com/Pinvou/CodeWhale/pull/4) by @asto18089 with numeric-noreply co-author credit.

No-Issue: narrow contract correction adapted from an external fork audit.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked grep_description_matches_default_exclusion_behavior`
- [ ] full workspace clippy/test gates (CI)

Known base failure: the Web Frontend workflow already fails on current `main` at `e32119564` in the same two release-copy tests ([base run](https://github.com/Hmbown/CodeWhale/actions/runs/30780343724)); these PRs do not touch `web/` or `CHANGELOG.md`.

## Checklist

- [x] Updated tool documentation
- [x] Added a regression test
- [x] TUI manual QA not applicable
- [x] Co-author credit uses a GitHub numeric noreply address