### PR TITLE
feat(engine): auto-review denial rationale + turn circuit breaker

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3,7 +3,8 @@ use super::*;
 use super::context::{COMPACTION_SUMMARY_MARKER, TURN_MAX_OUTPUT_TOKENS};
 use super::streaming::{TOOL_CALL_END_MARKERS, TOOL_CALL_MARKER_PAIRS};
 use super::turn_loop::{
-    merge_new_runtime_mcp_tools, registered_tool_approval_required, registered_tool_forces_prompt,
+    AutoReviewBlockBreaker, auto_review_block_tool_error, merge_new_runtime_mcp_tools,
+    registered_tool_approval_required, registered_tool_forces_prompt,
     workspace_write_carve_out_applies,
 };
 use crate::config::ApiProvider;
@@ -5772,6 +5773,201 @@ fn auto_review_still_blocks_interactive_destructive_shell() {
     );
     assert_eq!(audit["decision"], "ask_user");
     assert_eq!(audit["action_kind"], "destructive");
+}
+
+/// #5352: an Auto-Review block reaches the model with the original reason
+/// verbatim, first, plus the next-behavior guidance — never a bare denial.
+#[test]
+fn auto_review_block_error_names_the_next_behavior() {
+    let reason = "Auto-Review held tool 'exec_shell': sensitive or destructive action requires explicit review";
+    let rendered = auto_review_block_tool_error(reason).to_string();
+    assert!(
+        rendered.starts_with("Failed to authorize tool execution: "),
+        "{rendered}"
+    );
+    let reason_at = rendered.find(reason).expect("reason must stay verbatim");
+    let guidance_at = rendered
+        .find("This block is automatic")
+        .expect("guidance must be present");
+    assert!(
+        reason_at < guidance_at,
+        "reason first, guidance after: {rendered}"
+    );
+    assert!(
+        rendered.contains("do not look for a way around it"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("stop and tell the user"), "{rendered}");
+}
+
+/// #5352: three consecutive auto-blocks end the turn (Codex parity).
+#[test]
+fn auto_review_breaker_trips_after_three_consecutive_blocks() {
+    let mut breaker = AutoReviewBlockBreaker::new();
+    breaker.record(true);
+    breaker.record(true);
+    assert!(breaker.tripped().is_none(), "two blocks must not trip");
+    breaker.record(true);
+    let trip = breaker.tripped().expect("three consecutive blocks trip");
+    assert!(trip.contains("3 consecutive"), "{trip}");
+}
+
+/// #5352: any call that is not an auto-block resets the streak — an
+/// occasionally-blocked but progressing turn keeps running.
+#[test]
+fn auto_review_breaker_resets_the_streak_on_any_unblocked_call() {
+    let mut breaker = AutoReviewBlockBreaker::new();
+    for blocked in [true, true, false, true, true] {
+        breaker.record(blocked);
+    }
+    assert!(breaker.tripped().is_none());
+}
+
+/// #5352: ten auto-blocks inside the 50-call window trip even when the
+/// streak never reaches three (Codex's 10-of-50).
+#[test]
+fn auto_review_breaker_trips_on_ten_blocks_inside_the_window() {
+    let mut breaker = AutoReviewBlockBreaker::new();
+    // Two blocks then a pass, repeated: the streak never reaches three.
+    for _ in 0..4 {
+        breaker.record(true);
+        breaker.record(true);
+        breaker.record(false);
+        assert!(breaker.tripped().is_none());
+    }
+    breaker.record(true);
+    breaker.record(true);
+    let trip = breaker.tripped().expect("ten blocks in the window trip");
+    assert!(trip.contains("10 of the last"), "{trip}");
+}
+
+/// #5352: the window is rolling, not cumulative — old blocks age out, so a
+/// long productive stretch genuinely forgives an early rough patch.
+#[test]
+fn auto_review_breaker_forgets_blocks_older_than_the_window() {
+    let mut breaker = AutoReviewBlockBreaker::new();
+    for _ in 0..9 {
+        breaker.record(true);
+        breaker.record(false);
+    }
+    assert!(breaker.tripped().is_none());
+    for _ in 0..50 {
+        breaker.record(false);
+    }
+    // A cumulative counter would trip on this tenth block; the rolling
+    // window has already forgotten the first nine.
+    breaker.record(true);
+    assert!(breaker.tripped().is_none());
+}
+
+/// #5352 end to end: three auto-blocked calls in one batch feed the breaker
+/// at plan admission, every blocked result still reaches the model with the
+/// guidance attached, and the turn stops at the next request boundary — the
+/// mock scripts no second turn, so reaching the model again fails the test
+/// by itself.
+#[tokio::test]
+async fn auto_review_breaker_stops_the_turn_after_three_blocked_calls() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let workspace = tempdir().expect("tempdir");
+    let blocked_turn = vec![
+        canned::message_start("mock_msg_auto_blocked"),
+        canned::tool_use_block_start(0, "call-blocked-1", "Bash"),
+        canned::tool_input_delta(0, r#"{"command":"rm -rf /"}"#),
+        canned::block_stop(0),
+        canned::tool_use_block_start(1, "call-blocked-2", "Bash"),
+        canned::tool_input_delta(1, r#"{"command":"rm -rf /tmp"}"#),
+        canned::block_stop(1),
+        canned::tool_use_block_start(2, "call-blocked-3", "Bash"),
+        canned::tool_input_delta(2, r#"{"command":"rm -rf /var"}"#),
+        canned::block_stop(2),
+        canned::message_delta("tool_use", None),
+        canned::message_stop(),
+    ];
+    let mock = std::sync::Arc::new(MockLlmClient::new(vec![blocked_turn]));
+    let client: crate::core::model_client::SharedModelClient = mock.clone();
+    let (engine, handle) = Engine::new_with_model_client(
+        deterministic_engine_config(workspace.path()),
+        &Config::default(),
+        client,
+    );
+    let task = tokio::spawn(engine.run());
+
+    // `external_user_message_op` hardcodes Suggest; Auto is the mode under
+    // test, so the op is spelled out.
+    handle
+        .send(Op::SendMessage {
+            content: "Clean the disk.".to_string(),
+            mode: AppMode::Agent,
+            route: resolved_route_for_test(&Config::default(), crate::config::DEFAULT_TEXT_MODEL),
+            compaction: Box::new(CompactionConfig::default()),
+            goal_objective: None,
+            goal_token_budget: None,
+            goal_status: crate::tools::goal::GoalStatus::Active,
+            reasoning_effort: None,
+            reasoning_effort_auto: false,
+            auto_model: false,
+            allow_shell: true,
+            trust_mode: false,
+            auto_approve: false,
+            approval_mode: crate::tui::approval::ApprovalMode::Auto,
+            translation_enabled: false,
+            allowed_tools: None,
+            dynamic_tools: Vec::new(),
+            hook_executor: None,
+            verbosity: None,
+            provenance: UserInputProvenance::ExternalUser,
+        })
+        .await
+        .expect("send auto-blocked trajectory");
+
+    let mut blocked_results = Vec::new();
+    let mut rx = handle.rx_event.write().await;
+    let (status, error) = loop {
+        let event = tokio::time::timeout(model_turn_event_timeout(), rx.recv())
+            .await
+            .expect("timed out waiting for the auto-blocked trajectory")
+            .expect("engine event");
+        match event {
+            Event::ToolCallComplete { name, result, .. } if name == "Bash" => {
+                blocked_results.push(result);
+            }
+            Event::TurnComplete { status, error, .. } => break (status, error),
+            _ => {}
+        }
+    };
+    drop(rx);
+
+    assert_eq!(
+        blocked_results.len(),
+        3,
+        "all three blocked calls must still answer the model"
+    );
+    for result in &blocked_results {
+        let rendered = result
+            .as_ref()
+            .expect_err("auto-blocked call must fail")
+            .to_string();
+        assert!(rendered.contains("This block is automatic"), "{rendered}");
+        assert!(
+            rendered.contains("Auto-Review held tool 'Bash'"),
+            "original reason must stay verbatim: {rendered}"
+        );
+    }
+
+    assert_eq!(
+        status,
+        TurnOutcomeStatus::Failed,
+        "a breaker abort must never report Completed"
+    );
+    let error = error.expect("breaker abort must carry a terminal error");
+    assert!(
+        error.contains("3 consecutive tool calls were blocked by Auto-Review"),
+        "{error}"
+    );
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    task.await.expect("engine task");
 }
 
 #[test]

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -37,6 +37,79 @@ fn approval_intent_summary(text: &str) -> Option<String> {
     Some(summary)
 }
 
+/// #5352: an automatic Auto-Review block used to reach the model as a bare
+/// `permission_denied`, which invited the exact workaround loop the block
+/// exists to stop. Like the user-denial message (#5146), name the correct
+/// next behavior. The original reason stays first and verbatim — audit
+/// events and tests match on it.
+pub(super) fn auto_review_block_tool_error(reason: &str) -> ToolError {
+    ToolError::permission_denied(format!(
+        "{reason}. This block is automatic — do not look for a way around it; \
+         take a safer approach that stays inside the current permissions, or \
+         stop and tell the user what you wanted to run."
+    ))
+}
+
+/// #5352: how many consecutive auto-blocked tool calls end the turn.
+const AUTO_BLOCK_TRIP_CONSECUTIVE: u32 = 3;
+/// #5352: rolling window of recent planned tool calls the breaker remembers.
+const AUTO_BLOCK_WINDOW: usize = 50;
+/// #5352: how many auto-blocks within [`AUTO_BLOCK_WINDOW`] end the turn.
+const AUTO_BLOCK_TRIP_IN_WINDOW: usize = 10;
+
+/// #5352: circuit breaker over automatic Auto-Review blocks within one turn.
+///
+/// A model that keeps proposing blocked calls burns its whole step budget
+/// re-phrasing the same denied action. Codex aborts the turn at 3 consecutive
+/// denials or 10 in the last 50; these thresholds mirror that. State is
+/// turn-local — a fresh turn starts forgiven, like
+/// `consecutive_empty_repl_rounds` above it in the turn loop.
+pub(super) struct AutoReviewBlockBreaker {
+    consecutive: u32,
+    window: std::collections::VecDeque<bool>,
+}
+
+impl AutoReviewBlockBreaker {
+    pub(super) fn new() -> Self {
+        Self {
+            consecutive: 0,
+            window: std::collections::VecDeque::with_capacity(AUTO_BLOCK_WINDOW),
+        }
+    }
+
+    /// Record one planned tool call, in plan order. `auto_blocked` is true
+    /// only for calls blocked by the Auto-Review decision itself — not user
+    /// denials, repo law, or ask-rules, which have their own remedies.
+    pub(super) fn record(&mut self, auto_blocked: bool) {
+        if auto_blocked {
+            self.consecutive = self.consecutive.saturating_add(1);
+        } else {
+            self.consecutive = 0;
+        }
+        if self.window.len() == AUTO_BLOCK_WINDOW {
+            self.window.pop_front();
+        }
+        self.window.push_back(auto_blocked);
+    }
+
+    /// Which threshold tripped, if any, phrased for the turn-abort message.
+    pub(super) fn tripped(&self) -> Option<String> {
+        if self.consecutive >= AUTO_BLOCK_TRIP_CONSECUTIVE {
+            return Some(format!(
+                "{AUTO_BLOCK_TRIP_CONSECUTIVE} consecutive tool calls were blocked by Auto-Review"
+            ));
+        }
+        let in_window = self.window.iter().filter(|blocked| **blocked).count();
+        if in_window >= AUTO_BLOCK_TRIP_IN_WINDOW {
+            return Some(format!(
+                "{in_window} of the last {} tool calls were blocked by Auto-Review",
+                self.window.len()
+            ));
+        }
+        None
+    }
+}
+
 pub(super) fn registered_tool_approval_required(
     tool_name: &str,
     requirement: ApprovalRequirement,
@@ -373,6 +446,11 @@ impl Engine {
         // across model steps so 3 consecutive empty blocks end the turn, not
         // just 3 blocks inside one message.
         let mut consecutive_empty_repl_rounds: u32 = 0;
+        // #5352: turn-scoped Auto-Review denial breaker. Fed in plan order as
+        // calls are admitted below; checked at the top of the loop so the
+        // blocked batch's results still reach the transcript before the turn
+        // ends.
+        let mut auto_review_block_breaker = AutoReviewBlockBreaker::new();
         // Outer stream-retry counter: when the chunked-transfer connection
         // dies mid-stream and either nothing useful was streamed (#103
         // Phase 3), the host slept mid-turn (#2990), or a headless host hit
@@ -433,6 +511,24 @@ impl Engine {
                 let error = format!(
                     "Maximum model steps reached before completion (limit: {})",
                     self.config.max_steps
+                );
+                let _ = self.tx_event.send(Event::status(error.clone())).await;
+                return (TurnOutcomeStatus::Failed, Some(error));
+            }
+
+            // #5352: Auto-Review denial circuit breaker. Checked here — after
+            // the blocked batch's results landed in the transcript, before the
+            // next model request is authorized — so the model's step budget
+            // stops paying for re-phrasings of a denied action. Same
+            // delivered-answer carve-out as the step budget above.
+            if let Some(trip) = auto_review_block_breaker.tripped() {
+                if !step_budget_exhaustion_is_terminal {
+                    break;
+                }
+                let error = format!(
+                    "Turn stopped: {trip}. The current approach keeps hitting \
+                     permission blocks — take a different approach, or ask the \
+                     user to run it under Ask or adjust permissions."
                 );
                 let _ = self.tx_event.send(Event::status(error.clone())).await;
                 return (TurnOutcomeStatus::Failed, Some(error));
@@ -2181,6 +2277,10 @@ impl Engine {
                 let mut detached_start = false;
                 let mut resources = vec![ResourceClaim::GlobalExclusive];
                 let mut blocked_error: Option<ToolError> = None;
+                // #5352: true only when `blocked_error` came from the
+                // Auto-Review decision — the breaker must not count user
+                // denials, repo law, ask-rules, or missing-tool errors.
+                let mut auto_review_blocked_call = false;
                 let mut guard_result: Option<ToolResult> = None;
                 // #3026: set by a hook `ask` decision; applied AFTER the
                 // registry-based approval computation below so it cannot be
@@ -2485,7 +2585,8 @@ impl Engine {
                         AutoReviewPlanDecision::Block(reason) => {
                             approval_required = false;
                             approval_force_prompt = false;
-                            blocked_error = Some(ToolError::permission_denied(reason));
+                            auto_review_blocked_call = true;
+                            blocked_error = Some(auto_review_block_tool_error(&reason));
                         }
                     }
                 }
@@ -2601,6 +2702,10 @@ impl Engine {
                     tool_call_budget.refund();
                 }
 
+                // #5352: feed the breaker in plan order. Blocked plans never
+                // execute, so plan admission is the last moment every call —
+                // blocked or not — passes through one point.
+                auto_review_block_breaker.record(auto_review_blocked_call);
                 plans.push(ToolExecutionPlan {
                     index,
                     id: tool_id,

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 689696,
+  "max_total_owned_rust_lines": 689800,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
First P0 slice of #5352: denial rationale + the circuit breaker.

An Auto-Review block reached the model as a bare `permission_denied`, which is an invitation to re-phrase the same denied action until the step budget runs out. Two changes:

**Rationale.** `AutoReviewPlanDecision::Block` now goes through `auto_review_block_tool_error()`, which keeps the original reason first and verbatim (audit events and tests match on it) and appends the next behavior, same shape as the user-denial message from #5146: this block is automatic, don't look for a way around it, take a safer approach or stop and tell the user.

**Breaker.** `AutoReviewBlockBreaker`, turn-local like `consecutive_empty_repl_rounds` right above it: 3 consecutive auto-blocked calls, or 10 within the last 50 planned calls, stop the turn (the Codex thresholds cited in the issue — hardcoded for now, per the thread). It's fed at plan admission — the one point every call passes through, and blocked plans never execute — and checked at the top of the loop next to `at_max_steps`, so the blocked batch's results still land in the transcript and the abort happens at the request boundary. Same delivered-answer carve-out as the step budget: on an optional continuation it breaks instead of failing the turn.

Only blocks from the Auto-Review decision itself count. User denials already carry their own guidance (#5146), and repo-law / ask-rule blocks have their own remedies — counting them here would abort turns for reasons the model was already told how to handle.

### Validation

- `cargo fmt` / `cargo clippy --all-targets -- -D warnings` — clean
- 5 unit tests on the wrapper and breaker (trip at 3, streak reset, 10-of-50, window eviction)
- 1 end-to-end test: injected model proposes three `rm -rf` calls under Auto — all three results reach the model with the guidance attached, then the turn stops at the next request boundary with `Failed`; the mock scripts no second turn, so reaching the model again fails the test on its own
- Mutation-checked: disabling the breaker wiring alone, or reverting to the bare denial alone, each fails the end-to-end test
- Full `codewhale-tui` lib suite, twice: 10310 passed / 4 failed both rounds. The same four (`settings_command_opens_typed_editor…`, `model_picker_is_usable…`, `underwater_motion_keeps…`, `config_view_surfaces…`) fail identically on a clean `upstream/main` checkout on this machine, filtered or full, while main's own CI is green — they read the real `~/.codewhale/settings.toml` (this box has `calm_mode` set) instead of a hermetic default, so they're an environment sensitivity on main, not this diff. Happy to file that separately.
- `check-runtime-contract-budget.py` — PASS, all 55 metrics exactly at budget; this adds no model-facing schema bytes.

No-Issue: first P0 slice of #5352; the issue tracks more items and stays open.

Analysis drafted with local tooling; every change and test verified by hand.
