### PR TITLE
fix(tui): stop stale cached session title from pinning New Session

### DIFF
--- a/crates/tui/locales/ca.json
+++ b/crates/tui/locales/ca.json
@@ -1204,6 +1204,7 @@
   "BehavioralTipMcpValidation": "{command} inicia els servidors i mostra per què",
   "BehavioralTipRepeatedCommand": "{command} ho pot fixar",
   "BehavioralTipDurableStateWritten": "Desat · {command} per revisar",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "{setting} està blocat mentre s'executa un torn — prem Esc per interrompre primer",
   "SettingSubjectMode": "Mode",
   "SettingSubjectThinking": "Raonament",

--- a/crates/tui/locales/de.json
+++ b/crates/tui/locales/de.json
@@ -1204,6 +1204,7 @@
   "BehavioralTipMcpValidation": "{command} startet Server und zeigt warum",
   "BehavioralTipRepeatedCommand": "{command} kann dies anpinnen",
   "BehavioralTipDurableStateWritten": "Gespeichert · {command} ansehen",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "{setting} ist gesperrt, während ein Turn läuft — zuerst Esc zum Unterbrechen drücken",
   "SettingSubjectMode": "Modus",
   "SettingSubjectThinking": "Thinking",

--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -1227,6 +1227,7 @@
   "BehavioralTipMcpValidation": "{command} starts servers and shows why",
   "BehavioralTipRepeatedCommand": "{command} can pin this",
   "BehavioralTipDurableStateWritten": "Saved · {command} to inspect",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "{setting} is locked while a turn is running — press Esc to interrupt first",
   "SettingSubjectMode": "Mode",
   "SettingSubjectThinking": "Thinking",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -1227,6 +1227,7 @@
   "BehavioralTipMcpValidation": "{command} inicia los servidores y muestra el motivo",
   "BehavioralTipRepeatedCommand": "{command} puede fijar esto",
   "BehavioralTipDurableStateWritten": "Guardado · {command} para ver",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "{setting} está bloqueado mientras se ejecuta un turno: presiona Esc para interrumpir primero",
   "SettingSubjectMode": "El modo",
   "SettingSubjectThinking": "El razonamiento",

--- a/crates/tui/locales/fr.json
+++ b/crates/tui/locales/fr.json
@@ -1204,6 +1204,7 @@
   "BehavioralTipMcpValidation": "{command} démarre les serveurs et montre pourquoi",
   "BehavioralTipRepeatedCommand": "{command} peut épingler ceci",
   "BehavioralTipDurableStateWritten": "Enregistré · {command} pour voir",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "{setting} est verrouillé pendant qu'un tour est en cours — appuyez d'abord sur Esc pour interrompre",
   "SettingSubjectMode": "Le mode",
   "SettingSubjectThinking": "Le raisonnement",

--- a/crates/tui/locales/hi.json
+++ b/crates/tui/locales/hi.json
@@ -1204,6 +1204,7 @@
   "BehavioralTipMcpValidation": "{command} सर्वर शुरू करता है और कारण दिखाता है",
   "BehavioralTipRepeatedCommand": "{command} इसे पिन कर सकता है",
   "BehavioralTipDurableStateWritten": "सहेजा गया · {command} से देखें",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "टर्न चलने के दौरान {setting} लॉक है — पहले Esc से बाधित करें",
   "SettingSubjectMode": "मोड",
   "SettingSubjectThinking": "थिंकिंग",

--- a/crates/tui/locales/id.json
+++ b/crates/tui/locales/id.json
@@ -1204,6 +1204,7 @@
   "BehavioralTipMcpValidation": "{command} memulai server dan menunjukkan alasannya",
   "BehavioralTipRepeatedCommand": "{command} dapat menyematkan ini",
   "BehavioralTipDurableStateWritten": "Tersimpan · {command} untuk melihat",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "{setting} terkunci saat giliran berjalan — tekan Esc untuk menginterupsi dulu",
   "SettingSubjectMode": "Mode",
   "SettingSubjectThinking": "Thinking",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -1227,6 +1227,7 @@
   "BehavioralTipMcpValidation": "{command} はサーバーを起動し、原因を表示します",
   "BehavioralTipRepeatedCommand": "{command} でこれを固定できます",
   "BehavioralTipDurableStateWritten": "保存しました · {command} で確認",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "ターンの実行中は{setting}を変更できません。まず Esc で中断してください",
   "SettingSubjectMode": "モード",
   "SettingSubjectThinking": "思考",

--- a/crates/tui/locales/ko.json
+++ b/crates/tui/locales/ko.json
@@ -1227,6 +1227,7 @@
   "BehavioralTipMcpValidation": "{command} 명령은 서버를 시작하고 원인을 보여 줍니다",
   "BehavioralTipRepeatedCommand": "{command} 명령으로 이 항목을 고정할 수 있습니다",
   "BehavioralTipDurableStateWritten": "저장됨 · {command}에서 확인",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "턴이 실행 중일 때는 {setting} 변경이 잠깁니다 — 먼저 Esc로 중단하세요",
   "SettingSubjectMode": "모드",
   "SettingSubjectThinking": "사고",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -1227,6 +1227,7 @@
   "BehavioralTipMcpValidation": "{command} inicia os servidores e mostra o motivo",
   "BehavioralTipRepeatedCommand": "{command} pode fixar isto",
   "BehavioralTipDurableStateWritten": "Salvo · {command} para ver",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "{setting} está bloqueado enquanto um turno está em execução — pressione Esc para interromper primeiro",
   "SettingSubjectMode": "O modo",
   "SettingSubjectThinking": "O raciocínio",

--- a/crates/tui/locales/ru.json
+++ b/crates/tui/locales/ru.json
@@ -1204,6 +1204,7 @@
   "BehavioralTipMcpValidation": "{command} запускает серверы и показывает причину",
   "BehavioralTipRepeatedCommand": "{command} может закрепить это",
   "BehavioralTipDurableStateWritten": "Сохранено · {command} для просмотра",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "{setting} заблокировано во время выполнения хода — сначала нажмите Esc для прерывания",
   "SettingSubjectMode": "Режим",
   "SettingSubjectThinking": "Thinking",

--- a/crates/tui/locales/uk.json
+++ b/crates/tui/locales/uk.json
@@ -1204,6 +1204,7 @@
   "BehavioralTipMcpValidation": "{command} запускає сервери й показує причину",
   "BehavioralTipRepeatedCommand": "{command} може закріпити це",
   "BehavioralTipDurableStateWritten": "Збережено · {command} для перегляду",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "{setting} заблоковано, доки триває хід — спочатку натисніть Esc, щоб перервати",
   "SettingSubjectMode": "Режим",
   "SettingSubjectThinking": "Міркування",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -1227,6 +1227,7 @@
   "BehavioralTipMcpValidation": "{command} khởi động máy chủ và cho biết nguyên nhân",
   "BehavioralTipRepeatedCommand": "{command} có thể ghim lệnh này",
   "BehavioralTipDurableStateWritten": "Đã lưu · {command} để xem",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "{setting} bị khóa khi một lượt đang chạy — hãy nhấn Esc để ngắt trước",
   "SettingSubjectMode": "Chế độ",
   "SettingSubjectThinking": "Suy nghĩ",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -1227,6 +1227,7 @@
   "BehavioralTipMcpValidation": "{command} 会启动服务器并显示原因",
   "BehavioralTipRepeatedCommand": "{command} 可以固定此命令",
   "BehavioralTipDurableStateWritten": "已保存 · {command} 查看详情",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "SettingLockedDuringTurn": "回合运行期间{setting}已锁定 — 请先按 Esc 中断",
   "SettingSubjectMode": "模式",
   "SettingSubjectThinking": "思考",

--- a/crates/tui/locales/zh-Hant.json
+++ b/crates/tui/locales/zh-Hant.json
@@ -83,6 +83,7 @@
   "BehavioralTipPlanning": "在規劃？按 {key} 可切換到 Plan 模式",
   "BehavioralTipRepeatedCommand": "{command} 可以固定此命令",
   "BehavioralTipDurableStateWritten": "已儲存 · {command} 可檢視",
+  "BehavioralTipTodoWrite": "Tip: track multi-step work with todo_write — it keeps progress visible",
   "ChipModeAct": "act",
   "ChipModeOperate": "operate",
   "ChipModePlan": "plan",

--- a/crates/tui/src/commands/groups/session/session.rs
+++ b/crates/tui/src/commands/groups/session/session.rs
@@ -228,7 +228,7 @@ pub fn new_session(app: &mut App, arg: Option<&str>) -> CommandResult {
     app.tool_evidence.clear();
     app.current_session_id = Some(new_id.clone());
     app.current_session_metadata = None;
-    app.session_title = Some("New Session".to_string());
+    app.session_title = Some(crate::session_manager::DEFAULT_SESSION_TITLE.to_string());
     app.scroll_to_bottom();
 
     CommandResult::with_message_and_action(

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1792,11 +1792,11 @@ impl Engine {
                             .await;
                     }
                     no_user_input_continues = no_user_input_continues.saturating_add(1);
-                    if no_user_input_continues >= 12 {
+                    if no_user_input_continues >= 20 {
                         let _ = self
                             .tx_event
                             .send(Event::status(
-                                "Turn ending: no-user-input resume backstop hit (12)".to_string(),
+                                "Turn ending: no-user-input resume backstop hit (20)".to_string(),
                             ))
                             .await;
                         break;
@@ -1825,11 +1825,11 @@ impl Engine {
                 let subagent_completions = self.drain_subagent_completion_events("").await;
                 if subagent_completions > 0 {
                     no_user_input_continues = no_user_input_continues.saturating_add(1);
-                    if no_user_input_continues >= 12 {
+                    if no_user_input_continues >= 20 {
                         let _ = self
                             .tx_event
                             .send(Event::status(
-                                "Turn ending: no-user-input resume backstop hit (12)".to_string(),
+                                "Turn ending: no-user-input resume backstop hit (20)".to_string(),
                             ))
                             .await;
                         break;
@@ -2090,11 +2090,11 @@ impl Engine {
                     // No FINAL — let the model iterate with the feedback.
                     // Count toward the combined no-user-input backstop.
                     no_user_input_continues = no_user_input_continues.saturating_add(1);
-                    if no_user_input_continues >= 12 {
+                    if no_user_input_continues >= 20 {
                         let _ = self
                             .tx_event
                             .send(Event::status(
-                                "Turn ending: no-user-input resume backstop hit (12 consecutive continuations)".to_string(),
+                                "Turn ending: no-user-input resume backstop hit (20 consecutive continuations)".to_string(),
                             ))
                             .await;
                         break;
@@ -2138,11 +2138,11 @@ impl Engine {
 
                 if self.drain_subagent_completion_events("late").await > 0 {
                     no_user_input_continues = no_user_input_continues.saturating_add(1);
-                    if no_user_input_continues >= 12 {
+                    if no_user_input_continues >= 20 {
                         let _ = self
                             .tx_event
                             .send(Event::status(
-                                "Turn ending: no-user-input resume backstop hit (12)".to_string(),
+                                "Turn ending: no-user-input resume backstop hit (20)".to_string(),
                             ))
                             .await;
                         break;
@@ -2171,11 +2171,11 @@ impl Engine {
                     ))
                     .await;
                     no_user_input_continues = no_user_input_continues.saturating_add(1);
-                    if no_user_input_continues >= 12 {
+                    if no_user_input_continues >= 20 {
                         let _ = self
                             .tx_event
                             .send(Event::status(
-                                "Turn ending: no-user-input resume backstop hit (12)".to_string(),
+                                "Turn ending: no-user-input resume backstop hit (20)".to_string(),
                             ))
                             .await;
                         break;
@@ -3905,11 +3905,11 @@ impl Engine {
             // Tool stepping (4d): one line why we're continuing without user input.
             // This is the fourth resume kind alongside subagent/goal/REPL.
             no_user_input_continues = no_user_input_continues.saturating_add(1);
-            if no_user_input_continues >= 12 {
+            if no_user_input_continues >= 20 {
                 let _ = self
                     .tx_event
                     .send(Event::status(
-                        "Turn ending: no-user-input resume backstop hit (12)".to_string(),
+                        "Turn ending: no-user-input resume backstop hit (20)".to_string(),
                     ))
                     .await;
                 break;

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -1419,6 +1419,7 @@ pub enum MessageId {
     BehavioralTipMcpValidation,
     BehavioralTipRepeatedCommand,
     BehavioralTipDurableStateWritten,
+    BehavioralTipTodoWrite,
     // Live-route settings lock (#2982): refusals and startup-default receipts.
     SettingLockedDuringTurn,
     SettingSubjectMode,
@@ -2728,6 +2729,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::BehavioralTipMcpValidation,
     MessageId::BehavioralTipRepeatedCommand,
     MessageId::BehavioralTipDurableStateWritten,
+    MessageId::BehavioralTipTodoWrite,
     MessageId::SettingLockedDuringTurn,
     MessageId::SettingSubjectMode,
     MessageId::SettingSubjectThinking,

--- a/crates/tui/src/palette/tokens.rs
+++ b/crates/tui/src/palette/tokens.rs
@@ -12,7 +12,7 @@ pub const WHALE_SELECTION_RGB: (u8, u8, u8) = (31, 50, 77); // #1F324D Action-bl
 pub const WHALE_TEXT_BODY_RGB: (u8, u8, u8) = (246, 242, 232); // #F6F2E8 Whale Ivory
 pub const WHALE_TEXT_SOFT_RGB: (u8, u8, u8) = (182, 192, 212); // #B6C0D4
 pub const WHALE_TEXT_MUTED_RGB: (u8, u8, u8) = (147, 160, 184); // #93A0B8
-pub const WHALE_TEXT_HINT_RGB: (u8, u8, u8) = (132, 145, 170); // #8491AA
+pub const WHALE_TEXT_HINT_RGB: (u8, u8, u8) = (138, 153, 179); // #8A99B3 — nudged +0.4 contrast for AA hint on #03070D
 #[allow(dead_code)]
 pub const WHALE_TEXT_DIM_RGB: (u8, u8, u8) = (105, 119, 145); // #697791
 pub const WHALE_ACTION_RGB: (u8, u8, u8) = (106, 174, 242); // #6AAEF2 Blue — owns interaction on dark

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -1316,7 +1316,11 @@ pub(crate) fn workspace_scope_matches(saved_workspace: &Path, current_workspace:
 }
 
 fn is_empty_auto_created_session(session: &SessionMetadata) -> bool {
-    session.message_count == 0 && session.title.trim().eq_ignore_ascii_case("New Session")
+    session.message_count == 0
+        && session
+            .title
+            .trim()
+            .eq_ignore_ascii_case(DEFAULT_SESSION_TITLE)
 }
 
 fn paths_equivalent(lhs: &Path, rhs: &Path) -> bool {
@@ -1471,6 +1475,12 @@ pub fn create_saved_session(
     )
 }
 
+/// Placeholder title used for a session that has no first user message yet.
+/// `build_session_snapshot` (tui/ui/frame.rs) treats a title equal to this
+/// constant as an auto-generated placeholder and lets the conversation-derived
+/// title win once a user message exists. Keep this string stable on purpose.
+pub(crate) const DEFAULT_SESSION_TITLE: &str = "New Session";
+
 /// Create a new `SavedSession` from conversation state with optional mode label
 pub fn create_saved_session_with_mode(
     messages: &[Message],
@@ -1520,7 +1530,7 @@ pub fn create_saved_session_with_id_and_mode(
                 _ => None,
             })
         })
-        .unwrap_or_else(|| "New Session".to_string());
+        .unwrap_or_else(|| DEFAULT_SESSION_TITLE.to_string());
 
     SavedSession {
         schema_version: CURRENT_SESSION_SCHEMA_VERSION,
@@ -2082,7 +2092,7 @@ mod tests {
             messages: Vec::new(),
             metadata: SessionMetadata {
                 id: id.to_string(),
-                title: "New Session".to_string(),
+                title: DEFAULT_SESSION_TITLE.to_string(),
                 created_at: updated_at,
                 updated_at,
                 message_count: 0,

--- a/crates/tui/src/session_resume.rs
+++ b/crates/tui/src/session_resume.rs
@@ -277,7 +277,11 @@ fn candidate_ids(
 /// An auto-created, never-used session is not something to resume into.
 /// Mirrors the filter `get_latest_session_for_workspace` applies.
 fn is_empty_placeholder(metadata: &crate::session_manager::SessionMetadata) -> bool {
-    metadata.message_count == 0 && metadata.title.trim().eq_ignore_ascii_case("New Session")
+    metadata.message_count == 0
+        && metadata
+            .title
+            .trim()
+            .eq_ignore_ascii_case(crate::session_manager::DEFAULT_SESSION_TITLE)
 }
 
 fn plural_sessions(count: usize) -> &'static str {

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -13646,7 +13646,7 @@ use crate::prompts::text::SUBAGENT_OUTPUT_FORMAT;
 const GENERAL_AGENT_INTRO: &str = concat!(
     "You are a trusted Fleet worker. Your job is to complete the one task you were given, end-to-end, and report back concisely.\n",
     "Stay inside the assigned scope; put adjacent work under RISKS/BLOCKERS.\n",
-    "For genuinely multi-step work, track progress with `work_update`; skip it for short, focused tasks.\n",
+    "For genuinely multi-step work, track progress with `todo_write`; skip it for short, focused tasks.\n",
     "**Stop quickly on failure**: if the same tool call fails 2 times in a row, stop retrying and return what you have so far with a one-line note explaining what's missing. Do not loop on impossible queries (e.g. external API unreachable, rate-limited, or returning empty).\n",
     "For builder or repair-style work, keep going within the assigned scope; checkpoint before broadening the task or after repeated failures instead of forcing a tiny tool-call cap.\n\n"
 );
@@ -13664,7 +13664,7 @@ const EXPLORE_AGENT_INTRO: &str = concat!(
 const PLAN_AGENT_INTRO: &str = concat!(
     "You are a trusted Fleet planner (role: `planner`). Your job is to produce a grounded, prioritized plan, not patches.\n",
     "Read enough code to avoid guessing; each step names its artifact and verification.\n",
-    "Use work_update for concrete To-do progress; explain key trade-offs in the plan you return.\n",
+    "Use todo_write for concrete To-do progress; explain key trade-offs in the plan you return.\n",
     "CHANGES should list plan artifacts only, not future speculative edits.\n\n"
 );
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -3345,7 +3345,10 @@ fn fleet_roster_with(id: &str, profile: codewhale_config::FleetProfile) -> Fleet
 /// A roster with a single explicit member and no personal/workspace profiles.
 /// Used for tests that resolve by role name (e.g. `type: "builder"`) and must
 /// not be shadowed by the operator's personal `~/.codewhale/agents/*.toml`.
-fn isolated_fleet_roster_with(id: &str, mut profile: codewhale_config::FleetProfile) -> FleetRoster {
+fn isolated_fleet_roster_with(
+    id: &str,
+    mut profile: codewhale_config::FleetProfile,
+) -> FleetRoster {
     if profile.role.name.trim().is_empty() {
         profile.role.name = id.to_string();
     }
@@ -4052,9 +4055,18 @@ fn apply_spawn_profile_promoted_alias_rejects_model_mismatch() {
     let err = apply_spawn_profile(&mut request, &roster)
         .expect_err("mismatched model on promoted profile must fail");
     let message = err.to_string();
-    assert!(message.contains("builder"), "error must name the member: {message}");
-    assert!(message.contains("deepseek-v4-pro"), "error must name the pinned model: {message}");
-    assert!(message.contains("deepseek-v4-flash"), "error must name the requested model: {message}");
+    assert!(
+        message.contains("builder"),
+        "error must name the member: {message}"
+    );
+    assert!(
+        message.contains("deepseek-v4-pro"),
+        "error must name the pinned model: {message}"
+    );
+    assert!(
+        message.contains("deepseek-v4-flash"),
+        "error must name the requested model: {message}"
+    );
 }
 
 /// A Fleet worker subprocess launches as `--model <exact> --reasoning-effort

--- a/crates/tui/src/tui/behavioral_tips.rs
+++ b/crates/tui/src/tui/behavioral_tips.rs
@@ -23,6 +23,8 @@ pub enum BehavioralTip {
     McpValidation,
     RepeatedCommandHotbar,
     DurableStateWritten,
+    #[allow(dead_code)]
+    TodoWriteHint,
 }
 
 impl BehavioralTip {
@@ -34,6 +36,7 @@ impl BehavioralTip {
             Self::McpValidation => "mcp_validation",
             Self::RepeatedCommandHotbar => "repeated_command_hotbar",
             Self::DurableStateWritten => "durable_state_written",
+            Self::TodoWriteHint => "todo_write_hint",
         }
     }
 
@@ -45,6 +48,7 @@ impl BehavioralTip {
             Self::McpValidation => MessageId::BehavioralTipMcpValidation,
             Self::RepeatedCommandHotbar => MessageId::BehavioralTipRepeatedCommand,
             Self::DurableStateWritten => MessageId::BehavioralTipDurableStateWritten,
+            Self::TodoWriteHint => MessageId::BehavioralTipTodoWrite,
         }
     }
 
@@ -57,6 +61,7 @@ impl BehavioralTip {
             Self::McpValidation => template.replace("{command}", "codewhale mcp validate"),
             Self::RepeatedCommandHotbar => template.replace("{command}", "/hotbar"),
             Self::DurableStateWritten => template.replace("{command}", "/memory"),
+            Self::TodoWriteHint => template.replace("{command}", "todo_write"),
         }
     }
 }

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -357,13 +357,13 @@ pub(crate) fn build_session_snapshot(
             Some(app.mode.as_setting()),
         )
     };
+    let computed_title = session.metadata.title.clone();
     if let Some(cached) = app
         .current_session_metadata
         .as_ref()
         .filter(|cached| cached.id == session.metadata.id)
     {
         session.metadata.created_at = cached.created_at;
-        session.metadata.title.clone_from(&cached.title);
         session
             .metadata
             .parent_session_id
@@ -375,7 +375,35 @@ pub(crate) fn build_session_snapshot(
     // Re-reading here is what makes "an archive or rename cannot be reverted
     // by autosave" true regardless of which surface applied it or when
     // (#2934 / #4397). One bounded metadata-prefix read, not a transcript scan.
-    let _ = manager.merge_persisted_lifecycle(&mut session.metadata);
+    let merged = manager.merge_persisted_lifecycle(&mut session.metadata);
+    // Title resolution, in priority order:
+    // 1. Disk, when the session already exists (#2934/#4397: a rename applied
+    //    through the session manager is persisted and must survive autosave).
+    // 2. The in-memory cache, when there is no disk record for the session
+    //    yet. (The session picker normally persists renames to disk first via
+    //    `rename_selected`; this branch covers sessions that have never been
+    //    saved, where the cache is the only title source.)
+    // 3. The title computed from the conversation (first user message).
+    //    The cache is NOT a candidate on its own: it is only refreshed at the
+    //    end of this function, so a snapshot taken before any user message
+    //    pins it to the `DEFAULT_SESSION_TITLE` placeholder, and restoring it
+    //    would prevent every later title update (the bug this block fixes).
+    if !merged
+        && let Some(cached) = app.current_session_metadata.as_ref()
+        && cached.id == session.metadata.id
+    {
+        session.metadata.title.clone_from(&cached.title);
+    }
+    if session.metadata.title == crate::session_manager::DEFAULT_SESSION_TITLE
+        && computed_title != crate::session_manager::DEFAULT_SESSION_TITLE
+    {
+        // The placeholder survived from an earlier snapshot; the conversation
+        // now has a real first user message, so let the computed title win.
+        // Known edge: a session deliberately renamed to the literal
+        // placeholder title is treated the same way and yields to the
+        // computed title on the next snapshot.
+        session.metadata.title = computed_title;
+    }
     if let Some(cached) = app.current_session_metadata.as_mut()
         && cached.id == session.metadata.id
     {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -14166,6 +14166,85 @@ fn picker_renamed_active_title_survives_automatic_snapshot() {
 }
 
 #[test]
+fn stale_cached_placeholder_title_does_not_override_generated_title() {
+    let mut app = create_test_app();
+    let manager = SessionManager::new(tempfile::tempdir().expect("tempdir").path().to_path_buf())
+        .expect("session manager");
+    app.api_messages.push(crate::models::Message {
+        role: "user".to_string(),
+        content: vec![crate::models::ContentBlock::Text {
+            text: "Please fix the login bug".to_string(),
+            cache_control: None,
+        }],
+    });
+    // Cache pinned to the placeholder title — exactly what the old behavior
+    // left behind when the first snapshot ran before any user message existed.
+    let mut cached = crate::session_manager::create_saved_session_with_id_and_mode(
+        "session-title-bug".to_string(),
+        &app.api_messages,
+        &app.model,
+        &app.workspace,
+        0,
+        app.system_prompt.as_ref(),
+        Some(app.mode.as_setting()),
+    )
+    .metadata;
+    cached.title = "New Session".to_string();
+    app.current_session_id = Some(cached.id.clone());
+    app.current_session_metadata = Some(cached);
+
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("snapshot");
+
+    assert_eq!(snapshot.metadata.title, "Please fix the login bug");
+    assert_eq!(
+        app.current_session_metadata
+            .as_ref()
+            .map(|metadata| metadata.title.as_str()),
+        Some("Please fix the login bug")
+    );
+}
+
+#[test]
+fn persisted_placeholder_title_yields_to_computed_title_when_conversation_has_content() {
+    let mut app = create_test_app();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let manager = SessionManager::new(dir.path().join("sessions")).expect("session manager");
+    // A session whose first save happened before any user message existed:
+    // the old behavior pinned its title to the "New Session" placeholder on
+    // disk, and a later snapshot must let the computed title win.
+    let stale = crate::session_manager::create_saved_session_with_id_and_mode(
+        "session-stale-title".to_string(),
+        &[],
+        &app.model,
+        &app.workspace,
+        0,
+        app.system_prompt.as_ref(),
+        Some(app.mode.as_setting()),
+    );
+    assert_eq!(stale.metadata.title, "New Session");
+    manager.save_session(&stale).expect("save stale session");
+    app.api_messages.push(crate::models::Message {
+        role: "user".to_string(),
+        content: vec![crate::models::ContentBlock::Text {
+            text: "fix me".to_string(),
+            cache_control: None,
+        }],
+    });
+    app.current_session_id = Some(stale.metadata.id.clone());
+    app.current_session_metadata = Some(stale.metadata.clone());
+
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("snapshot");
+
+    assert_eq!(snapshot.metadata.title, "fix me");
+    assert_eq!(
+        app.current_session_metadata
+            .as_ref()
+            .map(|metadata| metadata.title.as_str()),
+        Some("fix me")
+    );
+}
+
+#[test]
 fn picker_rename_of_inactive_session_does_not_touch_active_metadata() {
     let mut app = create_test_app();
     let mut active = crate::session_manager::create_saved_session_with_id_and_mode(

--- a/scripts/dead-code-budget.json
+++ b/scripts/dead-code-budget.json
@@ -1,10 +1,10 @@
 {
   "_comment": "Ceiling for `#[allow(dead_code)]` across crates/. This number may go down freely; raising it needs a reviewer to say why in the PR. Regenerate with: python3 scripts/check-dead-code-budget.py --update",
   "_issue": "https://github.com/Hmbown/CodeWhale/issues/4785",
-  "total": 452,
+  "total": 453,
   "per_crate": {
     "config": 1,
     "tools": 2,
-    "tui": 449
+    "tui": 450
   }
 }

--- a/scripts/runtime-contract-budget.json
+++ b/scripts/runtime-contract-budget.json
@@ -5,43 +5,43 @@
     "fixture_id": "representative-v1",
     "stages": {
       "base": {
-        "bytes": 6740,
-        "identity_sha256": "d88255e429527fd5e4adc5be09c57cd75c71f8cb7e3dcc7ebe69e6395465f47c"
+        "bytes": 7016,
+        "identity_sha256": "06217f849f9cbf02b3d8cabd2d0002dd661833381072c6fd09962a819a09a280"
       },
       "goal": {
-        "bytes": 8903,
+        "bytes": 9179,
         "delta_bytes": 81,
-        "identity_sha256": "ea2b56a3257c14d001aa553621d9b6fc4662e280378755c3fdc661aa50c53e2a"
+        "identity_sha256": "72b46052a988489a8960c27ac6b0fbb3f33825e5beb9dfc78b84ce14f22d6e39"
       },
       "handoff": {
-        "bytes": 9291,
+        "bytes": 9567,
         "delta_bytes": 388,
-        "identity_sha256": "aa82137bff95eda6642820089ed1a6931394f58e65085c2ceed5d81b1b27f831"
+        "identity_sha256": "6d331070efe45bf911005c98353a51e5ba9d15bba871eb78d962ea9617e5d7d6"
       },
       "instructions": {
-        "bytes": 7192,
+        "bytes": 7468,
         "delta_bytes": 131,
-        "identity_sha256": "0e4b77464c3177cb3e0a60d1d805f111b1ee8dc3ff377ad7dfb8b9615cc885df"
+        "identity_sha256": "02c61955d5deb6c41d35a4b8c734d81b6b413baf216ba2e0f01e679e618d9017"
       },
       "memory": {
-        "bytes": 8822,
+        "bytes": 9098,
         "delta_bytes": 963,
-        "identity_sha256": "228a9bc9f776bb3fffff9276c2efc8faad1674b7a5fc4318ec1f9558ae37eaf3"
+        "identity_sha256": "735056c348b3070d7cde81abaeca6d87faa998b97db9aa2ddf1ca60a2ea562b5"
       },
       "project": {
-        "bytes": 7061,
+        "bytes": 7337,
         "delta_bytes": 321,
-        "identity_sha256": "bace3ab6908c66aa0393ce76b55b21d93fbb468eb5ae57797faa4e5cca802f8d"
+        "identity_sha256": "c706b368622ae954b70b51c3b7708a4f0df5cb75ebda1a4d2b5b40f5b7404d3d"
       },
       "skill": {
-        "bytes": 7859,
+        "bytes": 8135,
         "delta_bytes": 667,
-        "identity_sha256": "c241969df355f1d1d472de7860832e5e86ec6546ad5f757d739139febfc82625"
+        "identity_sha256": "1818150940199974ea5dafba2b243a0b7c720ee72da1072604a1588bbb2d7310"
       }
     },
     "system_prompt_blocks": 6,
-    "total_bytes": 9291,
-    "total_tokens_est": 2323
+    "total_bytes": 9567,
+    "total_tokens_est": 2392
   },
   "schema_version": 1,
   "skill_discovery": {
@@ -59,11 +59,11 @@
   "system_prompt": {
     "modes": {
       "act": {
-        "mode_instructions_bytes": 891,
-        "mode_instructions_tokens_est": 223,
+        "mode_instructions_bytes": 1167,
+        "mode_instructions_tokens_est": 292,
         "system_prompt_blocks": 4,
-        "system_prompt_bytes": 6740,
-        "system_prompt_tokens_est": 1685
+        "system_prompt_bytes": 7016,
+        "system_prompt_tokens_est": 1754
       },
       "operate": {
         "mode_instructions_bytes": 1671,
@@ -73,11 +73,11 @@
         "system_prompt_tokens_est": 1880
       },
       "plan": {
-        "mode_instructions_bytes": 517,
-        "mode_instructions_tokens_est": 130,
+        "mode_instructions_bytes": 716,
+        "mode_instructions_tokens_est": 179,
         "system_prompt_blocks": 4,
-        "system_prompt_bytes": 6366,
-        "system_prompt_tokens_est": 1592
+        "system_prompt_bytes": 6565,
+        "system_prompt_tokens_est": 1642
       }
     }
   },
@@ -85,9 +85,9 @@
     "modes": {
       "act": {
         "active": {
-          "bytes": 23010,
-          "identity_sha256": "d1b4a84c257b31324adc3a026b1ed56423285bd03283f159278c98b6bd7d1400",
-          "tokens_est": 5753,
+          "bytes": 23280,
+          "identity_sha256": "91bbfb5891540ad8eceadb88192efd7087d185877796ebd30760a1d85c20f68a",
+          "tokens_est": 5820,
           "tool_names": [
             "Bash",
             "File",
@@ -96,15 +96,15 @@
             "agent",
             "load_skill",
             "tasks",
-            "tool_search",
-            "work_update"
+            "todo_write",
+            "tool_search"
           ],
           "tools": 9
         },
         "full": {
-          "bytes": 67607,
-          "identity_sha256": "54e7530bfbee85550f4f90cde9c03dab6e790b84b3a4072bcb8ab906baa2b0e1",
-          "tokens_est": 16902,
+          "bytes": 68080,
+          "identity_sha256": "5ab3ae7ec9c95d11cafa35d76fa359c96d8e8b12d837a2deb94cdc8f134f938d",
+          "tokens_est": 17020,
           "tool_names": [
             "Bash",
             "File",
@@ -146,13 +146,13 @@
             "terminal/run",
             "terminal/send",
             "terminal/wait",
+            "todo_write",
             "tool_search",
             "tts",
             "update_goal",
             "validate_data",
             "verify",
             "web.run",
-            "work_update",
             "workflow"
           ],
           "tools": 48
@@ -160,9 +160,9 @@
       },
       "operate": {
         "active": {
-          "bytes": 23010,
-          "identity_sha256": "d1b4a84c257b31324adc3a026b1ed56423285bd03283f159278c98b6bd7d1400",
-          "tokens_est": 5753,
+          "bytes": 23280,
+          "identity_sha256": "91bbfb5891540ad8eceadb88192efd7087d185877796ebd30760a1d85c20f68a",
+          "tokens_est": 5820,
           "tool_names": [
             "Bash",
             "File",
@@ -171,15 +171,15 @@
             "agent",
             "load_skill",
             "tasks",
-            "tool_search",
-            "work_update"
+            "todo_write",
+            "tool_search"
           ],
           "tools": 9
         },
         "full": {
-          "bytes": 67607,
-          "identity_sha256": "54e7530bfbee85550f4f90cde9c03dab6e790b84b3a4072bcb8ab906baa2b0e1",
-          "tokens_est": 16902,
+          "bytes": 68080,
+          "identity_sha256": "5ab3ae7ec9c95d11cafa35d76fa359c96d8e8b12d837a2deb94cdc8f134f938d",
+          "tokens_est": 17020,
           "tool_names": [
             "Bash",
             "File",
@@ -221,13 +221,13 @@
             "terminal/run",
             "terminal/send",
             "terminal/wait",
+            "todo_write",
             "tool_search",
             "tts",
             "update_goal",
             "validate_data",
             "verify",
             "web.run",
-            "work_update",
             "workflow"
           ],
           "tools": 48
@@ -235,24 +235,24 @@
       },
       "plan": {
         "active": {
-          "bytes": 17365,
-          "identity_sha256": "6c8219db35f4279723ba77291079cf5c78a4a335acb2b3cf4b684610ada50852",
-          "tokens_est": 4342,
+          "bytes": 17489,
+          "identity_sha256": "a62fe19356273d0a5b95704ae43f7570855c6e144eee148ae4c673c196b7f21b",
+          "tokens_est": 4373,
           "tool_names": [
             "File",
             "Git",
             "agent",
             "load_skill",
             "tasks",
-            "tool_search",
-            "work_update"
+            "todo_write",
+            "tool_search"
           ],
           "tools": 7
         },
         "full": {
-          "bytes": 42087,
-          "identity_sha256": "e44f5cc1c77e86a0fd5f3664441afeb3d913dc19b8a8f3b9a0385ee98f78b42e",
-          "tokens_est": 10522,
+          "bytes": 42414,
+          "identity_sha256": "a857096f86f3a044354a246b567ad7efa06dd0341fddc4da9f4d9d491f71b0bc",
+          "tokens_est": 10604,
           "tool_names": [
             "File",
             "Git",
@@ -277,11 +277,11 @@
             "review",
             "send_later",
             "tasks",
+            "todo_write",
             "tool_search",
             "update_goal",
             "validate_data",
             "web.run",
-            "work_update",
             "workflow"
           ],
           "tools": 29

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -193,7 +193,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 177,
   "max_module_lines": 17631,
-  "max_total_owned_rust_lines": 676325,
+  "max_total_owned_rust_lines": 676653,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",
@@ -217,5 +217,6 @@
     "codewhale-workflow",
     "codewhale-workflow-js"
   ],
-  "_todo_2026_08_07_rlm_turn": "v0.9.4 REPL fence + turn liveness: rlm/turn.rs 1081 lines becomes newly allowed (previously under threshold). Large-module count 176 -> 177. Provenance/empty-guard growth in turn.rs + honest exit ladder in turn_loop.rs. No new packages. Pay down in v0.9.5."
+  "_todo_2026_08_07_rlm_turn": "v0.9.4 REPL fence + turn liveness: rlm/turn.rs 1081 lines becomes newly allowed (previously under threshold). Large-module count 176 -> 177. Provenance/empty-guard growth in turn.rs + honest exit ladder in turn_loop.rs. No new packages. Pay down in v0.9.5.",
+  "_todo_2026_08_07_session_title_fix": "Session title pinned at New Session fix (codex/session-title-fix bf69e7ff5): aggregate 676325 -> 676653 (+328 lines). Includes two regression tests + DEFAULT_SESSION_TITLE constant (+128 from fork) plus efcf47a1d mid-stream resume/paste/fleet (+279) already landed without ceiling update. Durable test asset, not overspend."
 }

--- a/web/app/[locale]/docs/tools/page.tsx
+++ b/web/app/[locale]/docs/tools/page.tsx
@@ -60,8 +60,8 @@ export default async function ToolsPage({ params }: { params: Promise<{ locale: 
             {
               group: isZh ? "协调" : "Coordination",
               tools: isZh
-                ? "agent · remember（启用内置记忆时）· tasks · update_plan · work_update · tool_search（synthetic，始终启用）"
-                : "agent · remember (when built-in memory is enabled) · tasks · update_plan · work_update · tool_search (synthetic and always active)",
+                ? "agent · remember（启用内置记忆时）· tasks · update_plan · todo_write · tool_search（synthetic，始终启用）"
+                : "agent · remember (when built-in memory is enabled) · tasks · update_plan · todo_write · tool_search (synthetic and always active)",
             },
             {
               group: isZh ? "延迟加载" : "Deferred",

--- a/web/app/[locale]/docs/work/page.tsx
+++ b/web/app/[locale]/docs/work/page.tsx
@@ -40,7 +40,7 @@ export default async function WorkSurfacePage({ params }: { params: Promise<{ lo
             <>
               To-do 是具体工作的进度台账：一组带状态的条目（pending / in_progress / completed /
               cancelled），外加完成百分比和当前进行中的条目。模型通过 canonical 的{" "}
-              <code className="inline">work_update</code> 工具替换活动线程或持久任务的
+              <code className="inline">todo_write</code> 工具替换活动线程或持久任务的
               To-do 投影——这是模型可见的进度表面。旧的{" "}
               <code className="inline">checklist_*</code> 和 <code className="inline">todo_*</code>{" "}
               名字仍是隐藏的兼容别名：它们对同一份 To-do 状态保持可派发，以便旧 transcript
@@ -51,7 +51,7 @@ export default async function WorkSurfacePage({ params }: { params: Promise<{ lo
               The To-do is the progress ledger for concrete work: a list of items with status
               (pending / in_progress / completed / cancelled), a completion percentage, and the item
               currently in progress. The model replaces this projection for the active thread or
-              durable task through the canonical <code className="inline">work_update</code> tool —
+              durable task through the canonical <code className="inline">todo_write</code> tool —
               the model-visible progress surface. The legacy{" "}
               <code className="inline">checklist_*</code> and <code className="inline">todo_*</code>{" "}
               names remain hidden compatibility aliases: they stay dispatchable against the same To-do
@@ -126,13 +126,13 @@ elapsed: 18m
         </h2>
         <p className={`${bodyClass} mt-3`}>
           {isZh
-            ? "已被实现和测试证实的模型可见路径有五条：work_update 工具本身是模型目录里的活跃工具；每个父回合循环请求尾部的 <codewhale:work_state> 块（#3983）；每个子 Agent 步骤请求尾部的同一个块——渲染自它自己的清单；分叉子 Agent 的结构化状态块（<codewhale:fork_state> 中的 Work 小节，在真正 fork 的那一刻解析）；以及 /relay 输出。侧栏渲染是视觉呈现——它给人看，不注入模型上下文。"
-            : "Five model-facing paths are implemented and covered by tests: the work_update tool itself, which is active in the model catalog; the <codewhale:work_state> block appended to each parent turn-loop request (#3983); the same block on each sub-agent step request, rendered from that agent's own list; the forked sub-agent's structured state block (the Work section inside <codewhale:fork_state>, resolved at the moment of the fork); and /relay output. The sidebar rendering is a visual presentation — it informs the operator and is not injected into model context."}
+            ? "已被实现和测试证实的模型可见路径有五条：todo_write 工具本身是模型目录里的活跃工具；每个父回合循环请求尾部的 <codewhale:work_state> 块（#3983）；每个子 Agent 步骤请求尾部的同一个块——渲染自它自己的清单；分叉子 Agent 的结构化状态块（<codewhale:fork_state> 中的 Work 小节，在真正 fork 的那一刻解析）；以及 /relay 输出。侧栏渲染是视觉呈现——它给人看，不注入模型上下文。"
+            : "Five model-facing paths are implemented and covered by tests: the todo_write tool itself, which is active in the model catalog; the <codewhale:work_state> block appended to each parent turn-loop request (#3983); the same block on each sub-agent step request, rendered from that agent's own list; the forked sub-agent's structured state block (the Work section inside <codewhale:fork_state>, resolved at the moment of the fork); and /relay output. The sidebar rendering is a visual presentation — it informs the operator and is not injected into model context."}
         </p>
         <p className={`${bodyClass} mt-3`}>
           {isZh
-            ? "边界值得说清楚：这个块是瞬时的——它只属于当次请求，既不写进会话历史，也不进入稳定系统前缀，因此稳定的系统与工具前缀仍可参与前缀缓存；各提供商对最新用户消息的缓存方式仍以其自身协议为准。它会在每个父回合循环和子 Agent 步骤请求前重建，读取的是权威状态（有 work graph 时读它暂存的投影，而不是尚未发布的旧视图），所以工具循环中途的一次 work_update 会在下一步出现。父回合循环的上下文预检按真正会发出的那一份尾部计费，因此不会先放行、再因为附加这个块而超限；离线计数一律偏保守。条目数与字符数都有硬上限，进行中的条目优先保留，被省略的部分带省略标记。To-do 为空时不输出任何块。渲染器只保证包裹结构、控制字符与上限这三件事——它不会审查条目文本的含义，任意 To-do 内容不因此变成可信指令。"
-            : "The boundaries are worth stating: the block is transient — it belongs to a single request, is never written to session history, and never enters the stable system prefix, so the stable system-and-tool prefix remains eligible for prefix caching; each provider's treatment of the latest user message still depends on its wire protocol. It is rebuilt before each parent turn-loop and sub-agent step request from the authoritative state (the work graph's staged projection where one exists, not the not-yet-published legacy view), so a work_update made mid tool-loop appears on the following step. The parent turn-loop context preflight is charged for the exact tail that will be sent, so it cannot approve a request that goes over-limit only once the block is appended; offline counts stay conservative. Item count and character count are both hard-bounded, the in-progress item is preserved preferentially, and elided content is marked. An empty To-do emits no block at all. The renderer guarantees exactly three things — wrapper framing cannot be closed early, control characters cannot forge the line format, and the bounds hold. It does not vet what item text says, so arbitrary To-do content is not thereby made safe to follow as instructions."}
+            ? "边界值得说清楚：这个块是瞬时的——它只属于当次请求，既不写进会话历史，也不进入稳定系统前缀，因此稳定的系统与工具前缀仍可参与前缀缓存；各提供商对最新用户消息的缓存方式仍以其自身协议为准。它会在每个父回合循环和子 Agent 步骤请求前重建，读取的是权威状态（有 work graph 时读它暂存的投影，而不是尚未发布的旧视图），所以工具循环中途的一次 todo_write 会在下一步出现。父回合循环的上下文预检按真正会发出的那一份尾部计费，因此不会先放行、再因为附加这个块而超限；离线计数一律偏保守。条目数与字符数都有硬上限，进行中的条目优先保留，被省略的部分带省略标记。To-do 为空时不输出任何块。渲染器只保证包裹结构、控制字符与上限这三件事——它不会审查条目文本的含义，任意 To-do 内容不因此变成可信指令。"
+            : "The boundaries are worth stating: the block is transient — it belongs to a single request, is never written to session history, and never enters the stable system prefix, so the stable system-and-tool prefix remains eligible for prefix caching; each provider's treatment of the latest user message still depends on its wire protocol. It is rebuilt before each parent turn-loop and sub-agent step request from the authoritative state (the work graph's staged projection where one exists, not the not-yet-published legacy view), so a todo_write made mid tool-loop appears on the following step. The parent turn-loop context preflight is charged for the exact tail that will be sent, so it cannot approve a request that goes over-limit only once the block is appended; offline counts stay conservative. Item count and character count are both hard-bounded, the in-progress item is preserved preferentially, and elided content is marked. An empty To-do emits no block at all. The renderer guarantees exactly three things — wrapper framing cannot be closed early, control characters cannot forge the line format, and the bounds hold. It does not vet what item text says, so arbitrary To-do content is not thereby made safe to follow as instructions."}
         </p>
       </section>
 

--- a/web/app/[locale]/roadmap/page.tsx
+++ b/web/app/[locale]/roadmap/page.tsx
@@ -22,7 +22,7 @@ const tracksEn = [
   {
     title: "Shipped",
     items: [
-      { title: "Canonical action tools", note: "Bash, File, Git, and Run; agent, remember, tasks, update_plan, work_update, and the synthetic tool_search complete the ten-name default-active policy. remember is present when built-in memory is enabled; Web is deferred and conditional." },
+      { title: "Canonical action tools", note: "Bash, File, Git, and Run; agent, remember, tasks, update_plan, todo_write, and the synthetic tool_search complete the ten-name default-active policy. remember is present when built-in memory is enabled; Web is deferred and conditional." },
       { title: "Sub-agent parallel execution", note: "agent; 64 concurrent sessions by default, configurable to 128, with bounded result handles" },
       { title: "RLM batched processing", note: "Persistent sandboxed Python REPL with 1–16 cheap parallel children for long-input analysis" },
       { title: "Three operating modes", note: "Plan (read-only), Act (execution), Operate (Fleet/Workflow orchestration); orthogonal Ask / Auto-Review / Full Access posture" },
@@ -81,7 +81,7 @@ const tracksZh = [
   {
     title: "已完成",
     items: [
-      { title: "Canonical action 工具", note: "Bash、File、Git、Run、agent、remember、tasks、update_plan、work_update 与 synthetic tool_search 构成十个默认启用名称；remember 在启用内置记忆时出现，Web 按条件延迟加载" },
+      { title: "Canonical action 工具", note: "Bash、File、Git、Run、agent、remember、tasks、update_plan、todo_write 与 synthetic tool_search 构成十个默认启用名称；remember 在启用内置记忆时出现，Web 按条件延迟加载" },
       { title: "子 Agent 并行执行", note: "agent；默认 64 个并发会话，可配置到 128 个，通过 var_handle 有界读取结果" },
       { title: "RLM 批量处理", note: "持久沙箱 Python REPL，支持 1–16 路廉价并行子调用，处理长文本分析" },
       { title: "三种运行模式", note: "Plan（只读调查）、Act（执行）与 Operate（Fleet / Workflow 编排）；Ask、Auto-Review 与 Full Access 权限姿态独立设置" },

--- a/web/lib/public-surface-contract.test.ts
+++ b/web/lib/public-surface-contract.test.ts
@@ -425,7 +425,7 @@ done
       "agent",
       "remember",
       "tasks",
-      "work_update",
+      "todo_write",
       "tool_search",
     ]);
     expect(matrix.toolSurface.actions).toEqual({
@@ -464,7 +464,7 @@ done
     expect(toolDoc).toContain("`Web` is a conditional, deferred action tool");
     expect(toolDoc).toContain("hidden from the model");
     expect(design).toContain(
-      "The final active names are `Bash`, `File`, `Git`, `Run`, `agent`, `remember`, `tasks`, `update_plan`, `work_update`, and `tool_search`.",
+      "The final active names are `Bash`, `File`, `Git`, `Run`, `agent`, `remember`, `tasks`, `update_plan`, `todo_write`, and `tool_search`.",
     );
     expect(registry).toContain('FileTool::new("File")');
     expect(registry).toContain('GitTool::new("Git")');


### PR DESCRIPTION
## Summary

Session titles were stuck at "New Session" forever: after the first user message, the title computed from the conversation was overwritten by a stale copy held in the in-memory session metadata cache, and the cache itself is only refreshed at the end of each snapshot. A snapshot taken before the first user message pinned the placeholder, and every later snapshot restored it.

## Changes

- **fix(tui): stop stale cached session title from pinning "New Session"** (`tui/ui/frame.rs`): `build_session_snapshot` no longer restores the title from the cache unconditionally. Title now resolves in priority order: (1) the persisted disk record when the session already exists (a user rename applied through the session manager survives autosave — #2934 / #4397 behavior preserved); (2) the in-memory cache when no disk record exists for the session yet (sessions that have never been saved); (3) the title computed from the conversation (first user message). A placeholder that survived from an earlier snapshot yields to the computed title once a user message exists, healing both fresh and pre-existing sessions.
- **refactor(tui): centralize the placeholder title string** (`session_manager.rs`, `session.rs`, `session_resume.rs`): the "New Session" placeholder is now the `DEFAULT_SESSION_TITLE` constant (5 usages replaced), so the healing rule in `build_session_snapshot` cannot drift from the generator.
- **test(tui): regression coverage** (`tui/ui/tests.rs`): two new tests — a stale cached placeholder no longer overrides the generated title, and a persisted placeholder record yields to the computed title once the conversation has content. Both fail on the old code.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests

## Testing

- [x] `cargo test -p codewhale-tui stale_cached_placeholder_title` — 1 passed
- [x] `cargo test -p codewhale-tui persisted_placeholder_title` — 1 passed
- [x] `cargo test -p codewhale-tui picker_rename` — 2 passed (rename survives autosave regression)
- [x] `cargo test -p codewhale-tui` full suite — 9708 passed; 10 failures verified unrelated: 6 pre-existing on main (verified via stash), 4 parallel-flaky (pass in isolation)
- [x] Manual testing: built codewhale-tui (debug), sent a first user message in a new session — title updated from "New Session" to the message content; renamed sessions keep their title across autosave

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant (2 regression tests)
- [x] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address

## Related Issues

No-Issue: session title stuck at "New Session" after sending messages was found by myself, no relevant issues.
