### PR TITLE
fix(prompts): align tool contract copy with runtime behavior

### DIFF
--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -25,6 +25,7 @@ pub(super) const MULTI_TOOL_PARALLEL_NAME: &str = "multi_tool_use.parallel";
 pub(super) const REQUEST_USER_INPUT_NAME: &str = "request_user_input";
 pub(super) const CODE_EXECUTION_TOOL_NAME: &str = "code_execution";
 const CODE_EXECUTION_TOOL_TYPE: &str = "code_execution_20250825";
+const CODE_EXECUTION_DESCRIPTION: &str = "Execute Python code with the local Python interpreter in the workspace and return stdout/stderr/return_code as JSON.";
 pub(super) use crate::tools::js_execution::JS_EXECUTION_TOOL_NAME;
 pub(super) const TOOL_SEARCH_NAME: &str = "tool_search";
 const TOOL_SEARCH_TYPE: &str = "tool_search_20251119";
@@ -269,7 +270,7 @@ pub(super) fn ensure_advanced_tooling(
         catalog.push(Tool {
             tool_type: Some(CODE_EXECUTION_TOOL_TYPE.to_string()),
             name: CODE_EXECUTION_TOOL_NAME.to_string(),
-            description: "Execute Python code in a local sandboxed runtime and return stdout/stderr/return_code as JSON.".to_string(),
+            description: CODE_EXECUTION_DESCRIPTION.to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -1237,7 +1238,15 @@ pub(super) async fn execute_code_execution_tool(
 
 #[cfg(test)]
 mod synthetic_name_tests {
-    use super::{default_synthetic_catalog_tool_names, is_synthetic_catalog_tool};
+    use super::{
+        CODE_EXECUTION_DESCRIPTION, default_synthetic_catalog_tool_names, is_synthetic_catalog_tool,
+    };
+
+    #[test]
+    fn code_execution_description_does_not_claim_process_sandboxing() {
+        assert!(CODE_EXECUTION_DESCRIPTION.contains("local Python interpreter"));
+        assert!(!CODE_EXECUTION_DESCRIPTION.contains("sandbox"));
+    }
 
     /// The published synthetic-name list and the predicate that classifies a
     /// catalog entry as synthetic must agree. A name that appears in the list

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -988,7 +988,7 @@ hãy tiếp tục suy nghĩ và trả lời bằng tiếng Việt.";
 /// static system-prompt prefix (preserves DeepSeek prefix cache across
 /// shell-access toggles).
 pub const SHELL_POLICY_DISABLED: &str = "Shell tools unavailable. For mandatory-use items referencing \
-`exec_shell`, use `code_execution` (Python sandbox). For GitHub triage, use \
+`exec_shell`, use `code_execution` (local Python interpreter). For GitHub triage, use \
 `github_issue_context` / `github_pr_context` as primary route.";
 
 // ── Personality selection ─────────────────────────────────────────────
@@ -1494,6 +1494,16 @@ mod tests {
     /// Discriminator unique to the injected relay block (not present in the
     /// agent prompt's own discussion of the convention).
     const HANDOFF_BLOCK_MARKER: &str = "left a relay artifact at `.codewhale/handoff.md`";
+
+    #[test]
+    fn prompt_tool_contract_copy_matches_runtime_behavior() {
+        assert!(SHELL_POLICY_DISABLED.contains("local Python interpreter"));
+        assert!(!SHELL_POLICY_DISABLED.contains("Python sandbox"));
+        assert!(!SUGGEST_APPROVAL.contains("CSV batch"));
+        assert!(!AGENT_PROMPT.contains("CSV batch"));
+        assert!(AGENT_PROMPT.contains("model_strength: \"same\""));
+        assert!(!AGENT_PROMPT.contains("defaults to `model_strength: \"faster\"`"));
+    }
 
     // Config-directory prompt override resolution (#3638). These exercise the
     // pure file resolver only; the global install path is intentionally not

--- a/crates/tui/src/prompts/text.rs
+++ b/crates/tui/src/prompts/text.rs
@@ -332,7 +332,7 @@ Execute rather than narrate. Verification still applies — check your work even
 /// Tool calls require confirmation.
 pub const SUGGEST_APPROVAL: &str = r#"##### Approval Policy: Suggest
 
-Read-only operations run silently. Write operations (file edits, patches, shell execution, sub-agent spawns, CSV batches) require user approval before executing.
+Read-only operations run silently. Write operations (file edits, patches, shell execution, sub-agent spawns) require user approval before executing.
 
 When you need approval:
 1. For multi-step changes, use `work_update` when it is present; otherwise state the approach briefly.
@@ -490,7 +490,7 @@ capability. Then stop.
 pub const AGENT_PROMPT: &str = r#"## Mode: agent
 
 Read-only tools (reads, searches, persistent RLM session tools, git inspection) run silently.
-Any write, patch, shell execution, sub-agent start, or CSV batch operation will ask for approval first.
+Any write, patch, shell execution, or sub-agent start will ask for approval first.
 
 Before requesting approval for multi-step writes, lay out your work with `work_update` so the user
 can see what you intend to do and approve with context. Do not create a second
@@ -515,9 +515,9 @@ OUTPUT: VERDICT, EVIDENCE, GAPS, NEXT.
 
 Child model choice is explicit. Use `model_strength: "same"` when the child needs your current
 capability level. Use `model_strength: "faster"` for read-only lookup/search, status, or other
-low-risk tasks that should run on a smaller/faster same-family model — `type: "scout"` already
-defaults to `model_strength: "faster"` for exactly this kind of bounded read-only work, so you only
-need to set it for non-scout children. Use an exact `model` only when you know the
+low-risk tasks that should run on a smaller/faster same-family model. Children inherit the active
+model by default (`model_strength: "same"`), including `type: "scout"`, so select `faster`
+explicitly whenever that tradeoff is appropriate. Use an exact `model` only when you know the
 provider-specific id; it overrides `model_strength`.
 Child thinking is explicit too. Use `thinking: "off"` for fast scout/lookups, `thinking: "high"`
 for ordinary reasoning, `thinking: "max"` for hard design/debug/release/security work, and

--- a/crates/tui/src/tools/js_execution.rs
+++ b/crates/tui/src/tools/js_execution.rs
@@ -94,7 +94,7 @@ pub fn js_execution_tool_definition() -> Tool {
         tool_type: Some(JS_EXECUTION_TOOL_TYPE.to_string()),
         name: JS_EXECUTION_TOOL_NAME.to_string(),
         description:
-            "Execute JavaScript code in a local sandboxed Node.js runtime and return stdout/stderr/return_code as JSON."
+            "Execute JavaScript code with the local Node.js runtime in the workspace and return stdout/stderr/return_code as JSON."
                 .to_string(),
         input_schema: json!({
             "type": "object",
@@ -207,6 +207,8 @@ mod tests {
         let tool = js_execution_tool_definition();
         assert_eq!(tool.name, JS_EXECUTION_TOOL_NAME);
         assert_eq!(tool.tool_type.as_deref(), Some(JS_EXECUTION_TOOL_TYPE));
+        assert!(tool.description.contains("local Node.js runtime"));
+        assert!(!tool.description.contains("sandbox"));
         let required = tool
             .input_schema
             .get("required")


### PR DESCRIPTION
## Summary

This draft implements the evidence recorded in #5215:

- describe `code_execution` and `js_execution` as local interpreter subprocesses, not sandboxes
- remove approval copy for a nonexistent CSV-batch tool
- state that scout children inherit `model_strength: "same"` unless `faster` is selected explicitly
- add focused assertions for all three contracts

This remains a draft pending maintainer discussion because `prompts/` is a trust-boundary surface under the contribution guide.

Adapted from [Pinvou/CodeWhale#4](https://github.com/Pinvou/CodeWhale/pull/4) by @asto18089 with numeric-noreply co-author credit.

Closes #5215

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked prompt_tool_contract_copy_matches_runtime_behavior`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked code_execution_description_does_not_claim_process_sandboxing`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked tool_definition_advertises_js_execution_name_and_required_code_field`
- [ ] full workspace clippy/test gates (CI)

Known base failure: the Web Frontend workflow already fails on current `main` at `e32119564` in the same two release-copy tests ([base run](https://github.com/Hmbown/CodeWhale/actions/runs/30780343724)); these PRs do not touch `web/` or `CHANGELOG.md`.

## Checklist

- [x] Updated prompt/tool documentation
- [x] Added or updated tests
- [x] TUI manual QA not applicable
- [x] Co-author credit uses a GitHub numeric noreply address