### PR TITLE
docs(web): publish the v0.9.5 release snapshot

### DIFF
--- a/docs/public-surface-facts.json
+++ b/docs/public-surface-facts.json
@@ -35,10 +35,10 @@
     ]
   },
   "latestPublishedRelease": {
-    "tag": "v0.9.4",
-    "version": "0.9.4",
-    "publishedAt": "2026-08-08T03:26:39Z",
-    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.4",
+    "tag": "v0.9.5",
+    "version": "0.9.5",
+    "publishedAt": "2026-08-08T16:39:59Z",
+    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.5",
     "sources": [
       "web/data/latest-published-release.json"
     ]

--- a/web/data/latest-published-release.json
+++ b/web/data/latest-published-release.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v0.9.4",
-  "version": "0.9.4",
-  "publishedAt": "2026-08-08T03:26:39Z",
-  "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.4"
+  "tag": "v0.9.5",
+  "version": "0.9.5",
+  "publishedAt": "2026-08-08T16:39:59Z",
+  "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.5"
 }

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -27,7 +27,7 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-08-08T10:27:49.102Z",
+  "generatedAt": "2026-08-08T16:49:45.358Z",
   "sourceRevision": null,
   "sourceCommittedAt": null,
   "version": "0.9.5",
@@ -264,9 +264,9 @@ export const FACTS: RepoFacts = {
   "toolCount": 69,
   "license": "MIT",
   "latestPublishedRelease": {
-    "tag": "v0.9.4",
-    "version": "0.9.4",
-    "publishedAt": "2026-08-08T03:26:39Z",
-    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.4"
+    "tag": "v0.9.5",
+    "version": "0.9.5",
+    "publishedAt": "2026-08-08T16:39:59Z",
+    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.5"
   }
 };


### PR DESCRIPTION
## Summary

- advance the separately modeled latest-published release from v0.9.4 to the now-public v0.9.5
- regenerate the checked-in web facts from the canonical source
- keep the immutable release source candidate unchanged at 853cb707

## Evidence

- GitHub Release v0.9.5 is public with 34/34 verified assets
- `npm run check:facts`
- `npm run check:docs`
- `npm run check:locales`
- `npm test` (256 passed)
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` (288 pages)

Post-release website truth update only; no runtime or release-tag changes.

No-Issue: this is the required post-publication facts snapshot for the already-released v0.9.5 tag.