### PR TITLE
feat(acp): expose file/search/git/patch/shell tools over session/prompt

### DIFF
--- a/crates/tui/src/acp_server.rs
+++ b/crates/tui/src/acp_server.rs
@@ -1,9 +1,8 @@
 //! Minimal Agent Client Protocol stdio adapter.
 //!
-//! This intentionally starts with the ACP baseline: initialize, new session,
-//! prompt, and cancel. It keeps stdout protocol-clean for editor clients and
-//! routes prompts through the same configured DeepSeek client as one-shot CLI
-//! mode.
+//! This starts from the ACP baseline: initialize, new session, prompt, and
+//! cancel. It keeps stdout protocol-clean for editor clients and routes
+//! prompts through the same configured DeepSeek client as one-shot CLI mode.
 //!
 //! `session/prompt` streams the provider response: each text delta is emitted
 //! as a `session/update` agent_message_chunk as it arrives, instead of buffering
@@ -12,23 +11,51 @@
 //! session can interrupt the turn mid-stream (returning `stopReason: "cancelled"`)
 //! instead of being queued behind it. A single writer task is preserved so
 //! stdout stays protocol-clean.
+//!
+//! Each ACP session owns a [`crate::tools::ToolRegistry`] built from the same
+//! file/search/git/patch/shell tools the CLI `exec` agent and the MCP server
+//! adapter (`crate::mcp_server`) already use. When the model emits a tool call,
+//! the turn driver executes it locally through that registry (no duplicate
+//! filesystem/shell implementation), reports progress to the client as
+//! `tool_call` / `tool_call_update` session updates, feeds the result back as
+//! a `tool_result` content block, and re-opens the provider stream so the
+//! model can keep going until it produces a final answer with no further tool
+//! calls.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
 use futures_util::StreamExt;
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, Lines};
+use tokio_util::sync::CancellationToken;
 
 use crate::client::DeepSeekClient;
 use crate::config::{ApiProvider, Config};
 use crate::llm_client::{LlmClient, StreamEventBox};
-use crate::models::{
-    ContentBlock, ContentBlockStart, Delta, Message, MessageRequest, StreamEvent, SystemPrompt,
-};
+use crate::models::{ContentBlock, ContentBlockStart, Delta, Message, MessageRequest, StreamEvent};
+use crate::tools::{ToolContext, ToolRegistry, ToolRegistryBuilder};
+use crate::worker_profile::ShellPolicy;
 
 const ACP_PROTOCOL_VERSION: u64 = 1;
+
+/// Hard cap on LLM <-> tool round-trips within a single `session/prompt`
+/// turn. Guards against a model that never stops calling tools; each round is
+/// one provider stream plus zero or more tool executions.
+const MAX_ACP_TOOL_ROUNDS: usize = 50;
+
+/// Maximum number of concurrent sessions kept in memory. When this limit is
+/// exceeded, the oldest session with no in-flight prompt is evicted.
+const MAX_ACP_SESSIONS: usize = 64;
+
+/// Content is streamed to the model in full (no truncation); this cap only
+/// bounds how much of a tool's output is echoed into the `tool_call_update`
+/// notification the editor renders, so a large `read_file`/`exec_shell`
+/// result does not flood the client UI.
+const TOOL_CALL_CONTENT_PREVIEW_CHARS: usize = 4_000;
 
 pub async fn run_acp_server(config: Config, model: String, default_cwd: PathBuf) -> Result<()> {
     let stdin = tokio::io::stdin();
@@ -82,8 +109,9 @@ pub async fn run_acp_server(config: Config, model: String, default_cwd: PathBuf)
         let params = message.get("params").cloned().unwrap_or_else(|| json!({}));
 
         // `session/prompt` is driven concurrently with the reader so a
-        // `session/cancel` can interrupt the in-flight provider call. Every
-        // other method is request/response and handled synchronously below.
+        // `session/cancel` can interrupt the in-flight provider call or a
+        // running tool. Every other method is request/response and handled
+        // synchronously below.
         if method == "session/prompt" {
             match server.begin_prompt(params) {
                 Ok(prepared) => {
@@ -92,56 +120,100 @@ pub async fn run_acp_server(config: Config, model: String, default_cwd: PathBuf)
                         messages,
                         cwd,
                     } = prepared;
-                    // Opening the stream borrows `&server` only briefly; the
-                    // returned `StreamEventBox` is `'static`, so it can be raced
-                    // against the reader without holding a borrow on the server,
-                    // and the main task keeps exclusive ownership of stdout.
-                    match server.open_prompt_stream(&messages, &cwd).await {
-                        Ok(stream) => {
-                            let response_id_policy = server.response_id_policy;
-                            let outcome = drive_prompt_stream(
-                                stream,
-                                &session_id,
-                                response_id_policy,
-                                &mut reader,
-                                &mut writer,
-                            )
-                            .await;
-                            match outcome {
-                                Ok(PromptOutcome::Completed(output)) => {
-                                    // Chunks were already streamed; record the full
-                                    // assistant turn in history for the next prompt.
-                                    server.finish_prompt(&session_id, &output);
-                                    if let Some(id) = id {
-                                        let id = response_id_policy.response_id(id);
-                                        write_jsonrpc_result(
-                                            &mut writer,
-                                            id,
-                                            json!({ "stopReason": "end_turn" }),
-                                        )
-                                        .await?;
-                                    }
-                                }
-                                Ok(PromptOutcome::Cancelled) => {
-                                    if let Some(id) = id {
-                                        let id = response_id_policy.response_id(id);
-                                        write_jsonrpc_result(
-                                            &mut writer,
-                                            id,
-                                            json!({ "stopReason": "cancelled" }),
-                                        )
-                                        .await?;
-                                    }
-                                }
-                                Err(err) => {
-                                    let id = id.map(|id| response_id_policy.response_id(id));
-                                    write_jsonrpc_error(&mut writer, id, -32603, err.to_string())
-                                        .await?;
-                                }
+                    let response_id_policy = server.response_id_policy;
+                    let Some(tool_registry) = server.session_tool_registry(&session_id) else {
+                        let id = id.map(|id| response_id_policy.response_id(id));
+                        write_jsonrpc_error(&mut writer, id, -32603, "unknown sessionId").await?;
+                        continue;
+                    };
+                    // The stream-opening closure borrows `&server` only
+                    // briefly per round; each returned `StreamEventBox` is
+                    // `'static`, so it can be raced against the reader
+                    // without holding a borrow on the server across an
+                    // await, and the main task keeps exclusive ownership of
+                    // stdout.
+                    let outcome = run_agentic_prompt_turn(
+                        &session_id,
+                        messages,
+                        &tool_registry,
+                        response_id_policy,
+                        &mut reader,
+                        &mut writer,
+                        |msgs| {
+                            // Rebind to references before the `async move`
+                            // block: `async move` moves every path it
+                            // touches, and these are already-`Copy`
+                            // references, so only `msgs` (the per-round
+                            // owned clone) is actually moved in — `server`,
+                            // `cwd`, and `tool_registry` stay borrowed from
+                            // the enclosing scope across every call this
+                            // `FnMut` closure makes.
+                            let server = &server;
+                            let cwd = &cwd;
+                            let tool_registry = &tool_registry;
+                            async move { server.open_prompt_stream(&msgs, cwd, tool_registry).await }
+                        },
+                    )
+                    .await;
+                    match outcome {
+                        Ok((PromptOutcome::Completed(_text), full_messages)) => {
+                            // Chunks were already streamed; record the full
+                            // conversation (including any tool rounds) for
+                            // the next prompt.
+                            server.commit_turn_messages(&session_id, full_messages);
+                            if let Some(id) = id {
+                                let id = response_id_policy.response_id(id);
+                                write_jsonrpc_result(
+                                    &mut writer,
+                                    id,
+                                    json!({ "stopReason": "end_turn" }),
+                                )
+                                .await?;
+                            }
+                        }
+                        Ok((PromptOutcome::Cancelled, mut partial_messages)) => {
+                            // Strip the trailing assistant message if it
+                            // carried tool_use blocks whose execution was
+                            // interrupted — dangling tool_use blocks without
+                            // tool_result blocks confuse the model on the
+                            // next prompt. All earlier completed tool rounds
+                            // stay in history.
+                            if partial_messages.last().map(|m| m.role.as_str()) == Some("assistant")
+                            {
+                                partial_messages.pop();
+                            }
+                            server.commit_turn_messages(&session_id, partial_messages);
+                            if let Some(id) = id {
+                                let id = response_id_policy.response_id(id);
+                                write_jsonrpc_result(
+                                    &mut writer,
+                                    id,
+                                    json!({ "stopReason": "cancelled" }),
+                                )
+                                .await?;
+                            }
+                        }
+                        Ok((PromptOutcome::MaxRounds(_text), full_messages)) => {
+                            // Max rounds reached — commit what we have
+                            // (unlike cancel, this is a normal completion).
+                            server.commit_turn_messages(&session_id, full_messages);
+                            if let Some(id) = id {
+                                let id = response_id_policy.response_id(id);
+                                write_jsonrpc_result(
+                                    &mut writer,
+                                    id,
+                                    json!({ "stopReason": "max_turn_requests" }),
+                                )
+                                .await?;
                             }
                         }
                         Err(err) => {
-                            let id = id.map(|id| server.response_id_policy.response_id(id));
+                            // The user message was already pushed into
+                            // session history by `begin_prompt`; roll it
+                            // back so the next prompt doesn't start with two
+                            // consecutive `user` messages.
+                            server.rollback_user_message(&session_id);
+                            let id = id.map(|id| response_id_policy.response_id(id));
                             write_jsonrpc_error(&mut writer, id, -32603, err.to_string()).await?;
                         }
                     }
@@ -185,6 +257,60 @@ enum PromptOutcome {
     Completed(String),
     /// A matching `session/cancel` arrived before the call finished.
     Cancelled,
+    /// The turn reached the maximum number of tool-call round-trips.
+    /// Carries whatever text the model produced in the final round.
+    MaxRounds(String),
+}
+
+/// A tool call the model requested, assembled from streamed
+/// `content_block_start` / `content_block_delta` / `content_block_stop`
+/// events. `parse_error` is set when the accumulated `input_json_delta`
+/// bytes did not parse as JSON — the call is still surfaced (rather than
+/// silently dropped) so the model gets a clear tool-result error instead of
+/// the turn hanging.
+#[derive(Debug, Clone)]
+struct PendingToolCall {
+    id: String,
+    name: String,
+    input: Value,
+    parse_error: Option<String>,
+}
+
+/// Accumulates one streamed `tool_use` content block until its
+/// `content_block_stop`.
+#[derive(Debug, Default)]
+struct ToolUseAccumulator {
+    id: String,
+    name: String,
+    initial_input: Value,
+    buffer: String,
+}
+
+impl ToolUseAccumulator {
+    fn finalize(self) -> PendingToolCall {
+        if self.buffer.trim().is_empty() {
+            return PendingToolCall {
+                id: self.id,
+                name: self.name,
+                input: self.initial_input,
+                parse_error: None,
+            };
+        }
+        match serde_json::from_str(&self.buffer) {
+            Ok(input) => PendingToolCall {
+                id: self.id,
+                name: self.name,
+                input,
+                parse_error: None,
+            },
+            Err(_) => PendingToolCall {
+                id: self.id,
+                name: self.name,
+                input: json!({}),
+                parse_error: Some(self.buffer),
+            },
+        }
+    }
 }
 
 /// The text payload an ACP client should see for a given stream event, if any.
@@ -214,8 +340,9 @@ fn stream_text_chunk(event: &StreamEvent) -> Option<&str> {
 /// the single protocol-clean stdout stream.
 ///
 /// Returns [`PromptOutcome::Completed`] with the full accumulated text once the
-/// stream ends (or emits `message_stop`), so the caller can record the turn in
-/// history. A matching `session/cancel` (request or notification form) ends it
+/// stream ends (or emits `message_stop`), plus any `tool_use` blocks the model
+/// emitted during the round, so the caller can execute them and continue the
+/// turn. A matching `session/cancel` (request or notification form) ends it
 /// early with [`PromptOutcome::Cancelled`] — dropping the stream aborts the
 /// underlying provider connection. The turn is single-flight: a cancel for a
 /// different session is acknowledged and ignored; any other concurrent *request*
@@ -227,12 +354,14 @@ async fn drive_prompt_stream<R, W>(
     response_id_policy: JsonRpcResponseIdPolicy,
     reader: &mut Lines<R>,
     writer: &mut W,
-) -> Result<PromptOutcome>
+) -> Result<(PromptOutcome, Vec<PendingToolCall>)>
 where
     R: AsyncBufRead + Unpin,
     W: AsyncWrite + Unpin,
 {
     let mut accumulated = String::new();
+    let mut tool_calls: Vec<PendingToolCall> = Vec::new();
+    let mut pending_tool_uses: HashMap<u32, ToolUseAccumulator> = HashMap::new();
     // Once input closes mid-turn we stop selecting on the reader and just drain
     // the stream to completion, rather than spinning on repeated EOFs.
     let mut reader_open = true;
@@ -241,7 +370,7 @@ where
             event = stream.next() => {
                 match event {
                     // Stream exhausted without an explicit stop: turn is done.
-                    None => return Ok(PromptOutcome::Completed(accumulated)),
+                    None => return Ok((PromptOutcome::Completed(accumulated), tool_calls)),
                     Some(Ok(event)) => {
                         if let Some(text) = stream_text_chunk(&event)
                             && !text.is_empty() {
@@ -249,8 +378,35 @@ where
                                 write_session_update(writer, session_id, text.to_string()).await?;
                             }
                         match event {
+                            StreamEvent::ContentBlockStart {
+                                index,
+                                content_block: ContentBlockStart::ToolUse { id, name, input, .. },
+                            } => {
+                                pending_tool_uses.insert(
+                                    index,
+                                    ToolUseAccumulator {
+                                        id,
+                                        name,
+                                        initial_input: input,
+                                        buffer: String::new(),
+                                    },
+                                );
+                            }
+                            StreamEvent::ContentBlockDelta {
+                                index,
+                                delta: Delta::InputJsonDelta { partial_json },
+                            } => {
+                                if let Some(acc) = pending_tool_uses.get_mut(&index) {
+                                    acc.buffer.push_str(&partial_json);
+                                }
+                            }
+                            StreamEvent::ContentBlockStop { index } => {
+                                if let Some(acc) = pending_tool_uses.remove(&index) {
+                                    tool_calls.push(acc.finalize());
+                                }
+                            }
                             StreamEvent::MessageStop => {
-                                return Ok(PromptOutcome::Completed(accumulated));
+                                return Ok((PromptOutcome::Completed(accumulated), tool_calls));
                             }
                             StreamEvent::Error { error } => {
                                 return Err(anyhow!("provider stream error: {error}"));
@@ -293,7 +449,7 @@ where
                                 write_jsonrpc_result(writer, id, json!(null)).await?;
                             }
                             // Dropping `stream` on return aborts the provider call.
-                            return Ok(PromptOutcome::Cancelled);
+                            return Ok((PromptOutcome::Cancelled, tool_calls));
                         }
                         // Cancel for some other session: acknowledge, keep going.
                         if let Some(id) = id {
@@ -321,17 +477,287 @@ where
     }
 }
 
+/// Outcome of executing one batch of tool calls from a single round.
+enum ToolBatchOutcome {
+    /// Every tool call ran to completion; carries the `tool_result` messages
+    /// to append to the conversation, in call order.
+    Completed(Vec<Message>),
+    /// A matching `session/cancel` arrived while a tool was running.
+    Cancelled,
+}
+
+/// Execute `tool_calls` in order against `registry`, reporting each one to
+/// the client as `tool_call` / `tool_call_update` session updates, while
+/// racing every execution against the reader for a `session/cancel`
+/// targeting `session_id`. On cancel, the tool's [`CancellationToken`] is
+/// signalled and the in-flight call is awaited to completion (so a
+/// cancel-aware tool like `exec_shell` gets a chance to kill its child
+/// process) before returning [`ToolBatchOutcome::Cancelled`].
+async fn execute_tool_calls_with_cancellation<R, W>(
+    registry: &ToolRegistry,
+    tool_calls: Vec<PendingToolCall>,
+    session_id: &str,
+    reader: &mut Lines<R>,
+    writer: &mut W,
+) -> Result<ToolBatchOutcome>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut result_messages = Vec::with_capacity(tool_calls.len());
+    let mut reader_open = true;
+
+    for call in tool_calls {
+        write_tool_call_start(writer, session_id, &call).await?;
+
+        if let Some(parse_error) = call.parse_error.clone() {
+            let content = format!("Error: tool arguments were not valid JSON: {parse_error}");
+            write_tool_call_update(writer, session_id, &call, "failed", Some(&content)).await?;
+            result_messages.push(tool_result_message(&call.id, content, true));
+            continue;
+        }
+
+        let cancel_token = CancellationToken::new();
+        let mut turn_context = registry.context().clone();
+        turn_context.cancel_token = Some(cancel_token.clone());
+        let exec_fut =
+            registry.execute_full_with_context(&call.name, call.input.clone(), Some(&turn_context));
+        tokio::pin!(exec_fut);
+
+        let exec_result = loop {
+            tokio::select! {
+                result = &mut exec_fut => break Some(result),
+                line = reader.next_line(), if reader_open => {
+                    let line = match line? {
+                        Some(line) => line,
+                        None => {
+                            reader_open = false;
+                            continue;
+                        }
+                    };
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    let message: Value = match serde_json::from_str(&line) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            write_jsonrpc_error(writer, None, -32700, format!("invalid json: {err}"))
+                                .await?;
+                            continue;
+                        }
+                    };
+                    let msg_id = message.get("id").cloned();
+                    match message.get("method").and_then(Value::as_str) {
+                        Some("session/cancel") => {
+                            let target = message.pointer("/params/sessionId").and_then(Value::as_str);
+                            if target.is_none() || target == Some(session_id) {
+                                if let Some(msg_id) = msg_id {
+                                    write_jsonrpc_result(writer, msg_id, json!(null)).await?;
+                                }
+                                cancel_token.cancel();
+                                // Give the tool a chance to observe the token and
+                                // wind down (e.g. kill a running child process)
+                                // before we drop it.
+                                let _ = (&mut exec_fut).await;
+                                break None;
+                            }
+                            if let Some(msg_id) = msg_id {
+                                write_jsonrpc_result(writer, msg_id, json!(null)).await?;
+                            }
+                        }
+                        _ => {
+                            if let Some(msg_id) = msg_id {
+                                write_jsonrpc_error(
+                                    writer,
+                                    Some(msg_id),
+                                    -32603,
+                                    "a session/prompt turn is already in progress",
+                                )
+                                .await?;
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        let Some(exec_result) = exec_result else {
+            return Ok(ToolBatchOutcome::Cancelled);
+        };
+
+        match exec_result {
+            Ok(tool_result) => {
+                let status = if tool_result.success {
+                    "completed"
+                } else {
+                    "failed"
+                };
+                write_tool_call_update(
+                    writer,
+                    session_id,
+                    &call,
+                    status,
+                    Some(&tool_result.content),
+                )
+                .await?;
+                result_messages.push(tool_result_message(
+                    &call.id,
+                    tool_result.content,
+                    !tool_result.success,
+                ));
+            }
+            Err(err) => {
+                let content = format!("Error: {err}");
+                write_tool_call_update(writer, session_id, &call, "failed", Some(&content)).await?;
+                result_messages.push(tool_result_message(&call.id, content, true));
+            }
+        }
+    }
+
+    Ok(ToolBatchOutcome::Completed(result_messages))
+}
+
+fn tool_result_message(tool_use_id: &str, content: String, is_error: bool) -> Message {
+    Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::ToolResult {
+            tool_use_id: tool_use_id.to_string(),
+            content,
+            is_error: Some(is_error),
+            content_blocks: None,
+        }],
+    }
+}
+
+/// Drive one `session/prompt` turn to completion, looping through as many
+/// LLM <-> tool round-trips as the model requests (bounded by
+/// [`MAX_ACP_TOOL_ROUNDS`]).
+///
+/// `open_stream` opens a fresh provider stream for the given message
+/// history; production callers wire it to [`AcpServer::open_prompt_stream`],
+/// while tests supply canned per-round streams so the loop can be exercised
+/// without a real provider. Returns the outcome of the final round plus the
+/// full message history (including any tool-call/tool-result rounds), which
+/// the caller commits to session history only when the turn completed
+/// normally.
+///
+/// `open_stream` takes the message history *by value* (a clone per round)
+/// rather than `&[Message]`: an `async fn`'s returned future captures the
+/// lifetime of every reference parameter, so a borrowed slice here would
+/// force `Fut` to depend on each call's borrow lifetime — which `FnMut`'s
+/// single associated `Fut` type cannot express. Taking ownership sidesteps
+/// that; production callers move the clone into an `async move` block.
+async fn run_agentic_prompt_turn<R, W, F, Fut>(
+    session_id: &str,
+    mut messages: Vec<Message>,
+    tool_registry: &ToolRegistry,
+    response_id_policy: JsonRpcResponseIdPolicy,
+    reader: &mut Lines<R>,
+    writer: &mut W,
+    mut open_stream: F,
+) -> Result<(PromptOutcome, Vec<Message>)>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+    F: FnMut(Vec<Message>) -> Fut,
+    Fut: Future<Output = Result<StreamEventBox>>,
+{
+    for _round in 0..MAX_ACP_TOOL_ROUNDS {
+        let stream = open_stream(messages.clone()).await?;
+        let (outcome, tool_calls) =
+            drive_prompt_stream(stream, session_id, response_id_policy, reader, writer).await?;
+
+        let text = match outcome {
+            PromptOutcome::Cancelled => return Ok((PromptOutcome::Cancelled, messages)),
+            PromptOutcome::Completed(text) => text,
+            PromptOutcome::MaxRounds(text) => text,
+        };
+
+        let mut assistant_content = Vec::new();
+        if !text.is_empty() {
+            assistant_content.push(ContentBlock::Text {
+                text: text.clone(),
+                cache_control: None,
+            });
+        }
+        for call in &tool_calls {
+            assistant_content.push(ContentBlock::ToolUse {
+                id: call.id.clone(),
+                name: call.name.clone(),
+                input: call.input.clone(),
+                caller: None,
+            });
+        }
+        if !assistant_content.is_empty() {
+            messages.push(Message {
+                role: "assistant".to_string(),
+                content: assistant_content,
+            });
+        }
+
+        if tool_calls.is_empty() {
+            return Ok((PromptOutcome::Completed(text), messages));
+        }
+
+        match execute_tool_calls_with_cancellation(
+            tool_registry,
+            tool_calls,
+            session_id,
+            reader,
+            writer,
+        )
+        .await?
+        {
+            ToolBatchOutcome::Cancelled => return Ok((PromptOutcome::Cancelled, messages)),
+            ToolBatchOutcome::Completed(tool_result_messages) => {
+                messages.extend(tool_result_messages);
+            }
+        }
+    }
+
+    // Max rounds reached: return the text accumulated in the final round
+    // rather than an error, so the client gets a structured completion
+    // with a clear stop reason.
+    let final_text = messages
+        .iter()
+        .rev()
+        .find(|m| m.role == "assistant")
+        .and_then(|m| {
+            m.content.iter().find_map(|b| match b {
+                ContentBlock::Text { text, .. } => Some(text.clone()),
+                _ => None,
+            })
+        })
+        .unwrap_or_default();
+    Ok((PromptOutcome::MaxRounds(final_text), messages))
+}
+
 struct AcpServer {
     config: Config,
     model: String,
     default_cwd: PathBuf,
     sessions: HashMap<String, AcpSession>,
+    /// Insertion-order tracking of session ids. Used to evict the *oldest*
+    /// session (by insertion order, not arbitrary HashMap iteration) when
+    /// the session cap is reached.
+    insertion_order: VecDeque<String>,
+    /// Whether the connected client accepts `terminal` tool calls, from
+    /// `initialize` params `clientCapabilities.terminal`. Defaults to `false`
+    /// (restrictive): clients that omit the field get no shell access. Older
+    /// ACP clients predating the `terminal` capability get a working agent
+    /// without shell, which is safe; the client can re-declare support on
+    /// reconnect or via `session/request_permission`.
+    client_supports_terminal: bool,
     response_id_policy: JsonRpcResponseIdPolicy,
 }
 
 struct AcpSession {
     cwd: PathBuf,
     messages: Vec<Message>,
+    /// Built once per session over the session `cwd`, then reused for every
+    /// prompt turn: `to_api_tools()` memoises the serialised catalog, and
+    /// `file_read_tracker` / the shell manager need to persist across turns.
+    tool_registry: Arc<ToolRegistry>,
 }
 
 /// The `&mut self` result of validating a `session/prompt`: the user turn is
@@ -361,6 +787,8 @@ impl AcpServer {
             model,
             default_cwd,
             sessions: HashMap::new(),
+            insertion_order: VecDeque::new(),
+            client_supports_terminal: false,
             response_id_policy: JsonRpcResponseIdPolicy::Preserve,
         }
     }
@@ -374,6 +802,12 @@ impl AcpServer {
     ) -> std::result::Result<AcpDispatch, AcpError> {
         match method {
             "initialize" => {
+                if let Some(terminal) = params
+                    .pointer("/clientCapabilities/terminal")
+                    .and_then(Value::as_bool)
+                {
+                    self.client_supports_terminal = terminal;
+                }
                 self.response_id_policy = JsonRpcResponseIdPolicy::from_initialize_params(&params);
                 Ok(AcpDispatch::Response(initialize_result(
                     params.get("protocolVersion").and_then(Value::as_u64),
@@ -399,14 +833,34 @@ impl AcpServer {
             .map(PathBuf::from)
             .unwrap_or_else(|| self.default_cwd.clone());
         let session_id = format!("codewhale-{}", uuid::Uuid::new_v4());
+        let tool_registry = Arc::new(build_acp_tool_registry(&cwd, self.client_supports_terminal));
+
+        // Evict oldest session when at capacity.
+        if self.sessions.len() >= MAX_ACP_SESSIONS {
+            // `VecDeque` preserves true insertion order; HashMap iteration
+            // does not. Pop from the front to evict the session created
+            // earliest.
+            if let Some(oldest) = self.insertion_order.pop_front() {
+                self.sessions.remove(&oldest);
+            }
+        }
+
+        self.insertion_order.push_back(session_id.clone());
         self.sessions.insert(
             session_id.clone(),
             AcpSession {
                 cwd,
                 messages: Vec::new(),
+                tool_registry,
             },
         );
         Ok(json!({ "sessionId": session_id }))
+    }
+
+    fn session_tool_registry(&self, session_id: &str) -> Option<Arc<ToolRegistry>> {
+        self.sessions
+            .get(session_id)
+            .map(|session| session.tool_registry.clone())
     }
 
     fn list_providers(&self) -> Value {
@@ -525,20 +979,29 @@ impl AcpServer {
         })
     }
 
-    /// Append a completed assistant turn to session history. A cancelled turn
-    /// never calls this, so cancelled output does not pollute the transcript.
-    fn finish_prompt(&mut self, session_id: &str, output: &str) {
-        if output.is_empty() {
-            return;
-        }
+    /// Commit the full message list produced by a completed turn into the
+    /// session's history — the original history plus every assistant/tool-
+    /// call/tool-result round the turn drove.
+    ///
+    /// Called on **all** outcomes: normal completion, max-rounds, AND cancel.
+    /// (The caller strips dangling assistant tool_use blocks on cancel before
+    /// committing, which produces a clean partial history the next prompt can
+    /// continue from instead of leaving the pre-turn state untouched.)
+    fn commit_turn_messages(&mut self, session_id: &str, messages: Vec<Message>) {
         if let Some(session) = self.sessions.get_mut(session_id) {
-            session.messages.push(Message {
-                role: "assistant".to_string(),
-                content: vec![ContentBlock::Text {
-                    text: output.to_string(),
-                    cache_control: None,
-                }],
-            });
+            session.messages = messages;
+        }
+    }
+
+    /// Remove the last user message from the session history. Used to unwind
+    /// the `begin_prompt` push when the turn itself fails (e.g. provider
+    /// stream error), so the next prompt doesn't start with two consecutive
+    /// `user` messages.
+    fn rollback_user_message(&mut self, session_id: &str) {
+        if let Some(session) = self.sessions.get_mut(session_id)
+            && session.messages.last().map(|m| m.role.as_str()) == Some("user")
+        {
+            session.messages.pop();
         }
     }
 
@@ -547,11 +1010,12 @@ impl AcpServer {
     /// [`StreamEventBox`] is `'static`, so the caller can race it against the
     /// reader without holding any borrow on the server. The cwd guard only needs
     /// to cover route resolution and client construction, not stream
-    /// consumption (ACP exposes no file/shell tools), so it is dropped here.
+    /// consumption, so it is dropped here.
     async fn open_prompt_stream(
         &self,
         messages: &[Message],
         cwd: &PathBuf,
+        tool_registry: &ToolRegistry,
     ) -> Result<StreamEventBox> {
         let _cwd_guard = ScopedCurrentDir::new(cwd)?;
         let last_user_text = messages
@@ -583,15 +1047,43 @@ impl AcpServer {
             })
             .map(str::to_string);
 
+        let tools = tool_registry.to_api_tools();
+
+        // Build the system prompt the same way the engine does: the
+        // CodeWhale constitution plus workspace-local AGENTS.md, CLAUDE.md,
+        // rules, and user custom instructions from config.
+        let project_context = crate::project_context::load_project_context(cwd);
+        let system = crate::prompts::build_system_prompt(
+            &crate::prompts::compose_prompt_with_approval_model_and_shell(
+                crate::prompts::Personality::Calm,
+                &route.model,
+            ),
+            project_context
+                .has_instructions()
+                .then_some(&project_context),
+        );
+
+        // Resolve `max_tokens` through the same route-limits machinery the
+        // TUI engine uses instead of a hardcoded fallback.
+        let route_limits =
+            crate::resolve_cli_route_limits(&self.config, route.provider, &route.model);
+        let effective_max_tokens = crate::route_budget::effective_max_output_tokens_for_route(
+            route.provider,
+            &route.model,
+            route_limits,
+        );
+
         let request = MessageRequest {
             model: route.model,
             messages: messages.to_vec(),
-            max_tokens: 4096,
-            system: Some(SystemPrompt::Text(
-                "You are a coding assistant inside an ACP-compatible editor. Give concise, actionable responses.".to_string(),
-            )),
-            tools: None,
-            tool_choice: None,
+            max_tokens: effective_max_tokens,
+            system: Some(system),
+            tools: Some(tools.clone()),
+            tool_choice: if tools.is_empty() {
+                None
+            } else {
+                Some(json!({ "type": "auto" }))
+            },
             metadata: None,
             thinking: None,
             reasoning_effort,
@@ -602,6 +1094,144 @@ impl AcpServer {
 
         client.create_message_stream(request).await
     }
+}
+
+/// Build the tool registry for one ACP session, rooted at the session's
+/// `cwd`. Reuses the same builder methods the CLI `exec` agent
+/// (`crate::main::run_exec_agent`) and the MCP server adapter
+/// (`crate::mcp_server`) use — no ACP-specific tool implementations.
+///
+/// `allow_shell` gates `exec_shell`/terminal tools on the client's declared
+/// `clientCapabilities.terminal` support (see [`AcpServer::client_supports_terminal`]).
+/// Shell commands run with safety-heuristic checks disabled
+/// (`auto_approve = true`), matching `codewhale exec --auto`: ACP has no
+/// per-tool approval round-trip yet, so gating on the safety heuristic
+/// instead would just make some tool calls silently fail.
+fn build_acp_tool_registry(workspace: &std::path::Path, allow_shell: bool) -> ToolRegistry {
+    let mut context = ToolContext::new(workspace);
+    context.auto_approve = true;
+    context.shell_policy = if allow_shell {
+        ShellPolicy::Full
+    } else {
+        ShellPolicy::None
+    };
+
+    let mut builder = ToolRegistryBuilder::new()
+        .with_file_tools()
+        .with_search_tools()
+        .with_git_tools()
+        .with_patch_tools();
+    if allow_shell {
+        builder = builder.with_shell_tools();
+    }
+
+    builder.build(context)
+}
+
+/// ACP `kind` hint for a tool call, used by the client to pick an icon/label.
+/// Falls back to `"other"` for tools without an obvious category.
+///
+/// `File` is a single canonical tool covering read/list/search/write/edit/
+/// patch (#4625), so its kind depends on the `action` argument rather than
+/// the tool name alone.
+fn tool_call_kind(call: &PendingToolCall) -> &'static str {
+    match call.name.as_str() {
+        "File" => match call.input.get("action").and_then(Value::as_str) {
+            Some("write" | "edit" | "patch") => "edit",
+            _ => "read",
+        },
+        "apply_patch" => "edit",
+        "Git" => "read",
+        "Bash" | "terminal/run" | "terminal/send" | "terminal/wait" | "terminal/cancel"
+        | "terminal/reset" => "execute",
+        _ => "other",
+    }
+}
+
+/// Human-readable title for a tool call: the tool name plus its primary
+/// argument (path/command/pattern) when present, so the client's tool-call
+/// card is legible without expanding raw input.
+fn tool_call_title(call: &PendingToolCall) -> String {
+    let detail = call
+        .input
+        .get("path")
+        .or_else(|| call.input.get("command"))
+        .or_else(|| call.input.get("pattern"))
+        .or_else(|| call.input.get("task_id"))
+        .and_then(Value::as_str);
+    match detail {
+        Some(detail) => format!("{}: {}", call.name, detail),
+        None => call.name.clone(),
+    }
+}
+
+fn truncate_for_acp(content: &str) -> String {
+    if content.chars().count() <= TOOL_CALL_CONTENT_PREVIEW_CHARS {
+        return content.to_string();
+    }
+    let truncated: String = content
+        .chars()
+        .take(TOOL_CALL_CONTENT_PREVIEW_CHARS)
+        .collect();
+    format!("{truncated}\n… [truncated for display; the full result was sent to the model]")
+}
+
+async fn write_tool_call_start<W>(
+    writer: &mut W,
+    session_id: &str,
+    call: &PendingToolCall,
+) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let notification = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "sessionId": session_id,
+            "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": call.id,
+                "title": tool_call_title(call),
+                "kind": tool_call_kind(call),
+                "status": "in_progress",
+                "rawInput": call.input,
+            }
+        }
+    });
+    write_json_line(writer, notification).await
+}
+
+async fn write_tool_call_update<W>(
+    writer: &mut W,
+    session_id: &str,
+    call: &PendingToolCall,
+    status: &str,
+    content: Option<&str>,
+) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut update = json!({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": call.id,
+        "status": status,
+    });
+    if let Some(content) = content {
+        update["content"] = json!([{
+            "type": "content",
+            "content": { "type": "text", "text": truncate_for_acp(content) }
+        }]);
+    }
+    let notification = json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+            "sessionId": session_id,
+            "update": update
+        }
+    });
+    write_json_line(writer, notification).await
 }
 
 struct ScopedCurrentDir {
@@ -828,6 +1458,8 @@ impl JsonRpcResponseIdPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
 
     #[test]
     fn initialize_advertises_baseline_acp_agent() {
@@ -1140,6 +1772,32 @@ mod tests {
         }
     }
 
+    /// Simulate one streamed `tool_use` content block at `index`: a start
+    /// event carrying the id/name, an `input_json_delta` with the full
+    /// arguments JSON, and the closing stop event — matching the real
+    /// provider's per-index streaming shape closely enough to exercise
+    /// [`drive_prompt_stream`]'s accumulator.
+    fn tool_use_events(index: u32, id: &str, name: &str, input_json: &str) -> Vec<StreamEvent> {
+        vec![
+            StreamEvent::ContentBlockStart {
+                index,
+                content_block: ContentBlockStart::ToolUse {
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    input: json!({}),
+                    caller: None,
+                },
+            },
+            StreamEvent::ContentBlockDelta {
+                index,
+                delta: Delta::InputJsonDelta {
+                    partial_json: input_json.to_string(),
+                },
+            },
+            StreamEvent::ContentBlockStop { index },
+        ]
+    }
+
     /// A stream that yields the given events immediately, then ends.
     fn ready_stream(events: Vec<StreamEvent>) -> StreamEventBox {
         Box::pin(futures_util::stream::iter(
@@ -1183,7 +1841,7 @@ mod tests {
         let mut reader = lines_from("");
         let mut out = Vec::new();
 
-        let outcome = drive_prompt_stream(
+        let (outcome, tool_calls) = drive_prompt_stream(
             stream,
             "sess_1",
             JsonRpcResponseIdPolicy::Preserve,
@@ -1195,6 +1853,7 @@ mod tests {
 
         // Full text is accumulated for history...
         assert_eq!(outcome, PromptOutcome::Completed("hello world".to_string()));
+        assert!(tool_calls.is_empty());
         // ...and each delta was emitted as its own session/update chunk.
         let updates = parse_lines(out);
         assert_eq!(updates.len(), 2);
@@ -1212,7 +1871,7 @@ mod tests {
         );
         let mut out = Vec::new();
 
-        let outcome = drive_prompt_stream(
+        let (outcome, tool_calls) = drive_prompt_stream(
             stream,
             "sess_1",
             JsonRpcResponseIdPolicy::Preserve,
@@ -1223,6 +1882,7 @@ mod tests {
         .expect("driver ok");
 
         assert_eq!(outcome, PromptOutcome::Cancelled);
+        assert!(tool_calls.is_empty());
         // Notification-form cancel (no id) is acknowledged by acting, not writing.
         assert!(out.is_empty());
     }
@@ -1237,7 +1897,7 @@ mod tests {
         );
         let mut out = Vec::new();
 
-        let outcome = drive_prompt_stream(
+        let (outcome, _tool_calls) = drive_prompt_stream(
             stream,
             "sess_1",
             JsonRpcResponseIdPolicy::StringifyNumeric,
@@ -1266,7 +1926,7 @@ mod tests {
             lines_from(r#"{"jsonrpc":"2.0","id":9,"method":"session/new","params":{}}"#);
         let mut out = Vec::new();
 
-        let outcome = drive_prompt_stream(
+        let (outcome, _tool_calls) = drive_prompt_stream(
             stream,
             "sess_1",
             JsonRpcResponseIdPolicy::StringifyNumeric,
@@ -1284,6 +1944,83 @@ mod tests {
                 .any(|v| v["id"] == "9" && v["error"]["code"] == -32603),
             "expected a prompt-in-progress error for the concurrent request, got {lines:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn drive_prompt_assembles_a_single_streamed_tool_call() {
+        let mut events = tool_use_events(0, "call_1", "read_file", r#"{"path":"src/lib.rs"}"#);
+        events.push(StreamEvent::MessageStop);
+        let stream = ready_stream(events);
+        let mut reader = lines_from("");
+        let mut out = Vec::new();
+
+        let (outcome, tool_calls) = drive_prompt_stream(
+            stream,
+            "sess_1",
+            JsonRpcResponseIdPolicy::Preserve,
+            &mut reader,
+            &mut out,
+        )
+        .await
+        .expect("driver ok");
+
+        assert_eq!(outcome, PromptOutcome::Completed(String::new()));
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id, "call_1");
+        assert_eq!(tool_calls[0].name, "read_file");
+        assert_eq!(tool_calls[0].input, json!({"path": "src/lib.rs"}));
+        assert!(tool_calls[0].parse_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn drive_prompt_assembles_multiple_parallel_tool_calls_in_order() {
+        let mut events = tool_use_events(0, "call_1", "read_file", r#"{"path":"a.rs"}"#);
+        events.extend(tool_use_events(
+            1,
+            "call_2",
+            "read_file",
+            r#"{"path":"b.rs"}"#,
+        ));
+        events.push(StreamEvent::MessageStop);
+        let stream = ready_stream(events);
+        let mut reader = lines_from("");
+        let mut out = Vec::new();
+
+        let (_outcome, tool_calls) = drive_prompt_stream(
+            stream,
+            "sess_1",
+            JsonRpcResponseIdPolicy::Preserve,
+            &mut reader,
+            &mut out,
+        )
+        .await
+        .expect("driver ok");
+
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[0].id, "call_1");
+        assert_eq!(tool_calls[1].id, "call_2");
+    }
+
+    #[tokio::test]
+    async fn drive_prompt_reports_malformed_tool_arguments_instead_of_dropping_the_call() {
+        let mut events = tool_use_events(0, "call_1", "read_file", "{not json");
+        events.push(StreamEvent::MessageStop);
+        let stream = ready_stream(events);
+        let mut reader = lines_from("");
+        let mut out = Vec::new();
+
+        let (_outcome, tool_calls) = drive_prompt_stream(
+            stream,
+            "sess_1",
+            JsonRpcResponseIdPolicy::Preserve,
+            &mut reader,
+            &mut out,
+        )
+        .await
+        .expect("driver ok");
+
+        assert_eq!(tool_calls.len(), 1);
+        assert!(tool_calls[0].parse_error.is_some());
     }
 
     #[test]
@@ -1321,5 +2058,417 @@ mod tests {
         // Session 1 should have the message
         let session1 = server.sessions.get(&sid1).unwrap();
         assert_eq!(session1.messages.len(), 1);
+    }
+
+    #[test]
+    fn concurrent_sessions_each_get_their_own_tool_registry() {
+        let mut server = AcpServer::new(
+            Config::default(),
+            "test-model".to_string(),
+            PathBuf::from("/tmp"),
+        );
+        // Shell access is gated on the client declaring terminal support at
+        // `initialize` time; sessions created without it omit `exec_shell`.
+        server.client_supports_terminal = true;
+        let s1 = server.new_session(json!({ "cwd": "/tmp" })).unwrap();
+        let s2 = server.new_session(json!({ "cwd": "/tmp" })).unwrap();
+        let id1 = s1["sessionId"].as_str().unwrap();
+        let id2 = s2["sessionId"].as_str().unwrap();
+
+        let reg1 = server.session_tool_registry(id1).expect("registry 1");
+        let reg2 = server.session_tool_registry(id2).expect("registry 2");
+        assert!(!Arc::ptr_eq(&reg1, &reg2));
+        // Both sessions expose the same reusable tool surface: the
+        // canonical `File` action tool (read/list/search/write/edit),
+        // `Git`, the `apply_patch` back-compat alias, and `Bash` (#4625
+        // consolidated the old per-action tool names).
+        assert!(reg1.contains("File"));
+        assert!(reg1.contains("Git"));
+        assert!(reg1.contains("apply_patch"));
+        assert!(reg1.contains("Bash"));
+    }
+
+    #[test]
+    fn shell_tool_omitted_when_client_declares_no_terminal_support() {
+        let workspace = std::env::temp_dir();
+        let registry = build_acp_tool_registry(&workspace, false);
+        assert!(!registry.contains("Bash"));
+        assert!(registry.contains("File"));
+    }
+
+    fn workspace_registry() -> (tempfile::TempDir, ToolRegistry) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = build_acp_tool_registry(dir.path(), true);
+        (dir, registry)
+    }
+
+    #[tokio::test]
+    async fn tool_registry_read_file_returns_real_contents() {
+        let (dir, registry) = workspace_registry();
+        std::fs::write(dir.path().join("hello.txt"), "hi there").unwrap();
+
+        let result = registry
+            .execute_full("File", json!({"action": "read", "path": "hello.txt"}))
+            .await
+            .expect("read_file succeeds");
+
+        assert!(result.success);
+        assert!(result.content.contains("hi there"));
+    }
+
+    #[tokio::test]
+    async fn tool_registry_write_file_creates_a_real_file() {
+        let (dir, registry) = workspace_registry();
+
+        let result = registry
+            .execute_full(
+                "File",
+                json!({"action": "write", "path": "created.txt", "content": "new content"}),
+            )
+            .await
+            .expect("write_file succeeds");
+
+        assert!(result.success);
+        let on_disk = std::fs::read_to_string(dir.path().join("created.txt")).unwrap();
+        assert_eq!(on_disk, "new content");
+    }
+
+    #[tokio::test]
+    async fn tool_registry_list_dir_reports_real_directory_contents() {
+        let (dir, registry) = workspace_registry();
+        std::fs::write(dir.path().join("a.txt"), "a").unwrap();
+        std::fs::write(dir.path().join("b.txt"), "b").unwrap();
+
+        let result = registry
+            .execute_full("File", json!({"action": "list", "path": "."}))
+            .await
+            .expect("list_dir succeeds");
+
+        assert!(result.success);
+        assert!(result.content.contains("a.txt"));
+        assert!(result.content.contains("b.txt"));
+    }
+
+    #[tokio::test]
+    async fn tool_registry_exec_shell_runs_a_real_command() {
+        let (_dir, registry) = workspace_registry();
+
+        let result = registry
+            .execute_full("Bash", json!({"command": "echo acp-terminal-check"}))
+            .await
+            .expect("exec_shell succeeds");
+
+        assert!(result.content.contains("acp-terminal-check"));
+    }
+
+    #[tokio::test]
+    async fn tool_registry_read_file_reports_failure_for_missing_path() {
+        let (_dir, registry) = workspace_registry();
+
+        let err = registry
+            .execute_full(
+                "File",
+                json!({"action": "read", "path": "does-not-exist.txt"}),
+            )
+            .await
+            .expect_err("missing file is a tool error");
+
+        assert!(!err.to_string().is_empty());
+    }
+
+    /// Feeds [`run_agentic_prompt_turn`] a fixed sequence of canned per-round
+    /// streams (no real provider), so the multi-round tool loop — including
+    /// nested tool calls across several rounds — is exercised end-to-end
+    /// against the real file-tool registry. A plain struct + inherent async
+    /// method (rather than a boxed closure) lets each test's `|msgs| scripted.next()`
+    /// closure return the async method's own anonymous future type directly,
+    /// so `Fut` is inferred without needing a `dyn Future` trait object.
+    struct ScriptedStreams(RefCell<VecDeque<StreamEventBox>>);
+
+    impl ScriptedStreams {
+        fn new(streams: Vec<StreamEventBox>) -> Self {
+            Self(RefCell::new(VecDeque::from(streams)))
+        }
+
+        async fn next(&self) -> Result<StreamEventBox> {
+            Ok(self
+                .0
+                .borrow_mut()
+                .pop_front()
+                .expect("test provided enough scripted rounds"))
+        }
+    }
+
+    #[tokio::test]
+    async fn agentic_turn_executes_a_tool_call_then_streams_the_final_answer() {
+        let (dir, registry) = workspace_registry();
+        std::fs::write(dir.path().join("VERSION"), "9.9.9").unwrap();
+
+        let round1 = ready_stream({
+            let mut events =
+                tool_use_events(0, "call_1", "File", r#"{"action":"read","path":"VERSION"}"#);
+            events.push(StreamEvent::MessageStop);
+            events
+        });
+        let round2 = ready_stream(vec![
+            text_delta("The version is 9.9.9"),
+            StreamEvent::MessageStop,
+        ]);
+
+        let scripted = ScriptedStreams::new(vec![round1, round2]);
+        let mut reader = lines_from("");
+        let mut out = Vec::new();
+
+        let (outcome, messages) = run_agentic_prompt_turn(
+            "sess_1",
+            vec![Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "What version is this?".to_string(),
+                    cache_control: None,
+                }],
+            }],
+            &registry,
+            JsonRpcResponseIdPolicy::Preserve,
+            &mut reader,
+            &mut out,
+            |_msgs| scripted.next(),
+        )
+        .await
+        .expect("turn completes");
+
+        assert_eq!(
+            outcome,
+            PromptOutcome::Completed("The version is 9.9.9".to_string())
+        );
+        // user -> assistant(tool_use) -> user(tool_result) -> assistant(text)
+        assert_eq!(messages.len(), 4);
+        assert!(matches!(
+            messages[1].content[0],
+            ContentBlock::ToolUse { .. }
+        ));
+        let ContentBlock::ToolResult {
+            content, is_error, ..
+        } = &messages[2].content[0]
+        else {
+            panic!("expected a tool_result message");
+        };
+        assert!(content.contains("9.9.9"));
+        assert_eq!(*is_error, Some(false));
+
+        // The client saw a tool_call start, a completed update, and the
+        // streamed final-answer chunk.
+        let lines = parse_lines(out);
+        assert!(
+            lines
+                .iter()
+                .any(|v| v["params"]["update"]["sessionUpdate"] == "tool_call")
+        );
+        assert!(lines.iter().any(
+            |v| v["params"]["update"]["sessionUpdate"] == "tool_call_update"
+                && v["params"]["update"]["status"] == "completed"
+        ));
+        assert!(lines.iter().any(|v| v["params"]["update"]["sessionUpdate"]
+            == "agent_message_chunk"
+            && v["params"]["update"]["content"]["text"] == "The version is 9.9.9"));
+    }
+
+    #[tokio::test]
+    async fn agentic_turn_chains_nested_tool_calls_across_rounds() {
+        let (dir, registry) = workspace_registry();
+        std::fs::write(dir.path().join("a.txt"), "contents-of-a").unwrap();
+        std::fs::write(dir.path().join("b.txt"), "contents-of-b").unwrap();
+
+        let round1 = ready_stream({
+            let mut events =
+                tool_use_events(0, "call_1", "File", r#"{"action":"read","path":"a.txt"}"#);
+            events.push(StreamEvent::MessageStop);
+            events
+        });
+        // After seeing a.txt's contents, the model asks for b.txt too.
+        let round2 = ready_stream({
+            let mut events =
+                tool_use_events(0, "call_2", "File", r#"{"action":"read","path":"b.txt"}"#);
+            events.push(StreamEvent::MessageStop);
+            events
+        });
+        let round3 = ready_stream(vec![
+            text_delta("Both files read"),
+            StreamEvent::MessageStop,
+        ]);
+
+        let scripted = ScriptedStreams::new(vec![round1, round2, round3]);
+        let mut reader = lines_from("");
+        let mut out = Vec::new();
+
+        let (outcome, messages) = run_agentic_prompt_turn(
+            "sess_1",
+            vec![Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "Read both files".to_string(),
+                    cache_control: None,
+                }],
+            }],
+            &registry,
+            JsonRpcResponseIdPolicy::Preserve,
+            &mut reader,
+            &mut out,
+            |_msgs| scripted.next(),
+        )
+        .await
+        .expect("turn completes");
+
+        assert_eq!(
+            outcome,
+            PromptOutcome::Completed("Both files read".to_string())
+        );
+        // user, assistant(tool_use a), user(result a), assistant(tool_use b),
+        // user(result b), assistant(text)
+        assert_eq!(messages.len(), 6);
+        let ContentBlock::ToolResult {
+            content: a_content, ..
+        } = &messages[2].content[0]
+        else {
+            panic!("expected tool_result for a.txt");
+        };
+        assert!(a_content.contains("contents-of-a"));
+        let ContentBlock::ToolResult {
+            content: b_content, ..
+        } = &messages[4].content[0]
+        else {
+            panic!("expected tool_result for b.txt");
+        };
+        assert!(b_content.contains("contents-of-b"));
+    }
+
+    #[tokio::test]
+    async fn agentic_turn_reports_a_tool_failure_back_to_the_model_and_keeps_going() {
+        let (_dir, registry) = workspace_registry();
+
+        let round1 = ready_stream({
+            let mut events = tool_use_events(
+                0,
+                "call_1",
+                "File",
+                r#"{"action":"read","path":"missing.txt"}"#,
+            );
+            events.push(StreamEvent::MessageStop);
+            events
+        });
+        let round2 = ready_stream(vec![
+            text_delta("That file does not exist"),
+            StreamEvent::MessageStop,
+        ]);
+
+        let scripted = ScriptedStreams::new(vec![round1, round2]);
+        let mut reader = lines_from("");
+        let mut out = Vec::new();
+
+        let (outcome, messages) = run_agentic_prompt_turn(
+            "sess_1",
+            vec![Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "Read missing.txt".to_string(),
+                    cache_control: None,
+                }],
+            }],
+            &registry,
+            JsonRpcResponseIdPolicy::Preserve,
+            &mut reader,
+            &mut out,
+            |_msgs| scripted.next(),
+        )
+        .await
+        .expect("turn completes even though the tool failed");
+
+        assert_eq!(
+            outcome,
+            PromptOutcome::Completed("That file does not exist".to_string())
+        );
+        let ContentBlock::ToolResult { is_error, .. } = &messages[2].content[0] else {
+            panic!("expected a tool_result message");
+        };
+        assert_eq!(*is_error, Some(true));
+
+        let lines = parse_lines(out);
+        assert!(lines.iter().any(
+            |v| v["params"]["update"]["sessionUpdate"] == "tool_call_update"
+                && v["params"]["update"]["status"] == "failed"
+        ));
+    }
+
+    #[cfg(windows)]
+    const SLOW_SHELL_COMMAND: &str = "ping -n 6 127.0.0.1 >NUL";
+    #[cfg(not(windows))]
+    const SLOW_SHELL_COMMAND: &str = "sleep 5";
+
+    #[tokio::test]
+    async fn agentic_turn_cancels_while_a_tool_is_running() {
+        let (_dir, registry) = workspace_registry();
+
+        // exec_shell runs long enough for the cancel line to win the race.
+        let round1 = ready_stream({
+            let mut events = tool_use_events(
+                0,
+                "call_1",
+                "exec_shell",
+                &json!({ "command": SLOW_SHELL_COMMAND }).to_string(),
+            );
+            events.push(StreamEvent::MessageStop);
+            events
+        });
+        let scripted = ScriptedStreams::new(vec![round1]);
+        let mut reader = lines_from(
+            r#"{"jsonrpc":"2.0","method":"session/cancel","params":{"sessionId":"sess_1"}}"#,
+        );
+        let mut out = Vec::new();
+
+        let (outcome, _messages) = run_agentic_prompt_turn(
+            "sess_1",
+            vec![Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "Run a slow command".to_string(),
+                    cache_control: None,
+                }],
+            }],
+            &registry,
+            JsonRpcResponseIdPolicy::Preserve,
+            &mut reader,
+            &mut out,
+            |_msgs| scripted.next(),
+        )
+        .await
+        .expect("turn resolves even when cancelled mid-tool");
+
+        assert_eq!(outcome, PromptOutcome::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn concurrent_acp_sessions_execute_tools_independently() {
+        let (dir1, registry1) = workspace_registry();
+        let (dir2, registry2) = workspace_registry();
+        std::fs::write(dir1.path().join("f.txt"), "session-one").unwrap();
+        std::fs::write(dir2.path().join("f.txt"), "session-two").unwrap();
+
+        let (result1, result2) = tokio::join!(
+            registry1.execute_full("File", json!({"action": "read", "path": "f.txt"})),
+            registry2.execute_full("File", json!({"action": "read", "path": "f.txt"})),
+        );
+
+        assert!(
+            result1
+                .expect("session 1 read")
+                .content
+                .contains("session-one")
+        );
+        assert!(
+            result2
+                .expect("session 2 read")
+                .content
+                .contains("session-two")
+        );
     }
 }

--- a/crates/tui/src/acp_server.rs
+++ b/crates/tui/src/acp_server.rs
@@ -53,7 +53,7 @@ const MAX_ACP_SESSIONS: usize = 64;
 
 /// Content is streamed to the model in full (no truncation); this cap only
 /// bounds how much of a tool's output is echoed into the `tool_call_update`
-/// notification the editor renders, so a large `read_file`/`exec_shell`
+/// notification the editor renders, so a large `File`/`Bash`
 /// result does not flood the client UI.
 const TOOL_CALL_CONTENT_PREVIEW_CHARS: usize = 4_000;
 
@@ -491,7 +491,7 @@ enum ToolBatchOutcome {
 /// racing every execution against the reader for a `session/cancel`
 /// targeting `session_id`. On cancel, the tool's [`CancellationToken`] is
 /// signalled and the in-flight call is awaited to completion (so a
-/// cancel-aware tool like `exec_shell` gets a chance to kill its child
+/// cancel-aware tool like `Bash` gets a chance to kill its child
 /// process) before returning [`ToolBatchOutcome::Cancelled`].
 async fn execute_tool_calls_with_cancellation<R, W>(
     registry: &ToolRegistry,
@@ -1101,15 +1101,15 @@ impl AcpServer {
 /// (`crate::main::run_exec_agent`) and the MCP server adapter
 /// (`crate::mcp_server`) use — no ACP-specific tool implementations.
 ///
-/// `allow_shell` gates `exec_shell`/terminal tools on the client's declared
+/// `allow_shell` gates `Bash`/terminal tools on the client's declared
 /// `clientCapabilities.terminal` support (see [`AcpServer::client_supports_terminal`]).
-/// Shell commands run with safety-heuristic checks disabled
-/// (`auto_approve = true`), matching `codewhale exec --auto`: ACP has no
-/// per-tool approval round-trip yet, so gating on the safety heuristic
-/// instead would just make some tool calls silently fail.
+/// `ToolContext::new` leaves `auto_approve` at its default (`false`), so the
+/// `SafetyLevel::Dangerous` heuristic still runs — matching `mcp_server`'s
+/// trust posture. ACP has no `session/request_permission` round-trip yet, so
+/// a blocked command surfaces as a normal `success: false` tool result
+/// (`BLOCKED: ...`) fed back to the model, rather than a silent failure.
 fn build_acp_tool_registry(workspace: &std::path::Path, allow_shell: bool) -> ToolRegistry {
     let mut context = ToolContext::new(workspace);
-    context.auto_approve = true;
     context.shell_policy = if allow_shell {
         ShellPolicy::Full
     } else {
@@ -2068,7 +2068,7 @@ mod tests {
             PathBuf::from("/tmp"),
         );
         // Shell access is gated on the client declaring terminal support at
-        // `initialize` time; sessions created without it omit `exec_shell`.
+        // `initialize` time; sessions created without it omit `Bash`.
         server.client_supports_terminal = true;
         let s1 = server.new_session(json!({ "cwd": "/tmp" })).unwrap();
         let s2 = server.new_session(json!({ "cwd": "/tmp" })).unwrap();
@@ -2150,13 +2150,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tool_registry_exec_shell_runs_a_real_command() {
+    async fn tool_registry_bash_runs_a_real_command() {
         let (_dir, registry) = workspace_registry();
 
         let result = registry
             .execute_full("Bash", json!({"command": "echo acp-terminal-check"}))
             .await
-            .expect("exec_shell succeeds");
+            .expect("Bash succeeds");
 
         assert!(result.content.contains("acp-terminal-check"));
     }
@@ -2408,12 +2408,12 @@ mod tests {
     async fn agentic_turn_cancels_while_a_tool_is_running() {
         let (_dir, registry) = workspace_registry();
 
-        // exec_shell runs long enough for the cancel line to win the race.
+        // Bash runs long enough for the cancel line to win the race.
         let round1 = ready_stream({
             let mut events = tool_use_events(
                 0,
                 "call_1",
-                "exec_shell",
+                "Bash",
                 &json!({ "command": SLOW_SHELL_COMMAND }).to_string(),
             );
             events.push(StreamEvent::MessageStop);

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -5852,11 +5852,11 @@ pub(crate) use context::compact_tool_result_for_route;
 /// Public so external hosts/wrappers can reuse the engine's input-budget math
 /// (see `context_input_budget_for_route`'s doc) instead of re-deriving it.
 pub use context::context_input_budget_for_route;
+pub(crate) use context::effective_max_output_tokens_for_route;
 #[cfg(test)]
 use context::route_context_budget_for_provider;
 use context::{
-    MAX_CONTEXT_RECOVERY_ATTEMPTS, MIN_RECENT_MESSAGES_TO_KEEP,
-    effective_max_output_tokens_for_route, estimate_input_tokens_conservative,
+    MAX_CONTEXT_RECOVERY_ATTEMPTS, MIN_RECENT_MESSAGES_TO_KEEP, estimate_input_tokens_conservative,
     extract_compaction_summary_prompt, is_context_length_error_message,
     route_context_budget_for_route, summarize_text,
 };

--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -9,7 +9,7 @@ use crate::config::ApiProvider;
 use crate::context_budget::ContextBudget;
 use crate::error_taxonomy::ErrorCategory;
 use crate::models::{Message, SystemPrompt};
-pub(super) use crate::route_budget::effective_max_output_tokens_for_route;
+pub(crate) use crate::route_budget::effective_max_output_tokens_for_route;
 #[cfg(test)]
 pub(super) use crate::route_budget::{TURN_MAX_OUTPUT_TOKENS, effective_max_output_tokens};
 use crate::tools::spec::ToolResult;

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -9151,7 +9151,7 @@ async fn run_interactive_with_notice(
 }
 
 #[derive(Debug)]
-struct CliAutoRoute {
+pub(crate) struct CliAutoRoute {
     provider: crate::config::ApiProvider,
     model: String,
     reasoning_effort: Option<crate::tui::app::ReasoningEffort>,
@@ -9203,7 +9203,7 @@ fn normalize_cli_reasoning_effort(value: &str) -> Result<Option<String>> {
         .map_err(anyhow::Error::msg)
 }
 
-fn config_for_cli_route(config: &Config, route: &CliAutoRoute) -> Config {
+pub(crate) fn config_for_cli_route(config: &Config, route: &CliAutoRoute) -> Config {
     let mut execution_config = config.clone();
     execution_config.provider = Some(config.provider_identity_for(route.provider));
     execution_config.set_provider_model_override(route.provider, Some(route.model.clone()));
@@ -9216,7 +9216,17 @@ fn config_for_cli_route(config: &Config, route: &CliAutoRoute) -> Config {
     execution_config
 }
 
-async fn resolve_cli_auto_route(
+pub(crate) fn resolve_cli_route_limits(
+    config: &Config,
+    provider: crate::config::ApiProvider,
+    model: &str,
+) -> Option<codewhale_config::route::RouteLimits> {
+    crate::route_runtime::resolve_runtime_route(config, provider, Some(model))
+        .ok()
+        .and_then(|route| crate::route_budget::known_route_limits(route.candidate.limits()))
+}
+
+pub(crate) async fn resolve_cli_auto_route(
     config: &Config,
     model: &str,
     prompt: &str,

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,190 @@
+﻿<#
+.SYNOPSIS
+    Builds CodeWhale binaries with progress reporting.
+
+.DESCRIPTION
+    Compiles all workspace binaries (codew, codewhale, codewhale-tui)
+    in release mode and shows live cargo output
+    with a PowerShell progress bar.
+
+.PARAMETER Debug
+    Build in debug mode instead of release.
+
+.PARAMETER Bin
+    Build only a specific binary (e.g. "codew", "codewhale", "codewhale-tui").
+    If omitted, builds all three.
+
+.PARAMETER Clean
+    Run `cargo clean` before building.
+
+.PARAMETER Fast
+    Faster release build: thin LTO and 16 codegen units instead of the
+    manifest's fat LTO + 1 codegen unit. Cuts build time roughly 2-4x at a
+    small binary size/perf cost. Ignored with -Debug.
+
+.EXAMPLE
+    .\scripts\build.ps1
+    .\scripts\build.ps1 -Debug
+    .\scripts\build.ps1 -Fast
+    .\scripts\build.ps1 -Bin codewhale-tui
+    .\scripts\build.ps1 -Clean
+#>
+
+param(
+    [switch]$Debug,
+    [string]$Bin,
+    [switch]$Clean,
+    [switch]$Fast
+)
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Resolve-Path "$ScriptDir/.."
+
+Write-Host @"
+╔══════════════════════════════════════════╗
+║           CodeWhale Build Tool           ║
+║              v0.8.68                      ║
+╚══════════════════════════════════════════╝
+"@ -ForegroundColor Cyan
+
+Push-Location $ProjectRoot
+
+try {
+    # ── Clean ──────────────────────────────────────────
+    if ($Clean) {
+        Write-Host "`n[1/3] Cleaning previous build artifacts..." -ForegroundColor Yellow
+        cargo clean 2>&1 | Out-Null
+        Write-Host "       Done." -ForegroundColor Green
+    }
+
+    # ── Profile ───────────────────────────────────────
+    $ProfileFlag = if ($Debug) { "" } else { "--release" }
+    $ProfileName = if ($Debug) { "debug" } else { "release" }
+    $TargetDir = "target/$ProfileName"
+
+    if ($Fast -and -not $Debug) {
+        # Override the manifest's fat LTO + codegen-units=1 for this build only.
+        $env:CARGO_PROFILE_RELEASE_LTO = "thin"
+        $env:CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "16"
+        Write-Host "       Fast mode: thin LTO, 16 codegen units" -ForegroundColor DarkYellow
+    }
+
+    Write-Host "`n[$(if ($Clean) { '2' } else { '1' })/3] Building in $ProfileName mode..." -ForegroundColor Yellow
+
+    # ── Build ─────────────────────────────────────────
+    $Binaries = if ($Bin) {
+        @($Bin)
+    } else {
+        @("codew", "codewhale", "codewhale-tui")
+    }
+
+    $BuildArgs = @(
+        "build",
+        $ProfileFlag
+    )
+    # Filter to requested binaries
+    foreach ($b in $Binaries) {
+        $BuildArgs += "--bin"
+        $BuildArgs += $b
+    }
+
+    # Run cargo and stream output, capturing progress
+    $TotalSteps = $Binaries.Count
+    $CurrentStep = 0
+
+    $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+    $pinfo.FileName = "cargo"
+    $pinfo.Arguments = $BuildArgs -join " "
+    $pinfo.WorkingDirectory = $ProjectRoot
+    $pinfo.RedirectStandardOutput = $true
+    $pinfo.RedirectStandardError = $true
+    $pinfo.UseShellExecute = $false
+    $pinfo.CreateNoWindow = $true
+    $pinfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8
+    $pinfo.StandardErrorEncoding = [System.Text.Encoding]::UTF8
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $pinfo
+
+    $outputLines = [System.Collections.Concurrent.ConcurrentBag[string]]::new()
+    $errorOutput = [System.Collections.Concurrent.ConcurrentBag[string]]::new()
+
+    $outputEvent = Register-ObjectEvent -InputObject $process `
+        -EventName 'OutputDataReceived' `
+        -Action {
+            if ($EventArgs.Data) {
+                [System.Console]::WriteLine($EventArgs.Data)
+                $Event.MessageData.Add($EventArgs.Data)
+            }
+        } -MessageData $outputLines
+
+    $errorEvent = Register-ObjectEvent -InputObject $process `
+        -EventName 'ErrorDataReceived' `
+        -Action {
+            if ($EventArgs.Data) {
+                Write-Host $EventArgs.Data -ForegroundColor Red
+                $Event.MessageData.Add($EventArgs.Data)
+            }
+        } -MessageData $errorOutput
+
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $process.Start() | Out-Null
+    $process.BeginOutputReadLine()
+    $process.BeginErrorReadLine()
+    $process.WaitForExit()
+
+    Unregister-Event -SourceIdentifier $outputEvent.Name -ErrorAction SilentlyContinue
+    Unregister-Event -SourceIdentifier $errorEvent.Name -ErrorAction SilentlyContinue
+
+    $stopwatch.Stop()
+
+    if ($process.ExitCode -ne 0) {
+        Write-Host "`nBuild FAILED with exit code $($process.ExitCode)" -ForegroundColor Red
+        exit $process.ExitCode
+    }
+
+    # ── Verify binaries ───────────────────────────────
+    Write-Host "`n[$(if ($Clean) { '3' } else { '2' })/3] Verifying binaries..." -ForegroundColor Yellow
+
+    # $IsWindows only exists in PowerShell Core; Windows PowerShell 5.1 is
+    # always Windows, so treat a missing variable as Windows too.
+    $ext = if ($IsWindows -or $PSVersionTable.PSEdition -ne 'Core') { ".exe" } else { "" }
+    $Found = @()
+    $Missing = @()
+
+    foreach ($b in $Binaries) {
+        $path = Join-Path $TargetDir "$b$ext"
+        if (Test-Path $path) {
+            $item = Get-Item $path
+            $sizeMB = [math]::Round($item.Length / 1MB, 2)
+            $Found += [PSCustomObject]@{
+                Binary   = $b
+                Path     = $item.FullName
+                Size     = "$sizeMB MB"
+                Modified = $item.LastWriteTime.ToString("yyyy-MM-dd HH:mm:ss")
+            }
+        } else {
+            $Missing += $b
+        }
+    }
+
+    # ── Summary ───────────────────────────────────────
+    Write-Host "`n╔══════════════════════════════════════════╗" -ForegroundColor Cyan
+    Write-Host   "║              BUILD SUCCESS                ║" -ForegroundColor Green
+    Write-Host   "╚══════════════════════════════════════════╝" -ForegroundColor Cyan
+
+    Write-Host "`n  Elapsed : $($stopwatch.Elapsed.ToString('mm\:ss'))" -ForegroundColor White
+    Write-Host "  Profile : $ProfileName" -ForegroundColor White
+    Write-Host ""
+
+    ($Found | Format-Table -Property Binary, Size, Modified -AutoSize | Out-String).TrimEnd() | Write-Host
+
+    if ($Missing.Count -gt 0) {
+        Write-Host "`nWARNING: Missing binaries: $($Missing -join ', ')" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

`session/prompt` in the ACP server only streamed model text — it never
executed the tool calls a model requested, so any editor or bridge
driving CodeWhale over ACP (Zed, third-party integrations such as the
community `acp-deepseek-adapter`) got a chat-only agent with no real
code-editing capability. That gap is the reason this was originally
built in a fork; documented as a known limitation by at least one
third-party ACP bridge, which worked around it by scraping
`exec --auto` stdout instead.

This wires the existing `ToolRegistry` into the ACP turn loop instead
of building a parallel implementation:

- `run_agentic_prompt_turn` drives multi-round `tool_use`/`tool_result`
  turns (capped at `MAX_ACP_TOOL_ROUNDS`) over the same file/search/git/
  patch/shell tools the TUI itself uses, and threads `response_id_policy`
  through every round so tool-round responses still get the
  client-specific id translation (Zed/avante.nvim) the existing
  streaming path already relies on.
- Shell access is gated on the client declaring `terminal` support at
  `initialize` (default `false`/restrictive). `MAX_ACP_SESSIONS` caps
  concurrent sessions with true insertion-order eviction (`VecDeque`,
  not `HashMap` iteration order, which is not insertion-ordered).
- Tool-call cancellation signals a `CancellationToken` and waits for the
  running tool (including a child shell process) to actually stop
  before returning the cancellation, instead of abandoning it.
- `max_tokens` for the ACP path now resolves through the same
  route-limits machinery the TUI/CLI use
  (`effective_max_output_tokens_for_route`) instead of a fixed 4096
  fallback.
- `scripts/build.ps1`: a release build script for Windows PowerShell
  5.1, used to produce and test the ACP binary against Zed on Windows.

Drafted with agent assistance (Claude Code); reviewed and
build-verified by the human author before submission.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --locked` (warning-free
      under the CI allow list)
- [x] `cargo test --workspace --all-features --locked` — 9353 passed;
      the 43 failures on this run are pre-existing and unrelated to this
      diff: `repl::runtime`/`tools::rlm`/`core::engine` Python-backed
      tests fail because this machine has no Python 3 on `PATH`
      (`no Python interpreter found on PATH`), and a handful of Windows
      job-kill/pipe-timing tests are flaky under full-parallel `cargo
      test --workspace` (confirmed by re-running one in isolation, which
      passed the timing/kill logic and only hit the same missing-Python
      wall). None touch `acp_server.rs`, `main.rs`, `core/engine.rs`,
      `core/engine/context.rs`, or `route_budget.rs`.
- [x] Targeted: `cargo test -p codewhale-tui --bin codewhale-tui acp_server`
      → 34/34 passed; `route_budget` → 11/11 passed.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (no TUI/UI surface changed; verified via the ACP unit tests and a Windows build against Zed)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (n/a — original submission, no harvested commits)