### PR TITLE
fix(mcp): omit nextCursor when there are no further pages

### DIFF
--- a/crates/tui/src/mcp_server.rs
+++ b/crates/tui/src/mcp_server.rs
@@ -233,7 +233,10 @@ impl McpServer {
                 }
             }
         }
-        json!({ "tools": tools, "nextCursor": Value::Null })
+        // MCP spec: `nextCursor` must be omitted (or be a string) when there
+        // are no more results. Emitting `null` violates the spec and breaks
+        // strict clients (e.g. Claude Code) that validate the response shape.
+        json!({ "tools": tools })
     }
 
     fn list_resources_response(&self) -> Value {
@@ -258,7 +261,9 @@ impl McpServer {
             }
         }
 
-        json!({ "resources": resources, "nextCursor": Value::Null })
+        // Same spec point as `list_tools_response`: omit `nextCursor` when
+        // there are no further pages rather than emitting `null`.
+        json!({ "resources": resources })
     }
 
     fn call_tool(
@@ -649,5 +654,37 @@ mod tests {
             Some("apply_patch")
         );
         assert_eq!(map.get("shell").map(String::as_str), Some("exec_shell"));
+    }
+
+    #[test]
+    fn list_responses_omit_null_next_cursor() {
+        // MCP spec: `nextCursor` must be omitted (or be a string) when there
+        // are no further pages. Emitting `null` breaks strict clients such as
+        // Claude Code, which validate the response shape.
+        let settings = McpServerSettings {
+            expose_tools: vec!["deepseek".to_string(), "apply_patch".to_string()],
+            require_approval: false,
+        };
+        let server = McpServer::new(PathBuf::from("."), settings).expect("build server");
+
+        let tools_value = server.list_tools_response();
+        let tools = tools_value
+            .as_object()
+            .expect("tools/list response is an object");
+        assert!(tools.contains_key("tools"));
+        assert!(
+            tools.get("nextCursor").is_none(),
+            "tools/list must omit nextCursor when there are no more pages"
+        );
+
+        let resources_value = server.list_resources_response();
+        let resources = resources_value
+            .as_object()
+            .expect("resources/list response is an object");
+        assert!(resources.contains_key("resources"));
+        assert!(
+            resources.get("nextCursor").is_none(),
+            "resources/list must omit nextCursor when there are no more pages"
+        );
     }
 }

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 689659,
+  "max_total_owned_rust_lines": 689696,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
Fixes #5335

## Problem

`serve --mcp` returns `"nextCursor": null` in both `tools/list` and `resources/list` responses. Per the MCP spec the field must be a string or absent; `null` is invalid, and strict clients such as Claude Code reject the shape (`expected string, received null (at nextCursor)`), leaving Codewhale's tools undiscoverable.

## Change

- Omit `nextCursor` entirely in `list_tools_response` and `list_resources_response` (`crates/tui/src/mcp_server.rs`).
- Add a regression test `list_responses_omit_null_next_cursor` asserting both responses drop the key.

## Verification

- `cargo check -p codewhale-tui` passes.
- `cargo test -p codewhale-tui list_responses_omit_null_next_cursor` passes (1 passed, 0 failed).
- End-to-end: built `codewhale-tui serve --mcp`, sent `initialize` + `tools/list` (+ `cursor: null` variant), responses contain no `nextCursor` key and return 6 tools / 2 resources.

Implementation and verification were carried out with Claude Code.