### PR TITLE
feat(tui/shell): surface real wait elapsed time in tool content

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -3625,6 +3625,12 @@ fn build_shell_delta_tool_result(delta: ShellDeltaResult, context: &ToolContext)
     } else {
         format!("{}\n\nSTDERR:\n{}", result.stdout, result.stderr)
     };
+    // The model cannot see metadata, so surface the real elapsed time in the
+    // visible content. Without it every wait result looks identical whether
+    // the task just started or has been running for minutes, which biases the
+    // model into busy-polling short waits and misjudging long ones.
+    output = format!("{}\n\n{output}", wait_timing_line(&result));
+
     if let Some(hint) = network_restricted_hint.as_deref() {
         output = format!("{hint}\n\n{output}");
     }
@@ -3681,6 +3687,36 @@ fn build_shell_delta_tool_result(delta: ShellDeltaResult, context: &ToolContext)
         object.insert("macos_provenance_restricted".to_string(), json!(true));
     }
     tool_result
+}
+
+/// Human-readable elapsed time for a shell task ("450 ms", "12.3 s", "2m5s").
+fn format_elapsed_ms(ms: u64) -> String {
+    if ms < 1_000 {
+        format!("{ms} ms")
+    } else if ms < 60_000 {
+        let secs = ms as f64 / 1_000.0;
+        format!("{secs} s")
+    } else {
+        let total_secs = ms / 1_000;
+        format!("{}m{}s", total_secs / 60, total_secs % 60)
+    }
+}
+
+/// One-line status + elapsed summary for wait/delta results, placed at the top
+/// of the visible content so the model can judge how long it actually waited.
+fn wait_timing_line(result: &ShellResult) -> String {
+    let status_phrase = match result.status {
+        ShellStatus::Running => "still running",
+        ShellStatus::Completed => "completed",
+        ShellStatus::Failed => "failed",
+        ShellStatus::Killed => "killed",
+        ShellStatus::TimedOut => "timed out",
+    };
+    let elapsed = format_elapsed_ms(result.duration_ms);
+    match result.task_id.as_deref() {
+        Some(task_id) => format!("Task {task_id} {status_phrase} after {elapsed}."),
+        None => format!("Task {status_phrase} after {elapsed}."),
+    }
 }
 
 async fn wait_for_shell_delta_cancellable(

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -1149,6 +1149,139 @@ fn shell_delta_result_exposes_lossless_high_exit_code_and_hex() {
 }
 
 #[test]
+fn shell_delta_result_surfaces_elapsed_time_in_content() {
+    let tmp = tempdir().expect("tempdir");
+    let ctx = ToolContext::new(tmp.path());
+    let mut result = failed_network_shell_result("", "");
+    result.status = ShellStatus::Running;
+    result.duration_ms = 42_500;
+    result.task_id = Some("shell-7".to_string());
+
+    let tool_result = build_shell_delta_tool_result(
+        ShellDeltaResult {
+            command: "cargo test --workspace".to_string(),
+            result,
+            stdout_total_len: 0,
+            stderr_total_len: 0,
+        },
+        &ctx,
+    );
+
+    assert!(
+        tool_result
+            .content
+            .starts_with("Task shell-7 still running after 42.5 s."),
+        "{}",
+        tool_result.content
+    );
+}
+
+#[test]
+fn shell_delta_timing_line_omits_task_id_when_unknown() {
+    let tmp = tempdir().expect("tempdir");
+    let ctx = ToolContext::new(tmp.path());
+    // failed_network_shell_result: ShellStatus::Failed, duration_ms: 25, task_id: None.
+    let result = failed_network_shell_result("", "");
+
+    let tool_result = build_shell_delta_tool_result(
+        ShellDeltaResult {
+            command: "echo probe".to_string(),
+            result,
+            stdout_total_len: 0,
+            stderr_total_len: 0,
+        },
+        &ctx,
+    );
+
+    assert!(
+        tool_result.content.starts_with("Task failed after 25 ms."),
+        "{}",
+        tool_result.content
+    );
+}
+
+#[test]
+fn shell_delta_timing_line_phrases_cover_terminal_statuses() {
+    let tmp = tempdir().expect("tempdir");
+    let ctx = ToolContext::new(tmp.path());
+    for (status, phrase) in [
+        (ShellStatus::Completed, "completed"),
+        (ShellStatus::Killed, "killed"),
+        (ShellStatus::TimedOut, "timed out"),
+    ] {
+        let mut result = failed_network_shell_result("", "");
+        result.status = status;
+        result.duration_ms = 5_000;
+        let tool_result = build_shell_delta_tool_result(
+            ShellDeltaResult {
+                command: "echo probe".to_string(),
+                result,
+                stdout_total_len: 0,
+                stderr_total_len: 0,
+            },
+            &ctx,
+        );
+        assert!(
+            tool_result
+                .content
+                .starts_with(&format!("Task {phrase} after 5 s.")),
+            "{}",
+            tool_result.content
+        );
+    }
+}
+
+#[test]
+fn shell_delta_timing_line_handles_zero_duration() {
+    let tmp = tempdir().expect("tempdir");
+    let ctx = ToolContext::new(tmp.path());
+    let mut result = failed_network_shell_result("", "");
+    result.status = ShellStatus::Completed;
+    result.duration_ms = 0;
+    let tool_result = build_shell_delta_tool_result(
+        ShellDeltaResult {
+            command: "echo probe".to_string(),
+            result,
+            stdout_total_len: 0,
+            stderr_total_len: 0,
+        },
+        &ctx,
+    );
+    assert!(
+        tool_result
+            .content
+            .starts_with("Task completed after 0 ms."),
+        "{}",
+        tool_result.content
+    );
+}
+
+#[test]
+fn shell_delta_timing_line_sits_below_network_hint() {
+    let tmp = tempdir().expect("tempdir");
+    let ctx = network_restricted_context(tmp.path());
+    let result = failed_network_shell_result("000", "");
+    let tool_result = build_shell_delta_tool_result(
+        ShellDeltaResult {
+            command: "gh issue list".to_string(),
+            result,
+            stdout_total_len: 3,
+            stderr_total_len: 0,
+        },
+        &ctx,
+    );
+    let content = tool_result.content;
+    let hint_pos = content.find("Shell command blocked").expect("hint present");
+    let timing_pos = content
+        .find("failed after 25 ms")
+        .expect("timing line present");
+    assert!(
+        hint_pos < timing_pos,
+        "hint must precede timing line: {content}"
+    );
+}
+
+#[test]
 fn shell_delta_result_includes_cargo_failure_summary() {
     let tmp = tempdir().expect("tempdir");
     let ctx = ToolContext::new(tmp.path());

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -183,7 +183,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 172,
   "max_module_lines": 19139,
-  "max_total_owned_rust_lines": 649063,
+  "max_total_owned_rust_lines": 649099,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
## Summary

The Bash `wait`/delta tool result kept `duration_ms` only in tool metadata, which the model cannot see. Every wait result therefore looked identical whether the task just started or had been running for minutes, biasing the model into busy-polling short waits and misjudging long stalls. This change surfaces the real elapsed time in the visible content so the model can judge how long it actually waited and decide whether to keep waiting.

Live repro (2026-08-04): a stalled clippy run reported "running" via wait while no new process existed; the model wasted ~30 minutes of waits because the timing information was invisible.

Another example: a process had been running for less than three minutes, but the AI issued several 300‑second waits without forcing the wait to end early. The AI then mistakenly assumed the task had been running for tens of minutes, flagged an anomaly, and forcibly terminated the process.

## Changes

- **`build_shell_delta_tool_result` (shell.rs)**: prefixes the visible content with a timing line built from `wait_timing_line()`, e.g. `Task shell-7 still running after 42.5 s.` / `Task failed after 25 ms.` / `Task completed after 2m5s.`. Task id is omitted when unknown. Hints (network-restricted / provenance / python) remain at the top of the content.
- **`format_elapsed_ms` helper**: human-readable duration (`450 ms`, `12.3 s`, `2m5s`).
- **Tests**: 5 new unit tests — elapsed time in content, task-id-less line, all terminal `ShellStatus` phrases (Completed/Killed/TimedOut), zero duration, and hint → timing → body ordering.
- **`source-structure-budget.json`**: `max_total_owned_rust_lines` 649063 → 649099 (aggregate production Rust growth of exactly 36 lines in shell.rs; the budget ratchet requires an explicit update).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Tests

## Testing

<!-- Exact gate commands (including the clippy allow list) are in
     CONTRIBUTING.md → "Pre-push verification". -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-tui` (no new warnings; the only warning is a pre-existing `needless_return` at `mcp.rs:262` inside a `#[cfg(windows)]` block, invisible to the ubuntu CI runner)
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list) — not run locally; CI will run it
- [x] `cargo test -p codewhale-tui shell_delta` (10/10 pass) and `cargo test -p codewhale-tui wait` (63/63 pass)
- [ ] `cargo test --workspace --all-features --locked` — not run locally (heavy); CI will run it
- [x] `python3 scripts/check-source-structure-budget.py` (PASS after budget update)
- [x] `python3 scripts/check-dead-code-budget.py` (463/466)
- [x] `python3 scripts/check-coauthor-trailers.py --range origin/main..HEAD` (PASS)

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (N/A — no UI change)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (no human co-authors; agent assistance noted in commit body)

## Related Issues

No-Issue: harness improvement backlog item (wait timing visibility), no public issue number.
