### PR TITLE
web: audit fixes — i18n parity, copy/spacing, test fixes

### DIFF
--- a/web/app/[locale]/docs/constitution/page.tsx
+++ b/web/app/[locale]/docs/constitution/page.tsx
@@ -86,7 +86,7 @@ export default async function ConstitutionPage({ params }: { params: Promise<{ l
             href="https://github.com/Hmbown/CodeWhale/blob/main/docs/CONFIGURATION.md#constitution-project-instructions-and-repo-authority"
             className="body-link"
           >
-            {isZh ? "configuration docs" : "configuration docs"}
+            {isZh ? "配置文档" : "configuration docs"}
           </Link>
           {isZh ? "。" : "."}
         </p>

--- a/web/lib/i18n/dictionaries/zh/chrome.ts
+++ b/web/lib/i18n/dictionaries/zh/chrome.ts
@@ -79,6 +79,6 @@ export const chrome: ChromeDict = {
   footerSecurity: "安全",
 
   switcherLabel: "语言",
-  switcherSwitchTo: "切换到{label}",
+  switcherSwitchTo: "切换到 {label}",
   partialBadge: "(部分)",
 };

--- a/web/lib/public-surface-contract.test.ts
+++ b/web/lib/public-surface-contract.test.ts
@@ -461,6 +461,12 @@ done
       roadmap.indexOf('title: "Underway"'),
     );
     expect(roadmap).toContain("Implemented in the v0.9.1 source candidate");
+    // docs/TOOL_SURFACE.md moved from six to seven model-facing names when
+    // the TUI promoted todo_write into DEFAULT_ACTIVE_NATIVE_TOOLS
+    // (bf6def00d). The committed facts files (docs/public-surface-facts.json
+    // and web/lib/facts.generated.ts) are owned by the release pipeline and
+    // still list the six-name matrix, so this quote check tracks the doc
+    // while the name loop below keeps the matrix↔doc↔site alignment honest.
     expect(toolDoc).toContain("exactly seven model-facing names");
     for (const name of matrix.toolSurface.defaultActive) {
       expect(toolDoc, name).toContain(`\`${name}\``);


### PR DESCRIPTION
## Summary

Audit and polish pass over the Codewhale community website (`web/`), per the maintainer brief. Three clear-cut fixes landed; the rest of the site verified clean.

## Changes

1. **`web/lib/public-surface-contract.test.ts`** — the quote check asserted `docs/TOOL_SURFACE.md` still said "exactly six model-facing names"; the doc moved to seven when `todo_write` joined `DEFAULT_ACTIVE_NATIVE_TOOLS` (bf6def00d). Updated to "exactly seven model-facing names" with a comment documenting that the committed facts files (`docs/public-surface-facts.json`, `web/lib/facts.generated.ts`) are release-pipeline-owned and still carry the six-name matrix — the name loop below still keeps matrix ↔ doc ↔ site aligned. (Overlaps with bot commit 865bc7940, which changed the same line; this keeps the drift comment.)
2. **`web/app/[locale]/docs/constitution/page.tsx`** — the zh branch of the "configuration docs" link label was untranslated English; now renders 「配置文档」.
3. **`web/lib/i18n/dictionaries/zh/chrome.ts`** — `switcherSwitchTo` "切换到{label}" → "切换到 {label}" to match the dictionary's own zh spacing conventions (cf. "最新发布 {tag}", "作者 {handle}"). Aria-label only.

## Verification (all on the rebased branch)

- `npm test` — 30 files / 258 tests passed
- `npm run check:facts` — PASS
- `npm run check:locales` — PASS (dictionary key parity 62/62 per locale)
- `npm run check:docs` — PASS
- `npx eslint .` — clean
- `npx tsc --noEmit` — clean
- `npm run build` — compiled successfully, 288 static pages

## Deliberately not fixed (findings)

- **Plan/Act/Work mode naming**: the site mixes "Plan · Work · Operate" (homepage, roadmap, getting-started, docs/modes meta) with "Plan → Act → Operate" (install page, FAQ, docs/modes cards). docs/MODES.md calls Work canonical with Act as a compatibility alias, but the TUI's own visible label is still "Act" (`AppMode::Agent => "Act"`). Ambiguous mid-rename — left untouched.
- **Facts drift**: `docs/TOOL_SURFACE.md` documents seven model-facing names; `docs/public-surface-facts.json` + `web/lib/facts.generated.ts` still list six (missing `todo_write`). Both files are pipeline-owned (excluded by brief); the site's facts-driven copy intentionally stays at six until the pipeline refreshes.
- **Roadmap zh** "子 Agent 并行执行" note uses "var_handle" (real term from docs/ARCHITECTURE.md) vs EN "bounded result handles" — plausibly correct, not changed.
- **zh FAQ Q9** asks about "Plan、Work、Operate" while EN asks "Plan, Act, and Operate" — tied to the naming ambiguity above, not changed.

No-Issue: web copy/test drift cleanup from the maintainer audit brief; the three fixed surfaces have no open tracking issues.