### PR TITLE
fix(telemetry): flush only at shutdown

### DIFF
--- a/crates/telemetry/src/actor.rs
+++ b/crates/telemetry/src/actor.rs
@@ -29,7 +29,6 @@ pub const BATCH_MAX_BYTES: usize = 64 * 1024;
 
 pub(crate) enum Message {
     Event(Box<Event>),
-    Flush(SyncSender<FlushOutcome>),
     Shutdown(SyncSender<FlushOutcome>),
 }
 
@@ -85,11 +84,6 @@ impl Handle {
         let _ = self.tx.send(Message::Event(Box::new(event)));
     }
 
-    /// Ask for a flush and wait at most `deadline` for the answer.
-    pub(crate) fn flush(&self, deadline: Duration) -> FlushOutcome {
-        self.round_trip(deadline, Message::Flush)
-    }
-
     /// Ask for a final flush and stop the thread.
     pub(crate) fn shutdown(&self, deadline: Duration) -> FlushOutcome {
         self.round_trip(deadline, Message::Shutdown)
@@ -121,10 +115,6 @@ fn run(context: &Context, rx: &Receiver<Message>) {
         let result = catch_unwind(AssertUnwindSafe(|| match message {
             Message::Event(event) => {
                 append(context, &event);
-                None
-            }
-            Message::Flush(ack) => {
-                let _ = ack.send(flush(context));
                 None
             }
             Message::Shutdown(ack) => {

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -68,9 +68,6 @@ pub use event::{
 /// handshake would hold a user's terminal past exit.
 pub const SHUTDOWN_FLUSH_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// Minimum gap between startup drains.
-pub const STARTUP_DRAIN_INTERVAL_HOURS: i64 = 6;
-
 /// Everything a write path needs once the process is armed.
 struct Armed {
     handle: actor::Handle,
@@ -260,19 +257,6 @@ pub fn exit_class() -> ExitClass {
     })
 }
 
-/// Flush whatever is buffered, waiting at most `deadline`.
-///
-/// Blocking, so async callers must hand this to `spawn_blocking` and bound it —
-/// [`SHUTDOWN_FLUSH_TIMEOUT`] is the teardown budget. Consent is re-resolved
-/// from disk inside the writer thread before anything is sent.
-///
-/// Returns [`FlushOutcome::Empty`] when unarmed.
-pub fn flush_blocking(deadline: Duration) -> FlushOutcome {
-    ARMED
-        .get()
-        .map_or(FlushOutcome::Empty, |armed| armed.handle.flush(deadline))
-}
-
 /// Final flush, then stop the writer thread.
 ///
 /// Returns [`FlushOutcome::Empty`] when unarmed.
@@ -280,31 +264,4 @@ pub fn shutdown_blocking(deadline: Duration) -> FlushOutcome {
     ARMED
         .get()
         .map_or(FlushOutcome::Empty, |armed| armed.handle.shutdown(deadline))
-}
-
-/// Whether a startup drain is due: a prior session crashed or was signalled and
-/// left events behind, and enough time has passed since the last attempt.
-///
-/// The check happens **before** the drain task is spawned, so "not due" means no
-/// task at all rather than a task that returns early.
-#[must_use]
-pub fn startup_drain_due() -> bool {
-    let Some(armed) = ARMED.get() else {
-        return false;
-    };
-    let path = buffer::buffer_path(&armed.root);
-    if buffer::read_lines(&path).is_empty() {
-        return false;
-    }
-    let state = envelope::read_state(&armed.root);
-    let Some(last) = state.last_flush else {
-        return true;
-    };
-    let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(&last) else {
-        return true;
-    };
-    chrono::Utc::now()
-        .signed_duration_since(parsed.with_timezone(&chrono::Utc))
-        .num_hours()
-        >= STARTUP_DRAIN_INTERVAL_HOURS
 }

--- a/crates/telemetry/src/tests.rs
+++ b/crates/telemetry/src/tests.rs
@@ -1157,11 +1157,6 @@ fn record_blocking_is_a_noop_when_unarmed() {
     });
     crate::set_exit_class(ExitClass::Panic);
     assert_eq!(crate::exit_class(), ExitClass::Clean);
-    assert_eq!(
-        crate::flush_blocking(Duration::from_millis(10)),
-        crate::FlushOutcome::Empty
-    );
-    assert!(!crate::startup_drain_due());
     assert!(
         !root.exists(),
         "an unarmed process must create no directory"

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1689,15 +1689,6 @@ fn arm_telemetry(cli: &Cli, command: Option<&Commands>) {
     codewhale_telemetry::record(codewhale_telemetry::Event::SessionStart {
         source: telemetry_session_source(command),
     });
-
-    // Recover a prior session that crashed or was signalled before it could
-    // flush. The due check happens *before* the spawn, so "not due" means no
-    // task at all rather than a task that returns early.
-    if codewhale_telemetry::startup_drain_due() {
-        tokio::task::spawn_blocking(|| {
-            codewhale_telemetry::flush_blocking(codewhale_telemetry::SHUTDOWN_FLUSH_TIMEOUT)
-        });
-    }
 }
 
 /// Close the armed session and flush, bounded.

--- a/crates/tui/tests/integration/telemetry_contract.rs
+++ b/crates/tui/tests/integration/telemetry_contract.rs
@@ -760,10 +760,20 @@ async fn mid_session_opt_out_stops_the_shutdown_flush() {
     let mut command = exec_command(&fixture, "hello");
     let mut child = command.spawn().expect("spawn codewhale-tui exec");
 
-    // Wait until the session has armed and started buffering, then take the
-    // documented way out from outside the process.
+    // Wait until this session's event is actually buffered, then leave enough
+    // time for any accidental background flush to reach the recorder. Nothing
+    // may be sent before shutdown.
     let buffer = fixture.telemetry_root().join("buffer.jsonl");
-    wait_until(Duration::from_secs(30), || buffer.exists());
+    wait_until(Duration::from_secs(30), || {
+        std::fs::read_to_string(&buffer)
+            .map(|body| body.contains("\"event\":\"session_start\""))
+            .unwrap_or(false)
+    });
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert_no_batches(&server, "before the shutdown flush").await;
+
+    // Now take the documented way out from outside the process. The only
+    // flush, at shutdown, must re-resolve this write and suppress the batch.
     fixture.write_config(&sentinel_config(&server.uri(), false));
 
     let status = child

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -99,13 +99,12 @@ claim one.
 ## When anything is sent, and where
 
 Nothing is sent at all unless telemetry resolved on **and** the first-run notice
-was answered with "Enable" on this machine. Given both, there are exactly two
-flush points: a startup drain, at most once every six hours, that recovers
-events a crashed or signalled prior session left behind; and one attempt during
-shutdown, bounded at three seconds. There is no mid-session flush, no per-turn
-flush, and no per-tool-call flush. Both re-resolve your setting from disk
-immediately beforehand, so `codewhale config set telemetry false` written from
-another terminal stops the flush of a session that is already running.
+was answered with "Enable" on this machine. Given both, there is exactly one
+flush point: an attempt during shutdown, bounded at three seconds. There is no
+startup flush, mid-session flush, per-turn flush, or per-tool-call flush. The
+shutdown flush re-resolves your setting from disk immediately beforehand, so
+`codewhale config set telemetry false` written from another terminal stops the
+flush of a session that is already running.
 
 A flush is **one `POST`** to the resolved endpoint — by default
 `https://telemetry.codewhale.net/v1/telemetry`. The request carries a
@@ -304,4 +303,3 @@ Prompts; completions; tool arguments; diffs; patches; file contents; filenames; 
 Two named traps for the implementer. `crates/state/src/lib.rs` persists `git_sha`, `git_branch`, `git_origin_url`, `cwd`, and `path` on the threads table (`:88, :394, :648`): a payload builder that accepts a `Thread` or `ThreadMeta` and derives `Serialize` breaches the contract in one line. **Never derive `Serialize` over an existing state type** — build every telemetry struct from scratch with explicit fields. And `crates/core/src/lib.rs:1381-1390` is the one place in the tree where the word `telemetry` sits inside a JSON object next to `prompt`, `base_url`, and `has_api_key`. It is the object someone will copy. Do not.
 
 ---
-

--- a/telemetry-ingest/README.md
+++ b/telemetry-ingest/README.md
@@ -197,8 +197,8 @@ validated batch body. Never on a network address — an IP-keyed limiter would
 mean this Worker handles IPs, which is the whole thing it must not do. That is a
 weaker limiter (an `install_id.json` can be rewritten between POSTs) and it is
 the right trade: Cloudflare's edge already absorbs volumetric abuse, and the
-client only flushes twice per session anyway (a startup drain at most once every
-six hours, and one three-second attempt at shutdown).
+client only flushes once per session anyway (one three-second attempt at
+shutdown).
 
 ### Size cap
 

--- a/telemetry-ingest/wrangler.jsonc
+++ b/telemetry-ingest/wrangler.jsonc
@@ -20,8 +20,7 @@
 
   // Per-install rate limiting. Keyed on `install_id` from the validated batch
   // body — never on a network address. 20 POSTs per 60s is generous against the
-  // client's two flush points per session (a startup drain at most once every
-  // six hours, and one bounded attempt at shutdown).
+  // client's single bounded flush attempt at shutdown.
   "ratelimits": [
     {
       "name": "RATE_LIMITER",


### PR DESCRIPTION
## Summary

- remove the impossible startup telemetry drain that could send current-session events before a mid-session opt-out
- make shutdown the only structural flush point while preserving the bounded deadline and consent re-check
- strengthen the process contract to prove an armed session sends nothing before shutdown, then prove an external opt-out suppresses the final batch
- align the client and ingest documentation with the one-flush behavior

## Root cause

`buffer::arm()` deliberately truncates every pre-existing telemetry buffer. The startup predicate therefore could not recover a prior session; it only observed `install_or_upgrade` and `session_start` events freshly queued by the current process. Under CI scheduling, that background task posted them before the test's external opt-out write.

This is the exact failure from protected exact-main CI run 31257458192, Ubuntu job 93102972086.

## Verification

- codewhale-telemetry unit tests: 45/45
- exact mid-session process regression: 5/5 repeated runs
- full TUI integration target: 263/263
- strict workspace all-target/all-feature Clippy
- source-structure budget: 685,101 <= 685,165
- runtime-contract budget: 55/55 exact
- dead-code budget: 453 exact
- formatting, diff, reference scan, and co-author gate

No-Issue: this is an immediate v0.9.5 privacy/release-gate failure discovered only by the protected exact-main proof after PR #5292 merged.
