### PR TITLE
docs(i18n): retire the stale zh-Hant partial-pack declaration

### DIFF
--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -77,7 +77,7 @@ pub struct SettingsSection {
     pub inline_diffs: InlineDiffValue,
     #[schemars(
         title = "UI locale",
-        description = "Locale used by the TUI. zh-Hant is a partial pack; missing strings fall back to English."
+        description = "Locale used by the TUI. Every shipped locale pack holds full English parity; nothing falls back."
     )]
     pub locale: UiLocale,
     pub theme: UiThemeValue,

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -1770,9 +1770,8 @@ background_color = "#1A1B26"
             schema["$defs"]["SettingsSection"]["properties"]["locale"]["description"]
                 .as_str()
                 .is_some_and(|copy| {
-                    copy.contains("zh-Hant")
-                        && copy.contains("partial")
-                        && copy.contains("fall back to English")
+                    copy.contains("Every shipped locale pack holds full English parity")
+                        && copy.contains("nothing falls back")
                 })
         );
         let approval_mode = &schema["$defs"]["ApprovalModeValue"]["enum"];

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -365,7 +365,7 @@ pub struct Settings {
     pub inline_diffs: String,
     /// UI locale: auto, en, ja, zh-Hans, zh-Hant, pt-BR, es-419, vi, ko,
     /// ca, de, fr, id, hi, ru, uk.
-    /// zh-Hant is a partial pack; missing strings fall back to English.
+    /// Every shipped pack holds full `en.json` parity; nothing falls back.
     pub locale: String,
     /// Named UI theme. Accepts `"system"` (follow terminal background),
     /// `"dark"`, `"light"`, `"grayscale"`, or one of the community
@@ -1682,7 +1682,7 @@ impl Settings {
             ),
             (
                 "locale",
-                "UI locale and default model language: auto, en, ja, zh-Hans, zh-Hant, pt-BR, es-419, vi, ko, ca, de, fr, id, hi, ru, uk; zh-Hant is partial and missing strings fall back to English",
+                "UI locale and default model language: auto, en, ja, zh-Hans, zh-Hant, pt-BR, es-419, vi, ko, ca, de, fr, id, hi, ru, uk; every shipped pack holds full English parity",
             ),
             (
                 "theme",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1532,8 +1532,8 @@ Common settings keys:
 - `locale` (`auto`, `en`, `ja`, `zh-Hans`, `zh-Hant`, `pt-BR`, `es-419`, `vi`,
   `ko`; default `auto`): UI chrome locale. `auto` checks `LC_ALL`,
   `LC_MESSAGES`, then `LANG`; unsupported locale selections resolve to English.
-  `zh-Hant` is a shipped partial pack, so strings it does not yet provide fall
-  back to English. The runtime also exposes the resolved locale in the system
+  Every shipped pack holds full `en.json` parity, so no string falls back
+  to English. The runtime also exposes the resolved locale in the system
   prompt as the fallback natural language for V4 reasoning and replies when the
   latest user message is ambiguous. Clear user language still takes priority;
   Chinese turns should produce Chinese `reasoning_content` and Chinese final

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -15,7 +15,8 @@ Customer-visible copy also follows the [Codewhale voice and terminal
 charter](VOICE.md); commands, key names, and glyphs remain code-owned around
 localized prose.
 
-Last updated: 2026-08-03 (v0.9.4 website dictionary spine, #4934).
+Last updated: 2026-08-12 (retire the stale `zh-Hant` partial declaration
+left behind by #5143).
 Source-of-truth README: `README.md` (English, post-#3087).
 
 ## Status legend
@@ -43,7 +44,7 @@ authoring contract.
 | English | `en.json` | 1299/1299 | **shipped** | Reference pack. |
 | Japanese | `ja.json` | 1299/1299 | **shipped** | Complete. |
 | Simplified Chinese | `zh-Hans.json` | 1299/1299 | **shipped** | Complete. |
-| Traditional Chinese | `zh-Hant.json` | 1299/1299 | **partial** | Key-complete — nothing falls back at runtime. Still declared partial in `PARTIAL_PACKS` per #4057; promoting it out is an open decision. |
+| Traditional Chinese | `zh-Hant.json` | 1299/1299 | **shipped** | Complete (#5143). Awaiting native-speaker review. |
 | Brazilian Portuguese | `pt-BR.json` | 1299/1299 | **shipped** | Complete. |
 | Latin American Spanish | `es-419.json` | 1299/1299 | **shipped** | Complete. Note the website tracks `es` — the shipped TUI pack is Latin American Spanish, not `es-ES`. |
 | Vietnamese | `vi.json` | 1299/1299 | **shipped** | Complete. |
@@ -172,10 +173,12 @@ carry an explicit `planned`/`partial`/`deferred` row in this matrix.
    tied to `Locale::shipped()` so these surfaces cannot silently drift.
 4. Run `python3 scripts/check-tui-locale-parity.py` and
    `cargo test -p codewhale-tui localization`.
-5. If the pack must ship incomplete, declare it partial (see `zh-Hant` /
-   #4057): keep it out of `shipped_complete()`, mark it in
-   `is_partial_pack()`, and add it to `PARTIAL_PACKS` in
-   `scripts/check-tui-locale-parity.py` with a tracking issue.
+5. If the pack must ship incomplete, declare it partial: keep it out of
+   `shipped_complete()`, mark it in `is_partial_pack()`, and add it to
+   `PARTIAL_PACKS` in `scripts/check-tui-locale-parity.py` with a tracking
+   issue. No pack is partial today — `PARTIAL_PACKS` is empty and
+   `is_partial_pack()` returns false for every shipped locale — so a new
+   entry is the only thing that reopens the English-fallback path.
 
 ### 2. README
 

--- a/scripts/check-tui-locale-parity.py
+++ b/scripts/check-tui-locale-parity.py
@@ -33,9 +33,9 @@ REFERENCE = "en"
 # Packs that ship deliberately incomplete, with English fallback for the
 # missing keys. Mirrors `Locale::is_partial_pack()`. Every entry needs an
 # issue reference; a partial pack without a tracking issue is silent drift.
-PARTIAL_PACKS = {
-    "zh-Hant": "#4057",  # Setup core only; English fallback for the rest.
-}
+# Empty since #5143 brought `zh-Hant` to full `en.json` parity and
+# `Locale::is_partial_pack()` began returning false for every shipped locale.
+PARTIAL_PACKS: dict[str, str] = {}
 
 PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 


### PR DESCRIPTION
## Summary

PR #5143 brought `zh-Hant.json` to full `en.json` parity and made `is_partial_pack()` return `false` for every shipped locale, but five surfaces still describe zh-Hant as a partial pack — including two user-facing strings (the `/config` help text and the settings schema description) and the `PARTIAL_PACKS` exemption that was still skipping zh-Hant in the CI parity gate. This retires all of them and puts zh-Hant through the full completeness + placeholder gate, which passes: 1333/1333 keys, placeholders intact.

The user-facing copy is restated as the invariant that actually holds ("every shipped pack holds full English parity") rather than a per-locale fact, so the next pack promotion cannot leave the same drift behind.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [x] `cargo test -p codewhale-tui --locked localization` — full workspace suite not run locally; copy/docs-level change with no behavior edits
- [x] `python3 scripts/check-tui-locale-parity.py` (PASS; zh-Hant 1333/1333 — complete)

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant (no behavior change; the existing zh-Hant parity assertions in `localization.rs` already lock the promoted state)
- [ ] Verified TUI behavior manually if UI changes (n/a — string/docs copy only)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (n/a — no harvested content)

No-Issue: docs/copy-only drift cleanup retiring stale zh-Hant partial-pack declarations; no open issue tracks it (parent issues #4786/#4787 already closed).