### PR TITLE
style(tui): clear deny-level clippy lints blocking the v0.9.4 train

### DIFF
--- a/crates/tui/src/automation_manager.rs
+++ b/crates/tui/src/automation_manager.rs
@@ -527,12 +527,12 @@ impl AutomationSchedule {
                     .ok_or_else(|| anyhow::anyhow!("CRON schedule exceeded its range"))?;
 
                 for _ in 0..MAX_CRON_SEARCH_MINUTES {
-                    if cron.matches(candidate_naive) {
-                        if let Some(candidate) = resolve_local_datetime(timezone, candidate_naive) {
-                            let candidate = candidate.with_timezone(&Utc);
-                            if candidate > after {
-                                return Ok(candidate);
-                            }
+                    if cron.matches(candidate_naive)
+                        && let Some(candidate) = resolve_local_datetime(timezone, candidate_naive)
+                    {
+                        let candidate = candidate.with_timezone(&Utc);
+                        if candidate > after {
+                            return Ok(candidate);
                         }
                     }
                     candidate_naive = candidate_naive
@@ -1294,7 +1294,7 @@ impl AutomationManager {
         if automation.next_run_at.is_none() {
             automation.status = AutomationStatus::Paused;
         }
-        self.save_automation(&automation)
+        self.save_automation(automation)
     }
 
     /// Snapshot runs still waiting on task-manager state, for reconciliation
@@ -1394,10 +1394,10 @@ impl AutomationManager {
                 .and_then(|raw| serde_json::from_str::<DelayedTriggerRecord>(&raw).ok())
             {
                 Some(record) => {
-                    if let Some(filter) = status_filter {
-                        if record.status != filter {
-                            continue;
-                        }
+                    if let Some(filter) = status_filter
+                        && record.status != filter
+                    {
+                        continue;
                     }
                     out.push(record);
                 }

--- a/crates/tui/src/client/anthropic.rs
+++ b/crates/tui/src/client/anthropic.rs
@@ -523,22 +523,21 @@ fn message_to_anthropic(message: &crate::models::Message) -> Option<Value> {
     if blocks.is_empty() {
         return None;
     }
-    if message.role == crate::models::INTERRUPTED_ASSISTANT_ROLE {
-        if let Some(text) = blocks
+    if message.role == crate::models::INTERRUPTED_ASSISTANT_ROLE
+        && let Some(text) = blocks
             .iter_mut()
             .find(|block| block.get("type").and_then(Value::as_str) == Some("text"))
-        {
-            let existing = text
-                .get("text")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_string();
-            text["text"] = json!(format!(
-                "{}{}",
-                crate::models::INTERRUPTED_ASSISTANT_CONTEXT_PREFIX,
-                existing
-            ));
-        }
+    {
+        let existing = text
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        text["text"] = json!(format!(
+            "{}{}",
+            crate::models::INTERRUPTED_ASSISTANT_CONTEXT_PREFIX,
+            existing
+        ));
     }
     Some(json!({
         "role": if message.role == crate::models::INTERRUPTED_ASSISTANT_ROLE {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -4339,41 +4339,42 @@ impl Engine {
         // makes a short LLM advisory call, and emits `Event::AdvisoryNote`.
         // Any failure is logged and swallowed — it must never affect the
         // parent turn's outcome.
-        if self.config.advisor_config.enabled && matches!(status, TurnOutcomeStatus::Completed) {
-            if let Some(client) = self.deepseek_client.clone() {
-                // Lazily create the shared emission guard on first use.
-                let guard = self
-                    .advisor_emission_guard
-                    .get_or_insert_with(|| {
-                        Arc::new(tokio::sync::Mutex::new(
-                            crate::tools::subagent::EmissionGuard::new(),
-                        ))
-                    })
-                    .clone();
+        if self.config.advisor_config.enabled
+            && matches!(status, TurnOutcomeStatus::Completed)
+            && let Some(client) = self.deepseek_client.clone()
+        {
+            // Lazily create the shared emission guard on first use.
+            let guard = self
+                .advisor_emission_guard
+                .get_or_insert_with(|| {
+                    Arc::new(tokio::sync::Mutex::new(
+                        crate::tools::subagent::EmissionGuard::new(),
+                    ))
+                })
+                .clone();
 
-                let advisor_messages: Vec<crate::models::Message> = self.session.messages.to_vec();
-                let advisor_config = self.config.advisor_config.clone();
-                let advisor_model = self.session.model.clone();
-                let advisor_tx = self.tx_event.clone();
-                let advisor_turn_id = turn.id.clone();
+            let advisor_messages: Vec<crate::models::Message> = self.session.messages.to_vec();
+            let advisor_config = self.config.advisor_config.clone();
+            let advisor_model = self.session.model.clone();
+            let advisor_tx = self.tx_event.clone();
+            let advisor_turn_id = turn.id.clone();
 
-                crate::utils::spawn_supervised(
-                    "advisor-watcher",
-                    std::panic::Location::caller(),
-                    async move {
-                        crate::tools::subagent::run_advisor_for_turn(
-                            advisor_turn_id,
-                            advisor_messages,
-                            advisor_config,
-                            client,
-                            advisor_model,
-                            guard,
-                            advisor_tx,
-                        )
-                        .await;
-                    },
-                );
-            }
+            crate::utils::spawn_supervised(
+                "advisor-watcher",
+                std::panic::Location::caller(),
+                async move {
+                    crate::tools::subagent::run_advisor_for_turn(
+                        advisor_turn_id,
+                        advisor_messages,
+                        advisor_config,
+                        client,
+                        advisor_model,
+                        guard,
+                        advisor_tx,
+                    )
+                    .await;
+                },
+            );
         }
 
         // ── Cross-turn goal continuation ───────────────────────────────────

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1520,7 +1520,7 @@ impl Engine {
                             .get_or_insert_with(Instant::now)
                             .elapsed();
                         let status = no_progress_status_message(&reason, elapsed);
-                        crate::logging::warn(&compact_no_progress_diagnostic(&reason, elapsed));
+                        crate::logging::warn(compact_no_progress_diagnostic(&reason, elapsed));
                         let _ = self.tx_event.send(Event::status(status.clone())).await;
                         return (TurnOutcomeStatus::Failed, Some(status));
                     }
@@ -1595,7 +1595,7 @@ impl Engine {
                                         .get_or_insert_with(Instant::now)
                                         .elapsed();
                                     let status = no_progress_status_message(&reason, elapsed);
-                                    crate::logging::warn(&compact_no_progress_diagnostic(
+                                    crate::logging::warn(compact_no_progress_diagnostic(
                                         &reason, elapsed,
                                     ));
                                     let _ = self.tx_event.send(Event::status(status.clone())).await;
@@ -3396,7 +3396,7 @@ impl Engine {
                             .get_or_insert_with(Instant::now)
                             .elapsed();
                         let status = no_progress_status_message(&reason, elapsed);
-                        crate::logging::warn(&compact_no_progress_diagnostic(&reason, elapsed));
+                        crate::logging::warn(compact_no_progress_diagnostic(&reason, elapsed));
                         let _ = self.tx_event.send(Event::status(status.clone())).await;
                         return (TurnOutcomeStatus::Failed, Some(status));
                     }

--- a/crates/tui/src/goal_loop.rs
+++ b/crates/tui/src/goal_loop.rs
@@ -270,7 +270,6 @@ mod tests {
                 tokens_used: 5_000,
                 time_used_seconds: 300,
                 continuations,
-                ..GoalProgress::default()
             };
             let budget = GoalBudget::with_token_budget(1_000_000);
             assert_eq!(

--- a/crates/tui/src/native_memory.rs
+++ b/crates/tui/src/native_memory.rs
@@ -243,7 +243,7 @@ impl NativeMemoryStore {
         // Markdown stays authoritative, but the freshness check runs under
         // a shared read lock; only a real tree change escalates to the
         // write-locked reindex (#5173).
-        self.with_fresh_index(|conn| self.query_hits(conn, &query, limit, None))
+        self.with_fresh_index(|conn| self.query_hits(conn, query, limit, None))
     }
 
     /// Search global memory plus the current repository's origin-scoped
@@ -263,7 +263,7 @@ impl NativeMemoryStore {
         self.with_fresh_index(|conn| {
             self.query_hits(
                 conn,
-                &query,
+                query,
                 limit,
                 Some((&global, workspace_path.as_deref())),
             )

--- a/crates/tui/src/tools/subagent/advisor.rs
+++ b/crates/tui/src/tools/subagent/advisor.rs
@@ -131,19 +131,20 @@ impl EmissionGuard {
         let now = Instant::now();
 
         // Rate limit: require at least `rate_limit` since last emission.
-        if let Some(last) = self.last_emission {
-            if now.duration_since(last) < config.rate_limit {
-                return false;
-            }
+        if let Some(last) = self.last_emission
+            && now.duration_since(last) < config.rate_limit
+        {
+            return false;
         }
 
         // Dedup: suppress if the note content hash matches the previous note
         // within the dedup window.
         let note_hash = hash_str(note);
-        if let (Some(prev_hash), Some(prev_at)) = (self.last_note_hash, self.last_note_hash_at) {
-            if prev_hash == note_hash && now.duration_since(prev_at) < config.dedup_window {
-                return false;
-            }
+        if let (Some(prev_hash), Some(prev_at)) = (self.last_note_hash, self.last_note_hash_at)
+            && prev_hash == note_hash
+            && now.duration_since(prev_at) < config.dedup_window
+        {
+            return false;
         }
 
         true
@@ -268,11 +269,11 @@ pub async fn run_advisor_for_turn(
         // We don't have the note content yet, so we only check the rate limit
         // here by testing with a placeholder. The dedup check runs after the
         // LLM call, when we have the actual content.
-        if let Some(last) = g.last_emission {
-            if std::time::Instant::now().duration_since(last) < config.rate_limit {
-                debug!(target: "advisor", "rate-limited, skipping advisor run for turn {turn_id}");
-                return;
-            }
+        if let Some(last) = g.last_emission
+            && std::time::Instant::now().duration_since(last) < config.rate_limit
+        {
+            debug!(target: "advisor", "rate-limited, skipping advisor run for turn {turn_id}");
+            return;
         }
     }
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -12632,6 +12632,10 @@ async fn per_worker_token_budget_does_not_double_count_scope_accounting() {
 /// Variant of [`spawn_budget_capped_worker`] that attaches the worker to a
 /// shared workflow budget scope before its first model turn (no per-worker
 /// cap), returning the manager, agent id, call counter, and task handle.
+// Test helper: the eight parameters mirror the distinct knobs each test case
+// tunes; grouping them into a struct would add boilerplate at every call site
+// without improving readability.
+#[allow(clippy::too_many_arguments)]
 async fn spawn_scope_budgeted_worker(
     manager: &Arc<RwLock<SubAgentManager>>,
     workspace: &Path,

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -1076,16 +1076,14 @@ fn agent_rows(app: &App) -> Vec<RankedWorkRow> {
                         )
                     })
                 })
-                .unwrap_or_else(|| {
-                    matches!(
-                        agent.status,
-                        SubAgentStatus::Completed
-                            | SubAgentStatus::Cancelled
-                            | SubAgentStatus::Failed(_)
-                            | SubAgentStatus::Interrupted(_)
-                            | SubAgentStatus::BudgetExhausted
-                    )
-                });
+                .unwrap_or(matches!(
+                    agent.status,
+                    SubAgentStatus::Completed
+                        | SubAgentStatus::Cancelled
+                        | SubAgentStatus::Failed(_)
+                        | SubAgentStatus::Interrupted(_)
+                        | SubAgentStatus::BudgetExhausted
+                ));
             let mut facts = vec![
                 status.to_string(),
                 summarize_assignment(&agent.assignment.objective),


### PR DESCRIPTION
## What

The v0.9.4 train's CI Lint job runs clippy with `-D warnings`; `codewhale-tui` failed with 30 deny-level lints across the bin (14) and test (16) targets — 16 unique sites. This unblocks the train→main PR.

## Lint counts

| Lint | Before | After |
| --- | --- | --- |
| collapsible_if | 7 | 0 |
| needless_borrow / needless_borrows_for_generic_args | 6 | 0 |
| too_many_arguments | 1 | 0 (allowed, see below) |
| unnecessary_lazy_evaluations | 1 | 0 |
| needless_update | 1 | 0 |
| **Total (unique sites)** | **16** | **0** |

## Fixes (all mechanical, behavior-preserving)

- **collapsible_if (7)**: merged nested `if`s using edition-2024 let-chains (`automation_manager.rs` ×2, `client/anthropic.rs`, `core/engine.rs`, `tools/subagent/advisor.rs` ×3)
- **needless borrows (6)**: dropped `&` on immediately-dereferenced args (`automation_manager.rs`, `native_memory.rs` ×2) and on `compact_no_progress_diagnostic(...)` passed to a generic `warn` (`turn_loop.rs` ×3)
- **unnecessary closure (1)**: `unwrap_or_else(|| matches!(...))` → `unwrap_or(matches!(...))` in `work_surface/model.rs`
- **needless_update (1)**: removed `..GoalProgress::default()` where all three fields are specified (`goal_loop.rs` test)
- **too_many_arguments (1)**: suppressed with `#[allow(clippy::too_many_arguments)]` + justification on `spawn_scope_budgeted_worker` (`tools/subagent/tests.rs`) — a test-only helper whose eight parameters are the distinct knobs each case tunes; grouping them into a struct would add boilerplate at every call site without improving readability

## Verification

- `cargo clippy -p codewhale-tui --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)
- `cargo fmt --all` — applied
- Targeted tests (`goal_loop`, `native_memory`, `advisor`, `automation_manager`, `anthropic`, `work_surface`, `turn_loop` filters) pass, except 12 pre-existing `anthropic`-filter failures (minimax/deepseek routing + stream seam tests) that reproduce identically on the base commit `7d6ee9d2a` and are unrelated to this change