### PR TITLE
feat: register OrcaRouter as a named provider

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -21,7 +21,7 @@
 # `api_key` / `base_url` are
 # still read as DeepSeek defaults when `[providers.deepseek]` is absent
 # (backward compatibility).
-provider = "deepseek" # deepseek | deepseek-cn | deepseek-anthropic | nvidia-nim | openai | atlascloud | wanjie-ark | volcengine | openrouter | xiaomi-mimo | novita | fireworks | siliconflow | siliconflow-CN | arcee | moonshot | zai | stepfun | minimax | sglang | vllm | ollama | huggingface | together | qianfan | openai-codex | anthropic | openmodel | deepinfra | sakana | longcat | opencode-go | opencode-zen | meta | xai | modelstudio-token-plan | modelstudio-coding-plan
+provider = "deepseek" # deepseek | deepseek-cn | deepseek-anthropic | nvidia-nim | openai | atlascloud | wanjie-ark | volcengine | openrouter | orcarouter | xiaomi-mimo | novita | fireworks | siliconflow | siliconflow-CN | arcee | moonshot | zai | stepfun | minimax | sglang | vllm | ollama | huggingface | together | qianfan | openai-codex | anthropic | openmodel | deepinfra | sakana | longcat | opencode-go | opencode-zen | meta | xai | modelstudio-token-plan | modelstudio-coding-plan
 api_key = "YOUR_DEEPSEEK_API_KEY" # must be non-empty
 base_url = "https://api.deepseek.com/beta"
 # provider = "deepseek-cn"                       # legacy alias (official host is still https://api.deepseek.com)
@@ -528,6 +528,15 @@ max_subagents = 10 # optional (1-20)
 # qwen/qwen3.7-max, google/gemma-4-31b-it, z-ai/glm-5.1, z-ai/glm-5.2,
 # moonshotai/kimi-k2.6,
 # nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free, and nvidia/nemotron-3-ultra.
+
+# OrcaRouter — OpenAI-compatible aggregation gateway (https://www.orcarouter.ai)
+[providers.orcarouter]
+# api_key = "YOUR_ORCAROUTER_API_KEY"
+# base_url = "https://api.orcarouter.ai/v1"
+# model = "deepseek/deepseek-v4-pro"
+# Namespaced wire models pass through verbatim (deepseek/deepseek-v4-pro,
+# deepseek/deepseek-v4-flash); OrcaRouter's own auto-routing model is
+# selectable as "orcarouter/auto".
 
 # Xiaomi MiMo OpenAI-compatible endpoint (https://platform.xiaomimimo.com)
 [providers.xiaomi_mimo]

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -272,6 +272,27 @@ impl Default for ModelRegistry {
                 supports_reasoning: true,
             },
             ModelInfo {
+                id: "deepseek/deepseek-v4-pro".to_string(),
+                provider: ProviderKind::Orcarouter,
+                aliases: vec!["orcarouter-deepseek-v4-pro".to_string()],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
+            ModelInfo {
+                id: "deepseek/deepseek-v4-flash".to_string(),
+                provider: ProviderKind::Orcarouter,
+                aliases: vec!["orcarouter-deepseek-v4-flash".to_string()],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
+            ModelInfo {
+                id: "orcarouter/auto".to_string(),
+                provider: ProviderKind::Orcarouter,
+                aliases: vec!["orcarouter-auto".to_string()],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
+            ModelInfo {
                 id: "arcee-ai/trinity-large-thinking".to_string(),
                 provider: ProviderKind::Openrouter,
                 aliases: vec![

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -41,6 +41,7 @@ enum ProviderArg {
     WanjieArk,
     Volcengine,
     Openrouter,
+    Orcarouter,
     XiaomiMimo,
     Novita,
     Fireworks,
@@ -119,6 +120,7 @@ impl From<ProviderArg> for ProviderKind {
             ProviderArg::WanjieArk => ProviderKind::WanjieArk,
             ProviderArg::Volcengine => ProviderKind::Volcengine,
             ProviderArg::Openrouter => ProviderKind::Openrouter,
+            ProviderArg::Orcarouter => ProviderKind::Orcarouter,
             ProviderArg::XiaomiMimo => ProviderKind::XiaomiMimo,
             ProviderArg::Novita => ProviderKind::Novita,
             ProviderArg::Fireworks => ProviderKind::Fireworks,
@@ -7840,8 +7842,8 @@ mod tests {
             .map(|provider| provider.kind())
             .collect();
         // Full registry keeps legacy dialect/plan kinds; ALL is the catalog surface.
-        assert_eq!(registry_kinds.len(), 42);
-        assert_eq!(ProviderKind::ALL.len(), 37);
+        assert_eq!(registry_kinds.len(), 43);
+        assert_eq!(ProviderKind::ALL.len(), 38);
         for kind in ProviderKind::ALL {
             assert!(
                 registry_kinds.contains(&kind),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -239,6 +239,8 @@ pub struct ProvidersToml {
     pub volcengine: ProviderConfigToml,
     #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub openrouter: ProviderConfigToml,
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
+    pub orcarouter: ProviderConfigToml,
     #[serde(
         default,
         skip_serializing_if = "ProviderConfigToml::is_empty",
@@ -610,6 +612,7 @@ impl ProvidersToml {
             ProviderKind::WanjieArk => &self.wanjie_ark,
             ProviderKind::Volcengine => &self.volcengine,
             ProviderKind::Openrouter => &self.openrouter,
+            ProviderKind::Orcarouter => &self.orcarouter,
             ProviderKind::XiaomiMimo => &self.xiaomi_mimo,
             ProviderKind::Novita => &self.novita,
             ProviderKind::Fireworks => &self.fireworks,
@@ -657,6 +660,7 @@ impl ProvidersToml {
             ProviderKind::WanjieArk => &mut self.wanjie_ark,
             ProviderKind::Volcengine => &mut self.volcengine,
             ProviderKind::Openrouter => &mut self.openrouter,
+            ProviderKind::Orcarouter => &mut self.orcarouter,
             ProviderKind::XiaomiMimo => &mut self.xiaomi_mimo,
             ProviderKind::Novita => &mut self.novita,
             ProviderKind::Fireworks => &mut self.fireworks,
@@ -3167,6 +3171,7 @@ impl ConfigToml {
                 ProviderKind::WanjieArk => DEFAULT_WANJIE_ARK_BASE_URL.to_string(),
                 ProviderKind::Volcengine => DEFAULT_VOLCENGINE_BASE_URL.to_string(),
                 ProviderKind::Openrouter => DEFAULT_OPENROUTER_BASE_URL.to_string(),
+                ProviderKind::Orcarouter => DEFAULT_ORCAROUTER_BASE_URL.to_string(),
                 ProviderKind::XiaomiMimo => DEFAULT_XIAOMI_MIMO_BASE_URL.to_string(),
                 ProviderKind::Novita => DEFAULT_NOVITA_BASE_URL.to_string(),
                 ProviderKind::Fireworks => DEFAULT_FIREWORKS_BASE_URL.to_string(),
@@ -3789,6 +3794,7 @@ fn root_default_model_is_foreign_to_provider(
         provider,
         ProviderKind::NvidiaNim
             | ProviderKind::Openrouter
+            | ProviderKind::Orcarouter
             | ProviderKind::Novita
             | ProviderKind::Fireworks
             | ProviderKind::Siliconflow
@@ -3878,6 +3884,11 @@ fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
     {
         return canonical.to_string();
     }
+    if provider == ProviderKind::Orcarouter
+        && let Some(canonical) = canonical_orcarouter_recent_model_id(&normalized)
+    {
+        return canonical.to_string();
+    }
     match (provider, normalized.as_str()) {
         (ProviderKind::NvidiaNim, "deepseek-v4-pro" | "deepseek-v4pro") => {
             DEFAULT_NVIDIA_NIM_MODEL.to_string()
@@ -3895,6 +3906,14 @@ fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
             "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
             | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
         ) => DEFAULT_OPENROUTER_FLASH_MODEL.to_string(),
+        (ProviderKind::Orcarouter, "deepseek-v4-pro" | "deepseek-v4pro") => {
+            DEFAULT_ORCAROUTER_MODEL.to_string()
+        }
+        (
+            ProviderKind::Orcarouter,
+            "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
+            | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
+        ) => DEFAULT_ORCAROUTER_FLASH_MODEL.to_string(),
         (ProviderKind::Novita, "deepseek-v4-pro" | "deepseek-v4pro") => {
             DEFAULT_NOVITA_MODEL.to_string()
         }
@@ -4226,6 +4245,24 @@ fn canonical_openrouter_recent_model_id(model: &str) -> Option<&'static str> {
     }
 }
 
+/// Canonical id resolution for OrcaRouter's own auto-routing model.
+///
+/// OrcaRouter is an aggregator whose upstream catalog uses the same
+/// namespaced ids as OpenRouter, so those ids pass through verbatim. The one
+/// OrcaRouter-specific alias worth normalizing is its `orcarouter/auto`
+/// router, which is not an upstream model and needs the bare `auto` spelling
+/// (as users naturally type it) to resolve to the namespaced wire id.
+fn canonical_orcarouter_recent_model_id(model: &str) -> Option<&'static str> {
+    let normalized = model.trim().to_ascii_lowercase();
+    let normalized = normalized.replace(['_', ' '], "-");
+    match normalized.as_str() {
+        ORCAROUTER_AUTO_MODEL | "auto" | "orcarouter-auto" | "orca-auto" => {
+            Some(ORCAROUTER_AUTO_MODEL)
+        }
+        _ => None,
+    }
+}
+
 fn default_model_for_provider(provider: ProviderKind) -> &'static str {
     match provider {
         ProviderKind::Deepseek => DEFAULT_DEEPSEEK_MODEL,
@@ -4236,6 +4273,7 @@ fn default_model_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::WanjieArk => DEFAULT_WANJIE_ARK_MODEL,
         ProviderKind::Volcengine => DEFAULT_VOLCENGINE_MODEL,
         ProviderKind::Openrouter => DEFAULT_OPENROUTER_MODEL,
+        ProviderKind::Orcarouter => DEFAULT_ORCAROUTER_MODEL,
         ProviderKind::XiaomiMimo => DEFAULT_XIAOMI_MIMO_MODEL,
         ProviderKind::Novita => DEFAULT_NOVITA_MODEL,
         ProviderKind::Fireworks => DEFAULT_FIREWORKS_MODEL,
@@ -4282,6 +4320,7 @@ fn default_base_url_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::WanjieArk => DEFAULT_WANJIE_ARK_BASE_URL,
         ProviderKind::Volcengine => DEFAULT_VOLCENGINE_BASE_URL,
         ProviderKind::Openrouter => DEFAULT_OPENROUTER_BASE_URL,
+        ProviderKind::Orcarouter => DEFAULT_ORCAROUTER_BASE_URL,
         ProviderKind::XiaomiMimo => DEFAULT_XIAOMI_MIMO_BASE_URL,
         ProviderKind::Novita => DEFAULT_NOVITA_BASE_URL,
         ProviderKind::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
@@ -6485,6 +6524,7 @@ struct EnvRuntimeOverrides {
     volcengine_model: Option<String>,
     wanjie_ark_model: Option<String>,
     openrouter_model: Option<String>,
+    orcarouter_model: Option<String>,
     moonshot_model: Option<String>,
     xiaomi_mimo_model: Option<String>,
     xiaomi_mimo_mode: Option<String>,
@@ -6522,6 +6562,7 @@ struct EnvRuntimeOverrides {
     volcengine_base_url: Option<String>,
     wanjie_ark_base_url: Option<String>,
     openrouter_base_url: Option<String>,
+    orcarouter_base_url: Option<String>,
     xiaomi_mimo_base_url: Option<String>,
     novita_base_url: Option<String>,
     fireworks_base_url: Option<String>,
@@ -6598,6 +6639,9 @@ impl EnvRuntimeOverrides {
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
             openrouter_model: std::env::var("OPENROUTER_MODEL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            orcarouter_model: std::env::var("ORCAROUTER_MODEL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
             moonshot_model: std::env::var("MOONSHOT_MODEL")
@@ -6703,6 +6747,9 @@ impl EnvRuntimeOverrides {
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
             openrouter_base_url: std::env::var("OPENROUTER_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            orcarouter_base_url: std::env::var("ORCAROUTER_BASE_URL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
             xiaomi_mimo_base_url: std::env::var("XIAOMI_MIMO_BASE_URL")
@@ -6949,6 +6996,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::WanjieArk => self.wanjie_ark_base_url.clone(),
             ProviderKind::Volcengine => self.volcengine_base_url.clone(),
             ProviderKind::Openrouter => self.openrouter_base_url.clone(),
+            ProviderKind::Orcarouter => self.orcarouter_base_url.clone(),
             ProviderKind::XiaomiMimo => self.xiaomi_mimo_base_url.clone(),
             ProviderKind::Novita => self.novita_base_url.clone(),
             ProviderKind::Fireworks => self.fireworks_base_url.clone(),
@@ -6996,6 +7044,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::WanjieArk => self.wanjie_ark_model.clone(),
             ProviderKind::Volcengine => self.volcengine_model.clone(),
             ProviderKind::Openrouter => self.openrouter_model.clone(),
+            ProviderKind::Orcarouter => self.orcarouter_model.clone(),
             ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => {
                 self.siliconflow_model.clone()
             }

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -20,12 +20,13 @@ use super::{
     DEFAULT_OPENAI_CODEX_BASE_URL, DEFAULT_OPENAI_CODEX_MODEL, DEFAULT_OPENAI_MODEL,
     DEFAULT_OPENCODE_GO_BASE_URL, DEFAULT_OPENCODE_GO_MODEL, DEFAULT_OPENCODE_ZEN_BASE_URL,
     DEFAULT_OPENCODE_ZEN_MODEL, DEFAULT_OPENMODEL_BASE_URL, DEFAULT_OPENMODEL_MODEL,
-    DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OPENROUTER_MODEL, DEFAULT_QIANFAN_BASE_URL,
-    DEFAULT_QIANFAN_MODEL, DEFAULT_SAKANA_BASE_URL, DEFAULT_SAKANA_MODEL, DEFAULT_SGLANG_BASE_URL,
-    DEFAULT_SGLANG_MODEL, DEFAULT_SILICONFLOW_BASE_URL, DEFAULT_SILICONFLOW_CN_BASE_URL,
-    DEFAULT_SILICONFLOW_MODEL, DEFAULT_STEPFUN_BASE_URL, DEFAULT_STEPFUN_MODEL,
-    DEFAULT_TELECOMJS_BASE_URL, DEFAULT_TELECOMJS_MODEL, DEFAULT_TOGETHER_BASE_URL,
-    DEFAULT_TOGETHER_MODEL, DEFAULT_VLLM_BASE_URL, DEFAULT_VLLM_MODEL, DEFAULT_VOLCENGINE_BASE_URL,
+    DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OPENROUTER_MODEL, DEFAULT_ORCAROUTER_BASE_URL,
+    DEFAULT_ORCAROUTER_MODEL, DEFAULT_QIANFAN_BASE_URL, DEFAULT_QIANFAN_MODEL,
+    DEFAULT_SAKANA_BASE_URL, DEFAULT_SAKANA_MODEL, DEFAULT_SGLANG_BASE_URL, DEFAULT_SGLANG_MODEL,
+    DEFAULT_SILICONFLOW_BASE_URL, DEFAULT_SILICONFLOW_CN_BASE_URL, DEFAULT_SILICONFLOW_MODEL,
+    DEFAULT_STEPFUN_BASE_URL, DEFAULT_STEPFUN_MODEL, DEFAULT_TELECOMJS_BASE_URL,
+    DEFAULT_TELECOMJS_MODEL, DEFAULT_TOGETHER_BASE_URL, DEFAULT_TOGETHER_MODEL,
+    DEFAULT_VLLM_BASE_URL, DEFAULT_VLLM_MODEL, DEFAULT_VOLCENGINE_BASE_URL,
     DEFAULT_VOLCENGINE_MODEL, DEFAULT_WANJIE_ARK_BASE_URL, DEFAULT_WANJIE_ARK_MODEL,
     DEFAULT_XAI_BASE_URL, DEFAULT_XAI_MODEL, DEFAULT_XIAOMI_MIMO_BASE_URL,
     DEFAULT_XIAOMI_MIMO_MODEL, DEFAULT_ZAI_BASE_URL, DEFAULT_ZAI_MODEL,
@@ -233,6 +234,12 @@ pub const fn credential_help(kind: ProviderKind) -> CredentialHelp {
             credential_url: Some("https://openrouter.ai/settings/keys"),
             docs_url: Some("https://openrouter.ai/docs/api/reference/authentication"),
             guidance: "Create an OpenRouter key from account settings.",
+        },
+        ProviderKind::Orcarouter => CredentialHelp {
+            acquisition: ApiKey,
+            credential_url: Some("https://www.orcarouter.ai"),
+            docs_url: Some("https://www.orcarouter.ai"),
+            guidance: "Create an OrcaRouter API key from the OrcaRouter dashboard.",
         },
         ProviderKind::XiaomiMimo => CredentialHelp {
             acquisition: ApiKey,
@@ -746,6 +753,17 @@ provider!(
     ["OPENROUTER_API_KEY"],
     "openrouter",
     aliases: ["open_router"]
+);
+provider!(
+    Orcarouter,
+    Orcarouter,
+    "orcarouter",
+    "OrcaRouter",
+    DEFAULT_ORCAROUTER_BASE_URL,
+    DEFAULT_ORCAROUTER_MODEL,
+    ["ORCAROUTER_API_KEY"],
+    "orcarouter",
+    aliases: ["orca_router"]
 );
 provider!(
     XiaomiMimo,
@@ -1514,6 +1532,7 @@ static ATLASCLOUD: Atlascloud = Atlascloud;
 static WANJIE_ARK: WanjieArk = WanjieArk;
 static VOLCENGINE: Volcengine = Volcengine;
 static OPENROUTER: Openrouter = Openrouter;
+static ORCAROUTER: Orcarouter = Orcarouter;
 static XIAOMI_MIMO: XiaomiMimo = XiaomiMimo;
 static NOVITA: Novita = Novita;
 static FIREWORKS: Fireworks = Fireworks;
@@ -1551,7 +1570,7 @@ static MODELSTUDIO_CODING_PLAN_ANTHROPIC: ModelstudioCodingPlanAnthropic =
     ModelstudioCodingPlanAnthropic;
 static CUSTOM: Custom = Custom;
 
-static PROVIDER_REGISTRY: [&dyn Provider; 42] = [
+static PROVIDER_REGISTRY: [&dyn Provider; 43] = [
     &DEEPSEEK,
     &DEEPSEEK_ANTHROPIC,
     &NVIDIA_NIM,
@@ -1560,6 +1579,7 @@ static PROVIDER_REGISTRY: [&dyn Provider; 42] = [
     &WANJIE_ARK,
     &VOLCENGINE,
     &OPENROUTER,
+    &ORCAROUTER,
     &XIAOMI_MIMO,
     &NOVITA,
     &FIREWORKS,

--- a/crates/config/src/provider_defaults.rs
+++ b/crates/config/src/provider_defaults.rs
@@ -29,6 +29,11 @@ pub(crate) const DEFAULT_VOLCENGINE_BASE_URL: &str =
     "https://ark.cn-beijing.volces.com/api/coding/v3";
 pub(crate) const DEFAULT_OPENROUTER_MODEL: &str = "deepseek/deepseek-v4-pro";
 pub(crate) const DEFAULT_OPENROUTER_FLASH_MODEL: &str = "deepseek/deepseek-v4-flash";
+pub(crate) const DEFAULT_ORCAROUTER_MODEL: &str = "deepseek/deepseek-v4-pro";
+pub(crate) const DEFAULT_ORCAROUTER_FLASH_MODEL: &str = "deepseek/deepseek-v4-flash";
+/// OrcaRouter's own auto-routing model: picks the best upstream model per
+/// request. Resolved from the bare `auto` alias on the OrcaRouter provider.
+pub(crate) const ORCAROUTER_AUTO_MODEL: &str = "orcarouter/auto";
 pub(crate) const OPENROUTER_ARCEE_TRINITY_LARGE_THINKING_MODEL: &str =
     "arcee-ai/trinity-large-thinking";
 pub(crate) const OPENROUTER_GEMMA_4_31B_MODEL: &str = "google/gemma-4-31b-it";
@@ -82,6 +87,7 @@ pub(crate) const DEFAULT_KIMI_CODE_BASE_URL: &str = "https://api.kimi.com/coding
 pub(crate) const DEFAULT_SGLANG_MODEL: &str = "deepseek-ai/DeepSeek-V4-Pro";
 pub(crate) const DEFAULT_SGLANG_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 pub(crate) const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+pub(crate) const DEFAULT_ORCAROUTER_BASE_URL: &str = "https://api.orcarouter.ai/v1";
 pub(crate) const XIAOMI_MIMO_PAY_AS_YOU_GO_BASE_URL: &str = "https://api.xiaomimimo.com/v1";
 pub(crate) const DEFAULT_XIAOMI_MIMO_BASE_URL: &str = "https://token-plan-sgp.xiaomimimo.com/v1";
 pub(crate) const XIAOMI_MIMO_TOKEN_PLAN_CN_BASE_URL: &str =

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -42,6 +42,8 @@ pub enum ProviderKind {
     #[serde(alias = "volcengine-ark", alias = "volcengine_ark", alias = "ark")]
     Volcengine,
     Openrouter,
+    #[serde(alias = "orca_router", alias = "orca")]
+    Orcarouter,
     #[serde(alias = "mimo", alias = "xiaomi", alias = "xiaomi_mimo")]
     XiaomiMimo,
     #[serde(alias = "novita-ai", alias = "novita_ai")]
@@ -204,7 +206,7 @@ impl ProviderKind {
     /// stay on the enum for serde and `provider_for_kind`, but they are not
     /// first-class catalog rows. Plan is `mode` / base_url; dialect is
     /// `wire = openai|anthropic` on the primary provider config.
-    pub const ALL: [Self; 37] = [
+    pub const ALL: [Self; 38] = [
         Self::Deepseek,
         Self::NvidiaNim,
         Self::Openai,
@@ -212,6 +214,7 @@ impl ProviderKind {
         Self::WanjieArk,
         Self::Volcengine,
         Self::Openrouter,
+        Self::Orcarouter,
         Self::XiaomiMimo,
         Self::Novita,
         Self::Fireworks,

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -4811,9 +4811,9 @@ fn meta_model_api_scopes_both_documented_key_names_to_official_endpoint() {
 fn provider_metadata_registry_covers_every_provider_kind_once() {
     let providers = provider::all_providers();
     // Full registry keeps legacy dialect/plan kinds for provider_for_kind.
-    assert_eq!(providers.len(), 42);
+    assert_eq!(providers.len(), 43);
     // Catalog surface is one identity per vendor (no dual-wire / plan rows).
-    assert_eq!(ProviderKind::ALL.len(), 37);
+    assert_eq!(ProviderKind::ALL.len(), 38);
     assert!(ProviderKind::ALL.len() < providers.len());
 
     let mut ids = std::collections::BTreeSet::new();
@@ -4949,6 +4949,40 @@ fn openrouter_provider_defaults_to_canonical_endpoint_and_model() {
     assert_eq!(resolved.provider, ProviderKind::Openrouter);
     assert_eq!(resolved.base_url, DEFAULT_OPENROUTER_BASE_URL);
     assert_eq!(resolved.model, DEFAULT_OPENROUTER_MODEL);
+}
+
+#[test]
+fn orcarouter_provider_defaults_to_canonical_endpoint_and_model() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+    let config = ConfigToml {
+        provider: ProviderKind::Orcarouter,
+        ..ConfigToml::default()
+    };
+
+    let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+    assert_eq!(resolved.provider, ProviderKind::Orcarouter);
+    assert_eq!(resolved.base_url, DEFAULT_ORCAROUTER_BASE_URL);
+    assert_eq!(resolved.model, DEFAULT_ORCAROUTER_MODEL);
+}
+
+#[test]
+fn orcarouter_provider_normalizes_deepseek_aliases() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+    let config = ConfigToml {
+        provider: ProviderKind::Orcarouter,
+        ..ConfigToml::default()
+    };
+
+    let resolved = config.resolve_runtime_options(&CliRuntimeOverrides {
+        model: Some("deepseek-v4-flash".to_string()),
+        ..CliRuntimeOverrides::default()
+    });
+
+    assert_eq!(resolved.provider, ProviderKind::Orcarouter);
+    assert_eq!(resolved.model, DEFAULT_ORCAROUTER_FLASH_MODEL);
 }
 
 #[test]

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -3123,6 +3123,7 @@ pub(super) fn apply_reasoning_effort(
             // Handled by the shared DeepSeek table above, before this match.
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => {}
             ApiProvider::Openrouter
+            | ApiProvider::Orcarouter
             | ApiProvider::XiaomiMimo
             | ApiProvider::Novita
             | ApiProvider::Siliconflow
@@ -3234,10 +3235,14 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::ModelstudioTokenPlanAnthropic
             | ApiProvider::ModelstudioCodingPlan
             | ApiProvider::ModelstudioCodingPlanAnthropic => {}
-            // OpenRouter/Novita/Together: pass through the actual user-chosen value.
-            // OpenRouter's unified scale is none/minimal/low/medium/high/xhigh;
-            // DeepSeek models hosted there accept those directly.
-            ApiProvider::Openrouter | ApiProvider::Novita | ApiProvider::Together => {
+            // OpenRouter/OrcaRouter/Novita/Together: pass through the actual
+            // user-chosen value. OpenRouter's unified scale is
+            // none/minimal/low/medium/high/xhigh; DeepSeek models hosted there
+            // accept those directly.
+            ApiProvider::Openrouter
+            | ApiProvider::Orcarouter
+            | ApiProvider::Novita
+            | ApiProvider::Together => {
                 let value = match normalized.as_str() {
                     "low" | "minimal" => "low",
                     "medium" | "mid" => "medium",
@@ -3336,7 +3341,10 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::ModelstudioTokenPlanAnthropic
             | ApiProvider::ModelstudioCodingPlan
             | ApiProvider::ModelstudioCodingPlanAnthropic => {}
-            ApiProvider::Openrouter | ApiProvider::Novita | ApiProvider::Together => {
+            ApiProvider::Openrouter
+            | ApiProvider::Orcarouter
+            | ApiProvider::Novita
+            | ApiProvider::Together => {
                 body["reasoning_effort"] = json!("xhigh");
                 body["thinking"] = json!({ "type": "enabled" });
             }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -58,6 +58,7 @@ pub enum ApiProvider {
     WanjieArk,
     Volcengine,
     Openrouter,
+    Orcarouter,
     XiaomiMimo,
     Novita,
     Fireworks,
@@ -316,7 +317,7 @@ impl ApiProvider {
 
     /// `ApiProvider` discriminant → `ProviderKind` lookup.
     /// Index 1 is `None` for the legacy `DeepseekCN` variant.
-    const KIND_LOOKUP: [Option<codewhale_config::ProviderKind>; 43] = [
+    const KIND_LOOKUP: [Option<codewhale_config::ProviderKind>; 44] = [
         Some(codewhale_config::ProviderKind::Deepseek),
         None, // DeepseekCN
         Some(codewhale_config::ProviderKind::DeepseekAnthropic),
@@ -326,6 +327,7 @@ impl ApiProvider {
         Some(codewhale_config::ProviderKind::WanjieArk),
         Some(codewhale_config::ProviderKind::Volcengine),
         Some(codewhale_config::ProviderKind::Openrouter),
+        Some(codewhale_config::ProviderKind::Orcarouter),
         Some(codewhale_config::ProviderKind::XiaomiMimo),
         Some(codewhale_config::ProviderKind::Novita),
         Some(codewhale_config::ProviderKind::Fireworks),
@@ -363,7 +365,7 @@ impl ApiProvider {
     ];
 
     /// `ProviderKind` discriminant → `ApiProvider` lookup.
-    const FROM_KIND_LOOKUP: [Self; 42] = [
+    const FROM_KIND_LOOKUP: [Self; 43] = [
         Self::Deepseek,
         Self::DeepseekAnthropic,
         Self::NvidiaNim,
@@ -372,6 +374,7 @@ impl ApiProvider {
         Self::WanjieArk,
         Self::Volcengine,
         Self::Openrouter,
+        Self::Orcarouter,
         Self::XiaomiMimo,
         Self::Novita,
         Self::Fireworks,
@@ -471,6 +474,7 @@ fn subagent_provider_key_matches(key: &str, provider: ApiProvider) -> bool {
             "deepseek_anthropic" | "deepseek_claude" | "deepseek_anthropic_api"
         ),
         ApiProvider::Openrouter => matches!(normalized.as_str(), "openrouter" | "open_router"),
+        ApiProvider::Orcarouter => matches!(normalized.as_str(), "orcarouter" | "orca_router"),
         ApiProvider::OpenaiCodex => matches!(
             normalized.as_str(),
             "openai_codex" | "codex" | "chatgpt" | "openai_chatgpt"
@@ -1415,6 +1419,9 @@ pub fn model_completion_names_for_provider(provider: ApiProvider) -> Vec<&'stati
             let mut models = vec![DEFAULT_OPENROUTER_MODEL, DEFAULT_OPENROUTER_FLASH_MODEL];
             models.extend_from_slice(RECENT_OPENROUTER_LARGE_MODELS);
             models
+        }
+        ApiProvider::Orcarouter => {
+            vec![DEFAULT_ORCAROUTER_MODEL, DEFAULT_ORCAROUTER_FLASH_MODEL]
         }
         ApiProvider::XiaomiMimo => vec![
             DEFAULT_XIAOMI_MIMO_MODEL,
@@ -3274,6 +3281,8 @@ pub struct ProvidersConfig {
     pub volcengine: ProviderConfig,
     #[serde(default)]
     pub openrouter: ProviderConfig,
+    #[serde(default, alias = "orca_router", alias = "orca")]
+    pub orcarouter: ProviderConfig,
     #[serde(
         default,
         alias = "xiaomi",
@@ -4807,6 +4816,7 @@ impl Config {
             ApiProvider::Atlascloud => &providers.atlascloud,
             ApiProvider::WanjieArk => &providers.wanjie_ark,
             ApiProvider::Openrouter => &providers.openrouter,
+            ApiProvider::Orcarouter => &providers.orcarouter,
             ApiProvider::XiaomiMimo => &providers.xiaomi_mimo,
             ApiProvider::Novita => &providers.novita,
             ApiProvider::Fireworks => &providers.fireworks,
@@ -4883,6 +4893,7 @@ impl Config {
             ApiProvider::Atlascloud => &mut providers.atlascloud,
             ApiProvider::WanjieArk => &mut providers.wanjie_ark,
             ApiProvider::Openrouter => &mut providers.openrouter,
+            ApiProvider::Orcarouter => &mut providers.orcarouter,
             ApiProvider::XiaomiMimo => &mut providers.xiaomi_mimo,
             ApiProvider::Novita => &mut providers.novita,
             ApiProvider::Fireworks => &mut providers.fireworks,
@@ -5234,6 +5245,7 @@ impl Config {
             ApiProvider::Atlascloud => DEFAULT_ATLASCLOUD_MODEL,
             ApiProvider::WanjieArk => DEFAULT_WANJIE_ARK_MODEL,
             ApiProvider::Openrouter => DEFAULT_OPENROUTER_MODEL,
+            ApiProvider::Orcarouter => DEFAULT_ORCAROUTER_MODEL,
             ApiProvider::XiaomiMimo => DEFAULT_XIAOMI_MIMO_MODEL,
             ApiProvider::Novita => DEFAULT_NOVITA_MODEL,
             ApiProvider::Fireworks => DEFAULT_FIREWORKS_MODEL,
@@ -5365,6 +5377,7 @@ impl Config {
             | ApiProvider::Atlascloud
             | ApiProvider::WanjieArk
             | ApiProvider::Openrouter
+            | ApiProvider::Orcarouter
             | ApiProvider::OpenaiCodex
             | ApiProvider::Novita
             | ApiProvider::Fireworks
@@ -5458,6 +5471,7 @@ impl Config {
                         ApiProvider::Atlascloud => DEFAULT_ATLASCLOUD_BASE_URL,
                         ApiProvider::WanjieArk => DEFAULT_WANJIE_ARK_BASE_URL,
                         ApiProvider::Openrouter => DEFAULT_OPENROUTER_BASE_URL,
+                        ApiProvider::Orcarouter => DEFAULT_ORCAROUTER_BASE_URL,
                         ApiProvider::XiaomiMimo => DEFAULT_XIAOMI_MIMO_BASE_URL,
                         ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
                         ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
@@ -6783,6 +6797,7 @@ fn root_deepseek_model_is_foreign_to_direct_provider(provider: ApiProvider, mode
         provider,
         ApiProvider::NvidiaNim
             | ApiProvider::Openrouter
+            | ApiProvider::Orcarouter
             | ApiProvider::Novita
             | ApiProvider::Fireworks
             | ApiProvider::Siliconflow
@@ -7021,6 +7036,7 @@ fn provider_env_base_url_override(provider: ApiProvider) -> Option<String> {
         ApiProvider::Openai => &["OPENAI_BASE_URL"],
         ApiProvider::Atlascloud => &["ATLASCLOUD_BASE_URL"],
         ApiProvider::Openrouter => &["OPENROUTER_BASE_URL"],
+        ApiProvider::Orcarouter => &["ORCAROUTER_BASE_URL"],
         ApiProvider::XiaomiMimo => &["XIAOMI_MIMO_BASE_URL", "MIMO_BASE_URL"],
         ApiProvider::WanjieArk => &[
             "WANJIE_ARK_BASE_URL",
@@ -7176,6 +7192,13 @@ fn apply_env_overrides_unlocked(config: &mut Config, policy: ConfigEnvironmentPo
                     .providers
                     .get_or_insert_with(ProvidersConfig::default)
                     .openrouter
+                    .base_url = Some(value);
+            }
+            ApiProvider::Orcarouter => {
+                config
+                    .providers
+                    .get_or_insert_with(ProvidersConfig::default)
+                    .orcarouter
                     .base_url = Some(value);
             }
             ApiProvider::XiaomiMimo => {
@@ -7712,6 +7735,7 @@ fn apply_env_overrides_unlocked(config: &mut Config, policy: ConfigEnvironmentPo
                 ApiProvider::Atlascloud => &mut providers.atlascloud,
                 ApiProvider::WanjieArk => &mut providers.wanjie_ark,
                 ApiProvider::Openrouter => &mut providers.openrouter,
+                ApiProvider::Orcarouter => &mut providers.orcarouter,
                 ApiProvider::XiaomiMimo => &mut providers.xiaomi_mimo,
                 ApiProvider::Novita => &mut providers.novita,
                 ApiProvider::Fireworks => &mut providers.fireworks,
@@ -8056,6 +8080,7 @@ fn apply_env_overrides_unlocked(config: &mut Config, policy: ConfigEnvironmentPo
                 ApiProvider::Atlascloud => &mut providers.atlascloud,
                 ApiProvider::WanjieArk => &mut providers.wanjie_ark,
                 ApiProvider::Openrouter => &mut providers.openrouter,
+                ApiProvider::Orcarouter => &mut providers.orcarouter,
                 ApiProvider::XiaomiMimo => &mut providers.xiaomi_mimo,
                 ApiProvider::Novita => &mut providers.novita,
                 ApiProvider::Fireworks => &mut providers.fireworks,
@@ -9436,6 +9461,7 @@ fn merge_providers(
             atlascloud: merge_provider_config(base.atlascloud, override_cfg.atlascloud),
             wanjie_ark: merge_provider_config(base.wanjie_ark, override_cfg.wanjie_ark),
             openrouter: merge_provider_config(base.openrouter, override_cfg.openrouter),
+            orcarouter: merge_provider_config(base.orcarouter, override_cfg.orcarouter),
             xiaomi_mimo: merge_provider_config(base.xiaomi_mimo, override_cfg.xiaomi_mimo),
             novita: merge_provider_config(base.novita, override_cfg.novita),
             fireworks: merge_provider_config(base.fireworks, override_cfg.fireworks),

--- a/crates/tui/src/config/models.rs
+++ b/crates/tui/src/config/models.rs
@@ -24,6 +24,8 @@ pub const DEFAULT_VOLCENGINE_BASE_URL: &str = "https://ark.cn-beijing.volces.com
 pub const DEFAULT_WANJIE_ARK_BASE_URL: &str = "https://maas-openapi.wanjiedata.com/api/v1";
 pub const DEFAULT_OPENROUTER_MODEL: &str = "deepseek/deepseek-v4-pro";
 pub const DEFAULT_OPENROUTER_FLASH_MODEL: &str = "deepseek/deepseek-v4-flash";
+pub const DEFAULT_ORCAROUTER_MODEL: &str = "deepseek/deepseek-v4-pro";
+pub const DEFAULT_ORCAROUTER_FLASH_MODEL: &str = "deepseek/deepseek-v4-flash";
 pub const OPENROUTER_ARCEE_TRINITY_LARGE_THINKING_MODEL: &str = "arcee-ai/trinity-large-thinking";
 pub const OPENROUTER_GEMMA_4_31B_MODEL: &str = "google/gemma-4-31b-it";
 pub const OPENROUTER_GEMMA_4_26B_A4B_MODEL: &str = "google/gemma-4-26b-a4b-it";
@@ -73,6 +75,7 @@ pub const RECENT_OPENROUTER_LARGE_MODELS: &[&str] = &[
     OPENROUTER_NEMOTRON_3_NANO_OMNI_MODEL,
 ];
 pub const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+pub const DEFAULT_ORCAROUTER_BASE_URL: &str = "https://api.orcarouter.ai/v1";
 pub const DEFAULT_XIAOMI_MIMO_MODEL: &str = "mimo-v2.5-pro";
 pub const XIAOMI_MIMO_V2_5_PRO_ULTRASPEED_MODEL: &str = "mimo-v2.5-pro-ultraspeed";
 pub const XIAOMI_MIMO_PAY_AS_YOU_GO_BASE_URL: &str = "https://api.xiaomimimo.com/v1";

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -279,6 +279,7 @@ fn provider_base_url_table_key(provider: ApiProvider) -> anyhow::Result<&'static
         ApiProvider::WanjieArk => Ok("wanjie_ark"),
         ApiProvider::Volcengine => Ok("volcengine"),
         ApiProvider::Openrouter => Ok("openrouter"),
+        ApiProvider::Orcarouter => Ok("orcarouter"),
         ApiProvider::XiaomiMimo => Ok("xiaomi_mimo"),
         ApiProvider::Novita => Ok("novita"),
         ApiProvider::Fireworks => Ok("fireworks"),

--- a/crates/tui/src/tui/ui/session_state.rs
+++ b/crates/tui/src/tui/ui/session_state.rs
@@ -845,6 +845,7 @@ pub(crate) fn mirror_saved_api_key_in_config(
         ApiProvider::WanjieArk => &mut providers.wanjie_ark,
         ApiProvider::Volcengine => &mut providers.volcengine,
         ApiProvider::Openrouter => &mut providers.openrouter,
+        ApiProvider::Orcarouter => &mut providers.orcarouter,
         ApiProvider::XiaomiMimo => &mut providers.xiaomi_mimo,
         ApiProvider::Novita => &mut providers.novita,
         ApiProvider::Fireworks => &mut providers.fireworks,

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -31,11 +31,11 @@ Sources to keep in sync:
 
 ## Provider Selection
 
-The canonical provider IDs are the 37 entries of `ProviderKind::ALL`
+The canonical provider IDs are the 38 entries of `ProviderKind::ALL`
 (`crates/config/src/provider_kind.rs:198-234`), in that order:
 
 `deepseek`, `nvidia-nim`, `openai`, `atlascloud`, `wanjie-ark`, `volcengine`,
-`openrouter`, `xiaomi-mimo`, `novita`, `fireworks`, `siliconflow`, `arcee`,
+`openrouter`, `orcarouter`, `xiaomi-mimo`, `novita`, `fireworks`, `siliconflow`, `arcee`,
 `siliconflow-CN`, `moonshot`, `sglang`, `vllm`, `ollama`, `huggingface`,
 `together`, `qianfan`, `openai-codex`, `anthropic`, `openmodel`, `zai`,
 `stepfun`, `minimax`, `deepinfra`, `sakana`, `longcat`, `opencode-go`,
@@ -401,6 +401,7 @@ Kimi remains API-key-only; external consent for Kimi is rejected.
 | `wanjie-ark` | `[providers.wanjie_ark]` | `WANJIE_ARK_API_KEY`, `WANJIE_API_KEY`, `WANJIE_MAAS_API_KEY` | `WANJIE_ARK_BASE_URL`, `WANJIE_BASE_URL`, `WANJIE_MAAS_BASE_URL`; default `https://maas-openapi.wanjiedata.com/api/v1` | `deepseek-reasoner` | OpenAI-compatible hosted route. `WANJIE_ARK_MODEL`, `WANJIE_MODEL`, and `WANJIE_MAAS_MODEL` are accepted. |
 | `volcengine` | `[providers.volcengine]` | `VOLCENGINE_API_KEY`, `VOLCENGINE_ARK_API_KEY`, `ARK_API_KEY` | `VOLCENGINE_BASE_URL`, `VOLCENGINE_ARK_BASE_URL`, `ARK_BASE_URL`; default `https://ark.cn-beijing.volces.com/api/coding/v3` | `DeepSeek-V4-Pro`, `DeepSeek-V4-Flash` | Volcengine/Volcano Engine Ark OpenAI-compatible coding endpoint. `VOLCENGINE_MODEL` and `VOLCENGINE_ARK_MODEL` are accepted. |
 | `openrouter` | `[providers.openrouter]` | `OPENROUTER_API_KEY` | `OPENROUTER_BASE_URL`; default `https://openrouter.ai/api/v1` | `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`; recent large IDs include `arcee-ai/trinity-large-thinking`, `minimax/minimax-m3`, `xiaomi/mimo-v2.5-pro`, `qwen/qwen3.6-flash`, `qwen/qwen3.6-35b-a3b`, `qwen/qwen3.6-max-preview`, `qwen/qwen3.6-27b`, `qwen/qwen3.6-plus`, `google/gemma-4-31b-it`, `z-ai/glm-5.1`, `z-ai/glm-5.2`, `moonshotai/kimi-k2.7-code`, `moonshotai/kimi-k2.6` | Additive open-model routing layer. It does not replace DeepSeek; it lets users route supported model IDs through OpenRouter when they choose it. |
+| `orcarouter` | `[providers.orcarouter]` | `ORCAROUTER_API_KEY` | `ORCAROUTER_BASE_URL`; default `https://api.orcarouter.ai/v1` | `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`; router alias `orcarouter/auto`; recent large IDs mirror the OpenRouter namespaced catalog | [OrcaRouter](https://www.orcarouter.ai) OpenAI-compatible aggregation gateway. Shares the namespaced `vendor/model` wire-model format and DeepSeek model set with OpenRouter, so the OpenRouter base-URL and model-normalization rules apply. `ORCAROUTER_MODEL` is accepted. Provider aliases: `orcarouter`, `orca_router`, `orca`. |
 | `xiaomi-mimo` | `[providers.xiaomi_mimo]` | `XIAOMI_MIMO_TOKEN_PLAN_API_KEY`, `MIMO_TOKEN_PLAN_API_KEY`, `XIAOMI_MIMO_API_KEY`, `XIAOMI_API_KEY`, `MIMO_API_KEY` | `XIAOMI_MIMO_BASE_URL`, `MIMO_BASE_URL`, `XIAOMI_MIMO_MODE`, `MIMO_MODE`; default `https://token-plan-sgp.xiaomimimo.com/v1` | Chat: `mimo-v2.5-pro`, `mimo-v2.5-pro-ultraspeed`, `mimo-v2.5`; speech/TTS: `mimo-v2.5-tts`, `mimo-v2.5-tts-voicedesign`, `mimo-v2.5-tts-voiceclone`, `mimo-v2-tts` | Xiaomi MiMo OpenAI-compatible chat completions route. Token Plan keys (`tp-...`) use `api-key` auth and the token-plan endpoint by default; pay-as-you-go mode uses standard API keys (`sk-...`) and `https://api.xiaomimimo.com/v1`. It sends `max_completion_tokens` and uses MiMo's `thinking` field for reasoning control. Token Plan cost/usage is credit/quota based; Codewhale shows it as unknown until Xiaomi exposes a reliable balance API. `codewhale speech` / `tts` uses the TTS models. |
 | `novita` | `[providers.novita]` | `NOVITA_API_KEY` | `NOVITA_BASE_URL`; default `https://api.novita.ai/openai/v1` | `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash` | OpenAI-compatible hosted route for DeepSeek model IDs. Use config or `CODEWHALE_MODEL` / `DEEPSEEK_MODEL` for model overrides. |
 | `fireworks` | `[providers.fireworks]` | `FIREWORKS_API_KEY` | `FIREWORKS_BASE_URL`; default `https://api.fireworks.ai/inference/v1` | `accounts/fireworks/models/deepseek-v4-pro` | OpenAI-compatible hosted route. Use config or `CODEWHALE_MODEL` / `DEEPSEEK_MODEL` for model overrides. |
@@ -539,6 +540,15 @@ parsed when the upstream gateway sends them. If a key/account type omits those
 fields, Codewhale treats them as absent for that response rather than as a
 different provider route.
 
+OrcaRouter (`https://api.orcarouter.ai/v1`) is a dedicated named route
+([OrcaRouter](https://www.orcarouter.ai)) that speaks the same OpenAI
+Chat Completions wire protocol and serves the same namespaced
+`vendor/model` catalog. It does not need an OpenRouter-compatible
+`base_url` override: select `provider = "orcarouter"` and its namespaced
+wire models (for example `deepseek/deepseek-v4-pro` or its own
+`orcarouter/auto` router) pass through verbatim, exactly as they do on the
+OpenRouter provider scope.
+
 ### Recent OpenRouter Large Models
 
 OpenRouter completions and static registry rows include the April 2026 onward
@@ -586,6 +596,7 @@ endpoint when the endpoint supports model listing.
 | `wanjie-ark` | `deepseek-reasoner` | yes | yes |
 | `volcengine` | `DeepSeek-V4-Pro`, `DeepSeek-V4-Flash` | yes | yes |
 | `openrouter` | `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `arcee-ai/trinity-large-thinking`, `minimax/minimax-m3`, `minimax/minimax-m2.7`, `xiaomi/mimo-v2.5-pro`, `xiaomi/mimo-v2.5`, `qwen/qwen3.6-flash`, `qwen/qwen3.6-35b-a3b`, `qwen/qwen3.6-max-preview`, `qwen/qwen3.6-27b`, `qwen/qwen3.6-plus`, `qwen/qwen3.7-max`, `moonshotai/kimi-k2.7-code`, `moonshotai/kimi-k2.6`, `z-ai/glm-5.1`, `z-ai/glm-5.2`, `z-ai/glm-5.3`, `z-ai/glm-5-turbo`, `tencent/hy3-preview`, `google/gemma-4-31b-it`, `google/gemma-4-26b-a4b-it`, `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`, `nvidia/nemotron-3-ultra-550b-a55b` | yes | yes |
+| `orcarouter` | `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `orcarouter/auto` | yes | yes |
 | `xiaomi-mimo` | `mimo-v2.5-pro`, `mimo-v2.5-pro-ultraspeed`, `mimo-v2.5`; speech/TTS IDs are selected through `codewhale speech` / `tts` | yes | yes for chat models; no for speech/TTS models |
 | `novita` | `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash` | yes | yes |
 | `fireworks` | `accounts/fireworks/models/deepseek-v4-pro` | yes | yes |

--- a/web/lib/facts-drift.ts
+++ b/web/lib/facts-drift.ts
@@ -112,6 +112,7 @@ function deriveProvidersFromConfig(cfg: string): ProviderFact[] {
     WanjieArk: { id: "wanjie-ark", label: "Wanjie Ark", env: "WANJIE_ARK_API_KEY / WANJIE_API_KEY / WANJIE_MAAS_API_KEY" },
     Volcengine: { id: "volcengine", label: "Volcengine Ark", env: "VOLCENGINE_API_KEY / VOLCENGINE_ARK_API_KEY / ARK_API_KEY" },
     Openrouter: { id: "openrouter", label: "OpenRouter", env: "OPENROUTER_API_KEY" },
+    Orcarouter: { id: "orcarouter", label: "OrcaRouter", env: "ORCAROUTER_API_KEY" },
     XiaomiMimo: { id: "xiaomi-mimo", label: "Xiaomi MiMo", env: "XIAOMI_MIMO_TOKEN_PLAN_API_KEY / MIMO_TOKEN_PLAN_API_KEY / XIAOMI_MIMO_API_KEY / XIAOMI_API_KEY / MIMO_API_KEY" },
     Novita: { id: "novita", label: "Novita AI", env: "NOVITA_API_KEY" },
     Fireworks: { id: "fireworks", label: "Fireworks AI", env: "FIREWORKS_API_KEY" },

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -99,6 +99,11 @@ export const FACTS: RepoFacts = {
       "env": "OPENROUTER_API_KEY"
     },
     {
+      "id": "orcarouter",
+      "label": "OrcaRouter",
+      "env": "ORCAROUTER_API_KEY"
+    },
+    {
       "id": "xiaomi-mimo",
       "label": "Xiaomi MiMo",
       "env": "XIAOMI_MIMO_TOKEN_PLAN_API_KEY / MIMO_TOKEN_PLAN_API_KEY / XIAOMI_MIMO_API_KEY / XIAOMI_API_KEY / MIMO_API_KEY"

--- a/web/scripts/facts-lib.mjs
+++ b/web/scripts/facts-lib.mjs
@@ -70,6 +70,7 @@ const PROVIDER_LABEL_MAP = {
   WanjieArk: { id: "wanjie-ark", label: "Wanjie Ark", env: "WANJIE_ARK_API_KEY / WANJIE_API_KEY / WANJIE_MAAS_API_KEY" },
   Volcengine: { id: "volcengine", label: "Volcengine Ark", env: "VOLCENGINE_API_KEY / VOLCENGINE_ARK_API_KEY / ARK_API_KEY" },
   Openrouter: { id: "openrouter", label: "OpenRouter", env: "OPENROUTER_API_KEY" },
+  Orcarouter: { id: "orcarouter", label: "OrcaRouter", env: "ORCAROUTER_API_KEY" },
   XiaomiMimo: { id: "xiaomi-mimo", label: "Xiaomi MiMo", env: "XIAOMI_MIMO_TOKEN_PLAN_API_KEY / MIMO_TOKEN_PLAN_API_KEY / XIAOMI_MIMO_API_KEY / XIAOMI_API_KEY / MIMO_API_KEY" },
   Novita: { id: "novita", label: "Novita AI", env: "NOVITA_API_KEY" },
   Fireworks: { id: "fireworks", label: "Fireworks AI", env: "FIREWORKS_API_KEY" },


### PR DESCRIPTION
## Summary

This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing OpenRouter provider is wired, so the model picker, config reference and docs stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

What's added:

- `crates/config`: `Orcarouter` `ProviderKind` (serde aliases `orca_router`/`orca`), `provider!` registration, default base URL `https://api.orcarouter.ai/v1`, default model `deepseek/deepseek-v4-pro`, flash model `deepseek/deepseek-v4-flash`, auto-routing model `orcarouter/auto`, `ORCAROUTER_API_KEY` env mapping, model normalization, and `ProvidersToml`/`EnvRuntimeOverrides` wiring.
- `crates/cli`: `--provider orcarouter` selection.
- `crates/tui`: `ApiProvider::Orcarouter` picker entry, config/key/model mappings, and reasoning-effort pass-through (same group as OpenRouter/Novita/Together).
- `crates/agent`: model registry entries for `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `orcarouter/auto`.
- `docs/PROVIDERS.md`, `config.example.toml`, and web facts (drift check green).

## Testing

Exact gate commands (including the clippy allow list) are in `CONTRIBUTING.md` → "Pre-push verification".

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy` on the touched crates under the CI allow list — clean. One pre-existing `needless_return` lint in `crates/tui/src/mcp.rs` (not touched here) also fails on clean `main` with this toolchain; unrelated to this change.
- [x] `cargo test -p codewhale-config --lib` — 535 passed; the 4 `xai_credentials` secure-store failures are Windows-only and reproduce on clean `main` (verified via `git stash`).
- [x] Targeted OrcaRouter config/registry tests, provider-registry drift check, and web facts drift check.
- [x] Live L3 against the real endpoint with a valid key: `codewhale --provider orcarouter models` (~189 models, default `deepseek/deepseek-v4-pro`), chat completion on the default model and on `orcarouter/auto`, and a wrong key rejected with `Authentication failed: Invalid token`.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address
