### PR TITLE
fix(release): use CNB asset download URLs

### DIFF
--- a/.cnb.yml
+++ b/.cnb.yml
@@ -19,8 +19,15 @@
 
 .rust_workspace_gates_stage: &rust_workspace_gates_stage
   name: rust workspace gates
+  # The all-feature TUI test crate is large enough that concurrent rustc and
+  # clippy processes or disposable test debug metadata can exceed the shared
+  # CNB runner's memory. Keep the full gate surface, but serialize Cargo,
+  # omit test-only debug tables, and allow the bounded run to finish.
+  timeout: 45m
   script: |
     set -eu
+    export CARGO_BUILD_JOBS=1
+    export CARGO_PROFILE_TEST_DEBUG=0
     ./scripts/release/check-versions.sh
     ./scripts/release/check-ohos-deps.sh
     cargo fmt --all -- --check

--- a/.cnb.yml
+++ b/.cnb.yml
@@ -22,7 +22,8 @@
   # The all-feature TUI test crate is large enough that concurrent rustc and
   # clippy processes or disposable test debug metadata can exceed the shared
   # CNB runner's memory. Keep the full gate surface, but serialize Cargo,
-  # omit test-only debug tables, and allow the bounded run to finish.
+  # omit test-only debug tables, and use the established workspace-test stack
+  # size so deep runtime API tests do not abort on the platform default.
   timeout: 45m
   script: |
     set -eu
@@ -33,7 +34,7 @@
     cargo fmt --all -- --check
     cargo check --workspace --all-targets --locked
     cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
-    cargo test --workspace --all-features --locked
+    RUST_MIN_STACK=16777216 cargo test --workspace --all-features --locked
     # Parity gates as first-class steps so drift surfaces as a named failure,
     # not a buried workspace-test entry. Mirrors release.yml's parity job.
     cargo test -p codewhale-protocol --test parity_protocol --locked

--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -220,8 +220,8 @@ const cnbRustGates = cnb.match(
 assert.ok(cnbRustGates, "CNB must retain the shared Rust workspace gate");
 assert.match(
   cnbRustGates[1],
-  /timeout: 45m[\s\S]*export CARGO_BUILD_JOBS=1[\s\S]*export CARGO_PROFILE_TEST_DEBUG=0[\s\S]*cargo check --workspace --all-targets --locked/,
-  "CNB must serialize the memory-heavy Rust gate without weakening its checks",
+  /timeout: 45m[\s\S]*export CARGO_BUILD_JOBS=1[\s\S]*export CARGO_PROFILE_TEST_DEBUG=0[\s\S]*cargo check --workspace --all-targets --locked[\s\S]*cargo clippy --workspace --all-targets --all-features --locked -- -D warnings[\s\S]*RUST_MIN_STACK=16777216 cargo test --workspace --all-features --locked/,
+  "CNB must serialize the memory-heavy Rust gate and preserve the workspace test stack contract",
 );
 assert.equal(
   (cnb.match(/^\s+- \*rust_workspace_gates_stage$/gm) || []).length,

--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -214,6 +214,21 @@ assert.match(runbook, /34/);
 assert.match(runbook, /does not create a tag/i);
 assert.match(runbook, /explicit.*approval/i);
 
+const cnbRustGates = cnb.match(
+  /\.rust_workspace_gates_stage: &rust_workspace_gates_stage([\s\S]*?)\n\.linux_rust_gates:/,
+);
+assert.ok(cnbRustGates, "CNB must retain the shared Rust workspace gate");
+assert.match(
+  cnbRustGates[1],
+  /timeout: 45m[\s\S]*export CARGO_BUILD_JOBS=1[\s\S]*export CARGO_PROFILE_TEST_DEBUG=0[\s\S]*cargo check --workspace --all-targets --locked/,
+  "CNB must serialize the memory-heavy Rust gate without weakening its checks",
+);
+assert.equal(
+  (cnb.match(/^\s+- \*rust_workspace_gates_stage$/gm) || []).length,
+  2,
+  "both CNB Rust pipelines must reuse the constrained workspace gate",
+);
+
 const cnbPreflight = cnb.match(
   /\.linux_release_preflight: &linux_release_preflight([\s\S]*?)\nmain:/,
 );

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
           bash scripts/release/install-dogfood.test.sh
           bash scripts/release/prepare-release.test.sh
           bash scripts/release/require-release-tag-checkout.test.sh
+          bash scripts/release/validate-crate-publish-order.test.sh
           bash scripts/release/verify-remote-tag.test.sh
           bash .github/scripts/update-homebrew-tap.test.sh
           node .github/scripts/release-workflows.test.js

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -2539,11 +2539,11 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
     fn cnb_release_base_url_includes_tag_directory() {
         assert_eq!(
             codewhale_release::cnb_release_base_url("0.8.47"),
-            "https://cnb.cool/Hmbown/CodeWhale/-/releases/v0.8.47"
+            "https://cnb.cool/codewhale.net/codewhale/-/releases/download/v0.8.47"
         );
         assert_eq!(
             codewhale_release::cnb_release_base_url("v0.8.47"),
-            "https://cnb.cool/Hmbown/CodeWhale/-/releases/v0.8.47"
+            "https://cnb.cool/codewhale.net/codewhale/-/releases/download/v0.8.47"
         );
     }
 

--- a/crates/release/src/lib.rs
+++ b/crates/release/src/lib.rs
@@ -47,7 +47,7 @@ pub const LEGACY_UPDATE_VERSION_ENV: &str = "DEEPSEEK_VERSION";
 /// User-Agent header sent with release metadata requests.
 pub const UPDATE_USER_AGENT: &str = "codewhale-updater";
 
-const CNB_RELEASE_ASSET_BASE: &str = "https://cnb.cool/Hmbown/CodeWhale/-/releases";
+const CNB_RELEASE_ASSET_BASE: &str = "https://cnb.cool/codewhale.net/codewhale/-/releases/download";
 const RELEASE_METADATA_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Build a reqwest client builder with the TLS roots appropriate for the
@@ -563,7 +563,7 @@ mod tests {
 
         assert_eq!(
             release_base_url_from_env("v1.2.3"),
-            Some("https://cnb.cool/Hmbown/CodeWhale/-/releases/v1.2.3".to_string())
+            Some("https://cnb.cool/codewhale.net/codewhale/-/releases/download/v1.2.3".to_string())
         );
 
         set_release_env(RELEASE_BASE_URL_ENV, "https://explicit.example.com");
@@ -740,11 +740,11 @@ mod tests {
     fn cnb_release_base_url_includes_tag_directory() {
         assert_eq!(
             cnb_release_base_url("0.8.47"),
-            "https://cnb.cool/Hmbown/CodeWhale/-/releases/v0.8.47"
+            "https://cnb.cool/codewhale.net/codewhale/-/releases/download/v0.8.47"
         );
         assert_eq!(
             cnb_release_base_url("v0.8.47"),
-            "https://cnb.cool/Hmbown/CodeWhale/-/releases/v0.8.47"
+            "https://cnb.cool/codewhale.net/codewhale/-/releases/download/v0.8.47"
         );
     }
 

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -1024,34 +1024,28 @@ mod atomic_write_tests {
 
     #[cfg(unix)]
     #[test]
-    fn write_atomic_workspace_replaces_symlink_when_target_is_unreadable() {
-        use std::os::unix::fs::{PermissionsExt, symlink};
+    fn write_atomic_workspace_replaces_self_referential_symlink_without_following() {
+        use std::os::unix::fs::symlink;
 
         let dir = tempdir().expect("tempdir");
-        let secret_dir = dir.path().join("secret");
-        fs::create_dir(&secret_dir).expect("create secret dir");
-        let secret_file = secret_dir.join("hidden.txt");
-        fs::write(&secret_file, b"hidden").expect("write hidden");
-        // Remove search permission so following the symlink fails with EACCES,
-        // while lstat on the symlink itself still succeeds.
-        fs::set_permissions(&secret_dir, fs::Permissions::from_mode(0o000))
-            .expect("lock secret dir");
+        let link = dir.path().join("self-link.txt");
+        symlink(&link, &link).expect("create self-referential symlink");
 
-        let link = dir.path().join("to-hidden.txt");
-        symlink(&secret_file, &link).expect("symlink to hidden file");
-
-        // Following metadata must fail; workspace write must still succeed.
         assert!(
-            fs::metadata(&link).is_err(),
-            "precondition: following the symlink must fail"
+            fs::symlink_metadata(&link)
+                .expect("lstat self-referential symlink")
+                .file_type()
+                .is_symlink()
+        );
+        let follow_error = fs::metadata(&link).expect_err("following the symlink must fail");
+        assert_ne!(
+            follow_error.kind(),
+            std::io::ErrorKind::NotFound,
+            "the fixture must catch a metadata-following regression"
         );
 
         let result = write_atomic_workspace(&link, b"new-content");
-
-        // Restore dir perms so tempdir cleanup can remove nested files.
-        let _ = fs::set_permissions(&secret_dir, fs::Permissions::from_mode(0o700));
-
-        result.expect("workspace write must not abort when symlink target is unreadable");
+        result.expect("workspace write must not follow a self-referential symlink");
         let link_meta = fs::symlink_metadata(&link).expect("link metadata");
         assert!(link_meta.file_type().is_file() && !link_meta.file_type().is_symlink());
         assert_eq!(fs::read(&link).expect("read"), b"new-content");

--- a/crates/tui/src/xai_oauth.rs
+++ b/crates/tui/src/xai_oauth.rs
@@ -2174,8 +2174,7 @@ consent_version = 1
         fs::create_dir(&config_dir).unwrap();
         let config_path = config_dir.join("config.toml");
         fs::write(&config_path, "[providers.xai]\nauth_mode = \"api_key\"\n").unwrap();
-        fs::write(config_dir.join("config.toml.lock"), "").unwrap();
-        fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o500)).unwrap();
+        fs::create_dir(config_dir.join("config.toml.bak")).unwrap();
         let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", &home);
         let legacy_path = seed_legacy_owned_credentials();
         let legacy_before = fs::read(&legacy_path).unwrap();
@@ -2196,8 +2195,7 @@ consent_version = 1
             Some(&config_path),
             Some(&mut live),
         );
-        fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o700)).unwrap();
-        let error = result.expect_err("read-only config directory must fail activation");
+        let error = result.expect_err("invalid backup path must fail activation");
         assert!(error.to_string().contains("not activated"), "{error:#}");
         let live_xai = live.provider_config_for(ApiProvider::Xai).unwrap();
         assert_eq!(live_xai.auth_mode.as_deref(), Some("api_key"));

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -21,6 +21,7 @@ Current packaging note:
   - `codewhale-release`
   - `codewhale-secrets`
   - `codewhale-state`
+  - `codewhale-telemetry`
   - `codewhale-workflow`
   - `codewhale-workflow-js`
   - `codewhale-execpolicy`
@@ -95,10 +96,12 @@ clippy/test/npm-smoke gates for `fix/*`, `rebrand/*`, `work/v*`, and `main`.
 GitHub Actions keeps the cheap drift/fmt statuses plus macOS and Windows
 coverage, while CNB carries the Linux work.
 
-`publish-crates.sh dry-run` performs a full `cargo publish --dry-run` for crates
-without unpublished workspace dependencies and a packaging preflight for dependent
-workspace crates. That avoids false negatives from crates.io not yet containing the
-new workspace version while still validating package contents before publish.
+`publish-crates.sh dry-run` first validates the maintained publication order
+against the locked Cargo workspace graph. It then performs a full
+`cargo publish --dry-run` for crates without unpublished workspace dependencies
+and a packaging preflight for dependent workspace crates. That avoids false
+negatives from crates.io not yet containing the new workspace version while
+still validating package contents before publish.
 
 For npm wrapper verification, build the single runtime and run the
 cross-platform smoke harness. This packs the npm wrapper, installs it into a
@@ -271,7 +274,7 @@ and fails branch-only release sources before assets are published.
    ```
 
    Both Cargo and npm publication fail closed unless `HEAD`, the clean local
-   checkout, and the remote `vX.Y.Z` tag still agree. The authoritative 18-crate
+   checkout, and the remote `vX.Y.Z` tag still agree. The authoritative 20-crate
    dependency order lives in `scripts/release/crates.sh`; do not maintain a
    second handwritten order in this runbook. The helper waits for each new
    version to appear on crates.io before moving to dependents and safely skips

--- a/npm/codewhale/scripts/artifacts.js
+++ b/npm/codewhale/scripts/artifacts.js
@@ -143,7 +143,7 @@ function releaseBaseUrl(version, repo = "Hmbown/CodeWhale") {
   // mirror that already builds and publishes binary release assets.
   if (usesCnbMirror()) {
     assertCnbMirrorSupportedPlatform();
-    return `https://cnb.cool/codewhale.net/codewhale/-/releases/v${version}/`;
+    return `https://cnb.cool/codewhale.net/codewhale/-/releases/download/v${version}/`;
   }
   return `https://github.com/${repo}/releases/download/v${version}/`;
 }

--- a/npm/codewhale/test/artifacts.test.js
+++ b/npm/codewhale/test/artifacts.test.js
@@ -172,15 +172,15 @@ test("CNB mirror URLs use the repository that publishes release assets", () => {
       ]);
       assert.equal(
         releaseBaseUrl("0.8.68"),
-        "https://cnb.cool/codewhale.net/codewhale/-/releases/v0.8.68/",
+        "https://cnb.cool/codewhale.net/codewhale/-/releases/download/v0.8.68/",
       );
       assert.equal(
         releaseAssetUrl("codewhale-linux-x64", "0.8.68"),
-        "https://cnb.cool/codewhale.net/codewhale/-/releases/v0.8.68/codewhale-linux-x64",
+        "https://cnb.cool/codewhale.net/codewhale/-/releases/download/v0.8.68/codewhale-linux-x64",
       );
       assert.equal(
         checksumManifestUrl("0.8.68"),
-        "https://cnb.cool/codewhale.net/codewhale/-/releases/v0.8.68/codewhale-artifacts-sha256.txt",
+        "https://cnb.cool/codewhale.net/codewhale/-/releases/download/v0.8.68/codewhale-artifacts-sha256.txt",
       );
     } finally {
       for (const key of keys) {

--- a/scripts/release/crates.sh
+++ b/scripts/release/crates.sh
@@ -19,8 +19,8 @@ release_crates=(
   codewhale-telemetry
   codewhale-lane
   codewhale-agent
-  codewhale-tui
   codewhale-core
+  codewhale-tui
   codewhale-app-server
   codewhale-cli
 )

--- a/scripts/release/publish-crates.sh
+++ b/scripts/release/publish-crates.sh
@@ -14,11 +14,6 @@ case "${mode}" in
     ;;
 esac
 
-if [[ "${mode}" == "publish" ]]; then
-  "${script_dir}/require-release-tag-checkout.sh"
-  "${script_dir}/verify-release-assets.sh"
-fi
-
 packages=("${release_crates[@]}")
 crates_user_agent="CodeWhale release publish check (https://github.com/Hmbown/CodeWhale)"
 
@@ -26,6 +21,9 @@ workspace_version=""
 workspace_codewhale_packages=()
 workspace_package_dep_flags=()
 
+metadata_inventory="$(
+  python3 "${script_dir}/validate-crate-publish-order.py" "${packages[@]}"
+)"
 while IFS=$'\t' read -r kind name value; do
   case "${kind}" in
     version)
@@ -36,79 +34,18 @@ while IFS=$'\t' read -r kind name value; do
       workspace_package_dep_flags+=("${value}")
       ;;
   esac
-done < <(
-  python3 - <<'PY'
-import json
-import subprocess
-
-metadata = json.loads(
-    subprocess.check_output(["cargo", "metadata", "--format-version", "1", "--no-deps"])
-)
-workspace_members = set(metadata["workspace_members"])
-workspace_packages = [
-    pkg for pkg in metadata["packages"] if pkg["id"] in workspace_members
-]
-workspace_by_name = {pkg["name"]: pkg for pkg in workspace_packages}
-
-versions = sorted({pkg["version"] for pkg in workspace_packages})
-if not versions:
-    raise SystemExit("workspace has no packages")
-if len(versions) != 1:
-    raise SystemExit(f"workspace packages have mixed versions: {', '.join(versions)}")
-print(f"version\t{versions[0]}\t")
-
-for pkg in sorted(workspace_packages, key=lambda item: item["name"]):
-    if not pkg["name"].startswith("codewhale-"):
-        continue
-    has_workspace_dep = any(
-        dep.get("path") and dep["name"] in workspace_by_name
-        for dep in pkg["dependencies"]
-    )
-    print(f"crate\t{pkg['name']}\t{1 if has_workspace_dep else 0}")
-PY
-)
+done <<<"${metadata_inventory}"
 
 if [[ -z "${workspace_version}" ]]; then
   echo "Could not determine workspace version." >&2
   exit 1
 fi
 
-missing_packages=()
-for workspace_package in "${workspace_codewhale_packages[@]}"; do
-  found=0
-  for package in "${packages[@]}"; do
-    if [[ "${package}" == "${workspace_package}" ]]; then
-      found=1
-      break
-    fi
-  done
-  if [[ "${found}" == "0" ]]; then
-    missing_packages+=("${workspace_package}")
-  fi
-done
+echo "Crate publication order OK: ${#packages[@]} workspace crates."
 
-extra_packages=()
-for package in "${packages[@]}"; do
-  found=0
-  for workspace_package in "${workspace_codewhale_packages[@]}"; do
-    if [[ "${package}" == "${workspace_package}" ]]; then
-      found=1
-      break
-    fi
-  done
-  if [[ "${found}" == "0" ]]; then
-    extra_packages+=("${package}")
-  fi
-done
-
-if (( ${#missing_packages[@]} > 0 || ${#extra_packages[@]} > 0 )); then
-  if (( ${#missing_packages[@]} > 0 )); then
-    echo "publish package list is missing workspace crates: ${missing_packages[*]}" >&2
-  fi
-  if (( ${#extra_packages[@]} > 0 )); then
-    echo "publish package list contains non-workspace crates: ${extra_packages[*]}" >&2
-  fi
-  exit 1
+if [[ "${mode}" == "publish" ]]; then
+  "${script_dir}/require-release-tag-checkout.sh"
+  "${script_dir}/verify-release-assets.sh"
 fi
 
 package_has_workspace_deps() {

--- a/scripts/release/validate-crate-publish-order.py
+++ b/scripts/release/validate-crate-publish-order.py
@@ -136,6 +136,11 @@ def validate_order(
             # They may legitimately point back across the publication DAG.
             if kind == "dev":
                 continue
+            if dependency_name not in positions:
+                raise ValidationError(
+                    f"{dependent} depends on workspace crate {dependency_name} "
+                    f"[{kind}], which is not in the codewhale-* release inventory"
+                )
             publish_edges.add((dependency_name, dependent, str(kind)))
 
     violations = sorted(

--- a/scripts/release/validate-crate-publish-order.py
+++ b/scripts/release/validate-crate-publish-order.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Validate the maintained crates.io publication order against Cargo metadata.
+
+On success, emit the workspace inventory consumed by publish-crates.sh.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+class ValidationError(Exception):
+    """A release-order or Cargo metadata contract violation."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--metadata-file",
+        type=Path,
+        help="Read Cargo metadata from this file instead of invoking cargo (tests only).",
+    )
+    parser.add_argument("crates", nargs="+", help="Maintained publication order")
+    return parser.parse_args()
+
+
+def load_metadata(metadata_file: Path | None) -> dict[str, Any]:
+    if metadata_file is not None:
+        try:
+            raw = metadata_file.read_text(encoding="utf-8")
+        except OSError as error:
+            raise ValidationError(f"could not read Cargo metadata: {error}") from error
+    else:
+        process = subprocess.run(
+            ["cargo", "metadata", "--locked", "--format-version", "1", "--no-deps"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if process.returncode != 0:
+            detail = process.stderr.strip()
+            suffix = f": {detail}" if detail else ""
+            raise ValidationError(
+                f"cargo metadata failed with exit code {process.returncode}{suffix}"
+            )
+        raw = process.stdout
+
+    try:
+        metadata = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ValidationError(f"Cargo metadata is not valid JSON: {error}") from error
+    if not isinstance(metadata, dict):
+        raise ValidationError("Cargo metadata root must be an object")
+    return metadata
+
+
+def workspace_packages(metadata: dict[str, Any]) -> list[dict[str, Any]]:
+    members = metadata.get("workspace_members")
+    packages = metadata.get("packages")
+    if not isinstance(members, list) or not isinstance(packages, list):
+        raise ValidationError("Cargo metadata must contain workspace_members and packages lists")
+
+    packages_by_id = {
+        package.get("id"): package
+        for package in packages
+        if isinstance(package, dict) and isinstance(package.get("id"), str)
+    }
+    missing_ids = [member for member in members if member not in packages_by_id]
+    if missing_ids:
+        raise ValidationError(
+            "Cargo metadata omits workspace package ids: " + ", ".join(missing_ids)
+        )
+    return [packages_by_id[member] for member in members]
+
+
+def validate_order(
+    packages: list[dict[str, Any]], ordered_crates: list[str]
+) -> tuple[str, dict[str, bool]]:
+    duplicate_crates = sorted(
+        {name for name in ordered_crates if ordered_crates.count(name) > 1}
+    )
+    if duplicate_crates:
+        raise ValidationError(
+            "publish package list contains duplicates: " + ", ".join(duplicate_crates)
+        )
+
+    names = [package.get("name") for package in packages]
+    if any(not isinstance(name, str) or not name for name in names):
+        raise ValidationError("workspace package is missing a name")
+    if len(set(names)) != len(names):
+        raise ValidationError("Cargo metadata contains duplicate workspace package names")
+
+    versions = sorted({package.get("version") for package in packages})
+    if len(versions) != 1 or not isinstance(versions[0], str) or not versions[0]:
+        rendered = ", ".join(str(version) for version in versions)
+        raise ValidationError(f"workspace packages have mixed versions: {rendered}")
+
+    workspace_by_name = {package["name"]: package for package in packages}
+    release_names = sorted(
+        name for name in workspace_by_name if name.startswith("codewhale-")
+    )
+    ordered_set = set(ordered_crates)
+    missing = sorted(set(release_names) - ordered_set)
+    extra = sorted(ordered_set - set(release_names))
+    if missing or extra:
+        messages = []
+        if missing:
+            messages.append("publish package list is missing workspace crates: " + " ".join(missing))
+        if extra:
+            messages.append(
+                "publish package list contains non-workspace crates: " + " ".join(extra)
+            )
+        raise ValidationError("\n".join(messages))
+
+    positions = {name: index for index, name in enumerate(ordered_crates)}
+    has_workspace_dependencies = {name: False for name in release_names}
+    publish_edges: set[tuple[str, str, str]] = set()
+    for dependent in release_names:
+        dependencies = workspace_by_name[dependent].get("dependencies", [])
+        if not isinstance(dependencies, list):
+            raise ValidationError(f"Cargo metadata dependencies for {dependent} must be a list")
+        for dependency in dependencies:
+            if not isinstance(dependency, dict) or dependency.get("path") is None:
+                continue
+            dependency_name = dependency.get("name")
+            if dependency_name not in workspace_by_name:
+                continue
+            has_workspace_dependencies[dependent] = True
+            kind = dependency.get("kind") or "normal"
+            # Cargo does not compile dev-dependencies while verifying a publish.
+            # They may legitimately point back across the publication DAG.
+            if kind == "dev":
+                continue
+            publish_edges.add((dependency_name, dependent, str(kind)))
+
+    violations = sorted(
+        (
+            dependency,
+            dependent,
+            kind,
+        )
+        for dependency, dependent, kind in publish_edges
+        if positions[dependency] >= positions[dependent]
+    )
+    if violations:
+        lines = ["crate publication order is not topological:"]
+        for dependency, dependent, kind in violations:
+            lines.append(
+                f"  {dependent} (position {positions[dependent] + 1}) depends on "
+                f"{dependency} (position {positions[dependency] + 1}) [{kind}]"
+            )
+        lines.append(
+            "Move every workspace dependency before its dependent in "
+            "scripts/release/crates.sh."
+        )
+        raise ValidationError("\n".join(lines))
+
+    return versions[0], has_workspace_dependencies
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        packages = workspace_packages(load_metadata(args.metadata_file))
+        version, dependency_flags = validate_order(packages, args.crates)
+    except ValidationError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    print(f"version\t{version}\t")
+    for name in sorted(dependency_flags):
+        print(f"crate\t{name}\t{1 if dependency_flags[name] else 0}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/validate-crate-publish-order.test.sh
+++ b/scripts/release/validate-crate-publish-order.test.sh
@@ -54,6 +54,105 @@ cat >"${metadata_file}" <<'JSON'
 }
 JSON
 
+expect_validation_failure() {
+  local label="$1"
+  local expected="$2"
+  local fixture="$3"
+  shift 3
+
+  local output="${tmp_dir}/${label}.txt"
+  if python3 "${script_dir}/validate-crate-publish-order.py" \
+    --metadata-file "${fixture}" "$@" >"${output}" 2>&1; then
+    echo "${label} unexpectedly passed" >&2
+    exit 1
+  fi
+  grep -F "${expected}" "${output}" >/dev/null
+  if grep -F "Traceback" "${output}" >/dev/null; then
+    echo "${label} emitted an unhandled traceback" >&2
+    exit 1
+  fi
+}
+
+expect_validation_failure \
+  duplicate-crate \
+  "publish package list contains duplicates: codewhale-core" \
+  "${metadata_file}" \
+  codewhale-build-support \
+  codewhale-core \
+  codewhale-core \
+  codewhale-tui \
+  codewhale-app-server \
+  codewhale-cli
+
+expect_validation_failure \
+  missing-crate \
+  "publish package list is missing workspace crates: codewhale-app-server" \
+  "${metadata_file}" \
+  codewhale-build-support \
+  codewhale-core \
+  codewhale-tui \
+  codewhale-cli
+
+expect_validation_failure \
+  extra-crate \
+  "publish package list contains non-workspace crates: codewhale-extra" \
+  "${metadata_file}" \
+  codewhale-build-support \
+  codewhale-core \
+  codewhale-tui \
+  codewhale-app-server \
+  codewhale-cli \
+  codewhale-extra
+
+mixed_metadata_file="${tmp_dir}/mixed-metadata.json"
+python3 - "${metadata_file}" "${mixed_metadata_file}" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+mixed = source.replace('"version": "0.9.5"', '"version": "0.9.4"', 1)
+if mixed == source:
+    raise SystemExit("failed to create mixed-version Cargo metadata fixture")
+pathlib.Path(sys.argv[2]).write_text(mixed, encoding="utf-8")
+PY
+expect_validation_failure \
+  mixed-versions \
+  "workspace packages have mixed versions: 0.9.4, 0.9.5" \
+  "${mixed_metadata_file}" \
+  codewhale-build-support \
+  codewhale-core \
+  codewhale-tui \
+  codewhale-app-server \
+  codewhale-cli
+
+nonrelease_metadata_file="${tmp_dir}/nonrelease-metadata.json"
+cat >"${nonrelease_metadata_file}" <<'JSON'
+{
+  "workspace_members": ["helper", "core"],
+  "packages": [
+    {
+      "id": "helper",
+      "name": "internal-helper",
+      "version": "0.9.5",
+      "dependencies": []
+    },
+    {
+      "id": "core",
+      "name": "codewhale-core",
+      "version": "0.9.5",
+      "dependencies": [
+        {"name": "internal-helper", "path": "/workspace/helper", "kind": null}
+      ]
+    }
+  ]
+}
+JSON
+expect_validation_failure \
+  nonrelease-workspace-dependency \
+  "codewhale-core depends on workspace crate internal-helper [normal], which is not in the codewhale-* release inventory" \
+  "${nonrelease_metadata_file}" \
+  codewhale-core
+
 bad_output="${tmp_dir}/bad-order.txt"
 if python3 "${script_dir}/validate-crate-publish-order.py" \
   --metadata-file "${metadata_file}" \

--- a/scripts/release/validate-crate-publish-order.test.sh
+++ b/scripts/release/validate-crate-publish-order.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+metadata_file="${tmp_dir}/metadata.json"
+cat >"${metadata_file}" <<'JSON'
+{
+  "workspace_members": ["build", "core", "tui", "app", "cli"],
+  "packages": [
+    {
+      "id": "build",
+      "name": "codewhale-build-support",
+      "version": "0.9.5",
+      "dependencies": []
+    },
+    {
+      "id": "core",
+      "name": "codewhale-core",
+      "version": "0.9.5",
+      "dependencies": [
+        {"name": "codewhale-cli", "path": "/workspace/cli", "kind": "dev"}
+      ]
+    },
+    {
+      "id": "tui",
+      "name": "codewhale-tui",
+      "version": "0.9.5",
+      "dependencies": [
+        {"name": "codewhale-build-support", "path": "/workspace/build", "kind": "build"},
+        {"name": "codewhale-core", "path": "/workspace/core", "kind": null}
+      ]
+    },
+    {
+      "id": "app",
+      "name": "codewhale-app-server",
+      "version": "0.9.5",
+      "dependencies": [
+        {"name": "codewhale-core", "path": "/workspace/core", "kind": null}
+      ]
+    },
+    {
+      "id": "cli",
+      "name": "codewhale-cli",
+      "version": "0.9.5",
+      "dependencies": [
+        {"name": "codewhale-tui", "path": "/workspace/tui", "kind": null},
+        {"name": "codewhale-app-server", "path": "/workspace/app", "kind": null}
+      ]
+    }
+  ]
+}
+JSON
+
+bad_output="${tmp_dir}/bad-order.txt"
+if python3 "${script_dir}/validate-crate-publish-order.py" \
+  --metadata-file "${metadata_file}" \
+  codewhale-build-support \
+  codewhale-tui \
+  codewhale-core \
+  codewhale-app-server \
+  codewhale-cli >"${bad_output}" 2>&1; then
+  echo "v0.9.5 publication order unexpectedly passed" >&2
+  exit 1
+fi
+grep -F \
+  "codewhale-tui (position 2) depends on codewhale-core (position 3) [normal]" \
+  "${bad_output}" >/dev/null
+
+good_output="${tmp_dir}/good-order.txt"
+python3 "${script_dir}/validate-crate-publish-order.py" \
+  --metadata-file "${metadata_file}" \
+  codewhale-build-support \
+  codewhale-core \
+  codewhale-tui \
+  codewhale-app-server \
+  codewhale-cli >"${good_output}"
+grep -F $'version\t0.9.5\t' "${good_output}" >/dev/null
+grep -F $'crate\tcodewhale-core\t1' "${good_output}" >/dev/null
+
+# Keep the checked-in order synchronized with the live locked workspace graph.
+# shellcheck source=scripts/release/crates.sh
+source "${script_dir}/crates.sh"
+python3 "${script_dir}/validate-crate-publish-order.py" \
+  "${release_crates[@]}" >"${tmp_dir}/workspace-order.txt"
+
+echo "crate publication order validation tests passed"


### PR DESCRIPTION
## Summary

- use the canonical `codewhale.net/codewhale` CNB repository slug in both updater implementations
- add the required `/-/releases/download/vX.Y.Z/` path so mirror mode receives asset bytes instead of release HTML
- preserve explicit mirror override precedence and the deliberate v0.9.6 compatibility asset inventory
- serialize the shared CNB Rust gate, omit debug metadata only from disposable test artifacts, and give the full gate an explicit 45-minute bound
- run the full workspace test command with the same 16 MiB test-thread stack used by GitHub CI and the release workflow

#5306 has merged. This PR is now the focused CNB URL and mirror-pipeline reliability slice on current `main`.

## Live proof

- old npm-shaped v0.9.5 manifest URL: HTTP 200 `text/html`, 118624 bytes
- corrected URL: HTTP 200 `text/plain`, 258-byte checksum manifest
- old Rust `Hmbown/CodeWhale` slug: HTTP 404
- exact head `cb1e994829783047111aafde05b4ba35a33ddf5c` reached CNB but failed while parallel Rust jobs compiled the TUI test crate
- exact head `b899c42be969aec53debd3138bef9fcd538ab17e` passed dependency setup, then exposed the next concrete failure: `runtime_api::tests::retry_endpoint_reuses_dropped_user_text_to_start_a_turn` overflowed the platform-default test stack and aborted with SIGABRT
- with `CARGO_BUILD_JOBS=1`, the all-target workspace check and all-feature clippy pass in an 8 GiB container; CNB's [`cpus: 16` runner contract](https://docs.cnb.cool/en/build/grammar.html) provides 32 GiB
- `RUST_MIN_STACK=16777216` is scoped only to the workspace test command, matching the established GitHub CI/release contract without raising compiler-thread stack reservations

## Verification

- `node --test npm/codewhale/test/artifacts.test.js` (11 passed)
- `cargo test --locked -p codewhale-release --lib` (37 passed)
- `cargo test --locked -p codewhale-cli --lib update::tests` (67 passed)
- `cargo check --locked -p codewhale-release -p codewhale-cli`
- `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib runtime_api::tests::retry_endpoint_reuses_dropped_user_text_to_start_a_turn --locked -- --exact --nocapture` (1 passed)
- `node .github/scripts/release-workflows.test.js`
- `cargo fmt --all -- --check`
- `git diff --check`

Exact head `5162341fd1df799f94f398d70781edee0463f83f` must pass both GitHub and CNB before merge.

Closes #5307
