### PR TITLE
fix(web): map Model Studio provider variants in facts drift guards

### DIFF
--- a/web/lib/facts-drift.ts
+++ b/web/lib/facts-drift.ts
@@ -140,6 +140,10 @@ function deriveProvidersFromConfig(cfg: string): ProviderFact[] {
     Meta: { id: "meta", label: "Meta Model API", env: "META_MODEL_API_KEY / MODEL_API_KEY" },
     Telecomjs: { id: "telecomjs", label: "TelecomJS TokenHub", env: "TELECOMJS_API_KEY" },
     Xai: { id: "xai", label: "xAI", env: "XAI_API_KEY" },
+    ModelstudioTokenPlan: { id: "modelstudio-token-plan", label: "Model Studio Token Plan", env: "MODELSTUDIO_API_KEY" },
+    ModelstudioTokenPlanAnthropic: { id: "modelstudio-token-plan-anthropic", label: "Model Studio Token Plan (Anthropic-compatible)", env: "MODELSTUDIO_API_KEY" },
+    ModelstudioCodingPlan: { id: "modelstudio-coding-plan", label: "Model Studio Coding Plan", env: "MODELSTUDIO_API_KEY" },
+    ModelstudioCodingPlanAnthropic: { id: "modelstudio-coding-plan-anthropic", label: "Model Studio Coding Plan (Anthropic-compatible)", env: "MODELSTUDIO_API_KEY" },
   };
   // Log loudly on unmapped variants so a new provider can never be silently
   // dropped from the drift-derived facts again. DeepseekCN (#1104) and the

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -27,7 +27,7 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-08-03T02:24:09.129Z",
+  "generatedAt": "2026-08-03T15:53:51.256Z",
   "sourceRevision": null,
   "sourceCommittedAt": null,
   "version": "0.9.4",
@@ -236,11 +236,31 @@ export const FACTS: RepoFacts = {
       "id": "telecomjs",
       "label": "TelecomJS TokenHub",
       "env": "TELECOMJS_API_KEY"
+    },
+    {
+      "id": "modelstudio-token-plan",
+      "label": "Model Studio Token Plan",
+      "env": "MODELSTUDIO_API_KEY"
+    },
+    {
+      "id": "modelstudio-token-plan-anthropic",
+      "label": "Model Studio Token Plan (Anthropic-compatible)",
+      "env": "MODELSTUDIO_API_KEY"
+    },
+    {
+      "id": "modelstudio-coding-plan",
+      "label": "Model Studio Coding Plan",
+      "env": "MODELSTUDIO_API_KEY"
+    },
+    {
+      "id": "modelstudio-coding-plan-anthropic",
+      "label": "Model Studio Coding Plan (Anthropic-compatible)",
+      "env": "MODELSTUDIO_API_KEY"
     }
   ],
   "defaultModel": "deepseek-v4-pro",
   "nodeEngines": ">=18",
-  "toolCount": 67,
+  "toolCount": 68,
   "license": "MIT",
   "latestPublishedRelease": {
     "tag": "v0.9.3",

--- a/web/scripts/facts-lib.mjs
+++ b/web/scripts/facts-lib.mjs
@@ -98,6 +98,10 @@ const PROVIDER_LABEL_MAP = {
   Meta: { id: "meta", label: "Meta Model API", env: "META_MODEL_API_KEY / MODEL_API_KEY" },
   Telecomjs: { id: "telecomjs", label: "TelecomJS TokenHub", env: "TELECOMJS_API_KEY" },
   Xai: { id: "xai", label: "xAI", env: "XAI_API_KEY" },
+  ModelstudioTokenPlan: { id: "modelstudio-token-plan", label: "Model Studio Token Plan", env: "MODELSTUDIO_API_KEY" },
+  ModelstudioTokenPlanAnthropic: { id: "modelstudio-token-plan-anthropic", label: "Model Studio Token Plan (Anthropic-compatible)", env: "MODELSTUDIO_API_KEY" },
+  ModelstudioCodingPlan: { id: "modelstudio-coding-plan", label: "Model Studio Coding Plan", env: "MODELSTUDIO_API_KEY" },
+  ModelstudioCodingPlanAnthropic: { id: "modelstudio-coding-plan-anthropic", label: "Model Studio Coding Plan (Anthropic-compatible)", env: "MODELSTUDIO_API_KEY" },
 };
 
 // DeepseekCN: not wired through shared ProviderKind (#1104).


### PR DESCRIPTION
Unblocks the Lint & Type Check failure on #5135. check-facts passes locally (`node scripts/check-facts.mjs`).