### PR TITLE
feat(tui/subagent): resume interrupted children from checkpoint via followup

### DIFF
--- a/crates/tui/src/tools/subagent/coord.rs
+++ b/crates/tui/src/tools/subagent/coord.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use super::{
-    COMPLETED_AGENT_RETENTION, SharedSubAgentManager, SubAgentRuntime, SubAgentStatus,
-    parse_agent_ref, subagent_session_projection, subagent_status_name,
+    COMPLETED_AGENT_RETENTION, ParentMailReceipt, SharedSubAgentManager, SubAgentRuntime,
+    SubAgentStatus, parse_agent_ref, subagent_session_projection, subagent_status_name,
     wait_for_subagents_from_input,
 };
 use crate::tools::registry::ToolRegistryBuilder;
@@ -232,6 +232,9 @@ impl ToolSpec for AgentsMessageTool {
 pub struct AgentsFollowupTool {
     manager: SharedSubAgentManager,
     caller_agent_id: Option<String>,
+    /// Runtime for checkpoint resume. `None` (legacy/test construction)
+    /// keeps the queue-only followup behavior.
+    runtime: Option<SubAgentRuntime>,
 }
 
 impl AgentsFollowupTool {
@@ -240,7 +243,14 @@ impl AgentsFollowupTool {
         Self {
             manager,
             caller_agent_id: None,
+            runtime: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_runtime(mut self, runtime: SubAgentRuntime) -> Self {
+        self.runtime = Some(runtime);
+        self
     }
 
     #[must_use]
@@ -257,7 +267,7 @@ impl ToolSpec for AgentsFollowupTool {
     }
 
     fn description(&self) -> &'static str {
-        "Queue a message and attempt to resume an idle or interrupted child. Running children receive the message on their next step; interrupted_continuable children keep a checkpoint and return the continuation_handle — live in-place resume is not automated yet (re-dispatch via agent)."
+        "Queue a message and attempt to resume an idle or interrupted child. Running children receive the message on their next step; interrupted_continuable children are resumed from their checkpoint into a fresh agent loop (new agent id, original prompt plus prior conversation tail) when a runtime is attached, and otherwise keep queue-only semantics with the continuation_handle returned."
     }
 
     fn input_schema(&self) -> Value {
@@ -297,8 +307,12 @@ impl ToolSpec for AgentsFollowupTool {
             .ok_or_else(|| ToolError::missing_field("message"))?
             .to_string();
 
-        let receipt = {
-            let mut manager = self.manager.write().await;
+        // Enforce the caller hierarchy, then decide between checkpoint resume
+        // (interrupted_continuable with a runtime attached) and queue-only
+        // followup while holding only the read lock. The resume path takes
+        // the write lock itself via the manager method.
+        let should_resume = {
+            let manager = self.manager.read().await;
             manager
                 .ensure_caller_controls_descendant(
                     &agent_ref,
@@ -306,6 +320,52 @@ impl ToolSpec for AgentsFollowupTool {
                     "agents/followup",
                 )
                 .map_err(|err| ToolError::invalid_input(err.to_string()))?;
+            manager
+                .get_result_by_ref(&agent_ref)
+                .ok()
+                .is_some_and(|snapshot| {
+                    matches!(snapshot.status, SubAgentStatus::Interrupted(_))
+                        && snapshot
+                            .checkpoint
+                            .as_ref()
+                            .is_some_and(|cp| cp.continuable && !cp.messages.is_empty())
+                })
+        };
+
+        let receipt = if should_resume {
+            match self.runtime.clone() {
+                Some(runtime) => {
+                    let mut manager = self.manager.write().await;
+                    let snapshot = manager
+                        .resume_from_checkpoint(
+                            Arc::clone(&self.manager),
+                            runtime,
+                            &agent_ref,
+                            &message,
+                        )
+                        .map_err(|err| ToolError::execution_failed(err.to_string()))?;
+                    ParentMailReceipt {
+                        agent_id: snapshot.agent_id.clone(),
+                        status: subagent_status_name(&snapshot.status).to_string(),
+                        queue_depth: 0,
+                        woke: true,
+                        continued_from_checkpoint: true,
+                        continuation_handle: None,
+                        note: format!(
+                            "resumed from checkpoint as new agent {} ({}); prior terminal record {} stays intact",
+                            snapshot.agent_id, snapshot.model, agent_ref
+                        ),
+                    }
+                }
+                None => {
+                    let mut manager = self.manager.write().await;
+                    manager
+                        .followup_child(&agent_ref, message)
+                        .map_err(|err| ToolError::invalid_input(err.to_string()))?
+                }
+            }
+        } else {
+            let mut manager = self.manager.write().await;
             manager
                 .followup_child(&agent_ref, message)
                 .map_err(|err| ToolError::invalid_input(err.to_string()))?
@@ -698,8 +758,9 @@ pub fn register_coordination_tools(
     // root registry (`None`) may control any child (TUI-DOG-017).
     let caller = runtime.parent_agent_id.clone();
     let message = AgentsMessageTool::new(Arc::clone(&manager)).with_optional_caller(caller.clone());
-    let followup =
-        AgentsFollowupTool::new(Arc::clone(&manager)).with_optional_caller(caller.clone());
+    let followup = AgentsFollowupTool::new(Arc::clone(&manager))
+        .with_optional_caller(caller.clone())
+        .with_runtime(runtime.clone());
     let interrupt =
         AgentsInterruptTool::new(Arc::clone(&manager)).with_optional_caller(caller.clone());
     let coordinate = AgentsCoordinateTool::new(Arc::clone(&manager), caller);
@@ -1245,7 +1306,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn followup_interrupted_continuable_queues_honestly_without_auto_resume() {
+    async fn followup_interrupted_continuable_without_runtime_queues_honestly() {
         let tmp = tempdir().unwrap();
         let manager = Arc::new(tokio::sync::RwLock::new(
             super::super::SubAgentManager::new(tmp.path().to_path_buf(), 4),
@@ -1264,6 +1325,8 @@ mod tests {
                 }],
             )
         };
+        // No runtime attached: checkpoint resume is unavailable, so followup
+        // keeps the honest queue-only semantics with the continuation handle.
         let tool = AgentsFollowupTool::new(Arc::clone(&manager));
         let result = tool
             .execute(
@@ -1279,13 +1342,63 @@ mod tests {
         assert_eq!(body["continuation_handle"], json!(handle));
         let note = body["note"].as_str().unwrap_or_default();
         assert!(
-            note.contains("not automated") && note.contains(&handle),
-            "note must fail honestly with the continuation handle: {note}"
+            note.contains("attach a runtime") && note.contains(&handle),
+            "note must point at the resume path with the continuation handle: {note}"
         );
 
         let guard = manager.read().await;
         assert_eq!(guard.queued_mail_depth(&agent_id).unwrap(), 1);
         assert!(!guard.child_was_woken(&agent_id));
+    }
+
+    #[tokio::test]
+    async fn followup_interrupted_continuable_resumes_with_runtime() {
+        let tmp = tempdir().unwrap();
+        let manager = Arc::new(tokio::sync::RwLock::new(
+            super::super::SubAgentManager::new(tmp.path().to_path_buf(), 4),
+        ));
+        let (agent_id, _handle) = {
+            let mut guard = manager.write().await;
+            guard.insert_test_interrupted_continuable_agent(
+                "paused_child",
+                tmp.path(),
+                vec![crate::models::Message {
+                    role: "user".to_string(),
+                    content: vec![crate::models::ContentBlock::Text {
+                        text: "prior work".to_string(),
+                        cache_control: None,
+                    }],
+                }],
+            )
+        };
+        let mut runtime = super::super::tests::stub_runtime();
+        runtime.manager = Arc::clone(&manager);
+        let tool = AgentsFollowupTool::new(Arc::clone(&manager)).with_runtime(runtime);
+        let result = tool
+            .execute(
+                json!({ "agent_id": agent_id, "message": "please continue" }),
+                &ToolContext::new(tmp.path()),
+            )
+            .await
+            .expect("followup ok");
+        let body: Value = serde_json::from_str(&result.content).unwrap();
+        assert_eq!(body["queued"], json!(true));
+        assert_eq!(body["woke"], json!(true));
+        assert_eq!(body["continued_from_checkpoint"], json!(true));
+        let note = body["note"].as_str().unwrap_or_default();
+        assert!(note.contains("resumed from checkpoint"), "{note}");
+        let resumed_id = body["agent_id"].as_str().unwrap_or_default();
+        assert_ne!(
+            resumed_id, agent_id,
+            "resume re-dispatches under a new agent id"
+        );
+
+        // A fresh record exists for the resumed session; the prior terminal
+        // record stays immutable (receipts are never rewritten).
+        let guard = manager.read().await;
+        guard.get_result(resumed_id).expect("resumed agent exists");
+        let prior = guard.get_result(&agent_id).expect("prior record");
+        assert!(matches!(prior.status, SubAgentStatus::Interrupted(_)));
     }
 }
 

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -1354,6 +1354,12 @@ pub(crate) struct SubAgentSpawnOptions {
     pub write_claim: Option<WriteScopeClaim>,
     pub isolated_worktree: bool,
     pub expected_artifact: Option<String>,
+    /// Checkpoint resume: the claim comes from the coordination ledger and is
+    /// already namespaced — skip re-namespacing in the spawn seam.
+    pub claim_pre_namespaced: bool,
+    /// Checkpoint resume: preserve the interrupted child's runtime posture
+    /// instead of rebuilding it from the caller's role.
+    pub preserve_runtime_profile: Option<WorkerRuntimeProfile>,
 }
 
 #[derive(Debug, Clone)]
@@ -2691,6 +2697,11 @@ pub struct SubAgentManager {
     queued_mail: HashMap<String, VecDeque<QueuedParentMessage>>,
     /// Test/observability: agent ids that received a live wake via followup.
     woken_agents: HashMap<String, bool>,
+    /// Checkpoint-resume idempotency map: interrupted agent id -> the agent
+    /// id of the session resumed from its checkpoint. A second followup on
+    /// the same interrupted id returns the existing resumed target instead of
+    /// spawning a duplicate agent loop (duplicate-resume guard).
+    resume_targets: HashMap<String, String>,
 }
 
 impl SubAgentManager {
@@ -2726,6 +2737,7 @@ impl SubAgentManager {
             last_cleanup_at: None,
             queued_mail: HashMap::new(),
             woken_agents: HashMap::new(),
+            resume_targets: HashMap::new(),
         }
     }
 
@@ -4345,17 +4357,17 @@ impl SubAgentManager {
                         .to_string();
             }
             SubAgentStatus::Interrupted(_) => {
-                // Honest gap: checkpoints are preserved and the continuation
-                // handle is returned, but there is no in-process
-                // `run_subagent_from_checkpoint` substrate yet. Auto-resume
-                // would require re-spawning with seeded checkpoint messages
-                // (new agent loop + runtime client), not just waking input_tx.
+                // Manager-level followup is queue-only; checkpoint resume is
+                // wired at the tool layer (`agents/followup`), which
+                // re-dispatches a fresh agent loop seeded with the checkpoint
+                // messages when a runtime is attached. This arm keeps the
+                // honest queue-only receipt for callers without a runtime.
                 receipt.woke = false;
                 receipt.continued_from_checkpoint = false;
                 receipt.continuation_handle = continuation_handle.clone();
                 receipt.note = if continuable {
                     format!(
-                        "queued; child is interrupted_continuable — live checkpoint resume is not automated (no run_subagent_from_checkpoint substrate). Re-dispatch via agent using continuation_handle={}",
+                        "queued; child is interrupted_continuable — attach a runtime to agents/followup to resume from checkpoint, or re-dispatch using continuation_handle={}",
                         continuation_handle.as_deref().unwrap_or("<missing>")
                     )
                 } else {
@@ -4381,6 +4393,148 @@ impl SubAgentManager {
             }
         }
         Ok(receipt)
+    }
+
+    /// Resume an `interrupted_continuable` child by re-dispatching a fresh
+    /// agent loop seeded with the checkpoint message tail and the follow-up
+    /// text (checkpoint-based continuation).
+    ///
+    /// The interrupted terminal record stays immutable — receipts are never
+    /// rewritten — so the resumed session runs under a new agent id, matching
+    /// the existing "re-dispatch using checkpoint {handle}" guidance. Step and
+    /// token budgets are not stored in the checkpoint and are not restored;
+    /// the resumed loop starts with the runtime's defaults.
+    ///
+    /// Callers must hold the manager write lock (same contract as
+    /// `spawn_background_with_assignment_options`); `manager_handle` is passed
+    /// through to the spawn machinery, which takes no further lock.
+    pub(crate) fn resume_from_checkpoint(
+        &mut self,
+        manager_handle: SharedSubAgentManager,
+        runtime: SubAgentRuntime,
+        agent_ref: &str,
+        followup_text: &str,
+    ) -> Result<SubAgentResult> {
+        let agent_id = self.resolve_agent_ref(agent_ref)?;
+        // Idempotency: a second resume on the same interrupted id returns the
+        // already-resumed target instead of spawning a duplicate agent loop
+        // that would concurrently write the same workspace.
+        if let Some(existing) = self.resume_targets.get(&agent_id).cloned() {
+            // Forward the follow-up to the already-resumed target (best
+            // effort; a terminal target simply cannot receive it) so a
+            // retried followup is never silently dropped.
+            let _ = self.followup_child(&existing, followup_text.to_string());
+            return self.get_result(&existing);
+        }
+        let (
+            agent_type,
+            resume_prompt,
+            assignment,
+            allowed_tools,
+            model,
+            fork_context,
+            workspace,
+            claim,
+            preserved_profile,
+        ) = {
+            let agent = self
+                .agents
+                .get(&agent_id)
+                .ok_or_else(|| anyhow!("Agent {agent_id} not found"))?;
+            if !matches!(agent.status, SubAgentStatus::Interrupted(_)) {
+                return Err(anyhow!(
+                    "Cannot resume agent {agent_id}: status is {} (only interrupted children are resumable)",
+                    subagent_status_name(&agent.status)
+                ));
+            }
+            let checkpoint = agent
+                .checkpoint
+                .as_ref()
+                .filter(|cp| cp.continuable && !cp.messages.is_empty())
+                .ok_or_else(|| {
+                    let continuable = agent.checkpoint.as_ref().is_some_and(|cp| cp.continuable);
+                    let messages = agent
+                        .checkpoint
+                        .as_ref()
+                        .map(|cp| cp.messages.len())
+                        .unwrap_or(0);
+                    anyhow!(
+                        "Agent {agent_id} has no continuable checkpoint to resume from (continuable={continuable}, messages={messages})"
+                    )
+                })?;
+            // Restore the interrupted child's write claim so the resumed loop
+            // stays inside the coordination ledger with the original bounded
+            // scope instead of inheriting the caller's unchecked write surface.
+            // The ledger claim is already namespaced and carries the isolation
+            // flag; both are passed through to the spawn seam.
+            let claim = self
+                .coordination
+                .write_claims
+                .iter()
+                .find(|record| record.claim.owner == agent_id)
+                .map(|record| (record.claim.clone(), record.isolated_worktree));
+            // Preserve the interrupted child's runtime posture (read_only /
+            // denied tools / shell) instead of rebuilding from the caller's
+            // role, which could widen the resumed child's authority.
+            let preserved_profile = self
+                .worker_records
+                .get(&agent_id)
+                .map(|record| record.spec.runtime_profile.clone());
+            (
+                agent.agent_type.clone(),
+                build_resume_prompt(&agent.prompt, checkpoint, followup_text),
+                agent.assignment.clone(),
+                agent.allowed_tools.clone(),
+                agent.model.clone(),
+                agent.fork_context,
+                agent.workspace.clone(),
+                claim,
+                preserved_profile,
+            )
+        };
+        // Resume runs at child depth with a detached cancellation token, the
+        // same seam a fresh spawn uses; fail closed on the depth ceiling.
+        // Checked on the parent runtime before derivation, matching the
+        // fresh-spawn order (would_exceed_depth at the spawn seam).
+        if runtime.would_exceed_depth() {
+            return Err(anyhow!(
+                "Cannot resume agent {agent_id}: sub-agent depth limit reached (current {}, max {})",
+                runtime.spawn_depth,
+                runtime.max_spawn_depth
+            ));
+        }
+        let runtime = runtime.background_runtime();
+        // Resume in the interrupted child's workspace, not the caller's
+        // (worktree/cwd children must not resume in the parent directory).
+        let mut runtime = runtime;
+        runtime.context.workspace = workspace;
+        let options = SubAgentSpawnOptions {
+            name: None, // the old session name stays owned by the terminal record
+            model: Some(model),
+            model_route: None,
+            nickname: None,
+            fork_context,
+            write_claim: claim.as_ref().map(|(claim, _)| claim.clone()),
+            isolated_worktree: claim
+                .as_ref()
+                .map(|(_, isolated)| *isolated)
+                .unwrap_or(false),
+            claim_pre_namespaced: claim.is_some(),
+            preserve_runtime_profile: preserved_profile,
+            ..Default::default()
+        };
+        let resumed = self.spawn_background_with_assignment_options(
+            manager_handle,
+            runtime,
+            agent_type,
+            resume_prompt,
+            assignment,
+            allowed_tools,
+            options,
+        )?;
+        self.resume_targets
+            .insert(agent_id, resumed.agent_id.clone());
+        Ok(resumed)
     }
 
     /// Interrupt a child, preserve checkpoint, fail closed on root/self.
@@ -4852,15 +5006,24 @@ impl SubAgentManager {
             Some(tools) => AgentWorkerToolProfile::Explicit(tools),
             None => AgentWorkerToolProfile::Inherited,
         };
-        let runtime_profile = worker_profile_for_spawn(
-            &runtime,
-            &agent_type,
-            &tool_profile,
-            &agent.model,
-            options.model_route.clone(),
-            options.write_claim.is_some(),
-        );
-        runtime.worker_profile = runtime_profile.clone();
+        let runtime_profile = match options.preserve_runtime_profile.clone() {
+            Some(preserved) => {
+                runtime.worker_profile = preserved.clone();
+                preserved
+            }
+            None => {
+                let profile = worker_profile_for_spawn(
+                    &runtime,
+                    &agent_type,
+                    &tool_profile,
+                    &agent.model,
+                    options.model_route.clone(),
+                    options.write_claim.is_some(),
+                );
+                runtime.worker_profile = profile.clone();
+                profile
+            }
+        };
         let write_capable = runtime_profile.permissions.write;
         if write_capable {
             self.ensure_coordination_process_lock()
@@ -4879,11 +5042,15 @@ impl SubAgentManager {
                 .clone()
                 .map(|mut claim| {
                     claim.owner = agent_id.clone();
-                    let claim = self.namespace_write_claim(
-                        &agent.workspace,
-                        options.isolated_worktree,
-                        claim,
-                    )?;
+                    let claim = if options.claim_pre_namespaced {
+                        claim
+                    } else {
+                        self.namespace_write_claim(
+                            &agent.workspace,
+                            options.isolated_worktree,
+                            claim,
+                        )?
+                    };
                     let active_owners = self.active_coordination_owners();
                     self.coordination
                         .register_claim(claim, options.isolated_worktree, |owner| {
@@ -6525,6 +6692,7 @@ impl ToolSpec for AgentTool {
             AgentToolAction::Followup => {
                 return AgentsFollowupTool::new(self.manager.clone())
                     .with_optional_caller(self.runtime.parent_agent_id.clone())
+                    .with_runtime(self.runtime.clone())
                     .execute(input, context)
                     .await;
             }
@@ -7244,6 +7412,8 @@ async fn spawn_subagent_from_input(
             write_claim,
             isolated_worktree: spawn_request.worktree.is_some(),
             expected_artifact: spawn_request.expected_artifact.clone(),
+            claim_pre_namespaced: false,
+            preserve_runtime_profile: None,
         },
     );
     let result = match result {
@@ -8396,6 +8566,82 @@ async fn checkpoint_subagent_progress(
     let mut manager = runtime.manager.write().await;
     manager.update_checkpoint(agent_id, checkpoint.clone());
     checkpoint
+}
+
+/// Render a checkpoint's message tail as readable prose for re-seeding a
+/// resumed session. Text and tool blocks are shown; images and internal
+/// thinking blocks are summarized/omitted (thinking was already consumed by
+/// the interrupted model step).
+fn checkpoint_messages_to_text(messages: &[Message]) -> String {
+    let mut lines = Vec::new();
+    for message in messages {
+        let mut parts: Vec<String> = Vec::new();
+        for block in &message.content {
+            match block {
+                ContentBlock::Text { text, .. } => parts.push(text.clone()),
+                ContentBlock::ToolUse {
+                    id, name, input, ..
+                } => parts.push(format!("[tool use {name} (id {id}): {input}]")),
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    is_error,
+                    ..
+                } => {
+                    let verdict = if is_error == &Some(true) {
+                        "error"
+                    } else {
+                        "ok"
+                    };
+                    parts.push(format!(
+                        "[tool result {tool_use_id} ({verdict}): {content}]"
+                    ))
+                }
+                ContentBlock::ServerToolUse {
+                    id, name, input, ..
+                } => parts.push(format!("[server tool use {name} (id {id}): {input}]")),
+                ContentBlock::ToolSearchToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } => parts.push(format!("[tool search result {tool_use_id}: {content}]")),
+                ContentBlock::CodeExecutionToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } => parts.push(format!("[code execution result {tool_use_id}: {content}]")),
+                ContentBlock::ImageUrl { .. } => parts.push("[image]".to_string()),
+                ContentBlock::Thinking { .. } => {}
+            }
+        }
+        if parts.is_empty() {
+            continue;
+        }
+        lines.push(format!("[{}]\n{}", message.role, parts.join("\n")));
+    }
+    lines.join("\n\n")
+}
+
+/// Build the prompt for a resumed session: the original objective plus the
+/// checkpoint context tail and the parent's follow-up as the latest
+/// instruction.
+fn build_resume_prompt(
+    original_prompt: &str,
+    checkpoint: &SubAgentCheckpoint,
+    followup_text: &str,
+) -> String {
+    format!(
+        "{original_prompt}\n\n\
+         [RESUMED SESSION — checkpoint {}]\n\
+         This session was interrupted after {} step(s). The prior conversation tail follows; \
+         continue the work from where it left off. The parent follow-up below is the latest \
+         instruction.\n\n\
+         --- prior conversation (tail) ---\n{}\n--- end prior conversation ---\n\n\
+         Parent follow-up: {followup_text}",
+        checkpoint.checkpoint_id,
+        checkpoint.steps_taken,
+        checkpoint_messages_to_text(&checkpoint.messages),
+    )
 }
 
 fn needs_input_for_interrupted_checkpoint(

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -9004,7 +9004,7 @@ fn persisted_advisory_assignment_roles_replay_and_repersist_as_consultant() {
 /// helpers (depth, cancellation, child_runtime). Doesn't construct a real
 /// HTTP client — calls that hit `runtime.client` would fail, but the
 /// helpers we test here don't.
-fn stub_runtime() -> SubAgentRuntime {
+pub(crate) fn stub_runtime() -> SubAgentRuntime {
     use tokio_util::sync::CancellationToken;
 
     let workspace = std::env::temp_dir().join("codewhale-test-stub");
@@ -13929,5 +13929,172 @@ fn the_launched_authority_is_the_one_the_spawn_boundary_accepts() {
     assert!(
         verify_fleet_authority_input(&other.fingerprint(), &input).is_err(),
         "one member's receipt must not authorize another member's child"
+    );
+}
+// -- resume-from-checkpoint tests (checkpoint-based continuation) --
+
+#[tokio::test]
+async fn resume_from_checkpoint_spawns_seeded_agent_with_checkpoint_context() {
+    let tmp = tempdir().unwrap();
+    let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
+    let (agent_id, _handle) = {
+        let mut guard = manager.write().await;
+        guard.insert_test_interrupted_continuable_agent(
+            "paused_child",
+            tmp.path(),
+            vec![Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "prior work".to_string(),
+                    cache_control: None,
+                }],
+            }],
+        )
+    };
+    let mut runtime = stub_runtime();
+    runtime.manager = Arc::clone(&manager);
+    // Deliberately leave the caller's workspace as the stub default (a temp
+    // dir different from the interrupted child's) so the workspace-restore
+    // behavior is actually exercised.
+    assert_ne!(
+        runtime.context.workspace,
+        tmp.path().to_path_buf(),
+        "test setup must use distinct workspaces"
+    );
+
+    let resumed = {
+        let mut guard = manager.write().await;
+        guard
+            .resume_from_checkpoint(Arc::clone(&manager), runtime, &agent_id, "please continue")
+            .expect("resume ok")
+    };
+    assert_ne!(
+        resumed.agent_id, agent_id,
+        "resume runs under a new agent id"
+    );
+
+    let guard = manager.read().await;
+    let agent = guard
+        .agents
+        .get(&resumed.agent_id)
+        .expect("resumed agent record");
+    assert!(agent.prompt.contains("RESUMED SESSION"), "{}", agent.prompt);
+    assert!(agent.prompt.contains("prior work"), "{}", agent.prompt);
+    assert!(agent.prompt.contains("please continue"), "{}", agent.prompt);
+    // The resumed loop runs in the interrupted child's workspace, not the
+    // caller's (worktree/cwd children must not resume in the wrong directory).
+    assert_eq!(
+        agent.workspace,
+        tmp.path(),
+        "resumed agent must keep the interrupted child's workspace"
+    );
+
+    // The prior terminal record stays immutable.
+    let prior = guard.agents.get(&agent_id).expect("prior record");
+    assert!(matches!(prior.status, SubAgentStatus::Interrupted(_)));
+}
+
+#[tokio::test]
+async fn resume_from_checkpoint_is_idempotent_across_repeated_followups() {
+    let tmp = tempdir().unwrap();
+    let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
+    let (agent_id, _handle) = {
+        let mut guard = manager.write().await;
+        guard.insert_test_interrupted_continuable_agent(
+            "paused_child",
+            tmp.path(),
+            vec![Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "prior work".to_string(),
+                    cache_control: None,
+                }],
+            }],
+        )
+    };
+    let mut runtime = stub_runtime();
+    runtime.manager = Arc::clone(&manager);
+
+    let first = {
+        let mut guard = manager.write().await;
+        guard
+            .resume_from_checkpoint(Arc::clone(&manager), runtime.clone(), &agent_id, "continue")
+            .expect("first resume ok")
+    };
+    let second = {
+        let mut guard = manager.write().await;
+        guard
+            .resume_from_checkpoint(Arc::clone(&manager), runtime, &agent_id, "continue again")
+            .expect("second resume ok")
+    };
+    assert_eq!(
+        first.agent_id, second.agent_id,
+        "a repeated resume must return the existing resumed target, not spawn a duplicate loop"
+    );
+
+    // The second follow-up must not be silently dropped: it is forwarded to
+    // the already-resumed target (delivered if it is still live, queued
+    // otherwise).
+    let guard = manager.read().await;
+    let delivered_or_queued = guard.child_was_woken(&first.agent_id)
+        || guard.queued_mail_depth(&first.agent_id).unwrap_or(0) >= 1;
+    assert!(
+        delivered_or_queued,
+        "a repeated followup must reach the resumed target"
+    );
+}
+
+#[tokio::test]
+async fn resume_from_checkpoint_rejects_non_interrupted_agents() {
+    let tmp = tempdir().unwrap();
+    let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
+    let agent_id = {
+        let mut guard = manager.write().await;
+        guard.insert_test_running_agent("running_child", tmp.path())
+    };
+    let mut runtime = stub_runtime();
+    runtime.manager = Arc::clone(&manager);
+
+    let result = {
+        let mut guard = manager.write().await;
+        guard.resume_from_checkpoint(Arc::clone(&manager), runtime, &agent_id, "nope")
+    };
+    let err = result.expect_err("non-interrupted agents must fail closed");
+    assert!(
+        err.to_string().contains("only interrupted children"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn resume_from_checkpoint_rejects_missing_continuable_checkpoint() {
+    let tmp = tempdir().unwrap();
+    let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
+    let agent_id = {
+        let mut guard = manager.write().await;
+        // Interrupted, but without a continuable checkpoint tail.
+        guard.insert_test_running_agent("interrupted_no_cp", tmp.path());
+        let id = guard
+            .agents
+            .iter()
+            .find(|(_, agent)| agent.session_name == "interrupted_no_cp")
+            .map(|(id, _)| id.clone())
+            .expect("agent id");
+        if let Some(agent) = guard.agents.get_mut(&id) {
+            agent.status = SubAgentStatus::Interrupted("no checkpoint".to_string());
+        }
+        id
+    };
+    let mut runtime = stub_runtime();
+    runtime.manager = Arc::clone(&manager);
+
+    let result = {
+        let mut guard = manager.write().await;
+        guard.resume_from_checkpoint(Arc::clone(&manager), runtime, &agent_id, "nope")
+    };
+    let err = result.expect_err("agents without a continuable checkpoint must fail closed");
+    assert!(
+        err.to_string().contains("no continuable checkpoint"),
+        "{err}"
     );
 }


### PR DESCRIPTION
## Summary

`agents/followup` on an `interrupted_continuable` child used to queue a dead-letter: the checkpoint was preserved and its `continuation_handle` returned, but nothing could actually resume the run — long tasks (document review, multi-step search) interrupted mid-way had to be re-dispatched from scratch, wasting tokens and time. This change wires checkpoint-based continuation: followup now re-dispatches a fresh agent loop seeded with the original prompt plus the checkpoint message tail and the follow-up text, under a new agent id, while the prior terminal record stays immutable.

Process: necessity review (scout) confirmed no resume substrate existed on `main`; implementation went through two adversarial review rounds (3 majors fixed: duplicate-resume idempotency, cwd-claim double-namespacing, runtime-posture widening).

## Changes

- **`resume_from_checkpoint` (SubAgentManager, mod.rs)**: re-dispatch via `spawn_background_with_assignment_options` with the interrupted child's `agent_type`/`assignment`/`allowed_tools`/`model` restored.
  - **Idempotency**: `resume_targets` map (old id → resumed id) — a repeated followup returns the existing target and forwards the message to it (never silently dropped).
  - **Spawn-seam fidelity**: child runtime via `background_runtime()` (depth +1, detached cancellation), depth ceiling checked before derivation; workspace restored to the interrupted child's directory; write claim restored from the coordination ledger (pre-namespaced, isolation flag preserved); runtime posture (`read_only` / denied tools / shell) preserved from the worker record instead of rebuilt from the caller's role.
- **`checkpoint_messages_to_text` / `build_resume_prompt`**: serialize the checkpoint message tail into a resume prompt (`[RESUMED SESSION — checkpoint …]` + prior conversation tail + parent follow-up).
- **`AgentsFollowupTool` (coord.rs)**: optional `SubAgentRuntime` via `with_runtime`; `execute` routes interrupted_continuable children with a runtime attached to the resume path, keeping honest queue-only semantics otherwise. Both registration points (AgentTool followup action, `register_coordination_tools`) attach the runtime.
- **Tests**: 5 manager tests (seeded resume, workspace restore, idempotency with message forwarding, reject non-interrupted, reject missing continuable checkpoint) + 2 coord tests (queue-only without runtime, resume with runtime). `stub_runtime` made `pub(crate)`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Tests

## Testing

<!-- Exact gate commands (including the clippy allow list) are in
     CONTRIBUTING.md → "Pre-push verification". -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-tui --bin codewhale-tui` (no new warnings; only the pre-existing `mcp.rs:262` warning inside a `#[cfg(windows)]` block, invisible to the ubuntu CI runner)
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list) — not run locally; CI will run it
- [x] `cargo test -p codewhale-tui resume_from_checkpoint` (4/4 pass) and `cargo test -p codewhale-tui followup_interrupted_continuable` (2/2 pass)
- [x] `cargo test -p codewhale-tui tools::subagent` (392/392 pass)
- [ ] `cargo test --workspace --all-features --locked` — not run locally (heavy); CI will run it

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (N/A — no UI change; resume path exercised via unit/coord tests)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (no human co-authors; agent assistance noted in commit body)

## Related Issues

No-Issue: harness improvement backlog item (sub-agent checkpoint resume), no public issue number. Necessity-review and two review rounds performed as part of the implementation workflow.
