### PR TITLE
feat(web): move the docs guide page onto the dictionary spine (#5337)

### DIFF
--- a/web/app/[locale]/docs/guide/page.tsx
+++ b/web/app/[locale]/docs/guide/page.tsx
@@ -2,39 +2,31 @@ import Link from "next/link";
 import { GettingStartedSteps } from "@/components/getting-started-steps";
 import { SessionMedia } from "@/components/session-media";
 import { GUIDE_NEXT_LINKS } from "@/lib/content/getting-started";
+import { getDocsGuide, pickText } from "@/lib/i18n/dictionaries";
 import { getMediaAsset } from "@/lib/media-manifest";
 import { buildPageMetadata } from "@/lib/page-meta";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
+  const t = getDocsGuide(locale);
   return buildPageMetadata({
     path: "/docs/guide",
     locale,
-    title: isZh ? "新手指引 · Codewhale 文档" : "Getting started · Codewhale Docs",
-    description: isZh
-      ? "从安装到配置理想 Fleet 的完整路径：安装、无需密钥的首次会话、连接提供商、设置 Fleet。"
-      : "The full path from install to your ideal fleet: install, a first keyless session, provider connection, and fleet setup.",
+    title: t.metaTitle,
+    description: t.metaDescription,
   });
 }
 
 export default async function GuidePage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
-  const bodyClass = isZh
-    ? "text-ink-soft leading-[1.9] tracking-wide"
-    : "text-ink-soft leading-relaxed";
+  const t = getDocsGuide(locale);
   const session = getMediaAsset("first-fleet-session");
 
   return (
     <section className="space-y-10">
       <section id="overview" className="scroll-mt-32">
-        <h2 className="font-display text-3xl mb-1">{isZh ? "新手指引" : "Getting started"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "从一条安装命令到配置好你的 Fleet，四步走完。每一步都只陈述当前版本真实的行为；未发布或待录制的内容会明确标注。"
-            : "Four steps from one install command to a fleet set up for your work. Every step states only what the current candidate actually does; anything unreleased or unrecorded is labeled as such."}
-        </p>
+        <h2 className="font-display text-3xl mb-1">{t.overviewTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{t.overviewLead}</p>
       </section>
 
       <section id="path" className="scroll-mt-32">
@@ -43,40 +35,30 @@ export default async function GuidePage({ params }: { params: Promise<{ locale: 
 
       {session && (
         <section id="session-media" className="scroll-mt-32">
-          <h2 className="font-display text-2xl mb-1">
-            {isZh ? "看一次真实会话" : "Watch a real session"}
-          </h2>
-          <p className={`${bodyClass} mt-3 mb-4`}>
-            {isZh
-              ? "下方是真实会话媒体位。它当前处于待录制状态——这是有意为之：在 v0.9.2 候选版 dogfood 录制完成前，本站不展示任何占位或摆拍影像。"
-              : "Below is the real-session media slot. It is deliberately in the pending state: until the v0.9.2 candidate dogfood recording exists, this site shows no placeholder or staged footage."}
-          </p>
+          <h2 className="font-display text-2xl mb-1">{t.sessionTitle}</h2>
+          <p className={`${t.bodyClassName} mt-3 mb-4`}>{t.sessionLead}</p>
           <SessionMedia asset={session} locale={locale} />
         </section>
       )}
 
       <section id="next" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "接下来" : "Where next"}</h2>
+        <h2 className="font-display text-2xl mb-1">{t.nextTitle}</h2>
         <div className="hairline-t mt-4">
           {GUIDE_NEXT_LINKS.map((item) => (
             <div key={item.href} className="py-4 hairline-b">
               <h3 className="font-display text-xl">
                 <Link href={`/${locale}${item.href}`} className="hover:text-indigo transition-colors">
-                  {isZh ? item.label.zh : item.label.en}
+                  {pickText(item.label, locale)}
                 </Link>
               </h3>
-              <p className={`${bodyClass} mt-1 text-sm`}>{isZh ? item.note.zh : item.note.en}</p>
+              <p className={`${t.bodyClassName} mt-1 text-sm`}>{pickText(item.note, locale)}</p>
             </div>
           ))}
         </div>
       </section>
 
       <section id="source" className="hairline-t pt-8">
-        <p className="text-sm text-ink-mute">
-          {isZh
-            ? "来源文档：docs/GUIDE.md, docs/KEYBINDINGS.md · 步骤文案来自 web/lib/content/getting-started.ts；更新时请同步修改 docs-map.ts。"
-            : "Source documents: docs/GUIDE.md, docs/KEYBINDINGS.md · Step copy lives in web/lib/content/getting-started.ts; update docs-map.ts when changing."}
-        </p>
+        <p className="text-sm text-ink-mute">{t.sourceNote}</p>
       </section>
     </section>
   );

--- a/web/lib/i18n/dictionaries.test.ts
+++ b/web/lib/i18n/dictionaries.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   DICTIONARY_LOCALES,
   EN_CHROME,
+  EN_DOCS_GUIDE,
   EN_HOME,
   fill,
   getChrome,
+  getDocsGuide,
   getHome,
+  pickText,
   splitToken,
 } from "./dictionaries";
 import { locales, partialLocales } from "./config";
@@ -174,6 +177,29 @@ describe("website dictionaries", () => {
         );
       }
     }
+  });
+
+  it("holds every shipped page dictionary to key parity and English fallback (#5337)", () => {
+    const enKeys = Object.keys(EN_DOCS_GUIDE).sort();
+    for (const locale of [...DICTIONARY_LOCALES, "fr", "und"]) {
+      // Page dictionaries are optional per locale: whatever getDocsGuide
+      // resolves — the locale's own file or the English fallback — must
+      // carry the exact reference shape, so a page never sees a missing key.
+      expect(Object.keys(getDocsGuide(locale)).sort(), `${locale} docs-guide keys`).toEqual(
+        enKeys,
+      );
+    }
+    // zh ships a real translation, not an English pass-through.
+    expect(getDocsGuide("zh").overviewTitle).not.toBe(EN_DOCS_GUIDE.overviewTitle);
+    // A locale without the file falls back to the English reference object.
+    expect(getDocsGuide("ja")).toBe(EN_DOCS_GUIDE);
+  });
+
+  it("pickText selects the locale side of legacy { en, zh } pairs", () => {
+    const pair = { en: "English", zh: "中文" };
+    expect(pickText(pair, "zh")).toBe("中文");
+    expect(pickText(pair, "en")).toBe("English");
+    expect(pickText(pair, "ja"), "non-zh locales read the English side").toBe("English");
   });
 
   it("keeps workflow and surface lists structurally aligned", () => {

--- a/web/lib/i18n/dictionaries/en/docs-guide.ts
+++ b/web/lib/i18n/dictionaries/en/docs-guide.ts
@@ -1,0 +1,22 @@
+import type { DocsGuideDict } from "../types";
+
+/**
+ * English reference dictionary for the docs "Getting started" page.
+ * Copy moved verbatim from `app/[locale]/docs/guide/page.tsx` — any wording
+ * change belongs in its own commit, never mixed into a structural move.
+ */
+export const docsGuide: DocsGuideDict = {
+  metaTitle: "Getting started · Codewhale Docs",
+  metaDescription:
+    "The full path from install to your ideal fleet: install, a first keyless session, provider connection, and fleet setup.",
+  bodyClassName: "text-ink-soft leading-relaxed",
+  overviewTitle: "Getting started",
+  overviewLead:
+    "Four steps from one install command to a fleet set up for your work. Every step states only what the current candidate actually does; anything unreleased or unrecorded is labeled as such.",
+  sessionTitle: "Watch a real session",
+  sessionLead:
+    "Below is the real-session media slot. It is deliberately in the pending state: until the v0.9.2 candidate dogfood recording exists, this site shows no placeholder or staged footage.",
+  nextTitle: "Where next",
+  sourceNote:
+    "Source documents: docs/GUIDE.md, docs/KEYBINDINGS.md · Step copy lives in web/lib/content/getting-started.ts; update docs-map.ts when changing.",
+};

--- a/web/lib/i18n/dictionaries/index.ts
+++ b/web/lib/i18n/dictionaries/index.ts
@@ -12,9 +12,11 @@
  * than a map entry, which keeps `DICTIONARY_LOCALES` equal to the set of
  * non-reference locale directories that `check-locales.mjs` walks.
  */
-import type { ChromeDict, HomeDict } from "./types";
+import type { ChromeDict, DocsGuideDict, HomeDict } from "./types";
 import { chrome as enChrome } from "./en/chrome";
 import { home as enHome } from "./en/home";
+import { docsGuide as enDocsGuide } from "./en/docs-guide";
+import { docsGuide as zhDocsGuide } from "./zh/docs-guide";
 import { chrome as zhChrome } from "./zh/chrome";
 import { home as zhHome } from "./zh/home";
 import { chrome as jaChrome } from "./ja/chrome";
@@ -61,6 +63,17 @@ const HOME: Record<string, HomeDict> = {
 /** Locales with their own dictionary directory (English is the reference). */
 export const DICTIONARY_LOCALES = Object.keys(CHROME) as readonly string[];
 
+/**
+ * Per-page dictionaries (#5337). Unlike chrome/home, a page dictionary is
+ * optional per locale: English is the required reference, any locale that
+ * ships the file is held to exact key parity, and everyone else falls back
+ * to English here — the same behavior page bodies already had for partial
+ * locales, now expressed through one lookup instead of an `isZh` ternary.
+ */
+const DOCS_GUIDE: Record<string, DocsGuideDict> = {
+  zh: zhDocsGuide,
+};
+
 export function getChrome(locale: string): ChromeDict {
   return CHROME[locale] ?? enChrome;
 }
@@ -69,9 +82,25 @@ export function getHome(locale: string): HomeDict {
   return HOME[locale] ?? enHome;
 }
 
+export function getDocsGuide(locale: string): DocsGuideDict {
+  return DOCS_GUIDE[locale] ?? enDocsGuide;
+}
+
+/**
+ * Select one side of a legacy `{ en, zh }` content pair by locale. This is
+ * the transitional bridge for `web/lib/content/` modules that still carry
+ * two-language pairs (#5337 Phase 3 dissolves them into dictionaries): it
+ * moves the branch out of page TSX and into the i18n layer, so call sites
+ * stay locale-agnostic.
+ */
+export function pickText(pair: { en: string; zh: string }, locale: string): string {
+  return locale === "zh" ? pair.zh : pair.en;
+}
+
 /** Reference dictionaries (parity baseline for the locale checks). */
 export const EN_CHROME = enChrome;
 export const EN_HOME = enHome;
+export const EN_DOCS_GUIDE = enDocsGuide;
 
 /** Interpolate `{name}` tokens in a dictionary template. Unknown tokens are
  * left intact so a template/variable drift is visible in review, not silent. */

--- a/web/lib/i18n/dictionaries/types.ts
+++ b/web/lib/i18n/dictionaries/types.ts
@@ -279,3 +279,26 @@ export interface HomeDict {
   communityLinksAria: string;
   contribute: string;
 }
+
+/**
+ * Docs "Getting started" page (`app/[locale]/docs/guide/page.tsx`).
+ *
+ * First of the per-page dictionaries that retire the page-body `isZh`
+ * branches left after #4934. Page dictionaries are optional per locale:
+ * English is the required reference, any other locale that ships the file
+ * is held to exact key parity (`check-locales.mjs` OPTIONAL_FILES), and a
+ * locale without it falls back to English at lookup time — matching how
+ * page bodies already behave for partial locales.
+ */
+export interface DocsGuideDict {
+  metaTitle: string;
+  metaDescription: string;
+  /** Body-copy typography for this locale (CJK needs looser leading). */
+  bodyClassName: string;
+  overviewTitle: string;
+  overviewLead: string;
+  sessionTitle: string;
+  sessionLead: string;
+  nextTitle: string;
+  sourceNote: string;
+}

--- a/web/lib/i18n/dictionaries/zh/docs-guide.ts
+++ b/web/lib/i18n/dictionaries/zh/docs-guide.ts
@@ -1,0 +1,22 @@
+import type { DocsGuideDict } from "../types";
+
+/**
+ * Simplified-Chinese dictionary for the docs "Getting started" page.
+ * Copy moved verbatim from the former `isZh` branches in
+ * `app/[locale]/docs/guide/page.tsx`.
+ */
+export const docsGuide: DocsGuideDict = {
+  metaTitle: "新手指引 · Codewhale 文档",
+  metaDescription:
+    "从安装到配置理想 Fleet 的完整路径：安装、无需密钥的首次会话、连接提供商、设置 Fleet。",
+  bodyClassName: "text-ink-soft leading-[1.9] tracking-wide",
+  overviewTitle: "新手指引",
+  overviewLead:
+    "从一条安装命令到配置好你的 Fleet，四步走完。每一步都只陈述当前版本真实的行为；未发布或待录制的内容会明确标注。",
+  sessionTitle: "看一次真实会话",
+  sessionLead:
+    "下方是真实会话媒体位。它当前处于待录制状态——这是有意为之：在 v0.9.2 候选版 dogfood 录制完成前，本站不展示任何占位或摆拍影像。",
+  nextTitle: "接下来",
+  sourceNote:
+    "来源文档：docs/GUIDE.md, docs/KEYBINDINGS.md · 步骤文案来自 web/lib/content/getting-started.ts；更新时请同步修改 docs-map.ts。",
+};

--- a/web/scripts/check-locales.mjs
+++ b/web/scripts/check-locales.mjs
@@ -21,6 +21,11 @@ const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const DICT_DIR = join(ROOT, "lib", "i18n", "dictionaries");
 const REFERENCE = "en";
 const FILES = ["chrome.ts", "home.ts"];
+// Per-page dictionaries (#5337): optional per locale. English is the
+// required reference; a locale that ships the file is held to the same
+// key/token parity, and a locale without it falls back to English at
+// lookup time — so absence is a valid state, never a failure.
+const OPTIONAL_FILES = ["docs-guide.ts"];
 
 /** Top-level keys of the exported object literal (two-space indented `key:`). */
 function extractKeys(source) {
@@ -59,36 +64,50 @@ const locales = readdirSync(DICT_DIR, { withFileTypes: true })
 console.log(`[check-locales] reference ${REFERENCE}: ${FILES.join(", ")}`);
 console.log(`[check-locales] locale dirs: ${locales.join(", ")}`);
 
-for (const file of FILES) {
+/** Compare one locale file against the English reference (parity + tokens). */
+function checkLocaleFile(locale, file, refKeys, refTokens) {
+  const path = join(DICT_DIR, locale, file);
+  const source = readFileSync(path, "utf8");
+  const keys = extractKeys(source);
+  const missing = [...refKeys].filter((k) => !keys.has(k));
+  const extra = [...keys].filter((k) => !refKeys.has(k));
+  if (missing.length) fail(`${locale}/${file}: missing keys: ${missing.join(", ")}`);
+  if (extra.length) fail(`${locale}/${file}: keys the reference lacks: ${extra.join(", ")}`);
+
+  const tokens = extractTokens(source);
+  for (const [key, refSet] of refTokens) {
+    const got = tokens.get(key) ?? new Set();
+    const dropped = [...refSet].filter((t) => !got.has(t));
+    if (dropped.length) {
+      fail(`${locale}/${file}: ${key} dropped template token(s): ${dropped.join(", ")}`);
+    }
+  }
+  if (!missing.length && !extra.length) {
+    console.log(`[check-locales] ${locale}/${file}: ${keys.size}/${refKeys.size} keys — complete`);
+  }
+}
+
+for (const file of [...FILES, ...OPTIONAL_FILES]) {
+  const required = FILES.includes(file);
   const refPath = join(DICT_DIR, REFERENCE, file);
+  if (!existsSync(refPath)) {
+    fail(`${REFERENCE}/${file}: reference file missing`);
+    continue;
+  }
   const refSource = readFileSync(refPath, "utf8");
   const refKeys = extractKeys(refSource);
   const refTokens = extractTokens(refSource);
 
   for (const locale of locales) {
-    const path = join(DICT_DIR, locale, file);
-    if (!existsSync(path)) {
-      fail(`${locale}/${file}: missing (reference has ${refKeys.size} keys)`);
+    if (!existsSync(join(DICT_DIR, locale, file))) {
+      if (required) {
+        fail(`${locale}/${file}: missing (reference has ${refKeys.size} keys)`);
+      } else {
+        console.log(`[check-locales] ${locale}/${file}: absent — falls back to English`);
+      }
       continue;
     }
-    const source = readFileSync(path, "utf8");
-    const keys = extractKeys(source);
-    const missing = [...refKeys].filter((k) => !keys.has(k));
-    const extra = [...keys].filter((k) => !refKeys.has(k));
-    if (missing.length) fail(`${locale}/${file}: missing keys: ${missing.join(", ")}`);
-    if (extra.length) fail(`${locale}/${file}: keys the reference lacks: ${extra.join(", ")}`);
-
-    const tokens = extractTokens(source);
-    for (const [key, refSet] of refTokens) {
-      const got = tokens.get(key) ?? new Set();
-      const dropped = [...refSet].filter((t) => !got.has(t));
-      if (dropped.length) {
-        fail(`${locale}/${file}: ${key} dropped template token(s): ${dropped.join(", ")}`);
-      }
-    }
-    if (!missing.length && !extra.length) {
-      console.log(`[check-locales] ${locale}/${file}: ${keys.size}/${refKeys.size} keys — complete`);
-    }
+    checkLocaleFile(locale, file, refKeys, refTokens);
   }
 }
 


### PR DESCRIPTION
## Summary

First slice of #5337 (one page group per PR). Retires the `isZh` ternaries in `app/[locale]/docs/guide/page.tsx` by introducing the per-page dictionary pattern the rest of the series reuses:

- `DocsGuideDict` (9 keys) + en/zh dictionaries — copy moved **verbatim**, no wording edits mixed in
- `getDocsGuide(locale)`: a locale's own file or the English reference fallback — the same behavior page bodies already had for partial locales, now expressed through one lookup
- `check-locales.mjs`: new `OPTIONAL_FILES` category — a page dictionary is optional per locale; shipping one binds that locale to full key/token parity; absence prints a visible "falls back to English" note instead of failing
- `pickText()`: transitional bridge for the legacy `{ en, zh }` content pairs still exported by `web/lib/content` (`GUIDE_NEXT_LINKS`), so the branch lives in the i18n layer until Phase 3 dissolves those modules
- `dictionaries.test.ts`: covers the parity/fallback contract and `pickText`

Draft while the two scoping questions in #5337 are open; ready to flip on a nod.

## Testing

Web-only change — the cargo gates don't apply; the web gates all ran:

- [x] `node scripts/check-locales.mjs` — PASS (zh docs-guide 9/9 complete; every other locale "absent — falls back to English")
- [x] `npx vitest run lib/i18n/dictionaries.test.ts` — 15 passed
- [x] `npx vitest run` — 253 passed; `lib/deploy-preflight.test.ts` fails identically on a clean checkout in this environment (needs CI deploy credentials) — unrelated to this change
- [x] `npx eslint .` — clean
- [x] Rendered en/zh output unchanged (pure structural move)

## Checklist

- [x] Updated docs or comments as needed (gate + dictionary doc comments)
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (n/a — website only)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (n/a — no harvested content)


No-Issue: phase 1 of the #5337 dictionary epic; the epic stays open until every isZh branch is retired, so this PR deliberately closes nothing.
