### PR TITLE
chore(ci): refresh the source-structure budget on main

### DIFF
--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 688490,
+  "max_total_owned_rust_lines": 688623,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
No-Issue: CI budget refresh; #5348 landed without its budget commit, leaving main failing its own Lint gate.

Merge as soon as green — this unblocks every open contributor PR inheriting the stale ceiling.