### PR TITLE
fix(subagents): cap nested max_depth by inherited budget

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -11841,9 +11841,11 @@ fn resolve_fixed_spawn_model_route(
 
 /// Effective absolute `max_spawn_depth` for a child, combining the inherited
 /// runtime budget, the caller's `max_depth` request, and a fleet profile's
-/// `delegation.max_spawn_depth` hint. An explicit request keeps its existing
-/// semantics (may widen up to the ceiling); a profile hint only narrows —
-/// either the request (min) or the inherited budget.
+/// `delegation.max_spawn_depth` hint. The inherited budget is an immutable
+/// absolute boundary: neither an explicit request nor a profile hint may widen
+/// a child past the depth the root/session selected. A request or hint only
+/// narrows — the effective depth is the minimum of the inherited budget and the
+/// clamped request/hint (#5253).
 fn child_max_spawn_depth_for_spawn(
     inherited: u32,
     child_spawn_depth: u32,
@@ -11853,7 +11855,7 @@ fn child_max_spawn_depth_for_spawn(
     match (requested, profile_hint) {
         (Some(requested), hint) => {
             let depth = hint.map_or(requested, |hint| requested.min(hint));
-            clamp_child_max_spawn_depth(child_spawn_depth, depth)
+            inherited.min(clamp_child_max_spawn_depth(child_spawn_depth, depth))
         }
         (None, Some(hint)) => inherited.min(clamp_child_max_spawn_depth(child_spawn_depth, hint)),
         (None, None) => inherited,

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -3793,8 +3793,8 @@ fn test_child_max_spawn_depth_profile_hint_only_narrows() {
     assert_eq!(child_max_spawn_depth_for_spawn(2, 0, None, Some(6)), 2);
     // Explicit request takes the min with the hint.
     assert_eq!(child_max_spawn_depth_for_spawn(2, 0, Some(3), Some(1)), 1);
-    // Explicit request alone keeps its existing widen-up-to-ceiling semantics.
-    assert_eq!(child_max_spawn_depth_for_spawn(2, 0, Some(3), None), 3);
+    // Explicit request alone still cannot widen past the inherited budget (#5253).
+    assert_eq!(child_max_spawn_depth_for_spawn(2, 0, Some(3), None), 2);
     assert_eq!(
         child_max_spawn_depth_for_spawn(
             2,
@@ -3802,10 +3802,36 @@ fn test_child_max_spawn_depth_profile_hint_only_narrows() {
             Some(codewhale_config::MAX_SPAWN_DEPTH_CEILING),
             None
         ),
-        codewhale_config::MAX_SPAWN_DEPTH_CEILING
+        2
     );
     // Neither request nor hint: inherit unchanged.
     assert_eq!(child_max_spawn_depth_for_spawn(5, 2, None, None), 5);
+}
+
+/// A descendant subagent must not widen the absolute recursion budget its root
+/// session selected by supplying an explicit `max_depth` on a nested spawn
+/// (#5253). The inherited budget is a hard cap even when the request (clamped
+/// to the global ceiling) is larger.
+#[test]
+fn test_child_max_spawn_depth_request_cannot_widen_inherited_budget() {
+    // Root chose an absolute max_spawn_depth of 2; a nested child at
+    // spawn_depth 2 requesting the global ceiling must stay bounded by 2,
+    // not jump to the ceiling. Before the fix this returned
+    // MAX_SPAWN_DEPTH_CEILING (8), letting the descendant keep spawning past
+    // the root's chosen boundary.
+    assert_eq!(
+        child_max_spawn_depth_for_spawn(
+            2,
+            2,
+            Some(codewhale_config::MAX_SPAWN_DEPTH_CEILING),
+            None
+        ),
+        2
+    );
+    // The inherited budget also caps an explicit request paired with a hint.
+    assert_eq!(child_max_spawn_depth_for_spawn(2, 1, Some(8), Some(6)), 2);
+    // A request below the inherited budget is still honored (clamp, don't force).
+    assert_eq!(child_max_spawn_depth_for_spawn(5, 0, Some(3), None), 3);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `child_max_spawn_depth_for_spawn` dropped the inherited absolute budget in the explicit-`max_depth` arm, so a nested spawn could widen recursion past the depth the root/session chose (#5253).
- Take `inherited.min(..)` in that arm, mirroring the profile-hint arm that already does. A request or hint may only narrow, never widen; `MAX_SPAWN_DEPTH_CEILING` (#3931) stays the outer bound.
- Add a dedicated regression test for the issue scenario and correct the two assertions in `test_child_max_spawn_depth_profile_hint_only_narrows` that had encoded the old widen-up-to-ceiling behavior.

## Root cause

For an explicit request, the code computed `clamp_child_max_spawn_depth(child_spawn_depth, depth)` and returned it directly, discarding `inherited`. With root `max_spawn_depth = 2`, a child at `spawn_depth = 2` requesting the ceiling got `child_max_spawn_depth_for_spawn(2, 2, Some(8), None) == 8` — the descendant then kept spawning past the root's chosen boundary. The `(None, Some(hint))` arm already guarded this with `inherited.min(..)`; the explicit-request arm did not.

## Test verification (RED → GREEN)

The fix is a pure-function logic change. The two functions (`child_max_spawn_depth_for_spawn`, `clamp_child_max_spawn_depth`) were extracted verbatim and exercised standalone to observe the transition on the exact logic:

```
== RED (upstream logic) ==
FAIL: nested request cannot widen inherited
rc=1
== GREEN (fixed logic) ==
ALL PASS
rc=0
```

The canonical regression test `test_child_max_spawn_depth_request_cannot_widen_inherited_budget` is added in `crates/tui/src/tools/subagent/tests.rs` and asserts the same scenario (`(2, 2, Some(CEILING), None) == 2`). It fails on the unpatched function and passes with the fix. The two updated assertions in the neighboring test previously asserted the buggy widen behavior (their comment literally read "keeps its existing widen-up-to-ceiling semantics"), so they are corrected to the capped values rather than left encoding the bug; the new behavior gets its own separate test.

> Note on local validation: `crates/tui` (~717k LOC) exceeds the memory available on my dev host to compile its test binary, so `cargo fmt --all -- --check` was run locally (clean) and the full `cargo clippy`/`cargo test --workspace --all-features` gate runs here on CI.

## Testing

- [x] `cargo fmt --all -- --check` (local, clean)
- [x] Extracted-logic RED → GREEN for the changed functions (above)
- [ ] `cargo clippy --workspace --all-targets --all-features` (runs on CI)
- [ ] `cargo test --workspace --all-features` (runs on CI; includes the new regression test)

## Checklist

- [x] Single-purpose fix, no unrelated changes
- [x] Added a regression test for the fixed behavior
- [x] No new binary name / env var / config key
- [x] Touches no trust-boundary surface

Fixes #5253
