### PR TITLE
fix(tui): confine unguarded tests to the isolated state root

### DIFF
--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -2467,169 +2467,39 @@ pub fn logout(app: &mut App) -> CommandResult {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::test_support::lock_test_env;
+    use crate::test_support::{EnvVarGuard, TestEnvLock, lock_test_env};
     use crate::tui::app::{App, TuiOptions};
     use crate::tui::approval::ApprovalMode;
     use std::env;
-    use std::ffi::OsString;
     use std::fs;
     use std::path::Path;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     struct EnvGuard {
-        home: Option<OsString>,
-        userprofile: Option<OsString>,
-        codewhale_config_path: Option<OsString>,
-        deepseek_config_path: Option<OsString>,
-        codewhale_allow_shell: Option<OsString>,
-        deepseek_allow_shell: Option<OsString>,
-        deepseek_approval_policy: Option<OsString>,
-        no_animations: Option<OsString>,
-        term_program: Option<OsString>,
-        ptyxis_version: Option<OsString>,
-        _lock: crate::test_support::TestEnvLock,
+        _vars: Vec<EnvVarGuard>,
+        _lock: TestEnvLock,
     }
 
     impl EnvGuard {
         fn new(home: &Path) -> Self {
-            let lock = crate::test_support::lock_test_env();
-            let home_str = OsString::from(home.as_os_str());
+            let lock = lock_test_env();
             let config_path = home.join(".deepseek").join("config.toml");
-            let config_str = OsString::from(config_path.as_os_str());
-            let home_prev = env::var_os("HOME");
-            let userprofile_prev = env::var_os("USERPROFILE");
-            let codewhale_config_prev = env::var_os("CODEWHALE_CONFIG_PATH");
-            let deepseek_config_prev = env::var_os("DEEPSEEK_CONFIG_PATH");
-            let codewhale_allow_shell_prev = env::var_os("CODEWHALE_ALLOW_SHELL");
-            let deepseek_allow_shell_prev = env::var_os("DEEPSEEK_ALLOW_SHELL");
-            let deepseek_approval_policy_prev = env::var_os("DEEPSEEK_APPROVAL_POLICY");
-            let no_animations_prev = env::var_os("NO_ANIMATIONS");
-            let term_program_prev = env::var_os("TERM_PROGRAM");
-            let ptyxis_version_prev = env::var_os("PTYXIS_VERSION");
-
-            // Safety: test-only environment mutation guarded by process-wide mutex.
-            unsafe {
-                env::set_var("HOME", &home_str);
-                env::set_var("USERPROFILE", &home_str);
-                env::remove_var("CODEWHALE_CONFIG_PATH");
-                env::set_var("DEEPSEEK_CONFIG_PATH", &config_str);
-                env::remove_var("CODEWHALE_ALLOW_SHELL");
-                env::remove_var("DEEPSEEK_ALLOW_SHELL");
-                env::remove_var("DEEPSEEK_APPROVAL_POLICY");
-                env::remove_var("NO_ANIMATIONS");
-                env::remove_var("TERM_PROGRAM");
-                env::remove_var("PTYXIS_VERSION");
-            }
-
+            let vars = vec![
+                EnvVarGuard::set("HOME", home),
+                EnvVarGuard::set("USERPROFILE", home),
+                EnvVarGuard::remove("CODEWHALE_CONFIG_PATH"),
+                EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", config_path),
+                EnvVarGuard::remove("CODEWHALE_ALLOW_SHELL"),
+                EnvVarGuard::remove("DEEPSEEK_ALLOW_SHELL"),
+                EnvVarGuard::remove("DEEPSEEK_APPROVAL_POLICY"),
+                EnvVarGuard::remove("NO_ANIMATIONS"),
+                EnvVarGuard::remove("TERM_PROGRAM"),
+                EnvVarGuard::remove("PTYXIS_VERSION"),
+            ];
             Self {
-                home: home_prev,
-                userprofile: userprofile_prev,
-                codewhale_config_path: codewhale_config_prev,
-                deepseek_config_path: deepseek_config_prev,
-                codewhale_allow_shell: codewhale_allow_shell_prev,
-                deepseek_allow_shell: deepseek_allow_shell_prev,
-                deepseek_approval_policy: deepseek_approval_policy_prev,
-                no_animations: no_animations_prev,
-                term_program: term_program_prev,
-                ptyxis_version: ptyxis_version_prev,
+                _vars: vars,
                 _lock: lock,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            if let Some(value) = self.home.take() {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    env::set_var("HOME", value);
-                }
-            } else {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    env::remove_var("HOME");
-                }
-            }
-
-            if let Some(value) = self.userprofile.take() {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    env::set_var("USERPROFILE", value);
-                }
-            } else {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    env::remove_var("USERPROFILE");
-                }
-            }
-
-            if let Some(value) = self.codewhale_config_path.take() {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    env::set_var("CODEWHALE_CONFIG_PATH", value);
-                }
-            } else {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    env::remove_var("CODEWHALE_CONFIG_PATH");
-                }
-            }
-
-            if let Some(value) = self.deepseek_config_path.take() {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    env::set_var("DEEPSEEK_CONFIG_PATH", value);
-                }
-            } else {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    env::remove_var("DEEPSEEK_CONFIG_PATH");
-                }
-            }
-
-            for (key, value) in [
-                ("CODEWHALE_ALLOW_SHELL", self.codewhale_allow_shell.take()),
-                ("DEEPSEEK_ALLOW_SHELL", self.deepseek_allow_shell.take()),
-                (
-                    "DEEPSEEK_APPROVAL_POLICY",
-                    self.deepseek_approval_policy.take(),
-                ),
-            ] {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    if let Some(value) = value {
-                        env::set_var(key, value);
-                    } else {
-                        env::remove_var(key);
-                    }
-                }
-            }
-
-            if let Some(value) = self.no_animations.take() {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    env::set_var("NO_ANIMATIONS", value);
-                }
-            } else {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    env::remove_var("NO_ANIMATIONS");
-                }
-            }
-
-            for (key, value) in [
-                ("TERM_PROGRAM", self.term_program.take()),
-                ("PTYXIS_VERSION", self.ptyxis_version.take()),
-            ] {
-                // Safety: test-only environment mutation guarded by a global mutex.
-                unsafe {
-                    if let Some(value) = value {
-                        env::set_var(key, value);
-                    } else {
-                        env::remove_var(key);
-                    }
-                }
             }
         }
     }

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -1554,6 +1554,8 @@ mod tests {
         let config_path = temp_root.path().join("config.toml");
         fs::write(&config_path, "reasoning_effort = \"max\"\n").expect("seed config");
         let _home = EnvVarGuard::set("CODEWHALE_HOME", &codewhale_home);
+        let _codewhale_config = EnvVarGuard::remove("CODEWHALE_CONFIG_PATH");
+        let _deepseek_config = EnvVarGuard::remove("DEEPSEEK_CONFIG_PATH");
 
         let mut app = app();
         app.config_path = Some(config_path.clone());
@@ -1623,25 +1625,13 @@ cost_currency = "cny"
         )
         .expect("seed settings");
 
-        let old_config_path = std::env::var_os("DEEPSEEK_CONFIG_PATH");
-        // Safety: test-only environment mutation guarded by a module mutex.
-        unsafe {
-            std::env::set_var("DEEPSEEK_CONFIG_PATH", &config_path);
-        }
+        let _config_path = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
 
         let app = app();
         let config = Config::default();
         let doc = build_document(&app, &config).expect("document");
 
         assert_eq!(doc.settings.cost_currency, CostCurrencyValue::Cny);
-        // Safety: restore the guarded test-only environment mutation above.
-        unsafe {
-            if let Some(value) = old_config_path {
-                std::env::set_var("DEEPSEEK_CONFIG_PATH", value);
-            } else {
-                std::env::remove_var("DEEPSEEK_CONFIG_PATH");
-            }
-        }
     }
 
     #[test]
@@ -1667,23 +1657,13 @@ background_color = "#1A1B26"
         )
         .expect("seed settings");
 
-        let old_config_path = std::env::var_os("DEEPSEEK_CONFIG_PATH");
-        unsafe {
-            std::env::set_var("DEEPSEEK_CONFIG_PATH", &config_path);
-        }
+        let _config_path = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
 
         let app = app();
         let config = Config::default();
         let doc = build_document(&app, &config).expect("document");
 
         assert_eq!(doc.settings.background_color.as_deref(), Some("#1a1b26"));
-        unsafe {
-            if let Some(value) = old_config_path {
-                std::env::set_var("DEEPSEEK_CONFIG_PATH", value);
-            } else {
-                std::env::remove_var("DEEPSEEK_CONFIG_PATH");
-            }
-        }
     }
 
     #[test]
@@ -1695,6 +1675,8 @@ background_color = "#1A1B26"
         let settings_path = codewhale_home.join("settings.toml");
         fs::write(&settings_path, "").expect("seed settings");
         let _home = EnvVarGuard::set("CODEWHALE_HOME", &codewhale_home);
+        let _codewhale_config = EnvVarGuard::remove("CODEWHALE_CONFIG_PATH");
+        let _deepseek_config = EnvVarGuard::remove("DEEPSEEK_CONFIG_PATH");
 
         let app = app();
         let config = Config::default();
@@ -1734,6 +1716,8 @@ background_color = "#1A1B26"
         )
         .expect("settings");
         let _home = EnvVarGuard::set("CODEWHALE_HOME", &codewhale_home);
+        let _codewhale_config = EnvVarGuard::remove("CODEWHALE_CONFIG_PATH");
+        let _deepseek_config = EnvVarGuard::remove("DEEPSEEK_CONFIG_PATH");
 
         let mut app = app();
         let mut config = Config::default();

--- a/crates/tui/src/models_dev_live.rs
+++ b/crates/tui/src/models_dev_live.rs
@@ -118,8 +118,25 @@ impl std::fmt::Display for ModelsDevRefreshError {
 }
 
 /// Resolve the on-disk cache path under the CodeWhale `catalog` state dir.
+///
+/// Under `cfg(test)` this is confined the same way settings and config paths
+/// are: `resolve_state_dir` lives in `codewhale-config`, which is compiled as a
+/// plain dependency here and so has no view of this crate's isolated test root.
+/// Without this shield a test that never asked for the developer's catalog read
+/// their real `~/.codewhale/catalog` and rendered against whatever models they
+/// last fetched (#5359).
 #[must_use]
 pub fn cache_path() -> Option<PathBuf> {
+    #[cfg(test)]
+    {
+        if !crate::test_support::guarded_environment_provides_state_paths() {
+            return Some(
+                crate::test_support::unsealed_test_state_root()
+                    .join("catalog")
+                    .join(CACHE_FILE),
+            );
+        }
+    }
     codewhale_config::resolve_state_dir("catalog")
         .ok()
         .map(|dir| dir.join(CACHE_FILE))
@@ -463,6 +480,41 @@ mod tests {
         }
       }
     }"#;
+
+    /// An unguarded test must not resolve the developer's catalog cache.
+    ///
+    /// `resolve_state_dir` lives in `codewhale-config`, which is a plain
+    /// dependency here and cannot see this crate's isolated test root, so this
+    /// path had no equivalent of the settings confinement (#5359). A picker
+    /// test then rendered against whatever models the developer last fetched.
+    #[test]
+    fn unguarded_cache_path_stays_inside_the_isolated_test_root() {
+        let path = cache_path().expect("cache path");
+        let isolated = crate::test_support::isolated_test_state_root();
+        assert!(
+            path.starts_with(isolated),
+            "catalog cache escaped the isolated test root: {}",
+            path.display()
+        );
+        assert_eq!(path.file_name().and_then(|n| n.to_str()), Some(CACHE_FILE));
+    }
+
+    /// A test that does seal the environment still resolves it, so the
+    /// confinement above cannot silently break the guarded callers.
+    #[test]
+    fn guarded_cache_path_follows_the_sealed_home() {
+        let _lock = lock_test_env();
+        let home = tempfile::tempdir().expect("tempdir");
+        let _guard = EnvVarGuard::set("CODEWHALE_HOME", home.path());
+
+        let path = cache_path().expect("cache path");
+
+        assert!(
+            path.starts_with(home.path()),
+            "sealed CODEWHALE_HOME was ignored: {}",
+            path.display()
+        );
+    }
 
     #[test]
     fn resolve_catalog_url_defaults_and_overrides() {

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -137,12 +137,12 @@ impl TuiPrefs {
         #[cfg(test)]
         {
             let honor_guarded_environment =
-                crate::test_support::current_thread_holds_test_env_lock();
+                crate::test_support::guarded_environment_provides_state_paths();
             crate::test_support::with_test_env_lock(|| {
                 if honor_guarded_environment {
                     tui_prefs_path_from_environment()
                 } else {
-                    Ok(crate::test_support::isolated_test_state_root().join(TUI_PREFS_FILE_NAME))
+                    Ok(crate::test_support::unsealed_test_state_root().join(TUI_PREFS_FILE_NAME))
                 }
             })
         }
@@ -2280,13 +2280,14 @@ fn lock_settings_transaction(
 fn settings_path_candidates() -> (Option<PathBuf>, Option<PathBuf>, Option<PathBuf>) {
     #[cfg(test)]
     {
-        let honor_guarded_environment = crate::test_support::current_thread_holds_test_env_lock();
+        let honor_guarded_environment =
+            crate::test_support::guarded_environment_provides_state_paths();
         crate::test_support::with_test_env_lock(|| {
             if honor_guarded_environment {
                 settings_path_candidates_from_environment()
             } else {
                 (
-                    Some(crate::test_support::isolated_test_state_root().join(SETTINGS_FILE_NAME)),
+                    Some(crate::test_support::unsealed_test_state_root().join(SETTINGS_FILE_NAME)),
                     None,
                     None,
                 )
@@ -4579,42 +4580,14 @@ mod tests {
         crate::test_support::lock_test_env()
     }
 
-    struct EnvVarRestore {
-        key: &'static str,
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarRestore {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let previous = std::env::var_os(key);
-            // SAFETY: tests using this helper hold config_path_test_guard.
-            unsafe {
-                std::env::set_var(key, value);
-            }
-            Self { key, previous }
-        }
-
-        fn remove(key: &'static str) -> Self {
-            let previous = std::env::var_os(key);
-            // SAFETY: tests using this helper hold config_path_test_guard.
-            unsafe {
-                std::env::remove_var(key);
-            }
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarRestore {
-        fn drop(&mut self) {
-            // SAFETY: tests using this helper hold config_path_test_guard.
-            unsafe {
-                match &self.previous {
-                    Some(value) => std::env::set_var(self.key, value),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
-    }
+    /// The shared guard, under this module's historical name.
+    ///
+    /// It was a byte-for-byte copy of `EnvVarGuard` until #5359 gave the shared
+    /// one a second job: recording which variables a test actually redirected,
+    /// so state-path resolution can tell a sealed environment from a test that
+    /// holds the lock for unrelated reasons. A private copy silently opts every
+    /// caller here out of that record.
+    use crate::test_support::EnvVarGuard as EnvVarRestore;
 
     #[test]
     fn startup_mode_writes_accept_act_plan_operate() {

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -2755,6 +2755,9 @@ mod tests {
         // the isolated per-process test root and never touch the parent's file.
         // The child is a fresh process, so the acquisition is uncontended.
         let _env_lock = crate::test_support::lock_test_env();
+        let inherited_home = std::env::var_os("CODEWHALE_HOME")
+            .expect("settings child needs an inherited Codewhale home");
+        let _state_home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", inherited_home);
         let signal = PathBuf::from(
             std::env::var(CHILD_SIGNAL_ENV).expect("child helper needs a signal path"),
         );
@@ -4987,19 +4990,9 @@ mod tests {
         // Point config path at a non-existent location so tui.toml is absent.
         let tmp = std::env::temp_dir().join("dst_tui_prefs_absent_test");
         std::fs::create_dir_all(&tmp).unwrap();
-        // SAFETY: test-only env mutation guarded by config_path_test_guard.
-        unsafe {
-            std::env::set_var(
-                "DEEPSEEK_CONFIG_PATH",
-                tmp.join("config.toml").to_str().unwrap(),
-            );
-        }
+        let _config_override = EnvVarRestore::set("DEEPSEEK_CONFIG_PATH", tmp.join("config.toml"));
         let prefs = TuiPrefs::load().expect("load should not fail when file absent");
         assert_eq!(prefs.theme, "dark", "should fall back to default theme");
-        // SAFETY: cleanup under the guard.
-        unsafe {
-            std::env::remove_var("DEEPSEEK_CONFIG_PATH");
-        }
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
@@ -5008,13 +5001,7 @@ mod tests {
         let _g = config_path_test_guard();
         let tmp = std::env::temp_dir().join("dst_tui_prefs_save_test");
         std::fs::create_dir_all(&tmp).unwrap();
-        // SAFETY: test-only env mutation guarded by config_path_test_guard.
-        unsafe {
-            std::env::set_var(
-                "DEEPSEEK_CONFIG_PATH",
-                tmp.join("config.toml").to_str().unwrap(),
-            );
-        }
+        let _config_override = EnvVarRestore::set("DEEPSEEK_CONFIG_PATH", tmp.join("config.toml"));
 
         let prefs = TuiPrefs {
             theme: "light".to_string(),
@@ -5031,10 +5018,6 @@ mod tests {
         assert_eq!(loaded.font_size, 14);
         assert_eq!(loaded.keybinds.submit.as_deref(), Some("ctrl+enter"));
 
-        // SAFETY: cleanup under the guard.
-        unsafe {
-            std::env::remove_var("DEEPSEEK_CONFIG_PATH");
-        }
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
@@ -5044,10 +5027,7 @@ mod tests {
         let tmp = std::env::temp_dir().join("dst_tui_prefs_comment_test");
         std::fs::create_dir_all(&tmp).unwrap();
         let config_file = tmp.join("config.toml");
-        // SAFETY: test-only env mutation guarded by config_path_test_guard.
-        unsafe {
-            std::env::set_var("DEEPSEEK_CONFIG_PATH", config_file.to_str().unwrap());
-        }
+        let _config_override = EnvVarRestore::set("DEEPSEEK_CONFIG_PATH", &config_file);
 
         // tui.toml lives next to config.toml
         let tui_path = tmp.join("tui.toml");
@@ -5068,10 +5048,6 @@ mod tests {
         assert!(body.contains("# footer note"), "footer lost: {body}");
         assert!(body.contains("light"), "new value not written: {body}");
 
-        // SAFETY: cleanup under the guard.
-        unsafe {
-            std::env::remove_var("DEEPSEEK_CONFIG_PATH");
-        }
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
@@ -5081,10 +5057,7 @@ mod tests {
         let tmp = std::env::temp_dir().join("dst_settings_comment_test");
         std::fs::create_dir_all(&tmp).unwrap();
         let config_file = tmp.join("config.toml");
-        // SAFETY: test-only env mutation guarded by config_path_test_guard.
-        unsafe {
-            std::env::set_var("DEEPSEEK_CONFIG_PATH", config_file.to_str().unwrap());
-        }
+        let _config_override = EnvVarRestore::set("DEEPSEEK_CONFIG_PATH", &config_file);
 
         // settings.toml lives next to config.toml
         let settings_path = tmp.join("settings.toml");
@@ -5104,10 +5077,6 @@ mod tests {
         assert!(body.contains("# trailing"), "trailing lost: {body}");
         assert!(body.contains("cny"), "new value not written: {body}");
 
-        // SAFETY: cleanup under the guard.
-        unsafe {
-            std::env::remove_var("DEEPSEEK_CONFIG_PATH");
-        }
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/crates/tui/src/test_support.rs
+++ b/crates/tui/src/test_support.rs
@@ -58,14 +58,28 @@ pub(crate) fn unsealed_test_state_root() -> PathBuf {
     if !current_thread_holds_test_env_lock() {
         return shared.to_path_buf();
     }
-    let root = shared.join(format!("env-holder-{:?}", std::thread::current().id()));
-    std::fs::create_dir_all(&root).unwrap_or_else(|error| {
-        panic!(
-            "failed to create per-holder test state root {}: {error}",
-            root.display()
-        )
-    });
-    root
+    // Create the directory once per thread. Path resolution runs on every
+    // settings read, and an unconditional `create_dir_all` there is a syscall
+    // per read — cheap on Linux, not free on Windows, and pure waste after the
+    // first call since a thread keeps its own directory for its whole life.
+    HOLDER_ROOT.with(|cached| {
+        cached
+            .get_or_init(|| {
+                let root = shared.join(format!("env-holder-{:?}", std::thread::current().id()));
+                std::fs::create_dir_all(&root).unwrap_or_else(|error| {
+                    panic!(
+                        "failed to create per-holder test state root {}: {error}",
+                        root.display()
+                    )
+                });
+                root
+            })
+            .clone()
+    })
+}
+
+thread_local! {
+    static HOLDER_ROOT: OnceLock<PathBuf> = const { OnceLock::new() };
 }
 
 /// Build a syntactically valid, non-secret JWT fixture without embedding a

--- a/crates/tui/src/test_support.rs
+++ b/crates/tui/src/test_support.rs
@@ -18,7 +18,8 @@ pub(crate) use crate::shell_dispatcher::test_env_lock::{
 /// and unsafe in a parallel test binary: an unguarded save can otherwise read
 /// or overwrite the developer's config. Tests that exercise path precedence
 /// still hold [`lock_test_env`] and provide explicit temporary environment
-/// values; every other test is confined here.
+/// values; every other test is confined here — enforced by
+/// [`guarded_environment_provides_state_paths`], not assumed.
 pub(crate) fn isolated_test_state_root() -> &'static Path {
     static ROOT: OnceLock<PathBuf> = OnceLock::new();
     ROOT.get_or_init(|| {
@@ -38,6 +39,33 @@ pub(crate) fn isolated_test_state_root() -> &'static Path {
         });
         root
     })
+}
+
+/// Where the calling test's state should live when it has not sealed the
+/// environment itself.
+///
+/// Two different callers land here. A test that never took [`lock_test_env`]
+/// gets the shared root, exactly as before — those tests already coexist there
+/// under [`with_test_state_io_lock`]. A test that *holds* the lock but sealed
+/// nothing gets a private directory instead: before #5359 it resolved the
+/// developer's real home, so it has never shared the process root, and several
+/// such tests run full settings transactions. Adding that traffic to the shared
+/// root pushed the transaction lock past its deadline and hung unrelated
+/// `config_command_*` tests. Keep them isolated from the developer *and* from
+/// each other.
+pub(crate) fn unsealed_test_state_root() -> PathBuf {
+    let shared = isolated_test_state_root();
+    if !current_thread_holds_test_env_lock() {
+        return shared.to_path_buf();
+    }
+    let root = shared.join(format!("env-holder-{:?}", std::thread::current().id()));
+    std::fs::create_dir_all(&root).unwrap_or_else(|error| {
+        panic!(
+            "failed to create per-holder test state root {}: {error}",
+            root.display()
+        )
+    });
+    root
 }
 
 /// Build a syntactically valid, non-secret JWT fixture without embedding a
@@ -73,9 +101,78 @@ pub(crate) fn with_test_state_io_lock<T>(operation: impl FnOnce() -> T) -> T {
 ///
 /// Callers that mutate process-global environment variables must hold
 /// [`lock_test_env`] until after this guard is dropped.
+///
+/// Every live guard is also recorded in [`guarded_env_keys`], so path
+/// resolution can distinguish a test that deliberately redirected `HOME`
+/// from one that merely holds the lock to serialize unrelated env access —
+/// see [`guarded_environment_provides_state_paths`].
 pub(crate) struct EnvVarGuard {
     key: &'static str,
     previous: Option<OsString>,
+}
+
+fn guarded_env_keys() -> &'static Mutex<std::collections::HashMap<&'static str, usize>> {
+    static KEYS: OnceLock<Mutex<std::collections::HashMap<&'static str, usize>>> = OnceLock::new();
+    KEYS.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+fn register_guarded_env_key(key: &'static str) {
+    let mut keys = match guarded_env_keys().lock() {
+        Ok(keys) => keys,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    *keys.entry(key).or_insert(0) += 1;
+}
+
+fn unregister_guarded_env_key(key: &'static str) {
+    let mut keys = match guarded_env_keys().lock() {
+        Ok(keys) => keys,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if let Some(count) = keys.get_mut(key) {
+        *count -= 1;
+        if *count == 0 {
+            keys.remove(key);
+        }
+    }
+}
+
+/// Whether some live [`EnvVarGuard`] currently covers `key`.
+pub(crate) fn env_var_currently_guarded(key: &str) -> bool {
+    match guarded_env_keys().lock() {
+        Ok(keys) => keys.contains_key(key),
+        Err(poisoned) => poisoned.into_inner().contains_key(key),
+    }
+}
+
+/// Whether the calling test actually provided the state-path environment it
+/// is about to resolve.
+///
+/// Holding [`lock_test_env`] alone is not that: many tests hold the lock only
+/// to serialize access to unrelated variables (`TERM_PROGRAM`, API keys) and
+/// have provided no temporary paths at all. Trusting the lock routed those
+/// tests to the developer's real `~/.codewhale` state, which is exactly the
+/// leak the isolated root exists to prevent (#5359). A test earns environment
+/// resolution by holding the lock *and* either setting one of the explicit
+/// override variables or redirecting `HOME`/`USERPROFILE` through
+/// [`EnvVarGuard`].
+pub(crate) fn guarded_environment_provides_state_paths() -> bool {
+    if !current_thread_holds_test_env_lock() {
+        return false;
+    }
+    // Explicit overrides may arrive from a parent process (the cross-process
+    // settings children), so presence in the environment counts even without
+    // a live guard in this process.
+    let explicit_override_present = [
+        "CODEWHALE_HOME",
+        "CODEWHALE_CONFIG_PATH",
+        "DEEPSEEK_CONFIG_PATH",
+    ]
+    .iter()
+    .any(|var| std::env::var(var).is_ok_and(|value| !value.trim().is_empty()));
+    explicit_override_present
+        || env_var_currently_guarded("HOME")
+        || env_var_currently_guarded("USERPROFILE")
 }
 
 impl EnvVarGuard {
@@ -87,6 +184,7 @@ impl EnvVarGuard {
         let previous = std::env::var_os(key);
         // SAFETY: callers hold the process-wide test env mutex.
         unsafe { std::env::set_var(key, value) };
+        register_guarded_env_key(key);
         Self { key, previous }
     }
 
@@ -98,6 +196,7 @@ impl EnvVarGuard {
         let previous = std::env::var_os(key);
         // SAFETY: callers hold the process-wide test env mutex.
         unsafe { std::env::remove_var(key) };
+        register_guarded_env_key(key);
         Self { key, previous }
     }
 
@@ -117,6 +216,7 @@ impl Drop for EnvVarGuard {
                 std::env::remove_var(self.key);
             }
         }
+        unregister_guarded_env_key(self.key);
     }
 }
 

--- a/crates/tui/src/test_support.rs
+++ b/crates/tui/src/test_support.rs
@@ -58,10 +58,9 @@ pub(crate) fn unsealed_test_state_root() -> PathBuf {
     if !current_thread_holds_test_env_lock() {
         return shared.to_path_buf();
     }
-    // Create the directory once per thread. Path resolution runs on every
-    // settings read, and an unconditional `create_dir_all` there is a syscall
-    // per read — cheap on Linux, not free on Windows, and pure waste after the
-    // first call since a thread keeps its own directory for its whole life.
+    // libtest runs each test in a fresh thread. Keep one root for that thread:
+    // a settings save resolves its path more than once, while different tests
+    // must not inherit each other's files.
     HOLDER_ROOT.with(|cached| {
         cached
             .get_or_init(|| {
@@ -174,17 +173,17 @@ pub(crate) fn guarded_environment_provides_state_paths() -> bool {
     if !current_thread_holds_test_env_lock() {
         return false;
     }
-    // Explicit overrides may arrive from a parent process (the cross-process
-    // settings children), so presence in the environment counts even without
-    // a live guard in this process.
-    let explicit_override_present = [
+    let guarded_override_present = [
         "CODEWHALE_HOME",
         "CODEWHALE_CONFIG_PATH",
         "DEEPSEEK_CONFIG_PATH",
     ]
     .iter()
-    .any(|var| std::env::var(var).is_ok_and(|value| !value.trim().is_empty()));
-    explicit_override_present
+    .any(|var| {
+        env_var_currently_guarded(var)
+            && std::env::var(var).is_ok_and(|value| !value.trim().is_empty())
+    });
+    guarded_override_present
         || env_var_currently_guarded("HOME")
         || env_var_currently_guarded("USERPROFILE")
 }
@@ -358,6 +357,31 @@ mod tests {
     use super::*;
     use std::sync::mpsc;
     use std::time::Duration;
+
+    #[test]
+    fn ambient_codewhale_home_is_not_a_test_seal() {
+        let _lock = lock_test_env();
+        let _ambient = EnvVarGuard::set("CODEWHALE_HOME", "/tmp/ambient-codewhale-home");
+        unregister_guarded_env_key("CODEWHALE_HOME");
+
+        let sealed = guarded_environment_provides_state_paths();
+
+        register_guarded_env_key("CODEWHALE_HOME");
+        assert!(!sealed, "ambient developer state must remain confined");
+    }
+
+    #[test]
+    fn removing_overrides_does_not_seal_the_ambient_home() {
+        let _lock = lock_test_env();
+        let _codewhale_home = EnvVarGuard::remove("CODEWHALE_HOME");
+        let _codewhale_config = EnvVarGuard::remove("CODEWHALE_CONFIG_PATH");
+        let _deepseek_config = EnvVarGuard::remove("DEEPSEEK_CONFIG_PATH");
+
+        assert!(
+            !guarded_environment_provides_state_paths(),
+            "removing an override must not expose the developer's HOME"
+        );
+    }
 
     #[test]
     fn unguarded_state_writes_use_isolated_test_root() {

--- a/crates/tui/src/tui/display_refresh.rs
+++ b/crates/tui/src/tui/display_refresh.rs
@@ -95,11 +95,7 @@ thread_local! {
 
 #[cfg(test)]
 fn pinned_probe() -> DisplayRefreshProbeResult {
-    PINNED.with(|pinned| {
-        let current = pinned.get();
-        pinned.set(current);
-        current.unwrap_or(UNMEASURED)
-    })
+    PINNED.with(|pinned| pinned.get().unwrap_or(UNMEASURED))
 }
 
 /// Pin the probe for the current thread until dropped.
@@ -116,10 +112,11 @@ pub(crate) struct DisplayRefreshPin {
 impl DisplayRefreshPin {
     /// Pin a measured panel at `hz`, as if the host reported it.
     pub(crate) fn measured(hz: u32) -> Self {
+        let accepted = accept_hz(hz);
         Self::install(DisplayRefreshProbeResult {
-            hz: accept_hz(hz),
+            hz: accepted,
             source: DisplayRefreshSource::EnvOverride,
-            skip_reason: if accept_hz(hz).is_some() {
+            skip_reason: if accepted.is_some() {
                 ""
             } else {
                 "out_of_range"

--- a/crates/tui/src/tui/display_refresh.rs
+++ b/crates/tui/src/tui/display_refresh.rs
@@ -4,7 +4,6 @@
 //! clamp to sane bounds, and never panic into the render loop. SSH / missing
 //! FFI paths fall back to the fixed [`crate::tui::frame_rate_limiter`] defaults.
 
-use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 /// Inclusive lower bound for accepted refresh rates.
@@ -58,9 +57,88 @@ impl DisplayRefreshProbeResult {
 const _: fn(DisplayRefreshProbeResult) -> &'static str = DisplayRefreshProbeResult::outcome;
 
 /// Once per process. Infallible.
+///
+/// Under `cfg(test)` the host panel is not consulted. The probe is
+/// `OnceLock`-cached and reads real hardware, so a cadence test on a 60 Hz
+/// developer machine computed a different interval than the same test on CI,
+/// with no way to pin the input the way `low_motion` and `fancy_animations`
+/// are already pinned (#5359). Tests get the unmeasured result — the same one
+/// a headless CI runner sees — and any test that wants a specific panel says
+/// so with [`DisplayRefreshPin`].
 pub fn probe_display_refresh() -> DisplayRefreshProbeResult {
-    static CACHE: OnceLock<DisplayRefreshProbeResult> = OnceLock::new();
-    *CACHE.get_or_init(probe_uncached)
+    #[cfg(test)]
+    {
+        pinned_probe()
+    }
+    #[cfg(not(test))]
+    {
+        static CACHE: std::sync::OnceLock<DisplayRefreshProbeResult> = std::sync::OnceLock::new();
+        *CACHE.get_or_init(probe_uncached)
+    }
+}
+
+/// What a test observes when it has not pinned a panel: no measurement, so
+/// [`animation_interval_for_hz`] falls back to [`FALLBACK_ANIMATION_MS`].
+#[cfg(test)]
+const UNMEASURED: DisplayRefreshProbeResult = DisplayRefreshProbeResult {
+    hz: None,
+    source: DisplayRefreshSource::None,
+    skip_reason: "not_probed_under_test",
+    duration_ms: 0,
+};
+
+#[cfg(test)]
+thread_local! {
+    static PINNED: std::cell::Cell<Option<DisplayRefreshProbeResult>> =
+        const { std::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+fn pinned_probe() -> DisplayRefreshProbeResult {
+    PINNED.with(|pinned| {
+        let current = pinned.get();
+        pinned.set(current);
+        current.unwrap_or(UNMEASURED)
+    })
+}
+
+/// Pin the probe for the current thread until dropped.
+///
+/// Thread-local rather than process-global: the cadence tests run in parallel
+/// with everything else, and a shared cell would let one test's panel decide
+/// another's interval.
+#[cfg(test)]
+pub(crate) struct DisplayRefreshPin {
+    previous: Option<DisplayRefreshProbeResult>,
+}
+
+#[cfg(test)]
+impl DisplayRefreshPin {
+    /// Pin a measured panel at `hz`, as if the host reported it.
+    pub(crate) fn measured(hz: u32) -> Self {
+        Self::install(DisplayRefreshProbeResult {
+            hz: accept_hz(hz),
+            source: DisplayRefreshSource::EnvOverride,
+            skip_reason: if accept_hz(hz).is_some() {
+                ""
+            } else {
+                "out_of_range"
+            },
+            duration_ms: 0,
+        })
+    }
+
+    fn install(next: DisplayRefreshProbeResult) -> Self {
+        let previous = PINNED.with(|pinned| pinned.replace(Some(next)));
+        Self { previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for DisplayRefreshPin {
+    fn drop(&mut self) {
+        PINNED.with(|pinned| pinned.set(self.previous));
+    }
 }
 
 fn probe_uncached() -> DisplayRefreshProbeResult {
@@ -304,5 +382,67 @@ mod tests {
         assert_eq!(a, b);
         // Either measured or skipped — never panics.
         assert!(a.outcome() == "ok" || a.outcome() == "skipped" || a.outcome() == "error");
+    }
+
+    /// The real host probe, which `probe_display_refresh` no longer reaches
+    /// under test. Its result is whatever this machine reports, so assert only
+    /// the invariants that hold everywhere — but keep calling it, so the FFI
+    /// and env-override paths stay compiled and exercised rather than becoming
+    /// dead code the moment tests stopped consulting the panel.
+    #[test]
+    fn the_host_probe_itself_stays_infallible_and_in_range() {
+        let probe = probe_uncached();
+        assert!(
+            probe.outcome() == "ok" || probe.outcome() == "skipped" || probe.outcome() == "error"
+        );
+        if let Some(hz) = probe.hz {
+            assert!(
+                (MIN_HZ..=MAX_HZ).contains(&hz),
+                "{hz} outside accepted range"
+            );
+            assert!(probe.skip_reason.is_empty());
+        } else {
+            assert!(!probe.skip_reason.is_empty(), "a skip must name its reason");
+        }
+    }
+
+    #[test]
+    fn unpinned_tests_never_see_the_host_panel() {
+        let probe = probe_display_refresh();
+        assert_eq!(probe.hz, None, "a test must not inherit the developer's Hz");
+        assert_eq!(probe.skip_reason, "not_probed_under_test");
+        assert_eq!(
+            adaptive_animation_interval_ms(false),
+            FALLBACK_ANIMATION_MS,
+            "the unmeasured fallback is what CI computes"
+        );
+    }
+
+    #[test]
+    fn a_pinned_panel_drives_the_cadence_and_is_restored_on_drop() {
+        assert_eq!(probe_display_refresh().hz, None);
+        {
+            let _pin = DisplayRefreshPin::measured(144);
+            assert_eq!(probe_display_refresh().hz, Some(144));
+            assert_eq!(
+                adaptive_animation_interval_ms(false),
+                animation_interval_for_hz(Some(144), false).as_millis() as u64
+            );
+            assert!(adaptive_animation_interval_ms(false) < FALLBACK_ANIMATION_MS);
+        }
+        assert_eq!(
+            probe_display_refresh().hz,
+            None,
+            "the pin must not outlive its scope"
+        );
+    }
+
+    #[test]
+    fn a_pin_outside_the_accepted_range_reads_as_unmeasured() {
+        let _pin = DisplayRefreshPin::measured(1);
+        let probe = probe_display_refresh();
+        assert_eq!(probe.hz, None);
+        assert_eq!(probe.skip_reason, "out_of_range");
+        assert_eq!(adaptive_animation_interval_ms(false), FALLBACK_ANIMATION_MS);
     }
 }

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -4685,7 +4685,6 @@ mod tests {
         style::{Color, Style},
     };
     use std::borrow::Cow;
-    use std::ffi::OsString;
     use std::fs;
     use std::path::PathBuf;
     use tempfile::TempDir;
@@ -5027,8 +5026,8 @@ mod tests {
     }
 
     struct ConfigSettingsEnvGuard {
+        _config_path: crate::test_support::EnvVarGuard,
         _tmp: TempDir,
-        previous_config_path: Option<OsString>,
         _lock: crate::test_support::TestEnvLock,
     }
 
@@ -5044,25 +5043,12 @@ mod tests {
             std::fs::create_dir_all(config_path.parent().expect("config parent"))
                 .expect("config dir");
             std::fs::write(&settings_path, settings_toml).expect("settings file");
-            let previous_config_path = std::env::var_os("DEEPSEEK_CONFIG_PATH");
-            unsafe {
-                std::env::set_var("DEEPSEEK_CONFIG_PATH", &config_path);
-            }
+            let config_path_guard =
+                crate::test_support::EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
             Self {
+                _config_path: config_path_guard,
                 _tmp: tmp,
-                previous_config_path,
                 _lock: lock,
-            }
-        }
-    }
-
-    impl Drop for ConfigSettingsEnvGuard {
-        fn drop(&mut self) {
-            unsafe {
-                match self.previous_config_path.take() {
-                    Some(previous) => std::env::set_var("DEEPSEEK_CONFIG_PATH", previous),
-                    None => std::env::remove_var("DEEPSEEK_CONFIG_PATH"),
-                }
             }
         }
     }

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 689974,
+  "max_total_owned_rust_lines": 689804,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 690140,
+  "max_total_owned_rust_lines": 692000,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 690031,
+  "max_total_owned_rust_lines": 690140,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 689960,
+  "max_total_owned_rust_lines": 689974,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 689696,
+  "max_total_owned_rust_lines": 689960,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
Fixes the four tests from #5359. Three independent mechanisms, each with a test that fails when only its own fix is reverted.

**The lock-holder trust hole.** `settings_path_candidates()` and `TuiPrefs::path()` routed lock-holding threads to the real environment, on the assumption that a test holding `lock_test_env()` had supplied temporary paths. Most holders take the lock only to serialize something unrelated — `TERM_PROGRAM`, `NO_ANIMATIONS` — and supplied nothing, so they read `~/.codewhale/settings.toml`. With `locale = zh-Hans` the settings dump renders 「设置：」 and the assertion on `"Settings:"` fails.

The contract was there, it just trusted the wrong signal. `guarded_environment_provides_state_paths()` now wants the lock **and** evidence the caller sealed something: an explicit `CODEWHALE_HOME` / `CODEWHALE_CONFIG_PATH` / `DEEPSEEK_CONFIG_PATH`, or a live `EnvVarGuard` over `HOME`/`USERPROFILE`. The explicit-variable branch reads the environment rather than the guard registry, so the cross-process settings children — which inherit `CODEWHALE_HOME` from their parent — keep resolving it.

`settings.rs` had a byte-identical private copy of `EnvVarGuard`; it is now an alias of the shared one, since a copy would opt all 32 of its call sites out of the record.

An unsealed lock holder gets a **per-thread** directory, not the shared root. Those tests have never shared it — before this they reached the developer's home — and several run full settings transactions. Routing them into the shared root put the transaction lock past its 120s deadline and hung unrelated `config_command_*` tests; that showed up in the first full-suite round and is why the per-holder split exists.

**`resolve_state_dir` has no test shield.** `models_dev_live::cache_path()` goes through `codewhale-config`, a plain dependency here with no view of this crate's isolated root, so an unguarded test read the developer's catalog. Same confinement, plus a test pinning that it stays inside the isolated root and a companion asserting a sealed `CODEWHALE_HOME` is still honored.

**The display probe.** `probe_display_refresh()` is `OnceLock`-cached and asks CoreGraphics for the host panel, so `adaptive_animation_interval_ms(false)` returned 66 ms on a 60 Hz box against the 80 ms floor the cadence test asserts — and the test could pin `low_motion` and `fancy_animations` but not the panel. Under `cfg(test)` it returns the unmeasured result a headless runner sees; `DisplayRefreshPin` pins a panel per thread for tests that want one. The real probe stays covered by a direct test rather than quietly becoming dead code.

### What this deliberately does not fix

`resolve_load_config_path()` and `try_default_config_path()` have the same trust hole. Tightening them regressed five config-path tests, because those seal the environment through a *third* private guard in `config/tests.rs` that writes `HOME` with `env::set_var` directly — invisible to the registry. Unifying the three guards is the real fix and is bigger than this change; better as a follow-up than half-applied here. Happy to take it if you want it.

### Correction to the issue

The issue attributed `model_picker_is_usable_and_opaque_at_blocker_sizes` to the catalog cache. That was wrong: the original contrast used `CODEWHALE_HOME=$(mktemp -d)`, which moves settings and catalog together. Fixing each alone separates them — the settings fix alone makes it pass, the catalog fix alone does not. It is a fourth symptom of the trust hole. The catalog gap is real, just not what broke that test, and now has its own assertion instead of an inferred one.

### Validation

Full `codewhale-tui` lib suite, same machine, back to back:

| | main (`d48db57e6`) | this branch |
| --- | --- | --- |
| failures | 5 | 1 |
| the four from #5359 | fail | **pass** |
| `tools::pdf::…forwards_page_window…` | fail | fail |

That pdf test is a pre-existing timing flake, not related to this change — on clean `main` it fails roughly one run in five (1/5 here), and it fails on `main` with this branch not applied.

- mutation-checked one fix at a time: reverting the predicate fails `settings_command_opens_typed_editor…`, `config_view_surfaces…` and `model_picker…`; removing the catalog confinement fails only the new catalog test, which reports the escaped path; the display tests fail without the pin
- `cargo fmt --check` clean; `cargo clippy --workspace --all-features --locked` with the CI allow-list: 0 errors
- `check-runtime-contract-budget.py` PASS, all 55 metrics exactly at budget
- `check-source-structure-budget.py` acknowledged in its own commit, per `6c8577715`

Closes #5359

Analysis drafted with local tooling; every change and test verified by hand.
