### PR TITLE
Build fix for FreeBSD.

### DIFF
--- a/crates/workflow-js/Cargo.toml
+++ b/crates/workflow-js/Cargo.toml
@@ -22,6 +22,12 @@ tokio.workspace = true
 [target.'cfg(target_os = "android")'.dependencies]
 rquickjs = { workspace = true, features = ["bindgen"] }
 
+# rquickjs does not ship pre-generated bindings for FreeBSD. Generate them at
+# build time so the crate compiles there instead of trying to include a
+# nonexistent bindings file.
+[target.'cfg(target_os = "freebsd")'.dependencies]
+rquickjs = { workspace = true, features = ["bindgen"] }
+
 # rquickjs does not ship pre-generated bindings for NetBSD. Generate them at
 # build time so the crate compiles there instead of trying to include a
 # nonexistent bindings file.


### PR DESCRIPTION
## Summary

No rquickjs bindings are available for FreeBSD, and compilation stops with the error message:

> warning: rquickjs-sys@0.12.1: rquickjs probably doesn't ship bindings for platform `x86_64-unknown-freebsd(n/a)`. try the `bindgen` feature instead.
> error: could not compile `rquickjs-sys` (lib) due to 1 previous error

This simple patch enable bindings generate for rquickjs on FreeBSD.

## Testing

<!-- Exact gate commands (including the clippy allow list) are in
     CONTRIBUTING.md → "Pre-push verification". -->

- [X] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)

Two warnings were generated, but I believe not related to my change:
> warning: variants `Text` and `Image` are never constructed
>    --> crates/tui/src/tui/clipboard.rs:187:5
> warning: this boolean expression can be simplified
>    --> crates/tui/src/commands/groups/session/structcopy.rs:879:25

Tested with Rust 1.96.0

- [ ] `cargo test --workspace --all-features --locked`

I cannot test due to a lack of access to all providers. My change should not affect this, it only helps build CodeWhale on FreeBSD.

## Checklist

- [X] Updated docs or comments as needed
- [X] Added or updated tests where relevant
- [X] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
