### PR TITLE
fix(tui): move lru to 0.18 and unpin ratatui-core (RUSTSEC-2026-0253)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +546,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytecount"
@@ -1282,6 +1297,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if 1.0.4",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -2884,6 +2905,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2972,11 +2999,11 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3477,6 +3504,39 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "parking"
@@ -4041,18 +4101,20 @@ dependencies = [
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags 2.13.1",
  "compact_str",
- "hashbrown 0.16.1",
- "indoc",
+ "critical-section",
+ "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
  "lru",
- "strum",
+ "palette",
+ "serde",
+ "strum 0.28.0",
  "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
@@ -4104,7 +4166,7 @@ dependencies = [
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -5152,7 +5214,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -5160,6 +5231,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -54,11 +54,13 @@ fd-lock = "4.0.4"
 dirs.workspace = true
 futures-util = "0.3.31"
 oauth2 = "5"
-# Pin ratatui 0.30.0 + transitive ratatui-core 0.1.0: core 0.1.1+ queries
-# cursor position in Terminal::clear and races our input loop at startup
-# (ratatui/ratatui#2483/#2640). Unpin when upstream fixes that.
+# ratatui-core >= 0.1.1 queries cursor position inside `Terminal::clear()`
+# and races our input loop at startup (ratatui/ratatui#2483/#2640).
+# ColorCompatBackend answers `get_cursor_position()` from tracked state
+# (#2640's recommended workaround), so the pin is no longer needed and lru
+# can resolve to >= 0.18.2 (RUSTSEC-2026-0253).
 ratatui = { version = "=0.30.0", features = ["unstable-rendered-line-info"] }
-ratatui-core = "=0.1.0"
+ratatui-core = "0.1"
 regex = "1.11"
 reqwest = { workspace = true, features = ["blocking", "stream", "form", "http2"] }
 rusqlite.workspace = true
@@ -93,7 +95,8 @@ globset = "0.4"
 ignore = "0.4"
 image = { version = "0.25", default-features = false, features = ["png"] }
 htmd = "0.5.4"
-lru = "0.16"
+# lru >= 0.18.2 fixes RUSTSEC-2026-0253 (panic-unsafe `pop()`).
+lru = "0.18"
 parking_lot = "0.12"
 tar = "0.4"
 flate2 = "1.1"

--- a/crates/tui/src/tui/color_compat.rs
+++ b/crates/tui/src/tui/color_compat.rs
@@ -49,6 +49,19 @@ pub(crate) struct ColorCompatBackend<W: Write> {
     /// Used as the primary fallback in `size()` before falling through to
     /// the live crossterm query.
     terminal_size: Option<Size>,
+    /// The last position the cursor was explicitly moved to.
+    ///
+    /// ratatui-core >= 0.1.1 issues a CPR query inside `Terminal::clear()`
+    /// (`backend.get_cursor_position()` → `ESC[6n`) to snapshot and restore
+    /// the cursor. With our input event loop already reading stdin, the
+    /// reply is consumed as input and the query times out —
+    /// ratatui/ratatui#2483, #2640. #2640's workaround for apps with a live
+    /// event loop is to answer from tracked state, which this backend does:
+    /// `get_cursor_position()` never touches the terminal. Only
+    /// `set_cursor_position()` updates the tracker; raw writes that move
+    /// the cursor out-of-band leave it behind, but every such path is
+    /// followed by a full repaint that repositions the cursor itself.
+    tracked_cursor: Position,
     render_debug: Option<RenderDebugLog>,
     ascii_safe: bool,
     /// The terminal's own background, when detection measured one
@@ -73,6 +86,7 @@ impl<W: Write> ColorCompatBackend<W> {
             active_ui_theme: UiTheme::detect(),
             forced_size: None,
             terminal_size: None,
+            tracked_cursor: Position::ORIGIN,
             render_debug: RenderDebugLog::from_env(),
             ascii_safe: ascii_safe_enabled(),
             detected_background: None,
@@ -209,10 +223,14 @@ impl<W: Write> Backend for ColorCompatBackend<W> {
     }
 
     fn get_cursor_position(&mut self) -> io::Result<Position> {
-        self.inner.get_cursor_position()
+        // Answer from tracked state instead of issuing a CPR query that
+        // races the input event loop — see `tracked_cursor`.
+        Ok(self.tracked_cursor)
     }
 
     fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+        let position = position.into();
+        self.tracked_cursor = position;
         self.inner.set_cursor_position(position)
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,8 @@ ignore = [
 # - sha2 0.10 vs 0.11 — blocked on oauth2 (0.10) vs schemaui 0.12 (0.11)
 # - thiserror 1 vs 2 — blocked on portable-pty 0.9 via filedescriptor 0.8 (v1) vs workspace v2
 # - toml 0.8 vs 1.1 + toml_edit 0.22 vs 0.25 + winnow 0.7 vs 1.0 — blocked on rust-i18n 4.2 (0.8 stack) vs workspace 1.1
+# - strum 0.27 vs 0.28 — ratatui-widgets 0.3.0 (via ratatui 0.30.0) pins 0.27
+#   while ratatui-core 0.1.2 uses 0.28; unifies once widgets moves forward
 multiple-versions = "warn"
 wildcards = "deny"
 # Explicitly allow the surviving duplicates so `cargo deny` does not warn
@@ -52,6 +54,8 @@ skip = [
     { name = "jni-sys", version = "0.3.0" },
     { name = "redox_syscall", version = "0.5.18" },
     { name = "security-framework", version = "2.11.1" },
+    { name = "strum", version = "0.28.0" },
+    { name = "strum_macros", version = "0.28.0" },
     { name = "windows-sys" },
     { name = "windows-targets" },
     { name = "windows_aarch64_gnullvm" },

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 687594,
+  "max_total_owned_rust_lines": 687612,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
Restore the green main gate: cargo-deny advisories failed on main (run 31581323909, head 5be072263) on **RUSTSEC-2026-0253** — `lru` 0.16.4's `LruCache::pop()` is panic-unsafe and can leave dangling list pointers; fixed upstream in 0.18.2.

## Why unpinning was required
`crates/tui/Cargo.toml` pinned `ratatui-core = "=0.1.0"` (commit e3a45388f) because ratatui-core >= 0.1.1 issues a CPR query in `Terminal::clear()` that races our startup input loop (ratatui/ratatui#2483, #2640). That pin required lru `^0.16`, so the advisory could not be fixed by updating lru alone.

## The fix (update, not ignore)
- `lru = "0.18"` → resolves 0.18.2 (panic-safety fix, lru-rs#238; API unchanged for our usage).
- `ratatui-core = "0.1"` → resolves 0.1.2, which accepts `lru ^0.18`.
- `ColorCompatBackend` now tracks the cursor on `set_cursor_position()` and answers `get_cursor_position()` from tracked state — exactly the workaround ratatui/ratatui#2640 recommends for apps with a live event loop. No CPR query ever touches our stdin reader, so the startup race the pin worked around stays gone.
- `ratatui` itself remains pinned at `=0.30.0`; the API surface is unchanged.

## Side effects handled
- New duplicate pair `strum` 0.27.2 (ratatui-widgets 0.3.0) vs 0.28.0 (ratatui-core 0.1.2): added to the deny.toml warn-ratchet skip list with justification, per the Epic #5249 ratchet policy. No other duplicates introduced.
- Source-structure budget: +18 lines of explanatory comments (687594 → 687612), bumped following established precedent.

## Verification (local, this branch)
- `cargo fmt` clean
- `cargo deny check advisories` → **ok** (RUSTSEC-2026-0253 no longer reachable)
- `cargo deny check bans licenses sources` → ok
- `cargo audit` → only the 2 pre-existing allowed warnings (yaml-rust via syntect)
- `cargo test -p codewhale-tui --locked` → **10,645 passed, 0 failed** (incl. 76 PTY release-QA tests) against the new ratatui stack
- `scripts/check-source-structure-budget.py` → PASS

Workspace-wide tests are running; CI will confirm on all platforms.

No-Issue: cargo-deny advisory fix; RUSTSEC-2026-0253 is a newly published upstream advisory, not a tracked issue. Restores the green main gate.