### PR TITLE
fix(release): preserve asset auth for npm publish

### DIFF
--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -320,6 +320,7 @@ assert.match(npmTagGate, /verify-remote-tag\.sh/);
 assert.match(npmAssetGate, /verify-release-assets\.sh/);
 assert.match(npmAssetGate, /GH_TOKEN: \$\{\{ github\.token \}\}/);
 assert.match(npmPublish, /working-directory: npm\/codewhale/);
+assert.match(npmPublish, /GH_TOKEN: \$\{\{ github\.token \}\}/);
 assert.match(npmPublish, /npm publish --access public/);
 assert.doesNotMatch(npmJob[1], /NPM_TOKEN|NODE_AUTH_TOKEN|secrets\./);
 assert.ok(

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,6 +498,11 @@ jobs:
         run: npm test
       - name: Publish npm wrapper with trusted publishing
         working-directory: npm/codewhale
+        env:
+          # npm runs prepublishOnly in this step; that guard revalidates the
+          # public GitHub Release and therefore needs the same read token as
+          # the explicit asset gate above.
+          GH_TOKEN: ${{ github.token }}
         run: npm publish --access public
 
   homebrew:


### PR DESCRIPTION
## Summary

- pass the read-only GitHub token into the npm trusted-publishing step because npm reruns the public-asset guard in prepublishOnly
- retain OIDC publication and the existing exact-tag/exact-asset gates
- add a workflow-contract assertion for the publish-step token

## Verification

- node --test .github/scripts/release-workflows.test.js
- git diff --check

Closes #5346

This PR does not publish npm, move a tag, replace release assets, or change any public channel.