### PR TITLE
fix(release): validate crate publication order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
           bash scripts/release/install-dogfood.test.sh
           bash scripts/release/prepare-release.test.sh
           bash scripts/release/require-release-tag-checkout.test.sh
+          bash scripts/release/validate-crate-publish-order.test.sh
           bash scripts/release/verify-remote-tag.test.sh
           bash .github/scripts/update-homebrew-tap.test.sh
           node .github/scripts/release-workflows.test.js

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -21,6 +21,7 @@ Current packaging note:
   - `codewhale-release`
   - `codewhale-secrets`
   - `codewhale-state`
+  - `codewhale-telemetry`
   - `codewhale-workflow`
   - `codewhale-workflow-js`
   - `codewhale-execpolicy`
@@ -95,10 +96,12 @@ clippy/test/npm-smoke gates for `fix/*`, `rebrand/*`, `work/v*`, and `main`.
 GitHub Actions keeps the cheap drift/fmt statuses plus macOS and Windows
 coverage, while CNB carries the Linux work.
 
-`publish-crates.sh dry-run` performs a full `cargo publish --dry-run` for crates
-without unpublished workspace dependencies and a packaging preflight for dependent
-workspace crates. That avoids false negatives from crates.io not yet containing the
-new workspace version while still validating package contents before publish.
+`publish-crates.sh dry-run` first validates the maintained publication order
+against the locked Cargo workspace graph. It then performs a full
+`cargo publish --dry-run` for crates without unpublished workspace dependencies
+and a packaging preflight for dependent workspace crates. That avoids false
+negatives from crates.io not yet containing the new workspace version while
+still validating package contents before publish.
 
 For npm wrapper verification, build the single runtime and run the
 cross-platform smoke harness. This packs the npm wrapper, installs it into a
@@ -271,7 +274,7 @@ and fails branch-only release sources before assets are published.
    ```
 
    Both Cargo and npm publication fail closed unless `HEAD`, the clean local
-   checkout, and the remote `vX.Y.Z` tag still agree. The authoritative 18-crate
+   checkout, and the remote `vX.Y.Z` tag still agree. The authoritative 20-crate
    dependency order lives in `scripts/release/crates.sh`; do not maintain a
    second handwritten order in this runbook. The helper waits for each new
    version to appear on crates.io before moving to dependents and safely skips

--- a/scripts/release/crates.sh
+++ b/scripts/release/crates.sh
@@ -19,8 +19,8 @@ release_crates=(
   codewhale-telemetry
   codewhale-lane
   codewhale-agent
-  codewhale-tui
   codewhale-core
+  codewhale-tui
   codewhale-app-server
   codewhale-cli
 )

--- a/scripts/release/publish-crates.sh
+++ b/scripts/release/publish-crates.sh
@@ -14,11 +14,6 @@ case "${mode}" in
     ;;
 esac
 
-if [[ "${mode}" == "publish" ]]; then
-  "${script_dir}/require-release-tag-checkout.sh"
-  "${script_dir}/verify-release-assets.sh"
-fi
-
 packages=("${release_crates[@]}")
 crates_user_agent="CodeWhale release publish check (https://github.com/Hmbown/CodeWhale)"
 
@@ -26,6 +21,9 @@ workspace_version=""
 workspace_codewhale_packages=()
 workspace_package_dep_flags=()
 
+metadata_inventory="$(
+  python3 "${script_dir}/validate-crate-publish-order.py" "${packages[@]}"
+)"
 while IFS=$'\t' read -r kind name value; do
   case "${kind}" in
     version)
@@ -36,79 +34,18 @@ while IFS=$'\t' read -r kind name value; do
       workspace_package_dep_flags+=("${value}")
       ;;
   esac
-done < <(
-  python3 - <<'PY'
-import json
-import subprocess
-
-metadata = json.loads(
-    subprocess.check_output(["cargo", "metadata", "--format-version", "1", "--no-deps"])
-)
-workspace_members = set(metadata["workspace_members"])
-workspace_packages = [
-    pkg for pkg in metadata["packages"] if pkg["id"] in workspace_members
-]
-workspace_by_name = {pkg["name"]: pkg for pkg in workspace_packages}
-
-versions = sorted({pkg["version"] for pkg in workspace_packages})
-if not versions:
-    raise SystemExit("workspace has no packages")
-if len(versions) != 1:
-    raise SystemExit(f"workspace packages have mixed versions: {', '.join(versions)}")
-print(f"version\t{versions[0]}\t")
-
-for pkg in sorted(workspace_packages, key=lambda item: item["name"]):
-    if not pkg["name"].startswith("codewhale-"):
-        continue
-    has_workspace_dep = any(
-        dep.get("path") and dep["name"] in workspace_by_name
-        for dep in pkg["dependencies"]
-    )
-    print(f"crate\t{pkg['name']}\t{1 if has_workspace_dep else 0}")
-PY
-)
+done <<<"${metadata_inventory}"
 
 if [[ -z "${workspace_version}" ]]; then
   echo "Could not determine workspace version." >&2
   exit 1
 fi
 
-missing_packages=()
-for workspace_package in "${workspace_codewhale_packages[@]}"; do
-  found=0
-  for package in "${packages[@]}"; do
-    if [[ "${package}" == "${workspace_package}" ]]; then
-      found=1
-      break
-    fi
-  done
-  if [[ "${found}" == "0" ]]; then
-    missing_packages+=("${workspace_package}")
-  fi
-done
+echo "Crate publication order OK: ${#packages[@]} workspace crates."
 
-extra_packages=()
-for package in "${packages[@]}"; do
-  found=0
-  for workspace_package in "${workspace_codewhale_packages[@]}"; do
-    if [[ "${package}" == "${workspace_package}" ]]; then
-      found=1
-      break
-    fi
-  done
-  if [[ "${found}" == "0" ]]; then
-    extra_packages+=("${package}")
-  fi
-done
-
-if (( ${#missing_packages[@]} > 0 || ${#extra_packages[@]} > 0 )); then
-  if (( ${#missing_packages[@]} > 0 )); then
-    echo "publish package list is missing workspace crates: ${missing_packages[*]}" >&2
-  fi
-  if (( ${#extra_packages[@]} > 0 )); then
-    echo "publish package list contains non-workspace crates: ${extra_packages[*]}" >&2
-  fi
-  exit 1
+if [[ "${mode}" == "publish" ]]; then
+  "${script_dir}/require-release-tag-checkout.sh"
+  "${script_dir}/verify-release-assets.sh"
 fi
 
 package_has_workspace_deps() {

--- a/scripts/release/validate-crate-publish-order.py
+++ b/scripts/release/validate-crate-publish-order.py
@@ -136,6 +136,11 @@ def validate_order(
             # They may legitimately point back across the publication DAG.
             if kind == "dev":
                 continue
+            if dependency_name not in positions:
+                raise ValidationError(
+                    f"{dependent} depends on workspace crate {dependency_name} "
+                    f"[{kind}], which is not in the codewhale-* release inventory"
+                )
             publish_edges.add((dependency_name, dependent, str(kind)))
 
     violations = sorted(

--- a/scripts/release/validate-crate-publish-order.py
+++ b/scripts/release/validate-crate-publish-order.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Validate the maintained crates.io publication order against Cargo metadata.
+
+On success, emit the workspace inventory consumed by publish-crates.sh.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+class ValidationError(Exception):
+    """A release-order or Cargo metadata contract violation."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--metadata-file",
+        type=Path,
+        help="Read Cargo metadata from this file instead of invoking cargo (tests only).",
+    )
+    parser.add_argument("crates", nargs="+", help="Maintained publication order")
+    return parser.parse_args()
+
+
+def load_metadata(metadata_file: Path | None) -> dict[str, Any]:
+    if metadata_file is not None:
+        try:
+            raw = metadata_file.read_text(encoding="utf-8")
+        except OSError as error:
+            raise ValidationError(f"could not read Cargo metadata: {error}") from error
+    else:
+        process = subprocess.run(
+            ["cargo", "metadata", "--locked", "--format-version", "1", "--no-deps"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if process.returncode != 0:
+            detail = process.stderr.strip()
+            suffix = f": {detail}" if detail else ""
+            raise ValidationError(
+                f"cargo metadata failed with exit code {process.returncode}{suffix}"
+            )
+        raw = process.stdout
+
+    try:
+        metadata = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ValidationError(f"Cargo metadata is not valid JSON: {error}") from error
+    if not isinstance(metadata, dict):
+        raise ValidationError("Cargo metadata root must be an object")
+    return metadata
+
+
+def workspace_packages(metadata: dict[str, Any]) -> list[dict[str, Any]]:
+    members = metadata.get("workspace_members")
+    packages = metadata.get("packages")
+    if not isinstance(members, list) or not isinstance(packages, list):
+        raise ValidationError("Cargo metadata must contain workspace_members and packages lists")
+
+    packages_by_id = {
+        package.get("id"): package
+        for package in packages
+        if isinstance(package, dict) and isinstance(package.get("id"), str)
+    }
+    missing_ids = [member for member in members if member not in packages_by_id]
+    if missing_ids:
+        raise ValidationError(
+            "Cargo metadata omits workspace package ids: " + ", ".join(missing_ids)
+        )
+    return [packages_by_id[member] for member in members]
+
+
+def validate_order(
+    packages: list[dict[str, Any]], ordered_crates: list[str]
+) -> tuple[str, dict[str, bool]]:
+    duplicate_crates = sorted(
+        {name for name in ordered_crates if ordered_crates.count(name) > 1}
+    )
+    if duplicate_crates:
+        raise ValidationError(
+            "publish package list contains duplicates: " + ", ".join(duplicate_crates)
+        )
+
+    names = [package.get("name") for package in packages]
+    if any(not isinstance(name, str) or not name for name in names):
+        raise ValidationError("workspace package is missing a name")
+    if len(set(names)) != len(names):
+        raise ValidationError("Cargo metadata contains duplicate workspace package names")
+
+    versions = sorted({package.get("version") for package in packages})
+    if len(versions) != 1 or not isinstance(versions[0], str) or not versions[0]:
+        rendered = ", ".join(str(version) for version in versions)
+        raise ValidationError(f"workspace packages have mixed versions: {rendered}")
+
+    workspace_by_name = {package["name"]: package for package in packages}
+    release_names = sorted(
+        name for name in workspace_by_name if name.startswith("codewhale-")
+    )
+    ordered_set = set(ordered_crates)
+    missing = sorted(set(release_names) - ordered_set)
+    extra = sorted(ordered_set - set(release_names))
+    if missing or extra:
+        messages = []
+        if missing:
+            messages.append("publish package list is missing workspace crates: " + " ".join(missing))
+        if extra:
+            messages.append(
+                "publish package list contains non-workspace crates: " + " ".join(extra)
+            )
+        raise ValidationError("\n".join(messages))
+
+    positions = {name: index for index, name in enumerate(ordered_crates)}
+    has_workspace_dependencies = {name: False for name in release_names}
+    publish_edges: set[tuple[str, str, str]] = set()
+    for dependent in release_names:
+        dependencies = workspace_by_name[dependent].get("dependencies", [])
+        if not isinstance(dependencies, list):
+            raise ValidationError(f"Cargo metadata dependencies for {dependent} must be a list")
+        for dependency in dependencies:
+            if not isinstance(dependency, dict) or dependency.get("path") is None:
+                continue
+            dependency_name = dependency.get("name")
+            if dependency_name not in workspace_by_name:
+                continue
+            has_workspace_dependencies[dependent] = True
+            kind = dependency.get("kind") or "normal"
+            # Cargo does not compile dev-dependencies while verifying a publish.
+            # They may legitimately point back across the publication DAG.
+            if kind == "dev":
+                continue
+            publish_edges.add((dependency_name, dependent, str(kind)))
+
+    violations = sorted(
+        (
+            dependency,
+            dependent,
+            kind,
+        )
+        for dependency, dependent, kind in publish_edges
+        if positions[dependency] >= positions[dependent]
+    )
+    if violations:
+        lines = ["crate publication order is not topological:"]
+        for dependency, dependent, kind in violations:
+            lines.append(
+                f"  {dependent} (position {positions[dependent] + 1}) depends on "
+                f"{dependency} (position {positions[dependency] + 1}) [{kind}]"
+            )
+        lines.append(
+            "Move every workspace dependency before its dependent in "
+            "scripts/release/crates.sh."
+        )
+        raise ValidationError("\n".join(lines))
+
+    return versions[0], has_workspace_dependencies
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        packages = workspace_packages(load_metadata(args.metadata_file))
+        version, dependency_flags = validate_order(packages, args.crates)
+    except ValidationError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    print(f"version\t{version}\t")
+    for name in sorted(dependency_flags):
+        print(f"crate\t{name}\t{1 if dependency_flags[name] else 0}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/validate-crate-publish-order.test.sh
+++ b/scripts/release/validate-crate-publish-order.test.sh
@@ -54,6 +54,105 @@ cat >"${metadata_file}" <<'JSON'
 }
 JSON
 
+expect_validation_failure() {
+  local label="$1"
+  local expected="$2"
+  local fixture="$3"
+  shift 3
+
+  local output="${tmp_dir}/${label}.txt"
+  if python3 "${script_dir}/validate-crate-publish-order.py" \
+    --metadata-file "${fixture}" "$@" >"${output}" 2>&1; then
+    echo "${label} unexpectedly passed" >&2
+    exit 1
+  fi
+  grep -F "${expected}" "${output}" >/dev/null
+  if grep -F "Traceback" "${output}" >/dev/null; then
+    echo "${label} emitted an unhandled traceback" >&2
+    exit 1
+  fi
+}
+
+expect_validation_failure \
+  duplicate-crate \
+  "publish package list contains duplicates: codewhale-core" \
+  "${metadata_file}" \
+  codewhale-build-support \
+  codewhale-core \
+  codewhale-core \
+  codewhale-tui \
+  codewhale-app-server \
+  codewhale-cli
+
+expect_validation_failure \
+  missing-crate \
+  "publish package list is missing workspace crates: codewhale-app-server" \
+  "${metadata_file}" \
+  codewhale-build-support \
+  codewhale-core \
+  codewhale-tui \
+  codewhale-cli
+
+expect_validation_failure \
+  extra-crate \
+  "publish package list contains non-workspace crates: codewhale-extra" \
+  "${metadata_file}" \
+  codewhale-build-support \
+  codewhale-core \
+  codewhale-tui \
+  codewhale-app-server \
+  codewhale-cli \
+  codewhale-extra
+
+mixed_metadata_file="${tmp_dir}/mixed-metadata.json"
+python3 - "${metadata_file}" "${mixed_metadata_file}" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+mixed = source.replace('"version": "0.9.5"', '"version": "0.9.4"', 1)
+if mixed == source:
+    raise SystemExit("failed to create mixed-version Cargo metadata fixture")
+pathlib.Path(sys.argv[2]).write_text(mixed, encoding="utf-8")
+PY
+expect_validation_failure \
+  mixed-versions \
+  "workspace packages have mixed versions: 0.9.4, 0.9.5" \
+  "${mixed_metadata_file}" \
+  codewhale-build-support \
+  codewhale-core \
+  codewhale-tui \
+  codewhale-app-server \
+  codewhale-cli
+
+nonrelease_metadata_file="${tmp_dir}/nonrelease-metadata.json"
+cat >"${nonrelease_metadata_file}" <<'JSON'
+{
+  "workspace_members": ["helper", "core"],
+  "packages": [
+    {
+      "id": "helper",
+      "name": "internal-helper",
+      "version": "0.9.5",
+      "dependencies": []
+    },
+    {
+      "id": "core",
+      "name": "codewhale-core",
+      "version": "0.9.5",
+      "dependencies": [
+        {"name": "internal-helper", "path": "/workspace/helper", "kind": null}
+      ]
+    }
+  ]
+}
+JSON
+expect_validation_failure \
+  nonrelease-workspace-dependency \
+  "codewhale-core depends on workspace crate internal-helper [normal], which is not in the codewhale-* release inventory" \
+  "${nonrelease_metadata_file}" \
+  codewhale-core
+
 bad_output="${tmp_dir}/bad-order.txt"
 if python3 "${script_dir}/validate-crate-publish-order.py" \
   --metadata-file "${metadata_file}" \

--- a/scripts/release/validate-crate-publish-order.test.sh
+++ b/scripts/release/validate-crate-publish-order.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+metadata_file="${tmp_dir}/metadata.json"
+cat >"${metadata_file}" <<'JSON'
+{
+  "workspace_members": ["build", "core", "tui", "app", "cli"],
+  "packages": [
+    {
+      "id": "build",
+      "name": "codewhale-build-support",
+      "version": "0.9.5",
+      "dependencies": []
+    },
+    {
+      "id": "core",
+      "name": "codewhale-core",
+      "version": "0.9.5",
+      "dependencies": [
+        {"name": "codewhale-cli", "path": "/workspace/cli", "kind": "dev"}
+      ]
+    },
+    {
+      "id": "tui",
+      "name": "codewhale-tui",
+      "version": "0.9.5",
+      "dependencies": [
+        {"name": "codewhale-build-support", "path": "/workspace/build", "kind": "build"},
+        {"name": "codewhale-core", "path": "/workspace/core", "kind": null}
+      ]
+    },
+    {
+      "id": "app",
+      "name": "codewhale-app-server",
+      "version": "0.9.5",
+      "dependencies": [
+        {"name": "codewhale-core", "path": "/workspace/core", "kind": null}
+      ]
+    },
+    {
+      "id": "cli",
+      "name": "codewhale-cli",
+      "version": "0.9.5",
+      "dependencies": [
+        {"name": "codewhale-tui", "path": "/workspace/tui", "kind": null},
+        {"name": "codewhale-app-server", "path": "/workspace/app", "kind": null}
+      ]
+    }
+  ]
+}
+JSON
+
+bad_output="${tmp_dir}/bad-order.txt"
+if python3 "${script_dir}/validate-crate-publish-order.py" \
+  --metadata-file "${metadata_file}" \
+  codewhale-build-support \
+  codewhale-tui \
+  codewhale-core \
+  codewhale-app-server \
+  codewhale-cli >"${bad_output}" 2>&1; then
+  echo "v0.9.5 publication order unexpectedly passed" >&2
+  exit 1
+fi
+grep -F \
+  "codewhale-tui (position 2) depends on codewhale-core (position 3) [normal]" \
+  "${bad_output}" >/dev/null
+
+good_output="${tmp_dir}/good-order.txt"
+python3 "${script_dir}/validate-crate-publish-order.py" \
+  --metadata-file "${metadata_file}" \
+  codewhale-build-support \
+  codewhale-core \
+  codewhale-tui \
+  codewhale-app-server \
+  codewhale-cli >"${good_output}"
+grep -F $'version\t0.9.5\t' "${good_output}" >/dev/null
+grep -F $'crate\tcodewhale-core\t1' "${good_output}" >/dev/null
+
+# Keep the checked-in order synchronized with the live locked workspace graph.
+# shellcheck source=scripts/release/crates.sh
+source "${script_dir}/crates.sh"
+python3 "${script_dir}/validate-crate-publish-order.py" \
+  "${release_crates[@]}" >"${tmp_dir}/workspace-order.txt"
+
+echo "crate publication order validation tests passed"


### PR DESCRIPTION
## Summary

- validate the maintained 20-crate publication order against locked Cargo metadata before any registry operation
- move codewhale-core before codewhale-tui and fail closed on duplicates, missing or extra crates, mixed versions, and normal/build dependency inversions
- exercise the exact v0.9.5 regression plus the live workspace graph in CI
- correct the release runbook inventory and dry-run contract

## Verification

- bash scripts/release/validate-crate-publish-order.test.sh
- ./scripts/release/publish-crates.sh dry-run (20/20 crates)
- cargo fmt --all -- --check
- bash scripts/release/check-versions.sh
- python3 scripts/check-source-structure-budget.py
- shellcheck and bash syntax checks
- git diff --check

Closes #5298