### PR TITLE
test(release): tolerate shared-runner route latency

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -375,7 +375,10 @@ async fn exact_turn_snapshot_restores_custom_endpoint_and_turn_receipt_after_bui
         .await
         .expect("send exact custom turn");
 
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    // This test runs alongside more than ten thousand TUI tests in the release
+    // parity job. Keep the assertion bounded, but leave enough headroom for a
+    // saturated shared runner to schedule the loopback SSE response.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     let mut lifecycle_stage = 0u8;
     let mut diagnostics = Vec::new();
     let mut rx = handle.rx_event.write().await;


### PR DESCRIPTION
## Release blocker

The first `v0.9.7` release workflow (`31675530356`) failed before artifact creation. Its locked parity job passed 10,317 TUI tests and failed only `exact_turn_snapshot_restores_custom_endpoint_and_turn_receipt_after_builtin_route` after the test exhausted its hard five-second event deadline under full parallel load. The release, artifact, Docker, Homebrew, and npm jobs were all skipped.

## Fix

Keep the exact provider identity, endpoint fingerprint, ordered dispatch, terminal receipt, and one-request assertions unchanged. Increase only the bounded shared-runner semantic-event deadline from 5 to 15 seconds, with an inline reason.

## Verification

- isolated failing test: PASS
- exact parity-shaped command `cargo test -p codewhale-tui --all-features --locked --lib`: 10,318 passed, 11 ignored, 0 failed
- `cargo fmt --all -- --check`: PASS
- `git diff --check`: PASS

## Tag boundary

The existing `v0.9.7` tag points to `5e3ac84c5cb925b4c90c34dfe582b75f04605cb1`, before this fix. No tag was moved and no release was published. Hunter approval is required for any tag-source decision.

Closes #5344
