### PR TITLE
feat(config): add model = auto for prompt-based tier selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`model = "auto"` for prompt-based tier selection**: When set, the
+  dispatcher analyses the user's prompt before delegating to the TUI and
+  selects `deepseek-v4-pro` for complex tasks (debugging, refactoring,
+  architecture, code generation) or `deepseek-v4-flash` for simple tasks
+  (lookups, formatting, Q&A). The classifier uses a lightweight rule-based
+  scoring system with keywords, length heuristics, and code-block detection.
+  Supported via `codewhale model set auto` or `model = "auto"` in config
+  (PR #5257).
+
 ## [0.9.4] - 2026-08-05
 Codewhale v0.9.4 ships the release-train harness work: the familiar Fleet
 roster/setup face with a clear operator-leader and user/folder scope, a

--- a/config.example.toml
+++ b/config.example.toml
@@ -74,6 +74,9 @@ base_url = "https://api.deepseek.com/beta"
 #   trinity-large-preview            — direct Arcee AI API model ID
 #   deepseek-ai/DeepSeek-V4-Pro      — SGLang self-hosted Pro model ID
 #   deepseek-ai/DeepSeek-V4-Flash    — SGLang self-hosted Flash model ID
+#   auto                         — auto-select between flash and pro based on task complexity.
+#                                  Complex tasks (debugging, refactoring, architecture) → pro;
+#                                  simple tasks (lookups, formatting, Q&A) → flash.
 default_text_model = "deepseek-v4-pro"
 
 # ─────────────────────────────────────────────────────────────────────────────────

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1724,7 +1724,11 @@ fn run() -> Result<()> {
     match command {
         Some(Commands::Run(args)) => {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
-            delegate_to_tui(&cli, &resolved_runtime, args.args)
+            let auto_resolved = try_auto_resolve_model(&resolved_runtime, &args.args);
+            delegate_to_tui(&cli, &resolved_runtime, args.args).map(|r| {
+                auto_resolved.map(|_| std::env::remove_var("CODEWHALE_MODEL"));
+                r
+            })
         }
         Some(Commands::Doctor(args)) => {
             let resolved_runtime =
@@ -1776,7 +1780,11 @@ fn run() -> Result<()> {
         Some(Commands::Exec(args)) => {
             reject_exec_global_flags(&args.args)?;
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
-            delegate_to_tui(&cli, &resolved_runtime, tui_args("exec", args))
+            let auto_resolved = try_auto_resolve_model(&resolved_runtime, &args.args);
+            delegate_to_tui(&cli, &resolved_runtime, tui_args("exec", args)).map(|r| {
+                auto_resolved.map(|_| std::env::remove_var("CODEWHALE_MODEL"));
+                r
+            })
         }
         Some(Commands::Fleet(args)) => {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
@@ -2109,6 +2117,31 @@ fn reject_exec_global_flags(args: &[String]) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// If the resolved model is `"auto"`, analyse the prompt and set
+/// `CODEWHALE_MODEL` to the resolved tier (`deepseek-v4-pro` or
+/// `deepseek-v4-flash`). Returns `Some(())` when auto-resolution was applied,
+/// so the caller can clean up the env var afterwards.
+///
+/// The prompt is extracted from the passthrough args (the text after
+/// `codewhale run` or `codewhale exec`).
+fn try_auto_resolve_model(
+    resolved_runtime: &codewhale_config::ResolvedRuntimeOptions,
+    prompt_args: &[String],
+) -> Option<()> {
+    if resolved_runtime.model != "auto" {
+        return None;
+    }
+    let prompt = if prompt_args.is_empty() {
+        // No prompt provided — nothing to analyse, leave as default.
+        return None;
+    } else {
+        prompt_args.join(" ")
+    };
+    let resolved = codewhale_config::auto_model::classify(&prompt);
+    std::env::set_var("CODEWHALE_MODEL", resolved);
+    Some(())
 }
 
 fn run_login_command(store: &mut ConfigStore, args: LoginArgs) -> Result<()> {
@@ -4039,6 +4072,7 @@ fn run_model_command(
             let canonical = match trimmed.to_ascii_lowercase().as_str() {
                 "pro" | "deepseek-v4pro" => "deepseek-v4-pro",
                 "flash" | "deepseek-v4flash" => "deepseek-v4-flash",
+                "auto" => "auto",
                 _ => trimmed,
             };
             store.config.default_text_model = Some(canonical.to_string());

--- a/crates/config/src/auto_model.rs
+++ b/crates/config/src/auto_model.rs
@@ -1,0 +1,223 @@
+//! Prompt-based auto-model classifier.
+//!
+//! When `model = "auto"` is configured, the dispatcher analyses the user's
+//! prompt before delegating to the TUI and chooses a tier:
+//!
+//! - **`deepseek-v4-pro`** — complex tasks (debugging, refactoring, design,
+//!   security review, multi-file changes, code generation, …).
+//! - **`deepseek-v4-flash`** — simple tasks (lookups, formatting, small edits,
+//!   translation, Q&A, …).
+//!
+//! This is a pure rule-based classifier. It lives in the config crate because
+//! the resolved model name is a config-level concern; the route resolver never
+//! sees the `"auto"` sentinel or the prompt text.
+
+/// The resolved model name for the pro tier.
+pub const PRO_MODEL: &str = "deepseek-v4-pro";
+
+/// The resolved model name for the flash tier.
+pub const FLASH_MODEL: &str = "deepseek-v4-flash";
+
+/// The threshold score above which a task is classified as complex (pro).
+/// Score ≥ 2 → pro, else → flash.
+const PRO_THRESHOLD: i32 = 2;
+
+/// Strong indicators of a complex task. Each match adds +3.
+const COMPLEX_STRONG: &[&str] = &[
+    // Debugging & fixing
+    "debug", "bug", "fix", "error", "crash", "异常", "错误", "调试", "故障",
+    "排查", "root cause",
+    // Architecture & design
+    "refactor", "重构", "architecture", "架构", "design pattern", "系统设计",
+    "高并发", "分布式", "microservice",
+    // Security
+    "security", "安全", "vulnerability", "漏洞", "渗透", "exploit",
+    // Code generation
+    "implement", "实现", "generate", "生成", "create", "创建", "build", "构建",
+    "开发", "prototype",
+    // Complex analysis
+    "analyze", "分析", "review", "审查", "audit", "审计", "optimize", "优化",
+    "migrate", "迁移",
+    // Multi-file / large scale
+    "multi-file", "multiple files", "多个文件", "整个项目", "full project",
+    "重构整个", "large scale",
+    // Testing
+    "unit test", "integration test", "e2e test", "测试用例", "test suite",
+    "coverage",
+    // Complex logic
+    "algorithm", "算法", "状态机", "state machine", "concurrent", "并行",
+    "异步", "async",
+    // Documentation / PRD
+    "architecture document", "设计文档", "技术方案", "prd",
+];
+
+/// Medium-strength indicators. Each match adds +1.
+const COMPLEX_MEDIUM: &[&str] = &[
+    "change", "修改", "update", "更新", "add", "添加", "新增", "feature",
+    "功能", "improve", "改进", "enhance", "config", "配置", "setup", "设置",
+    "deploy", "部署", "ci/cd", "pipeline", "script", "脚本", "tool", "工具",
+    "api", "interface", "接口", "endpoint", "database", "数据库", "schema",
+    "query", "document", "文档", "readme",
+];
+
+/// Simple-task indicators. Each match subtracts -1.
+const SIMPLE: &[&str] = &[
+    "find", "查找", "search", "搜索", "look up", "查询", "what is", "什么是",
+    "explain", "解释", "tell me", "告诉我", "how to", "如何", "format", "格式化",
+    "pretty", "list", "列出", "show", "显示", "print", "rename", "重命名",
+    "move", "移动", "copy", "复制", "delete", "删除", "remove", "typo", "拼写",
+    "spelling", "grammar", "quick", "快速", "simple", "简单", "hello world",
+    "demo", "example", "示例", "translate", "翻译", "convert", "转换",
+    "short", "简短", "brief", "简要",
+];
+
+/// Classify a prompt and return the resolved model name.
+///
+/// Uses a simple scoring system:
+/// - Strong complex keyword: +3
+/// - Medium complex keyword: +1
+/// - Simple keyword: -1
+/// - Prompt length > 500 chars: +2, > 200 chars: +1
+/// - Contains code fence or backtick: +1
+/// - Contains a file path: +1
+/// - Multi-line (> 5 newlines): +1
+///
+/// Total ≥ 2 → `PRO_MODEL`, else → `FLASH_MODEL`.
+#[must_use]
+pub fn classify(prompt: &str) -> &'static str {
+    if score(prompt) >= PRO_THRESHOLD {
+        PRO_MODEL
+    } else {
+        FLASH_MODEL
+    }
+}
+
+/// Compute the raw complexity score for a prompt.
+#[must_use]
+pub fn score(prompt: &str) -> i32 {
+    let lower = prompt.to_ascii_lowercase();
+    let mut score = 0i32;
+
+    // Strong complex keywords: +3 (first match only to avoid overcounting)
+    if COMPLEX_STRONG.iter().any(|kw| lower.contains(kw)) {
+        score += 3;
+    }
+
+    // Medium complex keywords: +1 each
+    for kw in COMPLEX_MEDIUM {
+        if lower.contains(kw) {
+            score += 1;
+        }
+    }
+
+    // Simple keywords: -1 each
+    for kw in SIMPLE {
+        if lower.contains(kw) {
+            score -= 1;
+        }
+    }
+
+    // Length factor: long prompts tend to be more complex
+    let len = prompt.len();
+    if len > 500 {
+        score += 2;
+    } else if len > 200 {
+        score += 1;
+    }
+
+    // Code fence or backtick: actual coding task
+    if prompt.contains("```") || prompt.contains('`') {
+        score += 1;
+    }
+
+    // File path pattern: e.g. /path/to/file.rs or C:\path
+    // Simple heuristic: path-like sequences contain / or \ and .
+    if (prompt.contains('/') || prompt.contains('\\')) && prompt.contains('.') {
+        score += 1;
+    }
+
+    // Multi-line: more lines = more context
+    if prompt.chars().filter(|&c| c == '\n').count() > 5 {
+        score += 1;
+    }
+
+    score
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_debug_task_uses_pro() {
+        assert_eq!(classify("帮我调试这个bug，程序崩溃了"), PRO_MODEL);
+    }
+
+    #[test]
+    fn test_refactor_task_uses_pro() {
+        assert_eq!(classify("refactor the user module with a new architecture"), PRO_MODEL);
+    }
+
+    #[test]
+    fn test_security_review_uses_pro() {
+        assert_eq!(classify("review this code for security vulnerabilities"), PRO_MODEL);
+    }
+
+    #[test]
+    fn test_simple_lookup_uses_flash() {
+        assert_eq!(classify("查找昨天的日志文件"), FLASH_MODEL);
+    }
+
+    #[test]
+    fn test_translation_uses_flash() {
+        assert_eq!(classify("translate this to Chinese"), FLASH_MODEL);
+    }
+
+    #[test]
+    fn test_formatting_uses_flash() {
+        assert_eq!(classify("format this code"), FLASH_MODEL);
+    }
+
+    #[test]
+    fn test_long_prompt_gets_bonus() {
+        let long = "a".repeat(300);
+        // No keywords, long prompt gives +1, total = 1 < 2 → flash
+        assert_eq!(classify(&long), FLASH_MODEL);
+    }
+
+    #[test]
+    fn test_very_long_prompt_gets_more_bonus() {
+        let long = "a".repeat(600);
+        // No keywords, very long prompt gives +2, total = 2 → pro
+        assert_eq!(classify(&long), PRO_MODEL);
+    }
+
+    #[test]
+    fn test_code_block_gets_bonus() {
+        // Code block without keywords, +1, total = 1 < 2 → flash
+        assert_eq!(classify("```\nhello\n```"), FLASH_MODEL);
+    }
+
+    #[test]
+    fn test_mixed_keywords_pro_wins() {
+        // "refactor" is strong (+3), "explain" is simple (-1), total = 2 → pro
+        assert_eq!(classify("refactor and explain the code"), PRO_MODEL);
+    }
+
+    #[test]
+    fn test_implement_task_uses_pro() {
+        assert_eq!(classify("implement a new feature for the user module"), PRO_MODEL);
+    }
+
+    #[test]
+    fn test_quick_question_uses_flash() {
+        assert_eq!(classify("what is the capital of France?"), FLASH_MODEL);
+    }
+
+    #[test]
+    fn test_score_never_negative() {
+        // Even for very simple queries, score should be predictable
+        let s = score("hello world");
+        assert!(s >= -10); // sanity check
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth_source;
+pub mod auto_model;
 pub mod catalog;
 mod config_document;
 pub mod external_credentials;


### PR DESCRIPTION
## Summary

Adds a new `model = "auto"` configuration that automatically selects between `deepseek-v4-pro` (complex tasks) and `deepseek-v4-flash` (simple tasks) based on the user's prompt.

## Motivation

Users often switch between flash (fast, cheap) and pro (powerful, expensive) models depending on the task. This PR automates that decision, saving both cost and cognitive load.

## How it works

1. **Config**: `model = "auto"` is accepted by `codewhale config` and `codewhale model set auto`
2. **Classifier** (`crates/config/src/auto_model.rs`): A lightweight rule-based system scores the prompt using keywords, length heuristics, code-block detection, and file-path patterns
3. **Dispatcher**: When `model = "auto"` is resolved, the CLI dispatcher analyses the prompt before delegating to the TUI and sets `CODEWHALE_MODEL` to the appropriate tier

## Changes

| File | Change |
|---|---|
| `crates/config/src/auto_model.rs` | **New** -- Prompt complexity classifier |
| `crates/config/src/lib.rs` | Register `auto_model` module |
| `crates/cli/src/lib.rs` | Add `auto` to `model set`; auto-resolve in `run`/`exec` handlers |

## Design decisions

- **Route resolver untouched**: The `RouteRequest` struct deliberately carries no prompt text (architectural constraint). The auto-resolution happens at the dispatcher level, before the TUI starts, so the resolver only ever sees concrete model names.
- **Existing `auto` preserved**: The route resolver's existing `auto` sentinel ("use provider default") is unchanged -- it operates at a different layer.
- **Environment variable bridge**: `CODEWHALE_MODEL` is set before spawning the TUI child process, which already reads this env var for model overrides.

## Example

```bash
codewhale model set auto
codewhale run "debug this bug"      # -> auto-detected as pro
codewhale run "find yesterday's log" # -> auto-detected as flash
```