### PR TITLE
fix(tui): sub-agent strip shows role+status (+nesting); render active goal

### DIFF
--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -338,6 +338,47 @@ mod tests {
         assert!(!label.contains("0s"));
     }
 
+    #[test]
+    fn active_subagent_status_label_names_fleet_role_not_raw_id() {
+        // #36: when the running agent is known, the strip leads with its
+        // fleet role ("builder: …") — never the raw agent id.
+        use crate::tools::subagent::{
+            FleetRole, SubAgentAssignment, SubAgentResult, SubAgentStatus,
+        };
+        let mut app = create_test_app();
+        app.subagent_cache.push(SubAgentResult {
+            name: "agent_e0b2dcf1".to_string(),
+            agent_id: "agent_e0b2dcf1".to_string(),
+            context_mode: "fresh".to_string(),
+            fork_context: false,
+            workspace: None,
+            git_branch: None,
+            agent_type: FleetRole::Builder,
+            assignment: SubAgentAssignment {
+                objective: "Wire the release lane".to_string(),
+                role: Some("builder".to_string()),
+            },
+            model: "test-model".to_string(),
+            nickname: None,
+            status: SubAgentStatus::Running,
+            worker_status: None,
+            runtime_permissions: None,
+            parent_run_id: None,
+            spawn_depth: 1,
+            result: None,
+            steps_taken: 1,
+            checkpoint: None,
+            needs_input: None,
+            duration_ms: 50,
+            from_prior_session: false,
+        });
+
+        let label = active_subagent_status_label(&app).expect("active agent label");
+
+        assert_eq!(label, "agents 1/1 running · builder: Wire the release lane");
+        assert!(!label.contains("agent_e0b2dcf1"), "{label}");
+    }
+
     fn create_test_app() -> App {
         let options = TuiOptions {
             ..crate::test_support::test_tui_options(PathBuf::from("."))
@@ -514,7 +555,22 @@ pub(crate) fn active_subagent_status_label(app: &App) -> Option<String> {
         .subagent_cache
         .iter()
         .find(|agent| matches!(agent.status, SubAgentStatus::Running))
-        .map(|agent| summarize_tool_output(&agent.assignment.objective))
+        .map(|agent| {
+            let summary = summarize_tool_output(&agent.assignment.objective);
+            // #36: the role is the signal, the id is noise — name the fleet
+            // role before the objective so the strip reads "builder: …".
+            let role = agent
+                .assignment
+                .role
+                .as_deref()
+                .filter(|role| !role.trim().is_empty())
+                .unwrap_or_else(|| agent.agent_type.as_str());
+            if summary.is_empty() {
+                role.to_string()
+            } else {
+                format!("{role}: {summary}")
+            }
+        })
         .filter(|summary| !summary.is_empty())
         .or_else(|| {
             app.agent_progress
@@ -835,21 +891,8 @@ pub(crate) fn footer_git_branch_spans(app: &App) -> Vec<Span<'static>> {
 /// goal hunts, and names the paused state so a stalled goal is never silent.
 fn footer_goal_spans(app: &App) -> Vec<Span<'static>> {
     let theme = &app.ui_theme;
-    let (objective, paused) = match (&app.hunt.quarry, &app.paused_quarry) {
-        (Some(objective), _) => {
-            if matches!(
-                app.hunt.verdict,
-                crate::tui::app::HuntVerdict::Hunted | crate::tui::app::HuntVerdict::Escaped
-            ) {
-                return Vec::new();
-            }
-            (
-                objective.clone(),
-                app.hunt.verdict == crate::tui::app::HuntVerdict::Wounded,
-            )
-        }
-        (None, Some(objective)) => (objective.clone(), true),
-        (None, None) => return Vec::new(),
+    let Some((objective, paused)) = active_goal_chip_state(app) else {
+        return Vec::new();
     };
     let mut label = objective.trim().replace(['\n', '\r'], " ");
     if label.chars().count() > 32 {
@@ -873,6 +916,34 @@ fn footer_goal_spans(app: &App) -> Vec<Span<'static>> {
         ));
     }
     spans
+}
+
+/// Objective + paused flag for the live goal, or `None` when no goal should
+/// render (unset, or terminal Hunted/Escaped). Shared by the classic footer
+/// chip and the ocean topbar chip so every shell surfaces the same state
+/// (#39: the ocean shell has no sidebar, so without a topbar chip a goal set
+/// via `create_goal` was invisible there).
+pub(crate) fn active_goal_chip_state(app: &App) -> Option<(String, bool)> {
+    let (objective, paused) = match (&app.hunt.quarry, &app.paused_quarry) {
+        (Some(objective), _) => {
+            if matches!(
+                app.hunt.verdict,
+                crate::tui::app::HuntVerdict::Hunted | crate::tui::app::HuntVerdict::Escaped
+            ) {
+                return None;
+            }
+            (
+                objective.clone(),
+                app.hunt.verdict == crate::tui::app::HuntVerdict::Wounded,
+            )
+        }
+        (None, Some(objective)) => (objective.clone(), true),
+        (None, None) => return None,
+    };
+    if objective.trim().is_empty() {
+        return None;
+    }
+    Some((objective, paused))
 }
 
 fn footer_shell_spans(app: &App) -> Vec<Span<'static>> {

--- a/crates/tui/src/tui/underwater.rs
+++ b/crates/tui/src/tui/underwater.rs
@@ -946,6 +946,36 @@ pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
         permission_label(app),
         Style::default().fg(permission_color),
     ));
+    // Active-goal chip (#39): the ocean shell has no sidebar, so the topbar
+    // is the only always-on surface where a goal set via `create_goal` can
+    // live. Objective truncated to a fixed budget; terminal goals render
+    // nothing. The cramped-layout rebuild below keeps the chip in `suffix`.
+    let goal_chip =
+        crate::tui::footer_ui::active_goal_chip_state(app).map(|(objective, paused)| {
+            let budget = if paused { 22 } else { 26 };
+            let flat = objective.trim().replace(['\n', '\r'], " ");
+            let text = if paused {
+                format!("goal paused {}", truncate_to_width(&flat, budget))
+            } else {
+                format!("goal {}", truncate_to_width(&flat, budget))
+            };
+            let color = if paused {
+                app.ui_theme.warning
+            } else {
+                app.ui_theme.status_working
+            };
+            (text, color)
+        });
+    if let Some((text, color)) = &goal_chip {
+        left.push(Span::styled(
+            " · ",
+            Style::default().fg(app.ui_theme.text_dim),
+        ));
+        left.push(Span::styled(
+            text.clone(),
+            Style::default().fg(*color).add_modifier(Modifier::BOLD),
+        ));
+    }
 
     let context_meter = (tier != ShellTier::Compact)
         .then(|| crate::tui::ui::context_usage_snapshot(app))
@@ -1082,7 +1112,7 @@ pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
         } else {
             effort_label.clone()
         };
-        let suffix = vec![
+        let mut suffix = vec![
             Span::styled(" · ", Style::default().fg(app.ui_theme.text_dim)),
             Span::styled(mode, Style::default().fg(mode_color)),
             Span::styled(" · ", Style::default().fg(app.ui_theme.text_dim)),
@@ -1090,7 +1120,28 @@ pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
             Span::styled(" · ", Style::default().fg(app.ui_theme.text_dim)),
             Span::styled(permission, Style::default().fg(permission_color)),
         ];
+        // The goal chip survives cramped layouts too — it is operator state,
+        // not decoration. The route label yields its budget first (down to
+        // nothing, as it always has); below that the goal itself truncates,
+        // and when even a minimal chip cannot fit it drops rather than
+        // clipping mid-word (#39).
         let indicator_width = status_indicator.map_or(0, |indicator| 1 + indicator.width());
+        let base_fixed = 4usize
+            .saturating_add(indicator_width)
+            .saturating_add(span_width(&suffix));
+        if let Some((text, color)) = &goal_chip {
+            let goal_room = left_budget.saturating_sub(base_fixed).saturating_sub(3);
+            if goal_room >= 8 {
+                suffix.push(Span::styled(
+                    " · ",
+                    Style::default().fg(app.ui_theme.text_dim),
+                ));
+                suffix.push(Span::styled(
+                    truncate_to_width(text, goal_room),
+                    Style::default().fg(*color).add_modifier(Modifier::BOLD),
+                ));
+            }
+        }
         let fixed_width = 4usize
             .saturating_add(indicator_width)
             .saturating_add(span_width(&suffix));
@@ -1555,6 +1606,64 @@ mod tests {
         assert!(
             header.contains(" · h · Full Access"),
             "effective effort missing: {header:?}"
+        );
+    }
+
+    #[test]
+    fn ocean_header_renders_active_goal_and_hides_it_when_unset_or_terminal() {
+        // #39: the ocean shell has no sidebar, so the topbar is the surface
+        // that must show a goal the moment `create_goal` sets it.
+        let mut app = test_app();
+        let idle = header_text(&app, 120);
+        assert!(
+            !idle.contains("goal"),
+            "no goal chip without an active goal: {idle:?}"
+        );
+
+        app.hunt.quarry = Some("Ship the v0.9.4 release train".to_string());
+        let hunting = header_text(&app, 120);
+        assert!(
+            hunting.contains("goal Ship the v0.9.4"),
+            "active goal missing from ocean topbar: {hunting:?}"
+        );
+
+        app.hunt.verdict = crate::tui::app::HuntVerdict::Hunted;
+        let done = header_text(&app, 120);
+        assert!(
+            !done.contains("goal"),
+            "terminal goal must not linger in the topbar: {done:?}"
+        );
+    }
+
+    #[test]
+    fn ocean_header_names_a_paused_goal() {
+        let mut app = test_app();
+        app.paused_quarry = Some("Audit the fleet roster".to_string());
+        let header = header_text(&app, 120);
+        assert!(
+            header.contains("goal paused Audit the"),
+            "paused goal must say so: {header:?}"
+        );
+    }
+
+    #[test]
+    fn ocean_header_keeps_goal_chip_in_cramped_layouts() {
+        let mut app = test_app();
+        app.model = "provider/model-with-a-deliberately-long-route-name".to_string();
+        app.hunt.quarry = Some("Ship it".to_string());
+        // Width pressure forces the cramped rebuild: the route yields first
+        // and the goal chip survives whole.
+        let header = header_text(&app, 80);
+        assert!(
+            header.contains("goal Ship it"),
+            "goal chip must survive width pressure: {header:?}"
+        );
+        // When even a minimal chip cannot fit alongside mode, effort, and
+        // permission, it drops cleanly instead of clipping mid-word.
+        let narrow = header_text(&app, 48);
+        assert!(
+            !narrow.contains("goal"),
+            "unsupportable goal chip must drop, not clip: {narrow:?}"
         );
     }
 

--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -680,7 +680,8 @@ mod tests {
             .iter()
             .find(|row| row.id.0 == "worker:agent_worker")
             .expect("agent work row");
-        assert_eq!(row.label, "Sub-agent Blue Whale · worker");
+        // #36: number + fleet role + short name — never the raw agent id.
+        assert_eq!(row.label, "1 worker · Blue Whale");
         assert!(row.detail.contains("Wire settled file activity"));
         assert!(row.detail.contains("using File.apply_patch"));
         assert!(row.detail.contains("step 2"));
@@ -691,6 +692,174 @@ mod tests {
                 agent_id: "agent_worker".to_string(),
             })
         );
+    }
+
+    fn cached_worker(
+        id: &str,
+        role: &str,
+        nickname: Option<&str>,
+        parent_run_id: Option<&str>,
+        status: SubAgentStatus,
+    ) -> SubAgentResult {
+        SubAgentResult {
+            // `name` is the raw session id in production snapshots — the
+            // strip must never render it (#36).
+            name: id.to_string(),
+            agent_id: id.to_string(),
+            context_mode: "fresh".to_string(),
+            fork_context: false,
+            workspace: None,
+            git_branch: None,
+            agent_type: FleetRole::Builder,
+            assignment: SubAgentAssignment {
+                objective: format!("objective for {id}"),
+                role: Some(role.to_string()),
+            },
+            model: "test-model".to_string(),
+            nickname: nickname.map(str::to_string),
+            status,
+            worker_status: None,
+            runtime_permissions: None,
+            parent_run_id: parent_run_id.map(str::to_string),
+            spawn_depth: u32::from(parent_run_id.is_some()) + 1,
+            result: None,
+            steps_taken: 1,
+            checkpoint: None,
+            needs_input: None,
+            duration_ms: 50,
+            from_prior_session: false,
+        }
+    }
+
+    #[test]
+    fn agent_rows_number_by_fleet_role_and_never_leak_raw_ids() {
+        // #36: the strip shows sequential number + fleet role; the raw agent
+        // id hash is noise and must never render as the "name". Flat fan-outs
+        // carry no nesting chrome.
+        let mut app = app();
+        app.current_session_id = Some(SESSION.to_string());
+        app.subagent_cache.push(cached_worker(
+            "agent_e0b2dcf1",
+            "builder",
+            None,
+            None,
+            SubAgentStatus::Running,
+        ));
+        app.subagent_cache.push(cached_worker(
+            "agent_99aa77bb",
+            "scout",
+            None,
+            None,
+            SubAgentStatus::Running,
+        ));
+
+        let rows = super::model::project(&mut app);
+        let first = rows
+            .iter()
+            .find(|row| row.id.0 == "worker:agent_e0b2dcf1")
+            .expect("first agent row");
+        let second = rows
+            .iter()
+            .find(|row| row.id.0 == "worker:agent_99aa77bb")
+            .expect("second agent row");
+        assert_eq!(first.label, "1 builder");
+        assert_eq!(second.label, "2 scout");
+        assert!(first.detail.starts_with("running"), "{}", first.detail);
+        for row in rows.iter().filter(|row| row.id.0.starts_with("worker:")) {
+            assert!(!row.label.contains("agent_e0b2dcf1"), "{}", row.label);
+            assert!(!row.label.contains("agent_99aa77bb"), "{}", row.label);
+            assert!(
+                !row.label.contains('↳'),
+                "flat fan-out must not show nesting chrome: {}",
+                row.label
+            );
+        }
+    }
+
+    #[test]
+    fn agent_rows_order_and_indent_nested_spawns_under_their_parent() {
+        // #36: nesting is visible only when actually present — the child
+        // renders directly under its parent with a `↳` indent.
+        let mut app = app();
+        app.current_session_id = Some(SESSION.to_string());
+        app.subagent_cache.push(cached_worker(
+            "agent_child",
+            "scout",
+            None,
+            Some("agent_parent"),
+            SubAgentStatus::Running,
+        ));
+        app.subagent_cache.push(cached_worker(
+            "agent_parent",
+            "builder",
+            None,
+            None,
+            SubAgentStatus::Running,
+        ));
+
+        let rows = super::model::project(&mut app);
+        let worker_labels = rows
+            .iter()
+            .filter(|row| row.id.0.starts_with("worker:"))
+            .map(|row| row.label.as_str())
+            .collect::<Vec<_>>();
+        let parent_pos = worker_labels
+            .iter()
+            .position(|label| *label == "1 builder")
+            .expect("parent row label");
+        let child_pos = worker_labels
+            .iter()
+            .position(|label| *label == "↳ 2 scout")
+            .expect("indented child row label");
+        assert!(
+            child_pos == parent_pos + 1,
+            "child must render directly under its parent: {worker_labels:?}"
+        );
+    }
+
+    #[test]
+    fn agent_rows_completed_agents_render_quietly_without_spawn_metadata() {
+        // #36: quiet completion — a finished agent keeps status + objective;
+        // in-flight metadata (tool, step counters, file tallies) must not
+        // linger as a receipt dump.
+        let mut app = app();
+        app.current_session_id = Some(SESSION.to_string());
+        app.subagent_cache.push(cached_worker(
+            "agent_done",
+            "builder",
+            None,
+            None,
+            SubAgentStatus::Completed,
+        ));
+        app.agent_progress_meta.insert(
+            "agent_done".to_string(),
+            crate::tui::app::AgentProgressMeta {
+                current_activity: Some(AgentCurrentActivity::bounded(
+                    AgentCurrentActivityStatus::Done,
+                    Some("apply_patch finished".to_string()),
+                    Some("File.apply_patch".to_string()),
+                    Some(7),
+                )),
+                current_tool: Some("apply_patch".to_string()),
+                files_touched: 4,
+                ..crate::tui::app::AgentProgressMeta::default()
+            },
+        );
+
+        let rows = super::model::project(&mut app);
+        let row = rows
+            .iter()
+            .find(|row| row.id.0 == "worker:agent_done")
+            .expect("completed agent row");
+        assert!(row.detail.contains("completed"), "{}", row.detail);
+        assert!(
+            row.detail.contains("objective for agent_done"),
+            "{}",
+            row.detail
+        );
+        assert!(!row.detail.contains("using "), "{}", row.detail);
+        assert!(!row.detail.contains("step 7"), "{}", row.detail);
+        assert!(!row.detail.contains("files changed"), "{}", row.detail);
     }
 
     #[test]

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -914,6 +914,110 @@ fn is_transient_failed_operation(node: &WorkNode) -> bool {
         && node.state == NodeState::Failed
 }
 
+/// One worker row before display ordering: the rendered row plus the parent
+/// link and fleet identity the strip uses to number, order, and indent
+/// nested spawns (#36).
+struct AgentRowSeed {
+    agent_id: String,
+    parent_run_id: Option<String>,
+    role: String,
+    name: Option<String>,
+    ranked: RankedWorkRow,
+}
+
+/// Indent marker for a nested spawn: nothing at the top level (no permanent
+/// chrome for the common flat fan-out), `↳` once nesting is actually
+/// present, with two extra spaces per additional level (#36).
+fn agent_nesting_indent(depth: usize) -> String {
+    match depth {
+        0 => String::new(),
+        level => format!("{}↳ ", "  ".repeat(level.saturating_sub(1))),
+    }
+}
+
+/// Compose the condensed strip label: sequential number + fleet role, plus a
+/// short name only when a real one exists (nickname or stable label). Raw
+/// agent-id hashes are never a name — when no name is known the label simply
+/// omits it rather than fabricating one (#36).
+fn agent_strip_label(indent: &str, number: usize, role: &str, name: Option<&str>) -> String {
+    let base = match name {
+        Some(name) => format!("{number} {role} · {name}"),
+        None => format!("{number} {role}"),
+    };
+    format!("{indent}{base}")
+}
+
+/// Order worker rows so nested spawns sit directly under their parent, then
+/// stamp each label with its display depth and a sequential number. Rows
+/// whose parent is not visible (e.g. the parent finished and left the cache)
+/// stay at the top level — honest flat rendering beats a dangling indent.
+fn order_agent_seeds(seeds: Vec<AgentRowSeed>) -> Vec<RankedWorkRow> {
+    let known_ids: HashSet<&str> = seeds.iter().map(|seed| seed.agent_id.as_str()).collect();
+    let mut children: std::collections::HashMap<&str, Vec<usize>> =
+        std::collections::HashMap::new();
+    let mut roots = Vec::new();
+    for (idx, seed) in seeds.iter().enumerate() {
+        if let Some(parent) = seed.parent_run_id.as_deref()
+            && known_ids.contains(parent)
+        {
+            children.entry(parent).or_default().push(idx);
+            continue;
+        }
+        roots.push(idx);
+    }
+
+    fn push_tree(
+        idx: usize,
+        depth: usize,
+        seeds: &[AgentRowSeed],
+        children: &std::collections::HashMap<&str, Vec<usize>>,
+        seen: &mut HashSet<usize>,
+        order: &mut Vec<(usize, usize)>,
+    ) {
+        if !seen.insert(idx) {
+            return;
+        }
+        order.push((idx, depth));
+        if let Some(child_indices) = children.get(seeds[idx].agent_id.as_str()) {
+            for child_idx in child_indices {
+                push_tree(*child_idx, depth + 1, seeds, children, seen, order);
+            }
+        }
+    }
+
+    let mut order = Vec::with_capacity(seeds.len());
+    let mut seen = HashSet::new();
+    for idx in roots {
+        push_tree(idx, 0, &seeds, &children, &mut seen, &mut order);
+    }
+    // Cycle/orphan backstop: emit anything the walk missed at the top level.
+    for idx in 0..seeds.len() {
+        push_tree(idx, 0, &seeds, &children, &mut seen, &mut order);
+    }
+
+    let mut slots: Vec<Option<AgentRowSeed>> = seeds.into_iter().map(Some).collect();
+    order
+        .into_iter()
+        .enumerate()
+        .map(|(position, (idx, depth))| {
+            let seed = slots[idx].take().expect("each row emitted exactly once");
+            let mut ranked = seed.ranked;
+            let indent = agent_nesting_indent(depth.min(3));
+            ranked.row.label = agent_strip_label(
+                &indent,
+                position.saturating_add(1),
+                &seed.role,
+                seed.name.as_deref(),
+            );
+            // `ordered_rows` re-sorts within status buckets by `order`; stamp
+            // the tree position so a child sorts directly under its parent
+            // whenever they share a bucket.
+            ranked.order = position;
+            ranked
+        })
+        .collect()
+}
+
 fn agent_rows(app: &App) -> Vec<RankedWorkRow> {
     let cached_ids = app
         .subagent_cache
@@ -921,7 +1025,7 @@ fn agent_rows(app: &App) -> Vec<RankedWorkRow> {
         .filter(|agent| !agent.from_prior_session)
         .map(|agent| agent.agent_id.as_str())
         .collect::<HashSet<_>>();
-    let mut rows = app
+    let mut seeds = app
         .subagent_cache
         .iter()
         .filter(|agent| !agent.from_prior_session)
@@ -942,48 +1046,97 @@ fn agent_rows(app: &App) -> Vec<RankedWorkRow> {
                 .role
                 .as_deref()
                 .filter(|role| !role.trim().is_empty())
-                .unwrap_or_else(|| agent.agent_type.as_str());
-            let name = app
-                .agent_label_map
-                .get(&agent.agent_id)
-                .cloned()
-                .or_else(|| agent.nickname.clone())
-                .unwrap_or_else(|| agent.name.clone());
+                .unwrap_or_else(|| agent.agent_type.as_str())
+                .to_string();
+            // A name is a nickname or stable label — never `agent.name`,
+            // which is the raw session id hash (#36).
+            let name = agent
+                .nickname
+                .clone()
+                .filter(|name| !name.trim().is_empty() && name != &agent.agent_id)
+                .or_else(|| app.agent_label_map.get(&agent.agent_id).cloned());
+            let terminal = current_activity
+                .map(|activity| {
+                    matches!(
+                        activity.status,
+                        AgentCurrentActivityStatus::Done
+                            | AgentCurrentActivityStatus::Canceled
+                            | AgentCurrentActivityStatus::Failed
+                            | AgentCurrentActivityStatus::Interrupted
+                    )
+                })
+                .or_else(|| {
+                    agent.worker_status.map(|worker_status| {
+                        matches!(
+                            worker_status,
+                            AgentWorkerStatus::Completed
+                                | AgentWorkerStatus::Cancelled
+                                | AgentWorkerStatus::Failed
+                                | AgentWorkerStatus::Interrupted
+                        )
+                    })
+                })
+                .unwrap_or_else(|| {
+                    matches!(
+                        agent.status,
+                        SubAgentStatus::Completed
+                            | SubAgentStatus::Cancelled
+                            | SubAgentStatus::Failed(_)
+                            | SubAgentStatus::Interrupted(_)
+                            | SubAgentStatus::BudgetExhausted
+                    )
+                });
             let mut facts = vec![
                 status.to_string(),
                 summarize_assignment(&agent.assignment.objective),
             ];
-            if let Some(detail) = current_activity.and_then(|activity| activity.detail.as_deref()) {
-                facts.push(detail.to_string());
+            // Quiet completion (#36): a finished agent keeps its one-line
+            // status and objective; in-flight metadata (current tool, step
+            // counters, file tallies) is working state, not a receipt, and
+            // must not linger as a spawn-metadata dump after the run ends.
+            if !terminal {
+                if let Some(detail) =
+                    current_activity.and_then(|activity| activity.detail.as_deref())
+                {
+                    facts.push(detail.to_string());
+                }
+                if let Some(tool) =
+                    current_activity.and_then(|activity| activity.current_tool.as_deref())
+                {
+                    facts.push(format!("using {tool}"));
+                }
+                if let Some(step) = current_activity.and_then(|activity| activity.step) {
+                    facts.push(format!("step {step}"));
+                }
+                if let Some(files) = meta
+                    .map(|meta| meta.files_touched)
+                    .filter(|count| *count > 0)
+                {
+                    facts.push(format!("{files} files changed"));
+                }
             }
-            if let Some(tool) =
-                current_activity.and_then(|activity| activity.current_tool.as_deref())
-            {
-                facts.push(format!("using {tool}"));
-            }
-            if let Some(step) = current_activity.and_then(|activity| activity.step) {
-                facts.push(format!("step {step}"));
-            }
-            if let Some(files) = meta
-                .map(|meta| meta.files_touched)
-                .filter(|count| *count > 0)
-            {
-                facts.push(format!("{files} files changed"));
-            }
-            RankedWorkRow {
-                bucket,
-                order,
-                is_plan_step: false,
-                row: WorkRow {
-                    id: WorkRowId(format!("worker:{}", agent.agent_id)),
-                    mark: agent_mark(bucket),
-                    label: format!("Sub-agent {name} · {role}"),
-                    detail: facts.join(" · "),
-                    tone: bucket_tone(bucket),
-                    selectable: true,
-                    primary_action: Some(SidebarRowAction::OpenAgentDetail {
-                        agent_id: agent.agent_id.clone(),
-                    }),
+            AgentRowSeed {
+                agent_id: agent.agent_id.clone(),
+                parent_run_id: agent.parent_run_id.clone(),
+                role,
+                name,
+                ranked: RankedWorkRow {
+                    bucket,
+                    order,
+                    is_plan_step: false,
+                    row: WorkRow {
+                        id: WorkRowId(format!("worker:{}", agent.agent_id)),
+                        mark: agent_mark(bucket),
+                        // Stamped by `order_agent_seeds` once the display
+                        // order (and therefore the number) is known.
+                        label: String::new(),
+                        detail: facts.join(" · "),
+                        tone: bucket_tone(bucket),
+                        selectable: true,
+                        primary_action: Some(SidebarRowAction::OpenAgentDetail {
+                            agent_id: agent.agent_id.clone(),
+                        }),
+                    },
                 },
             }
         })
@@ -995,7 +1148,7 @@ fn agent_rows(app: &App) -> Vec<RankedWorkRow> {
         .filter(|(id, _)| !cached_ids.contains(id.as_str()))
         .collect::<Vec<_>>();
     progress_only.sort_by_key(|(id, _)| (*id).clone());
-    rows.extend(
+    seeds.extend(
         progress_only
             .into_iter()
             .enumerate()
@@ -1008,11 +1161,7 @@ fn agent_rows(app: &App) -> Vec<RankedWorkRow> {
                 let bucket = current_activity
                     .map(|activity| current_activity_status_bucket(activity.status))
                     .unwrap_or(WorkBucket::Active);
-                let name = app
-                    .agent_label_map
-                    .get(id)
-                    .cloned()
-                    .unwrap_or_else(|| id.clone());
+                let name = app.agent_label_map.get(id).cloned();
                 let mut facts = vec![status.to_string()];
                 if let Some(detail) =
                     current_activity.and_then(|activity| activity.detail.as_deref())
@@ -1033,25 +1182,33 @@ fn agent_rows(app: &App) -> Vec<RankedWorkRow> {
                 {
                     facts.push(format!("{files} files changed"));
                 }
-                RankedWorkRow {
-                    bucket,
-                    order: 5_000usize.saturating_add(order),
-                    is_plan_step: false,
-                    row: WorkRow {
-                        id: WorkRowId(format!("worker:{id}")),
-                        mark: agent_mark(bucket),
-                        label: format!("Sub-agent {name}"),
-                        detail: facts.join(" · "),
-                        tone: bucket_tone(bucket),
-                        selectable: true,
-                        primary_action: Some(SidebarRowAction::OpenAgentDetail {
-                            agent_id: id.clone(),
-                        }),
+                AgentRowSeed {
+                    agent_id: id.clone(),
+                    parent_run_id: meta.and_then(|meta| meta.parent_run_id.clone()),
+                    // Role is unknown until the manager snapshot arrives;
+                    // "agent" is the honest fallback, not a fabrication.
+                    role: "agent".to_string(),
+                    name,
+                    ranked: RankedWorkRow {
+                        bucket,
+                        order: 5_000usize.saturating_add(order),
+                        is_plan_step: false,
+                        row: WorkRow {
+                            id: WorkRowId(format!("worker:{id}")),
+                            mark: agent_mark(bucket),
+                            label: String::new(),
+                            detail: facts.join(" · "),
+                            tone: bucket_tone(bucket),
+                            selectable: true,
+                            primary_action: Some(SidebarRowAction::OpenAgentDetail {
+                                agent_id: id.clone(),
+                            }),
+                        },
                     },
                 }
             }),
     );
-    rows
+    order_agent_seeds(seeds)
 }
 
 fn summarize_assignment(value: &str) -> String {


### PR DESCRIPTION
## What

Two feel/unclunk fixes from the owner's live dogfooding (FINISH-0.9.4.md Appendix #36, #39).

### Fix A — sub-agent status strip (#36)

**Before:** work-surface worker rows rendered `Sub-agent <name> · <role>` where the name fell back to the raw agent id hash (`Sub-agent agent_e0b2dcf1 · builder`). Nested fleets (a sub-agent spawning its own sub-agents) were indistinguishable from a flat fan-out, and a finished agent kept its in-flight metadata (`using File.apply_patch · step 7 · 4 files changed`) as a lingering receipt.

**After:**
- Rows read `1 builder`, `2 scout` — sequential number + fleet role, plus a short name only when a real one exists (nickname / stable label). The raw agent id is never rendered as a name; when no name is known the label simply omits it.
- Nested spawns order directly under their parent with a `↳` indent (deeper levels indent further, capped). Flat fan-outs get zero nesting chrome.
- Quiet completion: terminal agents keep only status + objective; tool/step/file metadata is working state and no longer dumps into the receipt.
- The classic footer agent label now leads with the fleet role: `agents 2/4 running · builder: <objective>`.

### Fix B — active goal invisible in the TUI (#39)

**Before:** the owner set a goal via `create_goal` (runtime confirmed it active, turn metadata carried the token budget) and saw nothing anywhere. Root cause: the default ocean shell has **no sidebar** (deliberate) and its phase strip never reads goal state — the existing goal surfaces (sidebar-top banner, classic footer chip) only exist in the classic shell.

**After:** the ocean topbar carries a goal chip — `goal <objective>` truncated to fit, `goal paused <objective>` when paused, nothing when no goal is active or the goal is terminal. Under width pressure the route label yields first; the chip then truncates, and drops cleanly (no mid-word clip) when even a minimal chip cannot fit. The active/paused/terminal resolution is shared with the classic footer chip via `active_goal_chip_state`, so both shells surface identical state. Token budget is intentionally not in the chip (header space; the sidebar Work summary already shows it).

## Test evidence

- `cargo fmt --all` — clean.
- `cargo test -p codewhale-tui --no-fail-fast` — 9641+ passed. Failures are exactly the known pre-existing set on the train tip: 19 provider-catalog tests (missing DeepSeek/MiniMax/Anthropic env keys) and 2 qa_pty timing tests. Both qa_pty failures (`v091_real_pty_visual_matrix_preserves_control_grammar`, `interactive_init_accepts_input_with_dispatcher_written_config`) were reproduced on the pristine train tip (stash + rebuild) — not regressions from this change.
- New regression tests:
  - `agent_rows_number_by_fleet_role_and_never_leak_raw_ids` — numbering, role labels, no raw ids, no nesting chrome when flat
  - `agent_rows_order_and_indent_nested_spawns_under_their_parent` — `↳` indent + parent adjacency
  - `agent_rows_completed_agents_render_quietly_without_spawn_metadata` — quiet completion
  - `active_subagent_status_label_names_fleet_role_not_raw_id` — classic footer strip
  - `ocean_header_renders_active_goal_and_hides_it_when_unset_or_terminal`, `ocean_header_names_a_paused_goal`, `ocean_header_keeps_goal_chip_in_cramped_layouts` — topbar goal chip
  - Updated `agent_rows_show_role_assignment_and_open_real_agent_details` for the new label format

## Design decisions where the spec was loose

- **Numbering** is a display ordinal over the visible worker rows (tree order), not the cross-surface `Agent N` label-map identity — deterministic, stable while fleet membership is stable, and requires no mutable state in the render path.
- **Nesting indent** is per-row (`↳` only on actual children whose parent is visible); orphans render flat rather than dangling.
- **Classic shell** already renders the goal in two places (sidebar banner + footer chip), so the topbar chip was added to the ocean header only.
- Not merged — stacked on the 0.9.4 release train.