### PR TITLE
fix(skills): use current Codewhale commands and paths

### DIFF
--- a/crates/tui/assets/skills/feishu/SKILL.md
+++ b/crates/tui/assets/skills/feishu/SKILL.md
@@ -35,8 +35,8 @@ Use this skill when the user asks for Feishu, Lark, or "飞书" integration work
    configured.
 4. For MCP, build or configure a server that exposes narrow tools such as
    `send_message`, `read_doc`, `append_sheet_row`, or `query_bitable`.
-5. Register the MCP server with `deepseek mcp add`, then run
-   `deepseek mcp validate` and `deepseek mcp tools`.
+5. Register the MCP server with `codewhale mcp add`, then run
+   `codewhale mcp validate` and `codewhale mcp tools`.
 6. Verify with a dry run, sandbox document, or read-back call before sending
    externally visible messages.
 

--- a/crates/tui/assets/skills/mcp-builder/SKILL.md
+++ b/crates/tui/assets/skills/mcp-builder/SKILL.md
@@ -18,20 +18,20 @@ or tool integration.
   default unless the server explicitly requires something else.
 - Add timeouts and clear error messages around external APIs.
 
-## DeepSeek Setup
+## Codewhale Setup
 
 Common commands:
 
 ```bash
-deepseek mcp init
-deepseek mcp add my-server --command node --arg server.js
-deepseek mcp add remote-server --url http://127.0.0.1:3000/mcp
-deepseek mcp list
-deepseek mcp validate
-deepseek mcp tools
+codewhale mcp init
+codewhale mcp add my-server --command node --arg server.js
+codewhale mcp add remote-server --url http://127.0.0.1:3000/mcp
+codewhale mcp list
+codewhale mcp validate
+codewhale mcp tools
 ```
 
-HTTP/SSE entries can include per-server headers in `~/.deepseek/mcp.json` when
+HTTP/SSE entries can include per-server headers in `~/.codewhale/mcp.json` when
 credentials or custom routing headers are required.
 
 ## Workflow
@@ -39,6 +39,6 @@ credentials or custom routing headers are required.
 1. Define the service boundary and the minimum useful tools.
 2. Choose transport and credential handling.
 3. Implement the server using a maintained MCP SDK when available.
-4. Add the server with `deepseek mcp add` or edit `~/.deepseek/mcp.json`.
-5. Run `deepseek mcp validate`, then `deepseek mcp tools`.
+4. Add the server with `codewhale mcp add` or edit `~/.codewhale/mcp.json`.
+5. Run `codewhale mcp validate`, then `codewhale mcp tools`.
 6. Test one happy path and one failure path before calling it done.

--- a/crates/tui/assets/skills/pdf/SKILL.md
+++ b/crates/tui/assets/skills/pdf/SKILL.md
@@ -13,7 +13,7 @@ Use this skill for any task where a PDF is the primary input or output.
    watermark, redact, fill forms, encrypt/decrypt, or create.
 2. Preserve originals. Write outputs with explicit names.
 3. Use the most reliable available tool:
-   - DeepSeek's file reader for basic text extraction from PDFs
+   - the built-in `read_file` tool for basic text extraction from PDFs
    - `pdftotext`, `pdfinfo`, `qpdf`, or `mutool` when installed
    - Python libraries such as `pypdf`, `pdfplumber`, `PyMuPDF`, or
      `reportlab` when available

--- a/crates/tui/assets/skills/skill-creator/SKILL.md
+++ b/crates/tui/assets/skills/skill-creator/SKILL.md
@@ -24,9 +24,11 @@ Discovery paths, in precedence order:
 - `<workspace>/.opencode/skills`
 - `<workspace>/.claude/skills`
 - `<workspace>/.cursor/skills`
+- `<workspace>/.codewhale/skills`
 - `~/.agents/skills`
 - `~/.claude/skills`
-- `~/.deepseek/skills`
+- `~/.codewhale/skills`
+- `~/.deepseek/skills` (legacy fallback)
 
 Use skills for model instructions, workflows, and lightweight conventions. Use
 MCP for live external APIs or durable tools. Use hooks for automatic local
@@ -43,7 +45,7 @@ my-skill/
 ```markdown
 ---
 name: my-skill
-description: Use when DeepSeek should follow this specific workflow.
+description: Use when Codewhale should follow this specific workflow.
 ---
 
 # My Skill

--- a/crates/tui/assets/skills/skill-installer/SKILL.md
+++ b/crates/tui/assets/skills/skill-installer/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: skill-installer
-description: Install, update, trust, or inspect DeepSeek skills from GitHub or local skill folders. Use when the user asks for available skills or wants a community skill installed.
+description: Install, update, trust, or inspect Codewhale skills from GitHub or local skill folders. Use when the user asks for available skills or wants a community skill installed.
 ---
 
 # Skill Installer
 
 Use this skill when the user wants to find, install, update, trust, or remove a
-DeepSeek skill.
+Codewhale skill.
 
 ## Commands
 
@@ -24,13 +24,14 @@ DeepSeek skill.
    - Existing local folder with `SKILL.md`
    - GitHub repo or registry entry
    - User request for a new skill scaffold
-2. Prefer DeepSeek's native `/skill` commands over ad hoc copying.
+2. Prefer Codewhale's native `/skill` commands over ad hoc copying.
 3. For GitHub/community skills, inspect the `SKILL.md` before recommending
    trust. Treat scripts and companion files as untrusted until reviewed.
 4. After installing, tell the user to restart the session if the skill does not
    appear immediately in the available-skills list.
 5. If a skill conflicts by name with a workspace skill, explain that workspace
-   skill directories take precedence over global `~/.deepseek/skills`.
+   skill directories take precedence over global `~/.codewhale/skills`, with
+   `~/.deepseek/skills` retained as a legacy fallback.
 
 Do not execute community skill scripts unless the user explicitly asks and the
 skill has been reviewed or trusted.

--- a/crates/tui/src/skills/system/tests.rs
+++ b/crates/tui/src/skills/system/tests.rs
@@ -33,6 +33,24 @@ fn fresh_install_creates_bundled_skills_and_marker() {
     assert_eq!(ver.trim(), BUNDLED_SKILL_VERSION);
 }
 
+#[test]
+fn bundled_integration_skills_use_current_codewhale_commands_and_paths() {
+    for (name, body) in [("mcp-builder", MCP_BUILDER_BODY), ("feishu", FEISHU_BODY)] {
+        assert!(
+            body.contains("codewhale mcp"),
+            "{name} must use the current CLI"
+        );
+        assert!(
+            !body.contains("deepseek mcp"),
+            "{name} must not recommend the retired CLI name"
+        );
+    }
+    assert!(SKILL_CREATOR_BODY.contains("<workspace>/.codewhale/skills"));
+    assert!(SKILL_CREATOR_BODY.contains("~/.codewhale/skills"));
+    assert!(SKILL_INSTALLER_BODY.contains("~/.codewhale/skills"));
+    assert!(PDF_BODY.contains("built-in `read_file` tool"));
+}
+
 /// #4227 (requested by @JayBeest): the contributor sync/gate/digest skill
 /// ships in generation 8, and its two load-bearing refusals — never move a
 /// contributor's HEAD, never touch a dirty tree — must survive any later


### PR DESCRIPTION
## Summary

- replace stale `deepseek mcp` commands with the current `codewhale mcp` CLI
- use `.codewhale` configuration and primary skill roots
- retain `.deepseek/skills` only as an explicitly labeled legacy fallback
- point the PDF skill at the built-in `read_file` tool
- add bundled-content regression coverage

Adapted from [Pinvou/CodeWhale#4](https://github.com/Pinvou/CodeWhale/pull/4) by @asto18089 with numeric-noreply co-author credit.

No-Issue: narrow contract correction adapted from an external fork audit.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked bundled_integration_skills_use_current_codewhale_commands_and_paths`
- [ ] full workspace clippy/test gates (CI)

Known base failure: the Web Frontend workflow already fails on current `main` at `e32119564` in the same two release-copy tests ([base run](https://github.com/Hmbown/CodeWhale/actions/runs/30780343724)); these PRs do not touch `web/` or `CHANGELOG.md`.

## Checklist

- [x] Updated bundled skill documentation
- [x] Added a regression test
- [x] TUI manual QA not applicable
- [x] Co-author credit uses a GitHub numeric noreply address