### PR TITLE
fix(tui): keep alternate scroll off while mouse capture is active (#5223)

### DIFF
--- a/crates/tui/src/tui/external_editor.rs
+++ b/crates/tui/src/tui/external_editor.rs
@@ -391,9 +391,10 @@ mod tests {
 
         let seq = String::from_utf8_lossy(&out);
         assert!(
-            seq.contains("\x1b[?1007h"),
-            "external editor resume must restore alternate-scroll mode: {seq:?}"
+            !seq.contains("\x1b[?1007h"),
+            "must not enable alternate-scroll"
         );
+        assert!(seq.contains("\x1b[?1007l"), "must reset alternate-scroll");
         assert!(
             seq.contains("\x1b[?1004h"),
             "external editor resume must restore focus events: {seq:?}"

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -440,10 +440,12 @@ enum TranslationEvent {
 // TurnComplete / focus-gain / resize. The alt-screen buffer's double-buffering
 // plus ratatui's `terminal.clear()` are sufficient to repaint cleanly.
 const TERMINAL_ORIGIN_RESET: &[u8] = b"\x1b[r\x1b[?6l\x1b[H";
-// Xterm alternate-scroll mode keeps wheel events inside the alternate-screen
-// viewport when mouse capture is requested but unavailable or temporarily
-// dropped. Leave it off with `--no-mouse-capture` so the host terminal owns
-// raw mouse selection behavior end-to-end.
+// Xterm alternate-scroll mode (DECSET 1007) converts wheel input into arrow
+// keys. It is only meaningful when mouse reporting is unavailable; while
+// mouse capture is active the terminal must deliver wheel events as mouse
+// events, so 1007 stays off (iTerm2 converts anyway, breaking transcript
+// wheel-scroll — #5223). `--no-mouse-capture` also keeps it off so the host
+// terminal owns raw mouse selection behavior end-to-end (#4026).
 const ENABLE_ALT_SCROLL_MODE: &[u8] = b"\x1b[?1007h";
 const DISABLE_ALT_SCROLL_MODE: &[u8] = b"\x1b[?1007l";
 /// Begin synchronized update (DEC 2026): tell the terminal to defer
@@ -17466,10 +17468,6 @@ fn set_alternate_scroll_mode<W: Write>(writer: &mut W, enabled: bool) {
     }
 }
 
-fn enable_alternate_scroll_mode<W: Write>(writer: &mut W) {
-    set_alternate_scroll_mode(writer, true);
-}
-
 pub(crate) fn disable_alternate_scroll_mode<W: Write>(writer: &mut W) {
     set_alternate_scroll_mode(writer, false);
 }
@@ -17545,13 +17543,13 @@ pub(crate) fn recover_terminal_modes<W: Write>(
 
     pop_keyboard_enhancement_flags(writer);
     push_keyboard_enhancement_flags(writer);
-    if use_mouse_capture {
-        enable_alternate_scroll_mode(writer);
-        if let Err(err) = execute!(writer, EnableMouseCapture) {
-            tracing::debug!(?err, "EnableMouseCapture ignored");
-        }
-    } else {
-        disable_alternate_scroll_mode(writer);
+    // DECSET 1007 converts wheel input into arrow keys. While mouse capture
+    // is active, mouse reporting is the authoritative wheel channel and
+    // terminals disagree about precedence (iTerm2 converts — #5223), so keep
+    // 1007 off; #4026 already leaves it off without mouse capture.
+    disable_alternate_scroll_mode(writer);
+    if use_mouse_capture && let Err(err) = execute!(writer, EnableMouseCapture) {
+        tracing::debug!(?err, "EnableMouseCapture ignored");
     }
     if use_bracketed_paste {
         try_enable_bracketed_paste_mode(writer);

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1257,12 +1257,16 @@ fn recover_terminal_modes_emits_expected_csi_sequences_with_gating() {
         "Kitty keyboard disambiguation flag must be re-pushed regardless of gating"
     );
     assert!(
-        on.contains("\x1b[?1007h"),
-        "alternate-scroll mode must be re-armed when mouse capture is active"
+        !on.contains("\x1b[?1007h"),
+        "alternate-scroll must stay off while mouse capture is active: wheel events must remain mouse events (#5223)"
+    );
+    assert!(
+        on.contains("\x1b[?1007l"),
+        "alternate-scroll must be reset while mouse capture is active"
     );
     assert!(
         !off.contains("\x1b[?1007h"),
-        "alternate-scroll mode must stay off when mouse capture is disabled"
+        "alternate-scroll mode must stay off when mouse capture is disabled (#4026)"
     );
     assert!(
         off.contains("\x1b[?1007l"),


### PR DESCRIPTION
## Summary

When a conversation's content outgrew the screen, mouse-wheel / trackpad
scrolling did not move the transcript; instead the wheel input toggled the
composer's input history. Root cause: `recover_terminal_modes()` armed both
`EnableMouseCapture` and xterm alternate-scroll mode (DECSET 1007) while mouse
capture is active. 1007 converts wheel input into arrow keys, and terminals
disagree about which takes precedence when both are enabled — iTerm2 converts,
so wheel events arrive as Up/Down keys and trigger composer input-history
navigation (`vim_move_up → history_up`) instead of transcript scrolling.

## Changes

- **fix(ui): keep 1007 off while mouse capture is active**: `recover_terminal_modes()` now unconditionally resets alternate-scroll mode (`\x1b[?1007l`). Mouse reporting is the authoritative wheel channel while capture is on; the no-mouse-capture contract from #4026 already leaves 1007 off, so both branches now converge on "off".

- **refactor(ui): drop unused `enable_alternate_scroll_mode()`**: no caller remains after the fix; the enable/disable pair is reduced to the disable-only path.

- **test(tui): flip CSI-sequence assertions**: `recover_terminal_modes_emits_expected_csi_sequences_with_gating` and `resume_tui_child_modes_reenables_shared_terminal_modes` now expect the reset (`\x1b[?1007l`) instead of the enable (`\x1b[?1007h`) while mouse capture is active.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests

## Testing

<!-- Exact gate commands (including the clippy allow list) are in
     CONTRIBUTING.md → "Pre-push verification". -->

- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo clippy --workspace --all-targets --all-features --locked` (no new warnings for touched files; one pre-existing warning in crates/tui/src/mcp.rs:262 is unrelated)
- [x] `cargo test -p codewhale-tui --bin codewhale-tui -- alternate_scroll recover_terminal_modes resume_tui_child_modes` (4 passed, 0 failed)
- [ ] End-to-end wheel-scroll verification on macOS/iTerm2 (Windows host cannot reproduce the iTerm2-specific terminal behavior; needs community verification from the reporter's environment)

## Checklist

- [x] Updated docs or comments as needed (constants + recover_terminal_modes comments updated)
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (blocked: iTerm2-specific, needs macOS host)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

## Related Issues

Closes #5223
