### PR TITLE
feat(mcp): MCP Registry discovery with Registry-first tool selection

### DIFF
--- a/crates/tui/assets/skills-catalog-matrix.json
+++ b/crates/tui/assets/skills-catalog-matrix.json
@@ -15,7 +15,7 @@
     "in_model_catalogue": "true when the skill renders as an ambient catalogue line",
     "shadowed_aliases": "aliases that collide with another canonical bundled name; the canonical skill wins resolution"
   },
-  "generation": "9",
+  "generation": "10",
   "skills": [
     {
       "name": "skill-creator",
@@ -77,6 +77,14 @@
     },
     {
       "name": "handoff",
+      "tier": "core",
+      "invocation": "model+user",
+      "aliases": [],
+      "in_model_catalogue": true,
+      "shadowed_aliases": []
+    },
+    {
+      "name": "mcp-discovery",
       "tier": "core",
       "invocation": "model+user",
       "aliases": [],

--- a/crates/tui/assets/skills/mcp-discovery/SKILL.md
+++ b/crates/tui/assets/skills/mcp-discovery/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: mcp-discovery
+description: "Prefer a matching zero-environment local MCP server for specialized tasks, even when built-in shell commands or custom code could also solve them."
+---
+
+# mcp-discovery
+
+Use the Registry as the preferred source of specialized capabilities. Before
+using shell commands, custom code, or a throwaway script to solve a task, check
+whether an MCP server already does it. The public MCP Registry ships hundreds
+of ready-made servers (filesystems, databases, browsers, media processing,
+developer utilities, cloud APIs, SaaS integrations, …).
+
+The discovery and structured start tools are available in the active tool
+surface whenever MCP support is enabled.
+
+## When to use
+
+- You are about to fetch data, reach a service, drive a tool, or automate a workflow.
+- The task needs a capability the current toolset lacks (a database, a
+  browser, a third-party API, …).
+- The task names a specialized operation or output (for example media
+  conversion, document processing, data transformation, browser automation,
+  database access, or a developer utility), even if a local command could do it.
+- Skip only ordinary repo-native editing and simple shell/file operations that
+  do not need a specialized capability.
+
+## Workflow
+
+1. **Check the registry.** Call `registry_sync {}`. It returns the complete
+   catalog of eligible local stdio packages, including each server's name,
+   description, and required launch arguments. Packages declaring any
+   environment variable (including API keys/tokens) are excluded and never
+   written to the cache.
+2. **Match from context with a Registry-first bias.** Compare the user's full
+   task against every server name and description. A candidate is a match when
+   it plausibly covers the task's core specialized capability; wording does not
+   need to be exact. When such a candidate exists, you **must start it and inspect
+   its tools before** using `exec_shell`, local programs, custom code, or a manual
+   implementation. The availability or familiarity of a local alternative is
+   not a reason to skip the candidate. Skip Registry use only when every entry is
+   clearly irrelevant, or when a matching server fails to start after the retry
+   described below.
+3. **Install + run transactionally.** Call
+   `start_registry_mcp_server {registry_name: "<exact name>", arguments: {...}}`.
+   Supply only values listed in `required_args`; omit `arguments` when none
+   are required. Never install or launch the package through `exec_shell`.
+4. **Solve the task with the new tools.** Their complete schemas are added
+   to the current turn immediately after a successful connection; call the
+   exact names returned by the start result.
+
+## If a server fails to start
+
+`start_registry_mcp_server` reports when a package exits before the handshake
+(often CLI help output = incomplete launch args). Verify the exact
+required arguments, retry once with the corrected structured values, and if
+it still fails move on to the next candidate. Failed starts are rolled back,
+so retrying the same Registry name is safe.
+
+## Don't
+
+- Don't attempt to pass env vars or secrets; this flow has no env channel.
+- Don't reconstruct or edit the Registry-provided package command.

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -109,6 +109,9 @@ fn agent_list_event(manager: &SubAgentManager) -> Event {
     }
 }
 
+const MCP_REGISTRY_FIRST_INSTRUCTION_SOURCE: &str = "runtime:mcp-registry-first";
+const MCP_REGISTRY_FIRST_INSTRUCTION: &str = "## MCP Registry-first policy\n\nFor any task centered on a specialized capability, including media or document conversion, data transformation, browser automation, database or service access, or a developer utility, you must call `registry_sync {}` before `exec_shell`, `fetch_url`, code execution, local programs, custom code, or a manual implementation. Compare the user's complete task yourself against every returned server name and description; wording need not be exact. If any server plausibly covers the core capability, you must call `start_registry_mcp_server` with its exact name and inspect its tools before considering a local alternative. An installed or familiar shell command is not a reason to skip Registry discovery. Use local tools directly only for ordinary repo-native work and simple file operations, when every Registry entry is clearly irrelevant, or after the matching server fails to start.";
+
 /// Snapshot of parent state that can be passed to forked sub-agents without
 /// rewriting the parent transcript.
 ///
@@ -1081,8 +1084,22 @@ impl Engine {
     }
 
     /// Create a new engine with the given configuration
-    pub fn new(config: EngineConfig, api_config: &Config) -> (Self, EngineHandle) {
+    pub fn new(mut config: EngineConfig, api_config: &Config) -> (Self, EngineHandle) {
         crate::tls::ensure_rustls_crypto_provider();
+
+        // Unlike a Skill body, this instruction is visible on the first model
+        // request. Keep selection semantic: the host supplies no keywords or
+        // ranking and the model compares the full user context with the full
+        // Registry catalog. Append it after configured instruction sources so
+        // the Registry-first decision sits close to the current user turn.
+        if config.features.enabled(Feature::Mcp) {
+            config
+                .instructions
+                .push(crate::prompts::InstructionSource::Inline {
+                    name: MCP_REGISTRY_FIRST_INSTRUCTION_SOURCE.to_string(),
+                    content: MCP_REGISTRY_FIRST_INSTRUCTION.to_string(),
+                });
+        }
 
         if let Some(objective) = normalized_goal_objective(config.goal_objective.as_deref()) {
             sync_goal_state_from_host(
@@ -3631,6 +3648,8 @@ impl Engine {
         let mut always_load = self.config.tools_always_load.clone();
         if self.config.features.enabled(Feature::Mcp) {
             always_load.insert("start_mcp_server".to_string());
+            always_load.insert("registry_sync".to_string());
+            always_load.insert("start_registry_mcp_server".to_string());
         }
         let bypass = input_policy.auto_approve
             || input_policy.approval_mode == crate::tui::approval::ApprovalMode::Bypass;
@@ -3646,6 +3665,9 @@ impl Engine {
             &always_load,
             capability.tool_surface_budget,
         );
+        if self.config.features.enabled(Feature::Mcp) {
+            apply_registry_first_shell_guidance(&mut catalog);
+        }
         for tool in &mut catalog {
             if plugin_tool_names.contains(&tool.name) {
                 tool.defer_loading = Some(false);
@@ -5908,9 +5930,9 @@ use self::streaming::{
 use self::tool_catalog::{
     CODE_EXECUTION_TOOL_NAME, JS_EXECUTION_TOOL_NAME, MULTI_TOOL_PARALLEL_NAME,
     REQUEST_USER_INPUT_NAME, ToolSurfacePolicy, active_tools_for_request,
-    build_model_tool_catalog_with_surface, default_synthetic_catalog_tool_names,
-    execute_code_execution_tool, execute_tool_search, is_tool_search_tool,
-    maybe_hydrate_requested_deferred_tool, missing_tool_error_message,
+    apply_registry_first_shell_guidance, build_model_tool_catalog_with_surface,
+    default_synthetic_catalog_tool_names, execute_code_execution_tool, execute_tool_search,
+    is_tool_search_tool, maybe_hydrate_requested_deferred_tool, missing_tool_error_message,
 };
 #[cfg(test)]
 use self::tool_catalog::{

--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -432,6 +432,16 @@ pub(crate) fn compact_tool_result_for_route(
         return String::new();
     }
 
+    // `registry_sync` is deliberately a complete model-side candidate set.
+    // Applying the generic 12K hard limit retains only the JSON head/tail and
+    // silently removes candidates from the middle, turning semantic matching
+    // back into an accidental position-based filter. The eligible local stdio
+    // catalog is bounded upstream by Registry pagination and environment/package
+    // filtering, so preserve it intact for the selection step.
+    if tool_name == "registry_sync" {
+        return raw.to_string();
+    }
+
     if let Some(summary) = compact_subagent_tool_result_for_context(tool_name, raw) {
         return summary;
     }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3,8 +3,9 @@ use super::*;
 use super::context::{COMPACTION_SUMMARY_MARKER, TURN_MAX_OUTPUT_TOKENS};
 use super::streaming::{TOOL_CALL_END_MARKERS, TOOL_CALL_MARKER_PAIRS};
 use super::turn_loop::{
-    registered_tool_approval_required, registered_tool_blocked_in_full_access,
-    registered_tool_forces_prompt, tool_error_degradation_runtime_hint,
+    merge_new_runtime_mcp_tools, registered_tool_approval_required,
+    registered_tool_blocked_in_full_access, registered_tool_forces_prompt,
+    tool_error_degradation_runtime_hint,
 };
 use crate::config::ApiProvider;
 use crate::models::{SystemBlock, Usage};
@@ -43,6 +44,33 @@ const REPRESENTATIVE_SKILL_DESCRIPTION: &str = "REPRESENTATIVE_SKILL_DESCRIPTION
 const REPRESENTATIVE_MEMORY_CHECKPOINT: &str = "REPRESENTATIVE_MEMORY_CHECKPOINT";
 const REPRESENTATIVE_GOAL_OBJECTIVE: &str = "REPRESENTATIVE_GOAL_OBJECTIVE";
 const REPRESENTATIVE_HANDOFF_RELAY: &str = "REPRESENTATIVE_HANDOFF_RELAY";
+
+#[test]
+fn registry_first_policy_is_in_the_initial_prompt_only_when_mcp_is_enabled() {
+    let enabled = EngineConfig::default();
+    let (engine, _handle) = Engine::new(enabled, &Config::default());
+    let prompt = crate::prompts::system_prompt_flat_text(
+        engine
+            .session
+            .system_prompt
+            .as_ref()
+            .expect("system prompt"),
+    );
+    assert!(prompt.contains(MCP_REGISTRY_FIRST_INSTRUCTION_SOURCE));
+    assert!(prompt.contains("must call `registry_sync {}` before `exec_shell`"));
+
+    let mut disabled = EngineConfig::default();
+    disabled.features.disable(Feature::Mcp);
+    let (engine, _handle) = Engine::new(disabled, &Config::default());
+    let prompt = crate::prompts::system_prompt_flat_text(
+        engine
+            .session
+            .system_prompt
+            .as_ref()
+            .expect("system prompt"),
+    );
+    assert!(!prompt.contains(MCP_REGISTRY_FIRST_INSTRUCTION_SOURCE));
+}
 
 #[test]
 fn custom_route_identity_change_rebuilds_client_for_new_named_endpoint() {
@@ -4677,6 +4705,24 @@ fn non_bypassable_registered_tools_block_without_prompt_in_full_access() {
         registered_tool_approval_required("start_mcp_server", ApprovalRequirement::Required, true),
         "start_mcp_server must require approval even when auto_approve is enabled"
     );
+    assert!(registered_tool_approval_required(
+        "start_mcp_server",
+        ApprovalRequirement::Required,
+        true
+    ));
+    // Registry launcher is host-constructed and cache-bound (no free-form
+    // command), so Full Access auto-approves it: `--auto` automation must
+    // be able to complete the discovery flow end to end. Ask still gates it.
+    assert!(!registered_tool_approval_required(
+        "start_registry_mcp_server",
+        ApprovalRequirement::Required,
+        true
+    ));
+    assert!(registered_tool_approval_required(
+        "start_registry_mcp_server",
+        ApprovalRequirement::Required,
+        false
+    ));
     assert!(registered_tool_blocked_in_full_access(
         "start_mcp_server",
         ApprovalRequirement::Required,
@@ -4687,8 +4733,17 @@ fn non_bypassable_registered_tools_block_without_prompt_in_full_access() {
         ApprovalRequirement::Required,
         true,
     ));
+    assert!(!registered_tool_blocked_in_full_access(
+        "start_registry_mcp_server",
+        ApprovalRequirement::Required,
+        true,
+    ));
     assert!(registered_tool_forces_prompt(
         "start_mcp_server",
+        ApprovalRequirement::Required,
+    ));
+    assert!(!registered_tool_forces_prompt(
+        "start_registry_mcp_server",
         ApprovalRequirement::Required,
     ));
     assert!(registered_tool_forces_prompt(
@@ -4710,6 +4765,25 @@ fn non_bypassable_registered_tools_block_without_prompt_in_full_access() {
         ApprovalRequirement::Required,
         true
     ));
+}
+
+#[test]
+fn runtime_mcp_refresh_only_activates_new_catalog_entries() {
+    let mut existing = api_tool("mcp_static_read");
+    existing.defer_loading = Some(true);
+    let mut catalog = vec![existing.clone()];
+    let mut active = HashSet::new();
+
+    merge_new_runtime_mcp_tools(
+        &mut catalog,
+        &mut active,
+        vec![api_tool("mcp_static_read"), api_tool("mcp_dynamic_render")],
+    );
+
+    assert_eq!(catalog.len(), 2);
+    assert!(!active.contains("mcp_static_read"));
+    assert!(active.contains("mcp_dynamic_render"));
+    assert_eq!(catalog[0].defer_loading, Some(true));
 }
 
 #[test]
@@ -5986,6 +6060,45 @@ fn model_tool_catalog_applies_native_and_mcp_deferral() {
 }
 
 #[test]
+fn registry_first_guidance_is_attached_to_the_shell_fallback_once() {
+    let mut catalog = vec![api_tool("read_file"), api_tool("exec_shell")];
+
+    apply_registry_first_shell_guidance(&mut catalog);
+    apply_registry_first_shell_guidance(&mut catalog);
+
+    let description = &catalog
+        .iter()
+        .find(|tool| tool.name == "exec_shell")
+        .expect("shell tool")
+        .description;
+    assert_eq!(description.matches("call registry_sync first").count(), 1);
+    assert!(description.contains("start_registry_mcp_server"));
+}
+
+#[test]
+fn registry_catalog_bypasses_generic_tool_result_compaction() {
+    let middle = "app.cleanor/cleanor";
+    let raw = format!(
+        "{{\"instruction\":\"compare all\",\"servers\":[{{\"name\":\"{}\"}},{{\"name\":\"{middle}\"}},{{\"name\":\"{}\"}}]}}",
+        "a".repeat(7_000),
+        "z".repeat(7_000),
+    );
+    let output = ToolResult::success(raw.clone());
+
+    let context = compact_tool_result_for_route(
+        ApiProvider::Deepseek,
+        "small-context-model",
+        None,
+        "registry_sync",
+        &output,
+    );
+
+    assert_eq!(context, raw);
+    assert!(context.contains(middle));
+    assert!(!context.contains("output compacted to protect context"));
+}
+
+#[test]
 fn capability_compact_surface_defers_nonessential_core_tools() {
     let always_load = HashSet::new();
     let catalog = build_model_tool_catalog_with_surface(
@@ -6130,6 +6243,28 @@ fn agent_catalog_keeps_canonical_file_tool_loaded() {
         "loaded File calls without fuzz should execute instead of hydrating the schema"
     );
     assert!(hydrated_this_batch.is_empty());
+}
+
+#[tokio::test]
+async fn registry_discovery_and_start_handlers_exist_in_agent_and_plan_modes() {
+    let (mut engine, _handle) = Engine::new(EngineConfig::default(), &Config::default());
+    engine.ensure_mcp_pool().await.expect("initialize MCP pool");
+
+    for mode in [AppMode::Agent, AppMode::Plan] {
+        let registry = engine
+            .build_turn_tool_registry_builder(
+                mode,
+                engine.config.todos.clone(),
+                engine.config.plan_state.clone(),
+            )
+            .build(engine.build_tool_context(mode, false));
+        assert!(registry.contains("registry_sync"), "missing in {mode:?}");
+        assert!(
+            registry.contains("start_registry_mcp_server"),
+            "missing in {mode:?}"
+        );
+        assert!(!registry.contains("registry_install_run_info"));
+    }
 }
 
 #[test]

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -212,6 +212,29 @@ pub(super) fn build_model_tool_catalog_with_surface(
     native_tools
 }
 
+const REGISTRY_FIRST_SHELL_GUIDANCE: &str = "Before using this tool for a task whose core operation is a specialized capability (for example media or document conversion, data transformation, browser automation, database or service access, or a developer utility), call registry_sync first. If its complete catalog contains any plausible match, call start_registry_mcp_server and inspect the connected tools before using a shell alternative. Use the shell directly for ordinary repo-native work and simple file operations, or after every Registry entry is clearly irrelevant or the matching server fails to start.";
+
+/// Put the Registry-first decision at the point where the model considers its
+/// strongest fallback. The discovery skill body is lazy-loaded, so relying on
+/// it alone creates a loop: the model must already prefer discovery before it
+/// can read the instruction that tells it to prefer discovery.
+///
+/// This is applied only while MCP is enabled. It changes no dispatch order and
+/// performs no task matching in the host; the model still compares the user's
+/// context against the Registry catalog itself.
+pub(super) fn apply_registry_first_shell_guidance(catalog: &mut [Tool]) {
+    let Some(shell) = catalog.iter_mut().find(|tool| tool.name == "exec_shell") else {
+        return;
+    };
+    if shell.description.contains(REGISTRY_FIRST_SHELL_GUIDANCE) {
+        return;
+    }
+    if !shell.description.ends_with(char::is_whitespace) {
+        shell.description.push(' ');
+    }
+    shell.description.push_str(REGISTRY_FIRST_SHELL_GUIDANCE);
+}
+
 fn apply_tool_surface_budget(
     catalog: &mut [Tool],
     surface_budget: ToolSurfaceBudget,

--- a/crates/tui/src/core/engine/tool_setup.rs
+++ b/crates/tui/src/core/engine/tool_setup.rs
@@ -72,13 +72,18 @@ impl Engine {
                 todo_list,
                 plan_state,
             );
+            if self.config.features.enabled(Feature::Mcp) {
+                builder = builder.with_registry_mcp_sync_tool();
+            }
             // `start_mcp_server` belongs to every executable mode. Keep its
             // handler aligned with the model catalog, which always loads the
             // tool while MCP is enabled. The former early return registered
             // it only in Plan mode, so Agent/Full Access advertised a tool
             // that could never cross the execution boundary.
             if let Some(ref pool) = self.mcp_pool {
-                builder = builder.with_runtime_mcp_tool(Arc::clone(pool));
+                builder = builder
+                    .with_runtime_mcp_tool(Arc::clone(pool))
+                    .with_registry_mcp_start_tool(Arc::clone(pool));
             }
             return builder;
         }
@@ -134,11 +139,21 @@ impl Engine {
         // so there's no failure mode worth gating on.
         builder = builder.with_notify_tool();
 
+        // Register the `registry_sync` tool for fetching and caching
+        // MCP Registry server metadata. Rides on `Feature::Mcp` — the same
+        // flag that gates the rest of the MCP system (defaults to enabled;
+        // opt out via `[features]` in config.toml).
+        if self.config.features.enabled(Feature::Mcp) {
+            builder = builder.with_registry_mcp_sync_tool();
+        }
+
         // Register the start_mcp_server tool so LLM can dynamically start
         // MCP servers from conversation context. Only when the pool has been
         // initialized (lazy via ensure_mcp_pool).
         if let Some(ref pool) = self.mcp_pool {
-            builder = builder.with_runtime_mcp_tool(Arc::clone(pool));
+            builder = builder
+                .with_runtime_mcp_tool(Arc::clone(pool))
+                .with_registry_mcp_start_tool(Arc::clone(pool));
         }
 
         builder

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -229,6 +229,22 @@ fn registered_tool_requires_non_bypassable_approval(tool_name: &str) -> bool {
     matches!(tool_name, "rlm_eval" | "rlm" | "start_mcp_server")
 }
 
+pub(super) fn merge_new_runtime_mcp_tools(
+    tool_catalog: &mut Vec<Tool>,
+    active_tool_names: &mut std::collections::HashSet<String>,
+    refreshed: Vec<Tool>,
+) {
+    for tool in refreshed {
+        if !tool_catalog
+            .iter()
+            .any(|existing| existing.name == tool.name)
+        {
+            active_tool_names.insert(tool.name.clone());
+            tool_catalog.push(tool);
+        }
+    }
+}
+
 impl Engine {
     pub(super) fn drain_shell_completion_events(
         &self,
@@ -393,7 +409,7 @@ impl Engine {
         let mut mode = tool_policy.mode;
         let mut questions_allowed = tool_policy.allows_questions();
         let strict_tool_mode = tool_policy.strict_tool_mode;
-        let tool_catalog = std::mem::take(&mut tool_policy.catalog);
+        let mut tool_catalog = std::mem::take(&mut tool_policy.catalog);
         let mut active_tool_names = std::mem::take(&mut tool_policy.active_names);
         let tool_registry = Some(&tool_policy.registry);
         // #4415: the turn's tool-call admission counter. It lives here —
@@ -3104,6 +3120,28 @@ impl Engine {
                 }
                 match result {
                     Ok(output) => {
+                        // A runtime MCP connection changes the callable tool
+                        // surface. Merge the complete schemas into this turn's
+                        // catalog before the next model request; waiting for the
+                        // next user turn leaves the model with names it cannot
+                        // legally call through the provider API.
+                        let mcp_catalog_changed = output
+                            .metadata
+                            .as_ref()
+                            .and_then(|metadata| metadata.get("mcp_catalog_changed"))
+                            .and_then(serde_json::Value::as_bool)
+                            .unwrap_or(false);
+                        if output.success
+                            && mcp_catalog_changed
+                            && let Some(pool) = self.mcp_pool.as_ref().cloned()
+                        {
+                            let refreshed = pool.lock().await.to_api_tools();
+                            merge_new_runtime_mcp_tools(
+                                &mut tool_catalog,
+                                &mut active_tool_names,
+                                refreshed,
+                            );
+                        }
                         emit_tool_audit(json!({
                             "event": "tool.result",
                             "tool_id": outcome.id.clone(),

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -3683,6 +3683,16 @@ impl McpPool {
         Ok(())
     }
 
+    /// Remove an in-memory runtime server after a failed start attempt.
+    /// This makes dynamic registration transactional: callers may retry the
+    /// same deterministic name after correcting an argument or install issue.
+    pub fn remove_runtime_server_config(&mut self, name: &str) {
+        self.drop_connection(name, "runtime server start rolled back");
+        if self.dynamic_servers.write().remove(name).is_some() {
+            self.catalog_generation.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
     /// Get list of connected server names
     #[allow(dead_code)] // Public API; the HTTP list endpoint no longer spawns a pool to call it (#3532)
     pub fn connected_servers(&self) -> Vec<&str> {

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -5139,3 +5139,15 @@ fn mcp_model_tool_names_and_server_attribution_share_one_definition() {
         Some("solo")
     );
 }
+
+#[test]
+fn removed_runtime_server_config_can_be_retried_with_same_name() {
+    let mut pool = McpPool::new(McpConfig::default());
+    let config: McpServerConfig = serde_json::from_str(r#"{"command": "node a.js"}"#).unwrap();
+
+    pool.add_runtime_server_config("retryable".to_string(), config.clone())
+        .unwrap();
+    pool.remove_runtime_server_config("retryable");
+    pool.add_runtime_server_config("retryable".to_string(), config)
+        .expect("rollback must release the deterministic runtime name");
+}

--- a/crates/tui/src/skills/system.rs
+++ b/crates/tui/src/skills/system.rs
@@ -12,7 +12,9 @@ use std::path::Path;
 /// requested by @JayBeest (#4227).
 /// Generation 9 adds the `handoff` workflow skill (baton-pass for
 /// continuous operate-mode operations).
-const BUNDLED_SKILL_VERSION: &str = "9";
+/// Generation 10 adds the bundled `mcp-discovery` skill (Registry-first
+/// tool selection).
+const BUNDLED_SKILL_VERSION: &str = "10";
 
 // ── system & extension (meta) ───────────────────────────────────────────────
 const SKILL_CREATOR_BODY: &str = include_str!("../../assets/skills/skill-creator/SKILL.md");
@@ -58,6 +60,7 @@ const CONTRIBUTOR_ONBOARDING_BODY: &str =
 // Optional integration (not auto-installed for every user): Feishu body kept for
 // digest/migration helpers only.
 const FEISHU_BODY: &str = include_str!("../../assets/skills/feishu/SKILL.md");
+const MCP_DISCOVERY_BODY: &str = include_str!("../../assets/skills/mcp-discovery/SKILL.md");
 
 // Legacy v4 body retained solely for digest-based safe retirement (#4691).
 const V4_BEST_PRACTICES_BODY: &str = include_str!("../../assets/skills/v4-best-practices/SKILL.md");
@@ -243,6 +246,11 @@ const BUNDLED_SKILLS: &[BundledSkill] = &[
         name: "contributor-onboarding",
         body: CONTRIBUTOR_ONBOARDING_BODY,
         introduced_in: 8,
+    },
+    BundledSkill {
+        name: "mcp-discovery",
+        body: MCP_DISCOVERY_BODY,
+        introduced_in: 10,
     },
 ];
 
@@ -559,7 +567,7 @@ mod tests {
             .find(|skill| skill.name == "contributor-onboarding")
             .expect("contributor-onboarding must be bundled");
         assert_eq!(skill.introduced_in, 8);
-        assert_eq!(BUNDLED_SKILL_VERSION, "9");
+        assert_eq!(BUNDLED_SKILL_VERSION, "10");
 
         let body = skill.body;
         assert!(body.contains("invocation: explicit-only"));

--- a/crates/tui/src/tools/mcp_registry.rs
+++ b/crates/tui/src/tools/mcp_registry.rs
@@ -1,0 +1,1283 @@
+//! MCP Registry sync tool.
+//!
+//! Provides `McpSyncRegistry` — fetches the MCP Registry index,
+//! filters for stdio-type servers, caches locally, and returns a summary.
+//! The cache is deliberately simple: every sync pulls the complete
+//! paginated listing and atomically replaces the previous `mcp-index.json`
+//! (no TTL freshness bookkeeping, no merge, no eviction). The on-disk file
+//! is the launch-metadata store for `start_registry_mcp_server`, and a
+//! failed sync leaves the previous snapshot untouched.
+//!
+//! Upstream contract (MCP Registry, preview — breaking changes possible):
+//!   * List operation `GET /v0.1/servers` (cursor / limit / search / version
+//!     / include_deleted params):
+//!     https://registry.modelcontextprotocol.io/docs#/operations/list-servers-v0.1
+//!     OpenAPI source: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/api/openapi.yaml
+//!   * Aggregator integration guide (pagination format, server status
+//!     lifecycle):
+//!     https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/registry-aggregators.mdx
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::mcp::McpPool;
+use crate::tools::spec::{
+    ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
+};
+use crate::utils::write_atomic;
+
+// === Registry API response types ===
+
+#[derive(Deserialize)]
+struct RegistryResponse {
+    servers: Vec<RegistryServerEntry>,
+    metadata: Option<RegistryMetadata>,
+}
+
+#[derive(Deserialize)]
+struct RegistryServerEntry {
+    server: RegistryServer,
+    // Registry-managed metadata. Carries the lifecycle `status` under the
+    // official extension key (see `RegistryOfficialMeta`); the
+    // publisher-provided subkey is deliberately not declared.
+    #[serde(rename = "_meta", default)]
+    meta: Option<RegistryResponseMeta>,
+}
+
+impl RegistryServerEntry {
+    /// Lifecycle status reported by the official registry extension.
+    /// `"active"` (or an absent extension) keeps the entry; `"deprecated"`
+    /// and `"deleted"` retire it — the aggregator guide recommends dropping
+    /// `deleted` entries (moderation takedowns: spam/malware/illegal) from
+    /// downstream indexes, and we treat `deprecated` the same so the model
+    /// is only offered servers the publisher still stands behind.
+    /// https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/registry-aggregators.mdx
+    fn lifecycle_status(&self) -> Option<&str> {
+        self.meta
+            .as_ref()
+            .and_then(|m| m.official.as_ref())
+            .and_then(|o| o.status.as_deref())
+    }
+}
+
+#[derive(Deserialize)]
+struct RegistryResponseMeta {
+    #[serde(rename = "io.modelcontextprotocol.registry/official", default)]
+    official: Option<RegistryOfficialMeta>,
+}
+
+/// `status` is required upstream (enum `active | deprecated | deleted`);
+/// kept Optional here so a missing extension never fails a page parse.
+#[derive(Deserialize)]
+struct RegistryOfficialMeta {
+    #[serde(default)]
+    status: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RegistryServer {
+    name: String,
+    description: String,
+    // `title`, `version`, `repository` are deliberately not declared —
+    // the cache no longer carries them (see `McpRegistryServerEntry`)
+    // and serde silently drops any extra fields, so we don't pay to
+    // validate or store data we'd immediately throw away. All three are
+    // optional in the upstream 2025-12 schema.
+    #[serde(default)]
+    packages: Option<Vec<RegistryPackage>>,
+}
+
+#[derive(Deserialize)]
+struct RegistryPackage {
+    #[serde(rename = "registryType")]
+    registry_type: String,
+    identifier: String,
+    // The upstream OCI entries (e.g. docker.io/foo/bar:1.2.3) omit the
+    // top-level `version` field because the tag is the version. Mirror that
+    // — Optional, with a fallback that parses the trailing `:tag` from the
+    // identifier when missing.
+    #[serde(default)]
+    version: Option<String>,
+    // The upstream 2025-12 schema dropped `runtimeHint` for nearly every
+    // entry (35/36 in the first page omit it; the runner is implied by
+    // `registryType`). Keep it Optional and fall back to a registry-type
+    // table when absent.
+    #[serde(rename = "runtimeHint", default)]
+    runtime_hint: Option<String>,
+    // The upstream schema now models `transport` as an object:
+    // `{"type": "stdio"}`. Older docs showed a bare string. Accept both
+    // so a future flip-back doesn't break us.
+    #[serde(deserialize_with = "deserialize_transport", default)]
+    transport: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "packageArguments")]
+    package_arguments: Vec<RegistryArg>,
+    #[serde(
+        rename = "runtimeArguments",
+        deserialize_with = "deserialize_runtime_arguments",
+        default
+    )]
+    runtime_arguments: Vec<String>,
+    /// Registry-provided environment requirements are intentionally kept
+    /// transient. Runtime-discovered servers have no configuration channel
+    /// for secrets/API keys, so any package declaring environment variables
+    /// is ineligible and never reaches the on-disk cache.
+    #[serde(rename = "environmentVariables", default)]
+    environment_variables: Value,
+}
+
+impl RegistryPackage {
+    fn declares_environment_variables(&self) -> bool {
+        match &self.environment_variables {
+            Value::Null => false,
+            Value::Array(values) => !values.is_empty(),
+            Value::Object(values) => !values.is_empty(),
+            // Fail closed if a future Registry schema uses an unexpected shape.
+            _ => true,
+        }
+    }
+}
+
+/// Deserialize `transport` as either a bare string (`"stdio"`) or an object
+/// (`{"type": "stdio"}`). The MCP Registry 2025-12 schema ships the object
+/// shape; older/draft docs showed the bare string. We accept both.
+fn deserialize_transport<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrString {
+        Bare(String),
+        Wrapped {
+            #[serde(rename = "type")]
+            r#type: String,
+        },
+    }
+
+    let opt: Option<OneOrString> = Option::deserialize(deserializer)?;
+    Ok(opt.map(|v| match v {
+        OneOrString::Bare(s) => s,
+        OneOrString::Wrapped { r#type } => r#type,
+    }))
+}
+
+/// Deserialize `runtimeArguments` as either `Vec<String>` (old schema)
+/// or `Vec<{value, name, default, type, ...}>` (2025-12 schema). In the
+/// object case we derive a string value from the available fields:
+/// - Named args (`type: "named"`): `"{name} {default}"` or just `name`
+/// - Positional args (`type: "positional"`): `default`
+/// - Legacy objects with `value`: use `value` directly
+fn deserialize_runtime_arguments<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrArg {
+        Bare(String),
+        Wrapped {
+            #[serde(default)]
+            value: Option<String>,
+            #[serde(default)]
+            name: Option<String>,
+            #[serde(default)]
+            default: Option<String>,
+        },
+    }
+
+    let raw: Vec<StringOrArg> = Vec::deserialize(deserializer)?;
+    let mut args = Vec::new();
+    for arg in raw {
+        match arg {
+            StringOrArg::Bare(value) => args.push(value),
+            StringOrArg::Wrapped {
+                value: Some(value), ..
+            } => args.push(value),
+            StringOrArg::Wrapped { name, default, .. } => {
+                if let Some(name) = name {
+                    args.push(name);
+                }
+                if let Some(default) = default {
+                    args.push(default);
+                }
+            }
+        }
+    }
+    Ok(args)
+}
+
+/// Derive a runtime hint from `registryType` when the upstream omits one.
+/// Kept small on purpose: only the runtimes we know how to launch.
+fn default_runtime_hint(registry_type: &str) -> Option<&'static str> {
+    match registry_type {
+        "npm" => Some("npx"),
+        "pypi" => Some("uvx"),
+        _ => None,
+    }
+}
+
+#[derive(Deserialize)]
+struct RegistryArg {
+    // Positional arguments ship without a name — only `value` and
+    // `type`. Named arguments (`{"name": "--foo", "value": "bar", ...}`)
+    // carry it. Accept both: when missing, downstream code uses `value`
+    // as the arg name.
+    #[serde(default)]
+    name: Option<String>,
+    description: Option<String>,
+    // Upstream allows omitting `isRequired`; default false per spec.
+    #[serde(rename = "isRequired", default)]
+    is_required: bool,
+    // Upstream `type` discriminator (`"positional"` / `"named"`). Drives
+    // cmd-format decisions downstream. Renamed because `type` is a
+    // reserved word in Rust.
+    #[serde(rename = "type", default)]
+    kind: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+    default: Option<String>,
+    // `format` dropped — never read by any consumer.
+}
+
+// === Cached index types ===
+
+#[derive(Deserialize)]
+struct RegistryMetadata {
+    #[serde(rename = "nextCursor")]
+    next_cursor: Option<String>,
+}
+
+// === Cached index types ===
+//
+// The cache file (`~/.codewhale/mcp-index.json`) is the on-disk source of
+// truth for Registry-discovered local MCP launch metadata.
+
+/// Bumped whenever the cache shape changes. Lets the loader detect an old
+/// cache file and trigger a full resync instead of failing to deserialize.
+pub const MCP_REGISTRY_CACHE_VERSION: u32 = 6;
+
+#[derive(Serialize, Deserialize)]
+pub struct McpRegistryIndex {
+    pub version: u32,
+    pub count: usize,
+    pub servers: Vec<McpRegistryServerEntry>,
+}
+
+/// One Registry catalog entry exposed to the model for contextual selection.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct DigestEntry {
+    pub name: String,
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_args: Vec<McpRegistryArgEntry>,
+}
+
+/// One cached server entry used by discovery and structured startup.
+///
+/// Everything else that the upstream Registry ships (`title`, repository,
+/// `packages[]`, optional named args,
+/// runtime_arguments at package level) is dropped. Fixed positional
+/// `packageArguments` (e.g. an `mcp` subcommand) are folded into
+/// `run_command` at render time rather than kept as fields.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct McpRegistryServerEntry {
+    pub name: String,
+    pub description: String,
+    pub launch: McpLaunchSpec,
+}
+
+/// Host-owned launch data for one zero-environment stdio server.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct McpLaunchSpec {
+    /// Template for the run command. The literal substring `<ARGS>` is
+    /// replaced by host-rendered structured argument values.
+    pub run_command: String,
+    pub required_args: Vec<McpRegistryArgEntry>,
+}
+
+/// One CLI argument required at install time. `is_required` was dropped
+/// because the cache only stores required args (others are filtered out
+/// during sync). `kind` carries the upstream `type` discriminator
+/// (`"positional"` vs `"named"`) so the cmd builder can decide whether
+/// to emit `--name value` or just `value`.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct McpRegistryArgEntry {
+    pub name: String,
+    pub kind: Option<String>,
+    pub description: Option<String>,
+    pub default: Option<String>,
+}
+
+// === Tool implementation ===
+
+pub struct McpSyncRegistry;
+
+const REGISTRY_API: &str = "https://registry.modelcontextprotocol.io/v0.1/servers";
+const PER_PAGE: usize = 100;
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+/// Bounded retries for one sync. The on-disk cache only changes at the
+/// final atomic replace, so a failed fetch (HTTP/parse error) never
+/// mutates state and retrying is side-effect free.
+const MAX_SYNC_ATTEMPTS: usize = 3;
+/// Connect budget for Registry-launched servers. The 10s global default is
+/// meant for pre-installed servers; Registry packages are typically fetched
+/// on first launch via npx/uvx, which routinely exceeds it.
+const REGISTRY_CONNECT_TIMEOUT_SECS: u64 = 60;
+
+fn cache_path() -> Result<PathBuf, ToolError> {
+    dirs::home_dir()
+        .ok_or_else(|| ToolError::execution_failed("Cannot determine home directory"))
+        .map(|h| h.join(".codewhale").join("mcp-index.json"))
+}
+
+fn read_cache(path: &PathBuf) -> Option<McpRegistryIndex> {
+    let data = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+/// Convert one fetched listing into launchable cache entries. Servers the
+/// upstream marks `deleted`/`deprecated` are dropped (the aggregator guide
+/// recommends removing `deleted` entries — moderation takedowns — from
+/// downstream indexes), as is anything the structured launcher cannot run.
+/// The cache is a full snapshot every sync, so this filtering is the whole
+/// story: retired servers simply never enter the fresh index.
+/// Status lives in registry-managed `_meta`
+/// (`ServerResponse._meta["io.modelcontextprotocol.registry/official"]
+/// .status`, enum `active | deprecated | deleted`).
+/// https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/api/openapi.yaml
+fn viable_entries(entries: Vec<RegistryServerEntry>) -> Vec<McpRegistryServerEntry> {
+    entries
+        .into_iter()
+        .filter(|entry| {
+            !matches!(
+                entry.lifecycle_status(),
+                Some("deleted") | Some("deprecated")
+            )
+        })
+        .filter_map(|entry| server_to_entry(entry.server))
+        .collect()
+}
+
+/// Render the run command template. Positional `packageArguments` with a
+/// fixed literal (or defaulted) value are part of the invocation itself —
+/// e.g. the `mcp` subcommand in `npx -y agentic-mermaid@0.1.2 mcp` — so
+/// they are folded into the command right after the package spec.
+/// `<ARGS>` is the splice point for everything user-supplied: positional
+/// placeholders plus each `required_args` entry, rendered as named or
+/// positional arguments by the structured Registry launcher.
+fn build_run_command(
+    runtime_hint: &str,
+    identifier: &str,
+    version: &str,
+    runtime_arguments: &[String],
+    package_arguments: &[RegistryArg],
+) -> String {
+    let runtime = runtime_hint;
+    let mut normalized_runtime_arguments = runtime_arguments.to_vec();
+    if runtime_hint == "npx"
+        && !normalized_runtime_arguments
+            .iter()
+            .any(|argument| matches!(argument.as_str(), "-y" | "--yes"))
+    {
+        normalized_runtime_arguments.insert(0, "-y".to_string());
+    }
+    let mid = normalized_runtime_arguments
+        .iter()
+        .map(|argument| shell_words::quote(argument))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mid_with_space = if mid.is_empty() {
+        String::new()
+    } else {
+        format!("{mid} ")
+    };
+    let (sep, tail) = match runtime_hint {
+        "npx" => ("@", version.to_string()),
+        "uvx" => ("==", version.to_string()),
+        _ => return String::new(),
+    };
+    // Upstream positional packageArguments ship without a `name`; named
+    // args always carry one. A nameless arg with a literal `value` (or a
+    // `default`) is a fixed token of the invocation, not user input —
+    // dropping it renders a command that cannot start the server (the
+    // agentic-mermaid `mcp` subcommand bug).
+    let fixed: Vec<String> = package_arguments
+        .iter()
+        .filter(|a| !a.is_required)
+        .filter(|a| a.name.is_none())
+        .filter_map(|a| a.value.as_deref().or(a.default.as_deref()))
+        .map(|value| shell_words::quote(value).into_owned())
+        .collect();
+    let fixed_str = if fixed.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", fixed.join(" "))
+    };
+    let package_spec = format!("{identifier}{sep}{tail}");
+    let package = shell_words::quote(&package_spec);
+    format!("{runtime} {mid_with_space}{package}{fixed_str} <ARGS>")
+}
+
+fn build_launch_spec(
+    runtime_hint: &str,
+    identifier: &str,
+    version: &str,
+    pkg: &RegistryPackage,
+) -> McpLaunchSpec {
+    McpLaunchSpec {
+        run_command: build_run_command(
+            runtime_hint,
+            identifier,
+            version,
+            &pkg.runtime_arguments,
+            &pkg.package_arguments,
+        ),
+        required_args: pkg
+            .package_arguments
+            .iter()
+            .filter(|a| a.is_required)
+            .enumerate()
+            .map(|(index, a)| McpRegistryArgEntry {
+                // Positional args omit `name` upstream; fall back to the
+                // value so the cache still carries something the cmd
+                // builder can render.
+                name: a
+                    .name
+                    .clone()
+                    .or_else(|| a.value.clone())
+                    .unwrap_or_else(|| format!("arg_{}", index + 1)),
+                kind: a.kind.clone(),
+                description: a.description.clone(),
+                default: a.default.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn server_to_entry(server: RegistryServer) -> Option<McpRegistryServerEntry> {
+    // We only need the FIRST viable stdio package per server for
+    // launch metadata; everything beyond it would just duplicate
+    // info. Filter to stdio, resolve runtime_hint + version, and stop
+    // at the first hit.
+    let first_pkg = server
+        .packages
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|p| p.transport.as_deref() == Some("stdio"))
+        .filter(|p| !p.declares_environment_variables())
+        // The automatic launcher currently has deterministic install/run
+        // semantics for package-manager-backed npm and PyPI entries only.
+        .filter(|p| matches!(p.registry_type.as_str(), "npm" | "pypi"))
+        .find_map(|p| {
+            let expected_hint = default_runtime_hint(&p.registry_type)?;
+            let hint = p
+                .runtime_hint
+                .clone()
+                .unwrap_or_else(|| expected_hint.to_string());
+            if hint != expected_hint {
+                return None;
+            }
+            let version = p.version.clone()?;
+            Some((p, hint, version))
+        });
+
+    let (pkg, hint, version) = first_pkg?;
+
+    Some(McpRegistryServerEntry {
+        name: server.name,
+        description: server.description,
+        launch: build_launch_spec(&hint, &pkg.identifier, &version, &pkg),
+    })
+}
+
+#[derive(Serialize)]
+struct RegistryCatalogResult {
+    instruction: &'static str,
+    count: usize,
+    servers: Vec<DigestEntry>,
+}
+
+fn catalog_from_cache(cache: &McpRegistryIndex) -> RegistryCatalogResult {
+    let servers = cache
+        .servers
+        .iter()
+        .map(|server| DigestEntry {
+            name: server.name.clone(),
+            description: server.description.clone(),
+            required_args: server.launch.required_args.clone(),
+        })
+        .collect::<Vec<_>>();
+    RegistryCatalogResult {
+        instruction: "REGISTRY-FIRST POLICY: Compare the user's full task against every server name and description. Treat a server as a match when it plausibly covers the task's core specialized capability; wording need not be exact. If any plausible match exists, you must call start_registry_mcp_server with its exact name and inspect its tools before using shell commands, local programs, custom code, or a manual implementation. A familiar local alternative is not a reason to skip it. Fall back only when every catalog entry is clearly irrelevant or the matching server fails to start.",
+        count: servers.len(),
+        servers,
+    }
+}
+
+async fn load_registry_catalog() -> Result<RegistryCatalogResult, ToolError> {
+    let path = cache_path()?;
+    sync_once(&path).await?;
+    let cache = read_cache(&path).ok_or_else(|| {
+        ToolError::execution_failed(format!(
+            "Registry cache was not written at {}",
+            path.display()
+        ))
+    })?;
+    Ok(catalog_from_cache(&cache))
+}
+
+/// Paginate the full registry listing. Continues from each page's cursor,
+/// appending entries, until the upstream reports no more pages — a complete
+/// listing is the only shape ever cached. Never writes anything; callers
+/// may retry freely because the on-disk cache only changes at the final
+/// atomic replace.
+async fn fetch_registry_entries(
+    client: &reqwest::Client,
+) -> Result<Vec<RegistryServerEntry>, ToolError> {
+    let mut all_entries: Vec<RegistryServerEntry> = Vec::new();
+    let mut cursor: Option<String> = None;
+    loop {
+        let mut url = format!("{REGISTRY_API}?version=latest&limit={PER_PAGE}");
+        if let Some(ref c) = cursor {
+            url.push_str(&format!("&cursor={}", urlencoding::encode(c)));
+        }
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .and_then(reqwest::Response::error_for_status)
+            .map_err(|e| ToolError::execution_failed(format!("Registry API: {e}")))?;
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ToolError::execution_failed(format!("Registry body: {e}")))?;
+        let body: RegistryResponse = serde_json::from_str(&text)
+            .map_err(|e| ToolError::execution_failed(format!("Registry JSON parse: {e}")))?;
+        all_entries.extend(body.servers);
+        cursor = body.metadata.and_then(|m| m.next_cursor);
+        if cursor.is_none() {
+            break;
+        }
+    }
+    Ok(all_entries)
+}
+
+/// Pull the full registry listing, convert it to a fresh snapshot, and
+/// atomically replace the cache file. The fetch is retried (bounded) on
+/// failure; the old cache only changes at the atomic replace, so a failed
+/// sync leaves the previous snapshot untouched. Returns `Err` only after
+/// the retries are exhausted.
+async fn sync_once(path: &Path) -> Result<(), ToolError> {
+    // rustls default-provider install pattern (matches `client.rs`).
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| ToolError::execution_failed(format!("HTTP client: {e}")))?;
+
+    let mut last_error: Option<ToolError> = None;
+    let mut servers: Option<Vec<McpRegistryServerEntry>> = None;
+    for _attempt in 0..MAX_SYNC_ATTEMPTS {
+        match fetch_registry_entries(&client).await {
+            Ok(entries) => {
+                servers = Some(viable_entries(entries));
+                break;
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+    let servers = servers.ok_or_else(|| {
+        last_error.unwrap_or_else(|| ToolError::execution_failed("Registry sync failed"))
+    })?;
+    let index = McpRegistryIndex {
+        version: MCP_REGISTRY_CACHE_VERSION,
+        count: servers.len(),
+        servers,
+    };
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| ToolError::execution_failed(format!("Create cache dir: {e}")))?;
+    }
+    let json_str = serde_json::to_string_pretty(&index)
+        .map_err(|e| ToolError::execution_failed(format!("Serialize: {e}")))?;
+    write_atomic(path, json_str.as_bytes())
+        .map_err(|e| ToolError::execution_failed(format!("Write cache: {e}")))?;
+    Ok(())
+}
+
+#[async_trait::async_trait]
+impl ToolSpec for McpSyncRegistry {
+    fn name(&self) -> &str {
+        "registry_sync"
+    }
+
+    fn description(&self) -> &str {
+        "List installable local MCP servers for Registry-first capability \
+         selection. Compare their names and descriptions against the user's \
+         full task context before using shell commands, local programs, custom \
+         code, or manually reproducing a specialized integration. \
+         The index contains only stdio packages \
+         that declare no environment variables or API keys. If any server \
+         plausibly covers the task's core specialized capability, call \
+         start_registry_mcp_server with its exact name and inspect its tools \
+         before choosing a local alternative; do not run its package command \
+         through exec_shell."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![ToolCapability::Network]
+    }
+
+    fn approval_requirement(&self) -> ApprovalRequirement {
+        ApprovalRequirement::Auto
+    }
+
+    fn supports_parallel(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, _input: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        let result = load_registry_catalog().await?;
+        let json = serde_json::to_string(&result)
+            .map_err(|e| ToolError::execution_failed(format!("Serialize: {e}")))?;
+        Ok(ToolResult::success(json))
+    }
+}
+
+/// Start one zero-environment stdio server selected from the Registry cache.
+/// The model supplies a Registry identity and structured CLI values; the host
+/// owns command construction, so no arbitrary shell command or environment
+/// channel is exposed by the discovery flow.
+pub struct StartRegistryMcpServer {
+    pool: Arc<AsyncMutex<McpPool>>,
+}
+
+impl StartRegistryMcpServer {
+    pub fn new(pool: Arc<AsyncMutex<McpPool>>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl ToolSpec for StartRegistryMcpServer {
+    fn name(&self) -> &str {
+        "start_registry_mcp_server"
+    }
+
+    fn description(&self) -> &str {
+        "Install and start a local stdio MCP server previously returned by \
+         registry_sync. Only Registry packages that declare no environment \
+         variables are eligible. Pass the exact registry_name and, when the \
+         discovery result lists required_args, provide their values in the \
+         structured arguments object. The connected server's complete tool \
+         schemas become callable in the same turn."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "registry_name": {
+                    "type": "string",
+                    "description": "Exact server name returned by registry_sync"
+                },
+                "arguments": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" },
+                    "description": "Values keyed by required_args[].name; omit when none are required"
+                }
+            },
+            "required": ["registry_name"]
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![ToolCapability::Network, ToolCapability::ExecutesCode]
+    }
+
+    fn approval_requirement(&self) -> ApprovalRequirement {
+        ApprovalRequirement::Required
+    }
+
+    async fn execute(&self, input: Value, ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        let registry_name = input
+            .get("registry_name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::invalid_input("missing required field: registry_name"))?;
+        let supplied: HashMap<String, String> = match input.get("arguments") {
+            Some(value) => serde_json::from_value(value.clone())
+                .map_err(|error| ToolError::invalid_input(format!("invalid arguments: {error}")))?,
+            None => HashMap::new(),
+        };
+
+        let path = cache_path()?;
+        let cache = read_cache(&path).ok_or_else(|| {
+            ToolError::execution_failed(format!(
+                "no current Registry cache at {}; run registry_sync first",
+                path.display()
+            ))
+        })?;
+        if cache.version != MCP_REGISTRY_CACHE_VERSION {
+            return Err(ToolError::execution_failed(format!(
+                "cache at {} is from an older schema version; run registry_sync first",
+                path.display()
+            )));
+        }
+        let entry = cache
+            .servers
+            .iter()
+            .find(|server| server.name == registry_name)
+            .ok_or_else(|| ToolError::invalid_input("registry_name is not present in the cache"))?;
+
+        let expected: HashSet<&str> = entry
+            .launch
+            .required_args
+            .iter()
+            .map(|arg| arg.name.as_str())
+            .collect();
+        if let Some(unknown) = supplied
+            .keys()
+            .find(|name| !expected.contains(name.as_str()))
+        {
+            return Err(ToolError::invalid_input(format!(
+                "unknown argument '{unknown}' for {registry_name}"
+            )));
+        }
+
+        let mut rendered_args = Vec::new();
+        for argument in &entry.launch.required_args {
+            let value = supplied
+                .get(&argument.name)
+                .cloned()
+                .or_else(|| argument.default.clone())
+                .ok_or_else(|| {
+                    ToolError::invalid_input(format!(
+                        "missing required argument '{}' for {registry_name}",
+                        argument.name
+                    ))
+                })?;
+            if matches!(argument.kind.as_deref(), Some("named")) && !argument.name.is_empty() {
+                rendered_args.push(shell_words::quote(&argument.name).into_owned());
+            }
+            rendered_args.push(shell_words::quote(&value).into_owned());
+        }
+
+        let command = entry
+            .launch
+            .run_command
+            .replace("<ARGS>", &rendered_args.join(" "));
+        let delegated = json!({
+            "server": command.trim(),
+            "name": registry_name,
+            // Registry packages cold-start through npx/uvx downloads; the
+            // 10s default connect budget is routinely exceeded on first
+            // launch. This override is host-supplied only — it is not part
+            // of the model-facing schema of either tool.
+            "connect_timeout": REGISTRY_CONNECT_TIMEOUT_SECS,
+        });
+        crate::tools::runtime_mcp::StartRuntimeMcpServer::new(Arc::clone(&self.pool))
+            .execute(delegated, ctx)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_no_packages_filtered() {
+        let server = RegistryServer {
+            name: "test".into(),
+            description: "desc".into(),
+            packages: None,
+        };
+        assert!(server_to_entry(server).is_none());
+    }
+
+    #[test]
+    fn server_remote_only_filtered() {
+        let server = RegistryServer {
+            name: "test".into(),
+            description: "desc".into(),
+            packages: Some(vec![RegistryPackage {
+                registry_type: "npm".into(),
+                identifier: "@test/pkg".into(),
+                version: Some("1.0.0".into()),
+                runtime_hint: Some("npx".into()),
+                transport: Some("streamable-http".into()),
+                package_arguments: vec![],
+                runtime_arguments: vec![],
+                environment_variables: Value::Null,
+            }]),
+        };
+        assert!(server_to_entry(server).is_none());
+    }
+
+    #[test]
+    fn server_stdio_kept() {
+        let server = RegistryServer {
+            name: "test".into(),
+            description: "desc".into(),
+            packages: Some(vec![RegistryPackage {
+                registry_type: "npm".into(),
+                identifier: "@test/pkg".into(),
+                version: Some("1.0.0".into()),
+                runtime_hint: Some("npx".into()),
+                transport: Some("stdio".into()),
+                package_arguments: vec![],
+                runtime_arguments: vec!["-y".into()],
+                environment_variables: Value::Null,
+            }]),
+        };
+        let entry = server_to_entry(server).unwrap();
+        assert_eq!(entry.launch.run_command, "npx -y @test/pkg@1.0.0 <ARGS>");
+    }
+
+    #[test]
+    fn server_declaring_environment_variables_is_filtered() {
+        let server = RegistryServer {
+            name: "needs-secret".into(),
+            description: "requires an API key".into(),
+            packages: Some(vec![RegistryPackage {
+                registry_type: "npm".into(),
+                identifier: "@test/secret-server".into(),
+                version: Some("1.0.0".into()),
+                runtime_hint: Some("npx".into()),
+                transport: Some("stdio".into()),
+                package_arguments: vec![],
+                runtime_arguments: vec!["-y".into()],
+                environment_variables: json!([{ "name": "API_KEY", "isRequired": true }]),
+            }]),
+        };
+        assert!(server_to_entry(server).is_none());
+    }
+
+    #[test]
+    fn fixed_positional_package_arguments_render_into_run_command() {
+        // Regression for the agentic-mermaid launch failure: upstream
+        // declares `packageArguments: [{"value": "mcp", "type":
+        // "positional"}]` (no `isRequired`), and dropping that token
+        // produced `npx -y agentic-mermaid@0.1.2 <ARGS>` — which starts
+        // the package's default entrypoint, not the MCP server.
+        let server = RegistryServer {
+            name: "io.github.adewale/agentic-mermaid".into(),
+            description: "Render Mermaid diagrams through MCP.".into(),
+            packages: Some(vec![RegistryPackage {
+                registry_type: "npm".into(),
+                identifier: "agentic-mermaid".into(),
+                version: Some("0.1.2".into()),
+                runtime_hint: Some("npx".into()),
+                transport: Some("stdio".into()),
+                package_arguments: vec![RegistryArg {
+                    name: None,
+                    description: None,
+                    is_required: false,
+                    kind: Some("positional".into()),
+                    value: Some("mcp".into()),
+                    default: None,
+                }],
+                runtime_arguments: vec!["-y".into()],
+                environment_variables: Value::Null,
+            }]),
+        };
+        let entry = server_to_entry(server).unwrap();
+        assert_eq!(
+            entry.launch.run_command,
+            "npx -y agentic-mermaid@0.1.2 mcp <ARGS>"
+        );
+        assert!(entry.launch.required_args.is_empty());
+    }
+
+    #[test]
+    fn placeholder_positional_package_argument_stays_in_required_args() {
+        // The flip side: a positional arg with neither `value` nor
+        // `default` is user input (e.g. an allowed directory), not a
+        // fixed token — it must NOT leak into the rendered command.
+        let server = RegistryServer {
+            name: "test".into(),
+            description: "desc".into(),
+            packages: Some(vec![RegistryPackage {
+                registry_type: "npm".into(),
+                identifier: "@test/fs".into(),
+                version: Some("1.0.0".into()),
+                runtime_hint: Some("npx".into()),
+                transport: Some("stdio".into()),
+                package_arguments: vec![RegistryArg {
+                    name: None,
+                    description: Some("Directory to expose".into()),
+                    is_required: true,
+                    kind: Some("positional".into()),
+                    value: None,
+                    default: None,
+                }],
+                runtime_arguments: vec!["-y".into()],
+                environment_variables: Value::Null,
+            }]),
+        };
+        let entry = server_to_entry(server).unwrap();
+        assert_eq!(entry.launch.run_command, "npx -y @test/fs@1.0.0 <ARGS>");
+        assert_eq!(entry.launch.required_args.len(), 1);
+    }
+
+    #[test]
+    fn fixed_argument_with_spaces_preserves_one_process_argument() {
+        let command = build_run_command(
+            "npx",
+            "@test/fs",
+            "1.0.0",
+            &[],
+            &[RegistryArg {
+                name: None,
+                description: None,
+                is_required: false,
+                kind: Some("positional".into()),
+                value: Some("/tmp/a folder".into()),
+                default: None,
+            }],
+        );
+        let parsed = shell_words::split(command.replace("<ARGS>", "").trim()).unwrap();
+        assert_eq!(parsed.last().map(String::as_str), Some("/tmp/a folder"));
+    }
+
+    #[test]
+    fn server_without_explicit_stdio_transport_is_filtered() {
+        let server = RegistryServer {
+            name: "test".into(),
+            description: "desc".into(),
+            packages: Some(vec![RegistryPackage {
+                registry_type: "npm".into(),
+                identifier: "@test/pkg".into(),
+                version: Some("1.0.0".into()),
+                runtime_hint: Some("npx".into()),
+                transport: None,
+                package_arguments: vec![],
+                runtime_arguments: vec![],
+                environment_variables: Value::Null,
+            }]),
+        };
+        assert!(server_to_entry(server).is_none());
+    }
+
+    #[test]
+    fn unsupported_registry_runtime_is_not_advertised() {
+        let server = RegistryServer {
+            name: "container-only".into(),
+            description: "OCI stdio server".into(),
+            packages: Some(vec![RegistryPackage {
+                registry_type: "oci".into(),
+                identifier: "docker.io/example/server:1.0.0".into(),
+                version: None,
+                runtime_hint: Some("docker".into()),
+                transport: Some("stdio".into()),
+                package_arguments: vec![],
+                runtime_arguments: vec![],
+                environment_variables: Value::Null,
+            }]),
+        };
+        assert!(server_to_entry(server).is_none());
+    }
+
+    #[test]
+    fn registry_type_and_runtime_must_match() {
+        let server = RegistryServer {
+            name: "mismatched".into(),
+            description: "invalid npm runner".into(),
+            packages: Some(vec![RegistryPackage {
+                registry_type: "npm".into(),
+                identifier: "example".into(),
+                version: Some("1.0.0".into()),
+                runtime_hint: Some("uvx".into()),
+                transport: Some("stdio".into()),
+                package_arguments: vec![],
+                runtime_arguments: vec![],
+                environment_variables: Value::Null,
+            }]),
+        };
+        assert!(server_to_entry(server).is_none());
+    }
+
+    /// End-to-end smoke test: drive `McpSyncRegistry::execute()` against the
+    /// real MCP Registry API, verify the cache file lands at the right
+    /// location with a valid shape, and verify the returned summary is
+    /// self-consistent.
+    ///
+    /// Marked `#[ignore]` because it depends on:
+    ///   * network access to https://registry.modelcontextprotocol.io
+    ///   * the upstream API schema matching our deserialization types
+    ///   * ~14s of wall clock for the first cold-cache sync
+    ///
+    /// Calls the public tool against an empty cache to exercise cold sync.
+    ///
+    /// Run manually with:
+    ///   cargo test -p codewhale-tui --bin codewhale-tui --locked \
+    ///     execute_writes_cache_file_and_returns_summary -- --ignored --nocapture
+    ///
+    /// This test deliberately overrides `HOME` to a tempdir so it never
+    /// touches the user's real `~/.codewhale/mcp-index.json`.
+    #[tokio::test]
+    #[ignore = "requires network access to the public MCP Registry; \
+                run with `cargo test -- --ignored`"]
+    async fn execute_writes_cache_file_and_returns_summary() {
+        use crate::test_support::{EnvVarGuard, lock_test_env};
+        use crate::tools::spec::ToolContext;
+
+        // Serialize env mutation across all tests in this binary.
+        let _env_lock = lock_test_env();
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Persist the tempdir so we can inspect the cache file after the
+        // test returns. `TempDir::keep` (newer API) disables Drop's
+        // cleanup so the directory leaks — acceptable for a manual-run
+        // integration smoke test that intentionally outlives its scope.
+        let tmp_path = tmp.keep();
+        let _home_guard = EnvVarGuard::set("HOME", &tmp_path);
+
+        let workspace = tmp_path.clone();
+        let ctx = ToolContext::new(workspace);
+
+        let input = json!({});
+
+        let result = McpSyncRegistry
+            .execute(input, &ctx)
+            .await
+            .expect("execute() should not error against the live Registry");
+
+        assert!(
+            result.success,
+            "execute returned non-success: content={}",
+            result.content
+        );
+
+        // Cache file should land under the overridden HOME.
+        let cache_path = tmp_path.join(".codewhale").join("mcp-index.json");
+        assert!(
+            cache_path.exists(),
+            "cache file should exist at {:?}",
+            cache_path
+        );
+
+        // Cache file must be valid JSON matching the McpRegistryIndex
+        // schema. If parsing fails here, either the write code is broken
+        // or the schema drifted from what execute() writes.
+        let raw = std::fs::read_to_string(&cache_path).expect("read cache");
+        let cache: McpRegistryIndex =
+            serde_json::from_str(&raw).expect("cache must parse as McpRegistryIndex");
+
+        // The Registry has hundreds of stdio servers as of 2026; expect at
+        // least 1 from a single page. If this fails the upstream either
+        // removed all stdio entries or our filter is wrong.
+        assert!(
+            cache.count > 0,
+            "expected at least 1 stdio server, got count={}",
+            cache.count
+        );
+        assert_eq!(
+            cache.servers.len(),
+            cache.count,
+            "cache.count must equal cache.servers.len()"
+        );
+        for entry in &cache.servers {
+            assert!(!entry.name.is_empty(), "server entry has empty name");
+            assert!(
+                entry.launch.run_command.ends_with("<ARGS>"),
+                "kept entry {} run_command should end with <ARGS>; got: {}",
+                entry.name,
+                entry.launch.run_command
+            );
+        }
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&result.content).expect("result content must parse");
+        assert_eq!(payload["count"].as_u64(), Some(cache.count as u64));
+        assert_eq!(
+            payload["servers"].as_array().map(Vec::len),
+            Some(cache.count)
+        );
+    }
+
+    fn make_test_cache() -> McpRegistryIndex {
+        let server = McpRegistryServerEntry {
+            name: "io.modelcontextprotocol/filesystem".into(),
+            description: "Read/write local files with sandboxed paths".into(),
+            launch: McpLaunchSpec {
+                run_command: "npx -y @modelcontextprotocol/server-filesystem@1.0.0 <ARGS>".into(),
+                required_args: vec![],
+            },
+        };
+        McpRegistryIndex {
+            version: MCP_REGISTRY_CACHE_VERSION,
+            count: 1,
+            servers: vec![server],
+        }
+    }
+
+    #[test]
+    fn catalog_exposes_every_server_for_model_selection() {
+        let cache = make_test_cache();
+        let catalog = catalog_from_cache(&cache);
+        assert_eq!(catalog.count, 1);
+        assert_eq!(catalog.servers.len(), 1);
+        assert_eq!(
+            catalog.servers[0].name,
+            "io.modelcontextprotocol/filesystem"
+        );
+        assert_eq!(
+            catalog.servers[0].description,
+            "Read/write local files with sandboxed paths"
+        );
+    }
+
+    /// Parse one `ServerResponse` JSON object the way the upstream list
+    /// endpoint ships it. Lifecycle status travels in registry-managed
+    /// `_meta` (`io.modelcontextprotocol.registry/official`), as a
+    /// SIBLING of `server` — not inside the server body — and this
+    /// helper keeps the tests honest about that path.
+    /// https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/api/openapi.yaml
+    fn parse_server_entry(server_json: Value, status: Option<&str>) -> RegistryServerEntry {
+        let mut response = json!({ "server": server_json });
+        if let Some(status) = status {
+            response["_meta"] =
+                json!({ "io.modelcontextprotocol.registry/official": { "status": status } });
+        }
+        serde_json::from_value(response).expect("ServerResponse must deserialize")
+    }
+
+    #[test]
+    fn viable_entries_keeps_only_active_launchable_servers() {
+        let launchable = |name: &str, status: Option<&str>| {
+            parse_server_entry(
+                json!({
+                    "name": name,
+                    "description": "d",
+                    "packages": [{
+                        "registryType": "npm",
+                        "identifier": "@test/pkg",
+                        "version": "1.0.0",
+                        "runtimeHint": "npx",
+                        "transport": "stdio",
+                        "packageArguments": [],
+                        "runtimeArguments": [],
+                        "environmentVariables": null
+                    }]
+                }),
+                status,
+            )
+        };
+        let entries = vec![
+            launchable("a/active", Some("active")),
+            launchable("b/deprecated", Some("deprecated")),
+            launchable("c/deleted", Some("deleted")),
+            // No `_meta` at all: treated as active.
+            launchable("d/no-meta", None),
+            // Missing a launchable package: dropped by the launcher filter.
+            parse_server_entry(json!({ "name": "e/no-pkg", "description": "d" }), None),
+        ];
+
+        let viable = viable_entries(entries);
+
+        let names: Vec<&str> = viable.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, ["a/active", "d/no-meta"]);
+    }
+
+    /// Minimal cache entry — only `name`/`description`/launch matter to the
+    /// catalog conversion tests.
+    fn cache_entry(name: &str, description: &str) -> McpRegistryServerEntry {
+        McpRegistryServerEntry {
+            name: name.into(),
+            description: description.into(),
+            launch: McpLaunchSpec {
+                run_command: "npx pkg@1.0.0 <ARGS>".into(),
+                required_args: vec![],
+            },
+        }
+    }
+
+    #[test]
+    fn catalog_is_not_programmatically_filtered_or_bounded() {
+        let servers = (0..12)
+            .map(|index| cache_entry(&format!("example/file-{index}"), "file server"))
+            .collect::<Vec<_>>();
+        let cache = McpRegistryIndex {
+            version: MCP_REGISTRY_CACHE_VERSION,
+            count: servers.len(),
+            servers,
+        };
+        let result = catalog_from_cache(&cache);
+        assert_eq!(result.count, 12);
+        assert_eq!(result.servers.len(), 12);
+    }
+
+    /// Manual smoke run: execute `McpSyncRegistry` against the live Registry
+    /// API and print the catalog payload + cache file metadata to stdout so an
+    /// operator can inspect what the model would receive. Pure stdout;
+    /// assertions stay minimal so a flaky upstream does not mask a useful
+    /// manual run.
+    ///
+    /// Run with:
+    ///   cargo test -p codewhale-tui --bin codewhale-tui --locked \
+    ///     execute_and_print_catalog_for_manual_inspection -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "manual smoke run; prints the tool result to stdout \
+                (requires network access to registry.modelcontextprotocol.io)"]
+    // The module tree denies `print_stderr` (scroll-demon guard, #1085) so
+    // TUI runtime code can never leak into ratatui's buffer. This test is
+    // the deliberate exception: it only runs manually (`--ignored`) and its
+    // entire purpose is printing the payload for operator inspection.
+    #[allow(clippy::print_stderr)]
+    async fn execute_and_print_catalog_for_manual_inspection() {
+        use crate::test_support::{EnvVarGuard, lock_test_env};
+
+        let _env_lock = lock_test_env();
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Persist the tempdir past the test so the cache file survives and
+        // can be inspected from the shell after the test returns.
+        let tmp_path = tmp.keep();
+        let _home_guard = EnvVarGuard::set("HOME", &tmp_path);
+
+        let ctx = ToolContext::new(tmp_path.clone());
+
+        let input = json!({});
+
+        let result = McpSyncRegistry
+            .execute(input, &ctx)
+            .await
+            .expect("execute() should not error against the live Registry");
+
+        let cache_path = tmp_path.join(".codewhale").join("mcp-index.json");
+
+        eprintln!("\n=== registry_sync output ===");
+        eprintln!("tool:               registry_sync");
+        eprintln!(
+            "status:             {}",
+            if result.success { "ok" } else { "fail" }
+        );
+        eprintln!("cache_path:         {}", cache_path.display());
+        eprintln!("cache_exists:       {}", cache_path.exists());
+        if cache_path.exists() {
+            match std::fs::metadata(&cache_path) {
+                Ok(meta) => eprintln!("cache_size_bytes:   {}", meta.len()),
+                Err(e) => eprintln!("cache_stat_error:   {e}"),
+            }
+        }
+        eprintln!("--- catalog payload (what the model sees) ---");
+        eprintln!("{}", result.content);
+        eprintln!("=== end ===\n");
+    }
+}

--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -36,6 +36,7 @@ pub mod image_ocr;
 pub mod js_execution;
 pub mod large_output_router;
 pub mod lsp;
+pub mod mcp_registry;
 pub mod native_memory;
 pub mod notify;
 pub mod pandoc;

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -987,6 +987,30 @@ impl ToolRegistryBuilder {
         self
     }
 
+    /// Register the `registry_sync` tool for fetching and caching
+    /// MCP Registry server metadata.
+    #[must_use]
+    pub fn with_registry_mcp_sync_tool(mut self) -> Self {
+        self.tools
+            .push(Arc::new(super::mcp_registry::McpSyncRegistry));
+        self
+    }
+
+    /// Register the structured Registry launcher. Unlike `start_mcp_server`,
+    /// this accepts no free-form command and can only launch cached,
+    /// zero-environment stdio candidates.
+    #[must_use]
+    pub fn with_registry_mcp_start_tool(
+        mut self,
+        mcp_pool: std::sync::Arc<tokio::sync::Mutex<crate::mcp::McpPool>>,
+    ) -> Self {
+        self.tools
+            .push(Arc::new(super::mcp_registry::StartRegistryMcpServer::new(
+                mcp_pool,
+            )));
+        self
+    }
+
     /// Include all agent tools under a typed shell policy.
     #[must_use]
     pub fn with_agent_tools_policy(self, shell_policy: crate::worker_profile::ShellPolicy) -> Self {

--- a/crates/tui/src/tools/runtime_mcp.rs
+++ b/crates/tui/src/tools/runtime_mcp.rs
@@ -255,8 +255,14 @@ impl ToolSpec for StartRuntimeMcpServer {
             .ok_or_else(|| ToolError::invalid_input("Missing required field: server"))?;
 
         let custom_name = input.get("name").and_then(|v| v.as_str());
-        let parsed =
+        let mut parsed =
             parse_mcp_command(server).map_err(|e| ToolError::invalid_input(e.to_string()))?;
+        // Host-supplied override (used by the Registry launcher, whose
+        // packages cold-start via npx/uvx downloads). Not exposed on the
+        // model-facing schema, so the model cannot widen its own timeouts.
+        if let Some(timeout) = input.get("connect_timeout").and_then(Value::as_u64) {
+            parsed.config.connect_timeout = Some(timeout);
+        }
 
         // Reject shell-wrapped commands that could execute arbitrary code
         if let Some(ref cmd) = parsed.config.command {
@@ -337,12 +343,14 @@ impl ToolSpec for StartRuntimeMcpServer {
         let mut pool = self.pool.lock().await;
         pool.add_runtime_server_config(server_name.clone(), parsed.config)
             .map_err(ToolError::invalid_input)?;
-        let conn = pool.get_or_connect(&server_name).await.map_err(|e| {
-            ToolError::execution_failed(format!(
-                "Failed to connect to MCP server '{}': {e}",
-                server_name
-            ))
-        })?;
+        let conn = match pool.get_or_connect(&server_name).await {
+            Ok(conn) => conn,
+            Err(error) => {
+                let message = connect_failure_message(&server_name, &error);
+                pool.remove_runtime_server_config(&server_name);
+                return Err(ToolError::execution_failed(message));
+            }
+        };
 
         let mcp_tools: Vec<McpTool> = conn.tools().to_vec();
 
@@ -374,8 +382,42 @@ impl ToolSpec for StartRuntimeMcpServer {
         }))
         .unwrap_or_else(|_| "{}".to_string());
 
-        Ok(ToolResult::success(result))
+        let mut output = ToolResult::success(result);
+        output.metadata = Some(json!({ "mcp_catalog_changed": true }));
+        Ok(output)
     }
+}
+
+/// Build the connect-failure message returned to the model. A spawned
+/// package that prints its CLI help and exits (the classic
+/// missing-subcommand case, e.g. `npx -y agentic-mermaid@0.1.2` without
+/// `mcp`) surfaces as `Stdio transport closed` before the handshake
+/// completes — a bare transport error gives the model no signal about
+/// *why*, and it tends to abandon the MCP route after one failed server.
+/// Classify that early-exit shape, note when the captured output looks
+/// like usage help, and point recovery at the registry: verify the exact
+/// structured arguments returned by `registry_sync`, then fall through to
+/// the next candidate from the search results instead of giving up.
+fn connect_failure_message(server_name: &str, err: &anyhow::Error) -> String {
+    let text = format!("{err:#}");
+    let base = format!("Failed to connect to MCP server '{server_name}': {text}");
+    let early_exit =
+        text.contains("Stdio transport closed") || text.contains("Stdio transport read error");
+    if !early_exit {
+        return base;
+    }
+    let looks_like_help = text.contains("usage")
+        || text.contains("Usage")
+        || text.contains("--help")
+        || text.contains("Commands:");
+    let help_note = if looks_like_help {
+        " Its output above looks like CLI usage help."
+    } else {
+        ""
+    };
+    format!(
+        "{base}\n\nThe server process exited before completing the MCP handshake.{help_note} The launch arguments are usually incomplete in this case (missing subcommand or required argument). For Registry-discovered servers, verify the structured required_args returned by registry_sync and retry; if this server still will not start, try the next candidate from the Registry catalog."
+    )
 }
 
 #[cfg(test)]
@@ -440,6 +482,38 @@ mod tests {
         assert_eq!(
             extract_name_from_url("https://example.com/").unwrap(),
             "example-com"
+        );
+    }
+
+    #[test]
+    fn connect_failure_message_flags_early_exit_with_help_output() {
+        let err = anyhow::anyhow!(
+            "Stdio transport closed\nMCP server stderr (last 2 lines):\nUsage: agentic-mermaid [OPTIONS] <COMMAND>"
+        );
+        let msg = connect_failure_message("agentic-mermaid", &err);
+        assert!(msg.contains("Failed to connect to MCP server 'agentic-mermaid'"));
+        assert!(msg.contains("exited before completing the MCP handshake"));
+        assert!(msg.contains("looks like CLI usage help"));
+        assert!(msg.contains("required_args"));
+        assert!(msg.contains("next candidate"));
+    }
+
+    #[test]
+    fn connect_failure_message_flags_early_exit_without_help_output() {
+        let err = anyhow::anyhow!("Stdio transport closed");
+        let msg = connect_failure_message("x", &err);
+        assert!(msg.contains("exited before completing the MCP handshake"));
+        assert!(!msg.contains("usage help"));
+        assert!(msg.contains("required_args"));
+    }
+
+    #[test]
+    fn connect_failure_message_passes_other_errors_through() {
+        let err = anyhow::anyhow!("connection refused");
+        let msg = connect_failure_message("x", &err);
+        assert_eq!(
+            msg,
+            "Failed to connect to MCP server 'x': connection refused"
         );
     }
 

--- a/crates/tui/src/tools/truncate.rs
+++ b/crates/tui/src/tools/truncate.rs
@@ -400,6 +400,13 @@ pub fn apply_spillover_with_artifact(
     tool_name: &str,
     session_id: &str,
 ) -> Option<PathBuf> {
+    // Registry discovery intentionally sends the complete eligible catalog to
+    // the model for semantic selection. Spilling it here would replace most of
+    // that candidate set with an artifact pointer before context shaping gets
+    // a chance to preserve it.
+    if tool_name == "registry_sync" {
+        return None;
+    }
     apply_spillover_inner(
         result,
         tool_id,
@@ -1340,6 +1347,24 @@ mod tests {
                 "metadata failure must leave no payload behind a guessable handle"
             );
         });
+    }
+
+    #[test]
+    fn registry_catalog_is_never_spilled_out_of_model_context() {
+        let original = "registry-entry\n".repeat(10_000);
+        assert!(original.len() > SPILLOVER_THRESHOLD_BYTES);
+        let mut result = ToolResult::success(original.clone());
+
+        let path = apply_spillover_with_artifact(
+            &mut result,
+            "call-registry",
+            "registry_sync",
+            "session-registry",
+        );
+
+        assert!(path.is_none());
+        assert_eq!(result.content, original);
+        assert!(result.metadata.is_none());
     }
 
     #[test]

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -2048,6 +2048,10 @@ mod tests {
             get_tool_category("mcp_linear_save_issue"),
             ToolCategory::McpAction
         );
+        assert_eq!(
+            get_tool_category("start_registry_mcp_server"),
+            ToolCategory::McpAction
+        );
         assert_eq!(get_tool_category("list_mcp_tools"), ToolCategory::McpRead);
     }
 
@@ -2082,6 +2086,11 @@ mod tests {
             classify_risk("web_search", cat, &json!({"q": "rust"})),
             RiskLevel::Benign
         );
+        // Registry discovery mirrors web_search: query-only network → Benign.
+        assert_eq!(
+            classify_risk("registry_sync", cat, &json!({})),
+            RiskLevel::Benign
+        );
         // fetch_url pulls arbitrary remote content, so it stays destructive.
         assert_eq!(
             classify_risk("fetch_url", cat, &json!({"url": "https://example.com"})),
@@ -2102,6 +2111,7 @@ mod tests {
             ("apply_patch", ToolCategory::FileWrite),
             ("exec_shell", ToolCategory::Shell),
             ("mcp_linear_save_issue", ToolCategory::McpAction),
+            ("start_registry_mcp_server", ToolCategory::McpAction),
             ("totally_new_tool", ToolCategory::Unknown),
         ] {
             assert_eq!(

--- a/crates/tui/src/tui/approval/policy.rs
+++ b/crates/tui/src/tui/approval/policy.rs
@@ -74,7 +74,7 @@ pub fn get_tool_category(name: &str) -> ToolCategory {
         ToolCategory::FileWrite
     } else if matches!(
         name,
-        "web_run" | "web_search" | "fetch_url" | "wait_for_dev_server"
+        "web_run" | "web_search" | "fetch_url" | "wait_for_dev_server" | "registry_sync"
     ) {
         ToolCategory::Network
     } else if matches!(
@@ -121,7 +121,7 @@ pub fn get_tool_category(name: &str) -> ToolCategory {
         || name.starts_with("get_")
     {
         ToolCategory::Safe
-    } else if name == "start_mcp_server" {
+    } else if matches!(name, "start_mcp_server" | "start_registry_mcp_server") {
         // Starting an MCP server spawns child processes or opens network
         // connections — classify as McpAction to trigger appropriate
         // approval prompts.
@@ -172,7 +172,7 @@ pub fn classify_risk(tool_name: &str, category: ToolCategory, params: &Value) ->
         // Query-only network is benign; opening a URL pulls arbitrary
         // remote content, so it stays destructive.
         ToolCategory::Network => match tool_name {
-            "web_search" | "wait_for_dev_server" => RiskLevel::Benign,
+            "web_search" | "wait_for_dev_server" | "registry_sync" => RiskLevel::Benign,
             // web_run is benign for search/query, but its `open`/`click`
             // actions fetch model-supplied URLs (arbitrary remote content) -
             // destructive, consistent with fetch_url.

--- a/crates/tui/src/tui/history/tool_run.rs
+++ b/crates/tui/src/tui/history/tool_run.rs
@@ -189,7 +189,9 @@ fn classify_tool_name_activity(name: &str) -> ToolRunActivity {
     match normalized.as_str() {
         "read_file" | "list_dir" | "view_image" | "explore" | "git_status" | "git_diff"
         | "git_log" | "git_show" | "git_blame" => ToolRunActivity::File,
-        "grep_files" | "file_search" | "web_search" | "fetch_url" => ToolRunActivity::Search,
+        "grep_files" | "file_search" | "web_search" | "fetch_url" | "registry_sync" => {
+            ToolRunActivity::Search
+        }
         "shell"
         | "exec_shell"
         | "exec_shell_wait"
@@ -197,6 +199,7 @@ fn classify_tool_name_activity(name: &str) -> ToolRunActivity {
         | "exec_shell_cancel"
         | "task_shell_start"
         | "task_shell_wait"
+        | "start_registry_mcp_server"
         | "run_tests"
         | "run_verifiers"
         | "wait_for_dev_server"

--- a/crates/tui/src/tui/widgets/tool_card.rs
+++ b/crates/tui/src/tui/widgets/tool_card.rs
@@ -87,8 +87,11 @@ pub fn tool_family_for_name(name: &str) -> ToolFamily {
         | "exec_shell_interact"
         | "exec_shell_cancel"
         | "task_shell_start"
-        | "task_shell_wait" => ToolFamily::Run,
-        "grep_files" | "file_search" | "web_search" | "fetch_url" => ToolFamily::Find,
+        | "task_shell_wait"
+        | "start_registry_mcp_server" => ToolFamily::Run,
+        "grep_files" | "file_search" | "web_search" | "fetch_url" | "registry_sync" => {
+            ToolFamily::Find
+        }
         "agent" => ToolFamily::Delegate,
         "rlm_open" | "rlm_eval" | "rlm_configure" | "rlm_close" | "rlm" => ToolFamily::Rlm,
         "run_tests"


### PR DESCRIPTION
## Summary

Add MCP Registry discovery with a Registry-first tool-selection policy: before the model reaches for `exec_shell`, custom code, or a manual implementation, it consults the public MCP Registry for a matching zero-environment stdio server.

- **`registry_sync`** — fetches the eligible zero-environment stdio catalog (paginated to completion with a bounded retry on fetch failure) and atomically replaces the local cache (no merge, TTL, or eviction bookkeeping). The result is kept intact through context compaction/spillover so the model always sees every candidate.
- **`start_registry_mcp_server`** — structured launcher that only starts cached Registry packages with host-constructed commands; there is no free-form command or env channel.
- **Registry-first policy** — injected into the initial system prompt and the `exec_shell` tool description while MCP is enabled (feature-gated).
- **In-turn schema merge** — runtime MCP connections merge their tool schemas into the current turn, so newly started servers are callable immediately.
- **`mcp-discovery` bundled skill** — documents the Registry-first workflow and match semantics.
- **Access posture** — Full Access / `--auto` auto-approves `start_registry_mcp_server` (host-constructed, cache-bound; unlike `start_mcp_server`'s free-form command); Ask mode still requires approval. Registry-launched servers get a 60s connect budget for `npx`/`uvx` cold starts instead of the 10s default; the override is host-supplied only and never exposed on the model-facing schema.

Verified end-to-end: the model ran `registry_sync`, matched a Registry server covering document conversion, started it, and converted a markdown file to PDF through its MCP tools without hand-written shell code.

## Context cost

Measured against the current registry catalog (389 servers):

- **Fixed per-request overhead** (MCP enabled): the Registry-first policy instruction (~915 chars ≈ 230 tokens) + the `exec_shell` guidance (~568 chars ≈ 140 tokens) + the two new tool schemas (~1.5–2KB ≈ 500 tokens). Roughly **500–900 tokens** on top of the pre-feature system prompt.
- **Dynamic when `registry_sync` runs**: the tool result carries the full eligible catalog — **~66KB ≈ 16K tokens** (name + description + required_args per server, plus the selection policy). This is deliberate: the complete candidate set is preserved through compaction/spillover so the model can match semantically, and it enters context once per sync call rather than every request.

## Testing

<!-- Exact gate commands (including the clippy allow list) are in
     CONTRIBUTING.md → "Pre-push verification". -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [x] `cargo test --workspace --all-features --locked`

Local run results: 9561 passed; 6 failed (codewhale-tui bin; all other workspace crates green). All 6 failures are environment/machine-state dependent, reproduce identically on the base commit (base comparison run at `cc8bbb1bb`), and are unrelated to this change:

- `sandbox::seatbelt::tests::*` (2) — host macOS 26 no longer ships `sandbox-exec`, so the generated policy cannot be parsed ("UNRUN: macOS sandbox-exec is unavailable"). Platform-bound suite per CONTRIBUTING.md.
- `tools::subagent::tests::git_repo_root_reports_attempted_paths_when_no_repo_found` — the test assumes the home directory is not inside a git repository; this machine's `~` is a git repo.
- `commands::groups::config::config::tests::settings_command_opens_typed_editor_and_preserves_text_mode` — hits the real `~/.codewhale/settings.toml.lock` on this machine and cannot acquire the lock.
- `tui::ui::tests::underwater_motion_keeps_its_smoother_cadence_during_live_status` — wall-clock frame-count assertion (41 vs 80) under host load.
- `tui::ui::tests::xai_api_key_confirmation_saves_only_the_selected_xai_slot` — focus-switch timing assertion under host load.

Note: the test profile emits one `linker_messages` rustc warning (`__eh_frame section too large` on ld compact unwind) — a toolchain/linker note, not a code warning; clippy is clean under `-D warnings`.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A — new contribution)

