### PR TITLE
feat(tui): workflow status chip in the ocean header (#5040)

### DIFF
--- a/crates/tui/src/automation_manager.rs
+++ b/crates/tui/src/automation_manager.rs
@@ -1604,6 +1604,7 @@ async fn fire_due_triggers_shared(
             allow_shell: Some(false),
             trust_mode: Some(false),
             auto_approve: Some(false),
+            owner_session_id: None,
         };
 
         match task_manager.add_task(new_task).await {

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -9001,6 +9001,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         // replace the instruction array. Project-scope config is filtered in
         // main.rs and cannot set instruction paths.
         instructions: override_cfg.instructions.or(base.instructions),
+        stop_words: override_cfg.stop_words.or(base.stop_words),
         allow_shell: override_cfg.allow_shell.or(base.allow_shell),
         prompt_suggestion: override_cfg.prompt_suggestion.or(base.prompt_suggestion),
         yolo: override_cfg.yolo.or(base.yolo),

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -2621,6 +2621,7 @@ impl Engine {
                         let shell_permits = shell_permits.clone();
                         let workspace = self.session.workspace.clone();
                         let context_override = batch_tool_context.clone();
+                        let cancel_token = self.cancel_token.clone();
 
                         tool_tasks.push(async move {
                             let _shell_permit = if plan.name == "exec_shell" {
@@ -2633,6 +2634,7 @@ impl Engine {
                                 plan.supports_parallel || plan.detached_start,
                                 plan.interactive,
                                 tx_event.clone(),
+                                Some(cancel_token),
                                 plan.name.clone(),
                                 plan.input.clone(),
                                 workspace,

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -7369,6 +7369,7 @@ async fn live_steer_crosses_message_submit_transform_exactly_once() {
 
     attempt_steer_with_queue_fallback(
         &mut app,
+        &Config::default(),
         &engine.handle,
         QueuedMessage::new("original steer".to_string(), None),
         DispatchRecovery::Immediate,
@@ -7403,6 +7404,7 @@ async fn denied_steer_restores_queued_draft_and_keeps_active_turn() {
 
     attempt_steer_with_queue_fallback(
         &mut app,
+        &Config::default(),
         &engine.handle,
         message.clone(),
         DispatchRecovery::Draft,
@@ -12297,7 +12299,7 @@ async fn steer_user_message_records_prompt_for_cancel_restore() {
         None,
     );
 
-    steer_user_message(&mut app, &engine.handle, queued)
+    steer_user_message(&mut app, &Config::default(), &engine.handle, queued)
         .await
         .expect("steer user message");
 
@@ -12344,6 +12346,7 @@ async fn steer_user_message_backgrounds_foreground_shell_before_dispatch() {
 
     steer_user_message(
         &mut app,
+        &Config::default(),
         &engine.handle,
         QueuedMessage::new("use the partial results".to_string(), None),
     )
@@ -12546,6 +12549,7 @@ async fn steer_failure_queues_message_and_surfaces_toast() {
 
     attempt_steer_with_queue_fallback(
         &mut app,
+        &Config::default(),
         &engine.handle,
         queued,
         DispatchRecovery::Immediate,
@@ -16914,6 +16918,7 @@ async fn steer_send_keeps_local_scroll_context() {
 
     steer_user_message(
         &mut app,
+        &Config::default(),
         &engine.handle,
         QueuedMessage::new("steer into the current turn".to_string(), None),
     )

--- a/crates/tui/src/tui/underwater.rs
+++ b/crates/tui/src/tui/underwater.rs
@@ -976,6 +976,24 @@ pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
             Style::default().fg(*color).add_modifier(Modifier::BOLD),
         ));
     }
+    // Workflow-run chip (#5040): the same `WorkflowPanel::top_bar_chip` the
+    // classic header shows, so a collapsed run stays visible on the ocean
+    // shell too. No workflow panel means no chip. The cramped-layout rebuild
+    // below keeps the chip in `suffix` alongside the goal chip.
+    let workflow_chip = app
+        .workflow_panel
+        .as_ref()
+        .map(|panel| (panel.top_bar_chip(), app.ui_theme.info));
+    if let Some((text, color)) = &workflow_chip {
+        left.push(Span::styled(
+            " · ",
+            Style::default().fg(app.ui_theme.text_dim),
+        ));
+        left.push(Span::styled(
+            text.clone(),
+            Style::default().fg(*color).add_modifier(Modifier::BOLD),
+        ));
+    }
 
     let context_meter = (tier != ShellTier::Compact)
         .then(|| crate::tui::ui::context_usage_snapshot(app))
@@ -1138,6 +1156,29 @@ pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
                 ));
                 suffix.push(Span::styled(
                     truncate_to_width(text, goal_room),
+                    Style::default().fg(*color).add_modifier(Modifier::BOLD),
+                ));
+            }
+        }
+        // The workflow chip (#5040) is operator state too, so it gets the
+        // goal chip's treatment: whatever room remains after the chips ahead
+        // of it, clean truncation, and a clean drop when even a minimal chip
+        // cannot fit. The route label still yields its budget first.
+        if let Some((text, color)) = &workflow_chip {
+            let workflow_room = left_budget
+                .saturating_sub(
+                    4usize
+                        .saturating_add(indicator_width)
+                        .saturating_add(span_width(&suffix)),
+                )
+                .saturating_sub(3);
+            if workflow_room >= 8 {
+                suffix.push(Span::styled(
+                    " · ",
+                    Style::default().fg(app.ui_theme.text_dim),
+                ));
+                suffix.push(Span::styled(
+                    truncate_to_width(text, workflow_room),
                     Style::default().fg(*color).add_modifier(Modifier::BOLD),
                 ));
             }
@@ -1664,6 +1705,65 @@ mod tests {
         assert!(
             !narrow.contains("goal"),
             "unsupportable goal chip must drop, not clip: {narrow:?}"
+        );
+    }
+
+    #[test]
+    fn ocean_header_renders_running_workflow_chip_and_hides_it_when_idle() {
+        // #5040: a collapsed workflow run must stay visible in the ocean
+        // topbar — the same chip the classic header shows.
+        let mut app = test_app();
+        let idle = header_text(&app, 120);
+        assert!(
+            !idle.contains("wf "),
+            "no workflow chip without a run: {idle:?}"
+        );
+
+        app.workflow_panel = Some(crate::tui::widgets::workflow_panel::WorkflowPanel::new(
+            "wf_1", "ship it", 0,
+        ));
+        let running = header_text(&app, 120);
+        assert!(
+            running.contains("wf running"),
+            "running workflow chip missing from ocean topbar: {running:?}"
+        );
+    }
+
+    #[test]
+    fn ocean_header_keeps_completed_workflow_status_visible() {
+        let mut app = test_app();
+        let mut panel =
+            crate::tui::widgets::workflow_panel::WorkflowPanel::new("wf_2", "ship it", 1_000);
+        panel.lifecycle = crate::tui::widgets::workflow_panel::WorkflowPanelLifecycle::Succeeded;
+        panel.completed_at_ms = Some(61_000);
+        app.workflow_panel = Some(panel);
+        let header = header_text(&app, 120);
+        assert!(
+            header.contains("wf success"),
+            "completed workflow status missing: {header:?}"
+        );
+    }
+
+    #[test]
+    fn ocean_header_keeps_workflow_chip_in_cramped_layouts() {
+        let mut app = test_app();
+        app.model = "provider/model-with-a-deliberately-long-route-name".to_string();
+        app.workflow_panel = Some(crate::tui::widgets::workflow_panel::WorkflowPanel::new(
+            "wf_3", "ship it", 0,
+        ));
+        // Width pressure forces the cramped rebuild: the route yields first
+        // and the workflow chip survives whole.
+        let header = header_text(&app, 80);
+        assert!(
+            header.contains("wf running"),
+            "workflow chip must survive width pressure: {header:?}"
+        );
+        // When even a minimal chip cannot fit alongside mode, effort, and
+        // permission, it drops cleanly instead of clipping mid-word.
+        let narrow = header_text(&app, 48);
+        assert!(
+            !narrow.contains("wf "),
+            "unsupportable workflow chip must drop, not clip: {narrow:?}"
         );
     }
 


### PR DESCRIPTION
Completes #5040 for the ocean shell. The train's ab3ef065f wired `WorkflowPanel::top_bar_chip` into the **classic** header only, so on ocean-shell sessions a collapsed workflow run was invisible.

## What

- `crates/tui/src/tui/underwater.rs` `render_header` now renders the same `WorkflowPanel::top_bar_chip` (via `app.workflow_panel`) in the ocean top bar — no parallel helper. Salvages the width-budgeting idea from the superseded #5113 review while reusing the train's machinery.
- Follows the goal chip's pattern (#5222, 3de386d25) in both header paths:
  - **Normal path:** chip appended after the goal chip, bold, `ui_theme.info`.
  - **Cramped rebuild:** the route label yields width first; the chip truncates cleanly (no mid-word clipping) in whatever room remains; it drops entirely when even a minimal chip can't fit alongside mode/effort/permission; and it renders nothing when no workflow is active.

## Tests

New tests in `underwater.rs` mirroring the goal chip's structure:

- `ocean_header_renders_running_workflow_chip_and_hides_it_when_idle` — running chip visible, absent when idle
- `ocean_header_keeps_completed_workflow_status_visible` — completed (`wf success`) status
- `ocean_header_keeps_workflow_chip_in_cramped_layouts` — survives 80-col pressure, drops cleanly at 48

## Gates

- `cargo fmt --all` — clean for the touched files (the train tip has pre-existing fmt drift in `settings.rs`, `tools/web_search.rs`, `tui/app/tests.rs`; left alone to keep this diff scoped).
- `cargo test -p codewhale-tui --no-fail-fast` — 9787 passed. Failures: the 19 known provider-catalog (env keys) + 2 known qa_pty toast-timing, **plus 6 pre-existing train-tip WIP fallout** unrelated to this change (verified by panic output): 3 zh-Hant locale-parity + `partial_locale_badge` (b02a05b5a promoted zh-Hant but the pack is 47 keys short of en.json), and `task_list_shows_owner_session_when_present` + `work_sidebar_hides_other_session_terminals...` (#5110's WIP owner-session feature).

## Also in this PR

`00479a709 fix(tui): complete stale call sites left at the train tip` — the train tip (145472341, [WIP] #5110) **did not compile** (`NewTaskRequest.owner_session_id`, `execute_tool_with_lock` cancel_token, `merge_config` stop_words, steer-test `&Config` args all stale). This minimal repair unblocks the gates; drop it if the train fixes the tip first.
