### PR TITLE
fix(tui): copy messages without visual rails

### DIFF
--- a/crates/tui/src/tui/ui/activity_detail.rs
+++ b/crates/tui/src/tui/ui/activity_detail.rs
@@ -12,7 +12,9 @@ use crate::tui::app::App;
 use crate::tui::footer_ui::one_line_summary;
 use crate::tui::history::{HistoryCell, ToolCell, ToolStatus};
 use crate::tui::pager::PagerView;
-use crate::tui::ui_text::{history_cell_to_text, truncate_line_to_width};
+use crate::tui::ui_text::{
+    history_cell_to_clipboard_text, history_cell_to_text, truncate_line_to_width,
+};
 
 fn selected_transcript_cell_index(app: &App) -> Option<usize> {
     app.viewport
@@ -513,7 +515,7 @@ pub(crate) fn copy_cell_to_clipboard(app: &mut App, cell_index: usize) -> bool {
         .last_transcript_area
         .map(|area| area.width)
         .unwrap_or(80);
-    let text = history_cell_to_text(cell, width);
+    let text = history_cell_to_clipboard_text(cell, width);
     if text.trim().is_empty() {
         app.status_message = Some("Message is empty".to_string());
         return false;
@@ -1720,5 +1722,25 @@ mod tests {
         assert!(open_reasoning_detail_pager(&mut app));
         let top = app.view_stack.top_kind();
         assert_eq!(top, Some(crate::tui::views::ModalKind::Pager));
+    }
+
+    #[test]
+    fn copy_cell_to_clipboard_uses_canonical_assistant_source() {
+        let mut app = test_app();
+        let content = "A long response with literal ● and ▏ glyphs that wraps visually.";
+        app.history = vec![HistoryCell::Assistant {
+            content: content.to_string(),
+            streaming: false,
+        }];
+        app.resync_history_revisions();
+        app.viewport.last_transcript_area = Some(ratatui::layout::Rect {
+            x: 0,
+            y: 0,
+            width: 12,
+            height: 24,
+        });
+
+        assert!(copy_cell_to_clipboard(&mut app, 0));
+        assert_eq!(app.clipboard.last_written_text(), Some(content));
     }
 }

--- a/crates/tui/src/tui/ui_text.rs
+++ b/crates/tui/src/tui/ui_text.rs
@@ -159,6 +159,25 @@ pub(super) fn history_cell_to_text(cell: &HistoryCell, width: u16) -> String {
         .join("\n")
 }
 
+/// Serialize one complete history cell for Copy Message.
+///
+/// User and assistant cells have canonical source text. Returning it directly
+/// preserves authored Markdown and hard line breaks while keeping role glyphs,
+/// continuation rails, and visual wrapping out of the clipboard. Selection
+/// copy cannot provide that contract: it serializes the rendered live cache,
+/// where Markdown has already been transformed and user-message soft wraps do
+/// not carry join metadata.
+///
+/// Complex cells intentionally retain the full-transcript representation.
+/// Tool and thinking transcript renderers include semantic headers and complete
+/// output that can differ from the capped or folded live cache.
+pub(super) fn history_cell_to_clipboard_text(cell: &HistoryCell, width: u16) -> String {
+    match cell {
+        HistoryCell::User { content } | HistoryCell::Assistant { content, .. } => content.clone(),
+        _ => history_cell_to_text(cell, width),
+    }
+}
+
 fn line_to_string(line: Line<'static>) -> String {
     let mut out = String::new();
     append_spans_plain(line.spans.iter(), &mut out);
@@ -552,5 +571,129 @@ mod tests {
                 assert!(!out.starts_with('\u{20e3}'));
             }
         }
+    }
+
+    #[test]
+    fn clipboard_text_for_assistant_uses_source_without_visual_rails() {
+        let content = "A long assistant response that will wrap at a narrow width.";
+        let cell = HistoryCell::Assistant {
+            content: content.to_string(),
+            streaming: false,
+        };
+
+        let rendered = history_cell_to_text(&cell, 12);
+        assert_ne!(rendered, content, "test setup must exercise rendering");
+        assert!(
+            rendered.contains('\n'),
+            "test setup must exercise visual wrapping: {rendered:?}"
+        );
+        assert_eq!(history_cell_to_clipboard_text(&cell, 12), content);
+    }
+
+    #[test]
+    fn clipboard_text_preserves_authored_rail_glyphs() {
+        let content = "● literal role glyph\n▏ literal rail glyph";
+        let cell = HistoryCell::Assistant {
+            content: content.to_string(),
+            streaming: false,
+        };
+
+        assert_eq!(history_cell_to_clipboard_text(&cell, 10), content);
+    }
+
+    #[test]
+    fn clipboard_text_preserves_markdown_source_and_hard_breaks() {
+        let content = r#"Heading
+
+```rust
+fn main() {
+    println!("hello");
+}
+```
+
+After code."#;
+        let cell = HistoryCell::Assistant {
+            content: content.to_string(),
+            streaming: false,
+        };
+
+        assert_eq!(history_cell_to_clipboard_text(&cell, 16), content);
+    }
+
+    #[test]
+    fn clipboard_text_for_user_uses_source_text() {
+        let content = "user text that wraps visually";
+        let cell = HistoryCell::User {
+            content: content.to_string(),
+        };
+
+        let rendered = history_cell_to_text(&cell, 8);
+        assert_ne!(rendered, content, "test setup must exercise rendering");
+        assert!(
+            rendered.contains('\n'),
+            "test setup must exercise visual wrapping: {rendered:?}"
+        );
+        assert_eq!(history_cell_to_clipboard_text(&cell, 8), content);
+    }
+
+    #[test]
+    fn clipboard_text_for_thinking_keeps_full_transcript_semantics() {
+        let content = "First paragraph lede.\n\
+            Second sentence of the first paragraph.\n\n\
+            Second paragraph: deeper analysis follows.\n\
+            More detail in paragraph two.\n\n\
+            Third paragraph: even more reasoning.\n\
+            With another line.\n\n\
+            Fourth paragraph: the conclusion.\n\
+            And one more line for good measure.\n\n\
+            Fifth paragraph: final verification.\n\
+            One last supporting detail.";
+        let cell = HistoryCell::Thinking {
+            content: content.to_string(),
+            streaming: false,
+            duration_secs: Some(3.2),
+        };
+
+        let live = cell
+            .lines_with_options(
+                80,
+                crate::tui::history::TranscriptRenderOptions {
+                    low_motion: true,
+                    ..crate::tui::history::TranscriptRenderOptions::default()
+                },
+            )
+            .into_iter()
+            .map(line_to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let transcript = history_cell_to_text(&cell, 80);
+        let copied = history_cell_to_clipboard_text(&cell, 80);
+
+        assert!(!live.contains("Fifth paragraph"), "{live:?}");
+        assert!(transcript.contains("Fifth paragraph"), "{transcript:?}");
+        assert_eq!(copied, transcript);
+    }
+
+    #[test]
+    fn clipboard_text_for_tool_keeps_full_transcript_semantics() {
+        use crate::tui::history::{GenericToolCell, ToolCell, ToolStatus};
+
+        let cell = HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+            name: "exec_shell".to_string(),
+            status: ToolStatus::Success,
+            input_summary: Some("cargo test".to_string()),
+            output: Some("complete tool output".to_string()),
+            prompts: None,
+            spillover_path: None,
+            output_summary: None,
+            is_diff: false,
+        }));
+
+        let transcript = history_cell_to_text(&cell, 80);
+        assert!(
+            transcript.contains("complete tool output"),
+            "{transcript:?}"
+        );
+        assert_eq!(history_cell_to_clipboard_text(&cell, 80), transcript);
     }
 }


### PR DESCRIPTION
## Summary

- Fix Copy Message for User and Assistant cells by copying canonical source content instead of rendered Ratatui lines.
- Keep Tool, Thinking, System, and other complex cells on the existing full-transcript path so complete output and detail semantics do not regress.
- Add regressions for narrow-width wrapping, authored `●`/`▏` glyphs, Markdown/code blocks, hard line breaks, and complex-cell transcript behavior.

The old path called `history_cell_to_text()`, so role glyphs, continuation rails, and visual wrapping entered the clipboard after `transcript_lines()` rendering. The new clipboard-specific helper bypasses rendering only where canonical source exists. It never matches or deletes Unicode glyphs, so identical authored characters remain intact.

The live selection cache is intentionally not reused: Markdown is already transformed there, User soft wraps lack safe join metadata, and Tool/Thinking live rendering may be folded or capped. Pager, Open Details, and file-location flows remain unchanged.

Closes #5314

## Testing

<!-- Exact gate commands (including the clippy allow list) are in
     CONTRIBUTING.md → "Pre-push verification". -->

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
  - Blocked by pre-existing `clippy::field_reassign_with_default` errors in `crates/tui/src/config/tests.rs:5123` and `:5134`; this PR does not modify that module.
- [ ] `cargo test --workspace --all-features --locked`
  - Result: 10,239 passed, 4 failed, 11 ignored. Failures are in untouched config, terminal-session, model-picker, and config-view tests. The terminal timeout test passed on exact rerun; the other exact reruns reproduce under the local `zh-Hans` settings/external-consent environment.

Focused regression checks:

- [x] `cargo test -p codewhale-tui --lib clipboard_text --locked` (8 passed)
- [x] `cargo test -p codewhale-tui --lib copy_cell_to_clipboard_uses_canonical_assistant_source --locked` (1 passed)

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes — Copy Message confirmed working by the reporter
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address — N/A; no harvested or co-authored code
