### PR TITLE
fix(tools): degrade Moonshot schemas instead of refusing conditionals

### DIFF
--- a/crates/tui/src/tools/schema_sanitize.rs
+++ b/crates/tui/src/tools/schema_sanitize.rs
@@ -406,7 +406,7 @@ fn drop_dependent_keywords(schema: &mut Value) -> Option<String> {
     dropped.dedup();
     Some(format!(
         "This provider cannot express conditional requirements, so they are not \
-         part of the schema above: {}. They are still enforced.",
+         part of the schema above: {}. Honor them when calling the tool.",
         dropped.join("; ")
     ))
 }
@@ -2850,7 +2850,7 @@ mod kimi_tests {
             "This provider cannot express conditional requirements, so they are \
              not part of the schema above: with `action` present, `prompt` is \
              also required; with `prompt` present, `action` is also required. \
-             They are still enforced."
+             Honor them when calling the tool."
         );
     }
 

--- a/crates/tui/src/tools/schema_sanitize.rs
+++ b/crates/tui/src/tools/schema_sanitize.rs
@@ -117,6 +117,10 @@ pub fn sanitize_for_responses(schema: &mut Value) -> Option<String> {
     obj.remove("allOf");
     obj.remove("enum");
     obj.remove("not");
+    // The Responses/Anthropic tool-schema subset does not accept Draft 2020
+    // dependency keywords. Runtime validation remains authoritative, while
+    // the tool description retains the same action contract for the model.
+    obj.remove("dependentSchemas");
     ensure_properties_object(obj);
     prune_dangling_required(schema);
     constraint_note
@@ -130,7 +134,10 @@ fn strict_schema_supported(schema: &Value) -> bool {
 
 fn has_strict_incompatible_composition(schema: &Value, is_root: bool) -> bool {
     if let Some(obj) = schema.as_object() {
-        if obj.contains_key("oneOf") || obj.contains_key("allOf") {
+        if obj.contains_key("oneOf")
+            || obj.contains_key("allOf")
+            || obj.contains_key("dependentSchemas")
+        {
             return true;
         }
         if is_root && obj.contains_key("anyOf") {
@@ -898,6 +905,28 @@ mod tests {
 
         assert!(!prepare_tools_for_strict_mode(&mut tools));
         assert_eq!(tools[0].strict, None);
+    }
+
+    #[test]
+    fn strict_mode_leaves_dependent_schema_tools_non_strict() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "action": {"type": "string"},
+                "message": {"type": "string"}
+            },
+            "dependentSchemas": {
+                "action": {
+                    "properties": {"message": {}},
+                    "required": ["message"]
+                }
+            }
+        });
+        let mut tools = vec![test_tool("agent", schema.clone())];
+
+        assert!(!prepare_tools_for_strict_mode(&mut tools));
+        assert_eq!(tools[0].strict, None);
+        assert_eq!(tools[0].input_schema, schema);
     }
 
     #[test]

--- a/crates/tui/src/tools/schema_sanitize.rs
+++ b/crates/tui/src/tools/schema_sanitize.rs
@@ -99,6 +99,7 @@ pub fn sanitize_for_responses(schema: &mut Value) -> Option<String> {
     let constraint_note = schema
         .as_object()
         .and_then(root_composition_constraint_note);
+    let dependent_note = drop_dependent_keywords(schema);
 
     sanitize(schema);
 
@@ -107,7 +108,7 @@ pub fn sanitize_for_responses(schema: &mut Value) -> Option<String> {
     }
 
     let Some(obj) = schema.as_object_mut() else {
-        return constraint_note;
+        return combine_constraint_notes(constraint_note, dependent_note);
     };
 
     merge_root_composition_properties(obj);
@@ -117,13 +118,9 @@ pub fn sanitize_for_responses(schema: &mut Value) -> Option<String> {
     obj.remove("allOf");
     obj.remove("enum");
     obj.remove("not");
-    // The Responses/Anthropic tool-schema subset does not accept Draft 2020
-    // dependency keywords. Runtime validation remains authoritative, while
-    // the tool description retains the same action contract for the model.
-    obj.remove("dependentSchemas");
     ensure_properties_object(obj);
     prune_dangling_required(schema);
-    constraint_note
+    combine_constraint_notes(constraint_note, dependent_note)
 }
 
 fn strict_schema_supported(schema: &Value) -> bool {
@@ -393,78 +390,47 @@ fn root_composition_constraint_note(obj: &Map<String, Value>) -> Option<String> 
     None
 }
 
-/// Strip `dependentSchemas` / `dependentRequired` from every node, returning a
-/// note describing the requirements that stopped being advertised.
+/// Strip `dependentSchemas` / `dependentRequired` from every node.
 ///
 /// MFJS validates each node against a closed keyword allow-list, so a schema
 /// carrying either keyword is refused outright — and that refusal reaches
 /// `sanitize_moonshot_chat_tools`, which fails the whole request build, so one
 /// composed schema would break *every* tool-bearing Moonshot turn rather than
-/// degrade its own tool. Dropping the keywords leaves the canonical flat
-/// schema: the same properties are advertised, only the discrimination between
-/// them goes unstated, and the tool parser enforces it regardless.
+/// degrade its own tool.
 fn drop_dependent_keywords(schema: &mut Value) -> Option<String> {
-    let mut dropped: Vec<String> = Vec::new();
-    strip_dependent_keywords(schema, &mut dropped);
-    if dropped.is_empty() {
-        return None;
-    }
-    dropped.sort();
-    dropped.dedup();
-    Some(format!(
-        "This provider cannot express conditional requirements, so they are not \
-         part of the schema above: {}. Honor them when calling the tool.",
-        dropped.join("; ")
-    ))
+    strip_dependent_keywords(schema).then(|| {
+        "This provider cannot express conditional requirements from the original schema. \
+         Honor any such requirements documented by the tool when calling it."
+            .to_string()
+    })
 }
 
-fn strip_dependent_keywords(schema: &mut Value, dropped: &mut Vec<String>) {
+fn combine_constraint_notes(first: Option<String>, second: Option<String>) -> Option<String> {
+    match (first, second) {
+        (Some(first), Some(second)) => Some(format!("{first} {second}")),
+        (Some(note), None) | (None, Some(note)) => Some(note),
+        (None, None) => None,
+    }
+}
+
+fn strip_dependent_keywords(schema: &mut Value) -> bool {
     match schema {
         Value::Object(obj) => {
-            if let Some(Value::Object(groups)) = obj.remove("dependentRequired") {
-                for (trigger, names) in groups {
-                    let mut names: Vec<String> = names
-                        .as_array()
-                        .map(|values| {
-                            values
-                                .iter()
-                                .filter_map(Value::as_str)
-                                .map(|name| format!("`{name}`"))
-                                .collect()
-                        })
-                        .unwrap_or_default();
-                    if names.is_empty() {
-                        continue;
-                    }
-                    names.sort();
-                    names.dedup();
-                    dropped.push(format!(
-                        "with `{trigger}` present, {} is also required",
-                        names.join(" + ")
-                    ));
-                }
-            }
-            if let Some(Value::Object(groups)) = obj.remove("dependentSchemas") {
-                for (trigger, branch) in groups {
-                    match required_group_label(&branch) {
-                        Some(label) => dropped.push(format!(
-                            "with `{trigger}` present, {label} is also required"
-                        )),
-                        None => dropped
-                            .push(format!("`{trigger}` carries extra conditional constraints")),
-                    }
-                }
-            }
+            let mut dropped = obj.remove("dependentRequired").is_some();
+            dropped |= obj.remove("dependentSchemas").is_some();
             for value in obj.values_mut() {
-                strip_dependent_keywords(value, dropped);
+                dropped |= strip_dependent_keywords(value);
             }
+            dropped
         }
         Value::Array(items) => {
+            let mut dropped = false;
             for item in items {
-                strip_dependent_keywords(item, dropped);
+                dropped |= strip_dependent_keywords(item);
             }
+            dropped
         }
-        _ => {}
+        _ => false,
     }
 }
 
@@ -1291,19 +1257,14 @@ fn sanitize_kimi_parameters_candidate(
     // simultaneously be `type: object`. Flatten the actual root shape used by
     // apply_patch and retain its dropped required-group contract as a prompt
     // note for the model.
-    // MFJS has no conditional keywords. Degrade to the canonical flat schema
-    // instead of refusing it, which would fail the whole request build. This
-    // runs before the Responses pass: that pass prunes `required` entries with
-    // no sibling `properties`, which is exactly the shape a `dependentSchemas`
-    // branch has, and the note would lose the field names it is reporting.
-    let dependent_note = drop_dependent_keywords(parameters);
-
+    // MFJS has no conditional keywords. The shared compatibility pass drops
+    // them with a bounded description note instead of failing the whole turn.
     let constraint_note = sanitize_for_responses(parameters);
 
     // Restore nullable unions collapsed by the registry's provider-neutral
     // sanitizer, translate MFJS-safe scalar const values, and normalize nested
-    // composition. Codewhale still validates tool input before execution, so
-    // widening oneOf to MFJS's anyOf remains safe; allOf fails closed.
+    // composition. This changes model-facing schema guidance only; each tool
+    // keeps responsibility for validating its own arguments. allOf fails closed.
     normalize_kimi_compatibility(parameters, true)?;
 
     // MFJS requires `type` to live inside each anyOf branch, never alongside
@@ -1323,11 +1284,7 @@ fn sanitize_kimi_parameters_candidate(
         return Err(KimiParameterSchemaError::RootMustBeObject);
     }
 
-    Ok(match (constraint_note, dependent_note) {
-        (Some(root), Some(dependent)) => Some(format!("{root} {dependent}")),
-        (Some(only), None) | (None, Some(only)) => Some(only),
-        (None, None) => None,
-    })
+    Ok(constraint_note)
 }
 
 fn inline_internal_kimi_root_ref(parameters: &mut Value) -> Result<(), KimiParameterSchemaError> {
@@ -2869,17 +2826,11 @@ mod kimi_tests {
         assert_eq!(schema["required"], json!(["action"]));
         validate_mfjs_parameters(&schema).expect("degraded schema must validate");
 
-        // Pin the wording, not just the field names: the note is built before
-        // the Responses pass precisely because that pass prunes the branch's
-        // `required`, and a reordering would silently degrade this to the
-        // "carries extra conditional constraints" fallback.
         let note = note.expect("dropping a requirement must be reported to the model");
         assert_eq!(
             note,
-            "This provider cannot express conditional requirements, so they are \
-             not part of the schema above: with `action` present, `prompt` is \
-             also required; with `prompt` present, `action` is also required. \
-             Honor them when calling the tool."
+            "This provider cannot express conditional requirements from the original schema. \
+             Honor any such requirements documented by the tool when calling it."
         );
     }
 
@@ -2926,10 +2877,23 @@ mod kimi_tests {
                 .contains_key("path")
         );
         validate_mfjs_parameters(&schema).expect("degraded schema must validate");
-        assert!(
-            note.expect("nested drop is still a dropped constraint")
-                .contains("`path`")
-        );
+        assert!(note.is_some(), "nested drop must still be reported");
+    }
+
+    #[test]
+    fn kimi_reports_malformed_dependent_keywords_that_it_drops() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {},
+            "dependentRequired": false,
+            "dependentSchemas": ["invalid"]
+        });
+
+        let note = sanitize_for_kimi_parameters(&mut schema).expect("degraded schema");
+
+        assert!(note.is_some(), "every dropped dependency must be reported");
+        assert!(!contains_key_anywhere(&schema, "dependentRequired"));
+        assert!(!contains_key_anywhere(&schema, "dependentSchemas"));
     }
 
     #[test]

--- a/crates/tui/src/tools/schema_sanitize.rs
+++ b/crates/tui/src/tools/schema_sanitize.rs
@@ -386,6 +386,81 @@ fn root_composition_constraint_note(obj: &Map<String, Value>) -> Option<String> 
     None
 }
 
+/// Strip `dependentSchemas` / `dependentRequired` from every node, returning a
+/// note describing the requirements that stopped being advertised.
+///
+/// MFJS validates each node against a closed keyword allow-list, so a schema
+/// carrying either keyword is refused outright — and that refusal reaches
+/// `sanitize_moonshot_chat_tools`, which fails the whole request build, so one
+/// composed schema would break *every* tool-bearing Moonshot turn rather than
+/// degrade its own tool. Dropping the keywords leaves the canonical flat
+/// schema: the same properties are advertised, only the discrimination between
+/// them goes unstated, and the tool parser enforces it regardless.
+fn drop_dependent_keywords(schema: &mut Value) -> Option<String> {
+    let mut dropped: Vec<String> = Vec::new();
+    strip_dependent_keywords(schema, &mut dropped);
+    if dropped.is_empty() {
+        return None;
+    }
+    dropped.sort();
+    dropped.dedup();
+    Some(format!(
+        "This provider cannot express conditional requirements, so they are not \
+         part of the schema above: {}. They are still enforced.",
+        dropped.join("; ")
+    ))
+}
+
+fn strip_dependent_keywords(schema: &mut Value, dropped: &mut Vec<String>) {
+    match schema {
+        Value::Object(obj) => {
+            if let Some(Value::Object(groups)) = obj.remove("dependentRequired") {
+                for (trigger, names) in groups {
+                    let mut names: Vec<String> = names
+                        .as_array()
+                        .map(|values| {
+                            values
+                                .iter()
+                                .filter_map(Value::as_str)
+                                .map(|name| format!("`{name}`"))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    if names.is_empty() {
+                        continue;
+                    }
+                    names.sort();
+                    names.dedup();
+                    dropped.push(format!(
+                        "with `{trigger}` present, {} is also required",
+                        names.join(" + ")
+                    ));
+                }
+            }
+            if let Some(Value::Object(groups)) = obj.remove("dependentSchemas") {
+                for (trigger, branch) in groups {
+                    match required_group_label(&branch) {
+                        Some(label) => dropped.push(format!(
+                            "with `{trigger}` present, {label} is also required"
+                        )),
+                        None => dropped
+                            .push(format!("`{trigger}` carries extra conditional constraints")),
+                    }
+                }
+            }
+            for value in obj.values_mut() {
+                strip_dependent_keywords(value, dropped);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                strip_dependent_keywords(item, dropped);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn required_group_label(item: &Value) -> Option<String> {
     let mut names: Vec<String> = item
         .get("required")?
@@ -1187,6 +1262,13 @@ fn sanitize_kimi_parameters_candidate(
     // simultaneously be `type: object`. Flatten the actual root shape used by
     // apply_patch and retain its dropped required-group contract as a prompt
     // note for the model.
+    // MFJS has no conditional keywords. Degrade to the canonical flat schema
+    // instead of refusing it, which would fail the whole request build. This
+    // runs before the Responses pass: that pass prunes `required` entries with
+    // no sibling `properties`, which is exactly the shape a `dependentSchemas`
+    // branch has, and the note would lose the field names it is reporting.
+    let dependent_note = drop_dependent_keywords(parameters);
+
     let constraint_note = sanitize_for_responses(parameters);
 
     // Restore nullable unions collapsed by the registry's provider-neutral
@@ -1212,7 +1294,11 @@ fn sanitize_kimi_parameters_candidate(
         return Err(KimiParameterSchemaError::RootMustBeObject);
     }
 
-    Ok(constraint_note)
+    Ok(match (constraint_note, dependent_note) {
+        (Some(root), Some(dependent)) => Some(format!("{root} {dependent}")),
+        (Some(only), None) | (None, Some(only)) => Some(only),
+        (None, None) => None,
+    })
 }
 
 fn inline_internal_kimi_root_ref(parameters: &mut Value) -> Result<(), KimiParameterSchemaError> {
@@ -2709,6 +2795,112 @@ mod kimi_tests {
         assert_eq!(error, KimiParameterSchemaError::UnresolvedRootReference);
         assert!(!error.to_string().contains("private-schema-name-9217"));
         assert_eq!(schema, original, "a rejected schema must never be emitted");
+    }
+
+    fn contains_key_anywhere(value: &Value, key: &str) -> bool {
+        match value {
+            Value::Object(map) => {
+                map.contains_key(key) || map.values().any(|v| contains_key_anywhere(v, key))
+            }
+            Value::Array(items) => items.iter().any(|v| contains_key_anywhere(v, key)),
+            _ => false,
+        }
+    }
+
+    fn action_discriminated_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {"type": "string", "enum": ["start", "status"]},
+                "prompt": {"type": "string"},
+                "agent_id": {"type": "string"}
+            },
+            "required": ["action"],
+            "dependentRequired": {
+                "prompt": ["action"]
+            },
+            "dependentSchemas": {
+                "action": {"required": ["prompt"]}
+            }
+        })
+    }
+
+    #[test]
+    fn kimi_degrades_dependent_keywords_to_the_flat_schema() {
+        let mut schema = action_discriminated_schema();
+
+        let note = sanitize_for_kimi_parameters(&mut schema).expect("must not refuse the schema");
+
+        assert!(!contains_key_anywhere(&schema, "dependentSchemas"));
+        assert!(!contains_key_anywhere(&schema, "dependentRequired"));
+        let properties = schema["properties"].as_object().expect("properties");
+        for name in ["action", "prompt", "agent_id"] {
+            assert!(properties.contains_key(name), "{name} left the flat schema");
+        }
+        assert_eq!(schema["required"], json!(["action"]));
+        validate_mfjs_parameters(&schema).expect("degraded schema must validate");
+
+        // Pin the wording, not just the field names: the note is built before
+        // the Responses pass precisely because that pass prunes the branch's
+        // `required`, and a reordering would silently degrade this to the
+        // "carries extra conditional constraints" fallback.
+        let note = note.expect("dropping a requirement must be reported to the model");
+        assert_eq!(
+            note,
+            "This provider cannot express conditional requirements, so they are \
+             not part of the schema above: with `action` present, `prompt` is \
+             also required; with `prompt` present, `action` is also required. \
+             They are still enforced."
+        );
+    }
+
+    #[test]
+    fn kimi_leaves_schemas_without_dependent_keywords_unannotated() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"]
+        });
+
+        let note = sanitize_for_kimi_parameters(&mut schema).expect("plain schema");
+
+        assert_eq!(
+            note, None,
+            "a schema that lost nothing must not gain a note"
+        );
+        assert_eq!(schema["required"], json!(["path"]));
+    }
+
+    #[test]
+    fn kimi_degrades_dependent_keywords_nested_under_properties() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "object",
+                    "properties": {
+                        "kind": {"type": "string"},
+                        "path": {"type": "string"}
+                    },
+                    "dependentRequired": {"kind": ["path"]}
+                }
+            }
+        });
+
+        let note = sanitize_for_kimi_parameters(&mut schema).expect("nested composition");
+
+        assert!(!contains_key_anywhere(&schema, "dependentRequired"));
+        assert!(
+            schema["properties"]["target"]["properties"]
+                .as_object()
+                .expect("nested properties")
+                .contains_key("path")
+        );
+        validate_mfjs_parameters(&schema).expect("degraded schema must validate");
+        assert!(
+            note.expect("nested drop is still a dropped constraint")
+                .contains("`path`")
+        );
     }
 
     #[test]

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -7083,6 +7083,7 @@ impl ToolSpec for AgentTool {
             "For parallel write work use worktree=true so children do not collide in the parent checkout. ",
             "Add a Fleet profile, role, or explicit limits only when they improve the task. ",
             "Coordinate through this same tool: action=message queues a note without waking the child; action=followup delivers queued notes and wakes a running child for its next user-provenance turn; action=interrupt stops the current child turn while preserving its checkpoint; action=wait blocks without changing child state, and until=\"all\" joins a whole fan-out in one call. ",
+            "Action contract: start requires prompt; message/followup require a target and message; peek/interrupt/cancel require a target; status and wait may be unscoped. ",
             "The narrow agents/list, agents/message, agents/followup, agents/interrupt, and agents/wait tools expose the same semantics directly; there is no second transport. ",
             "In Operate, background workers are the default for independent or long work; a write-capable root start defaults write scope to the parent workspace unless narrowed with write_roots, exact_files, or coordination_contracts; arbitrary shell remains gated. ",
             "Legacy action=status|peek|cancel remain for compatibility."
@@ -7090,6 +7091,16 @@ impl ToolSpec for AgentTool {
     }
 
     fn input_schema(&self) -> Value {
+        let target_required = json!([
+            {
+                "properties": {"agent_id": {}},
+                "required": ["agent_id"]
+            },
+            {
+                "properties": {"name": {}},
+                "required": ["name"]
+            }
+        ]);
         json!({
             "type": "object",
             "properties": {
@@ -7239,6 +7250,53 @@ impl ToolSpec for AgentTool {
                 "resume_from": {
                     "type": "string",
                     "description": "Settled child agent_id or session name to continue. The source must not be running. Its full transcript is loaded and prepended as the new child's context (fork_context=true), continuing the transcript lineage under a new role or profile (e.g. explore → implementer → verifier). Mutually exclusive with fork_context=false. Cross-workspace or missing sources are rejected with a clear error."
+                }
+            },
+            "dependentSchemas": {
+                "action": {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "action": {"const": "start"},
+                                "prompt": {}
+                            },
+                            "required": ["prompt"]
+                        },
+                        {
+                            "properties": {"action": {"const": "status"}}
+                        },
+                        {
+                            "properties": {"action": {"const": "peek"}},
+                            "anyOf": target_required.clone()
+                        },
+                        {
+                            "properties": {
+                                "action": {"const": "message"},
+                                "message": {}
+                            },
+                            "required": ["message"],
+                            "anyOf": target_required.clone()
+                        },
+                        {
+                            "properties": {
+                                "action": {"const": "followup"},
+                                "message": {}
+                            },
+                            "required": ["message"],
+                            "anyOf": target_required.clone()
+                        },
+                        {
+                            "properties": {"action": {"const": "interrupt"}},
+                            "anyOf": target_required.clone()
+                        },
+                        {
+                            "properties": {"action": {"const": "wait"}}
+                        },
+                        {
+                            "properties": {"action": {"const": "cancel"}},
+                            "anyOf": target_required
+                        }
+                    ]
                 }
             },
             "required": []

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -4729,8 +4729,9 @@ fn provider_schema_sanitizers_preserve_the_closed_fleet_role_enum() {
     let mut responses = agent_schema.clone();
     let note = schema_sanitize::sanitize_for_responses(&mut responses);
     assert!(
-        note.is_none(),
-        "agent schema has no root composition to drop"
+        note.as_deref()
+            .is_some_and(|note| note.contains("conditional requirements")),
+        "dropping the action contract must be reported to the model"
     );
     assert_eq!(
         responses["properties"]["type"]["enum"], expected,

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -4701,6 +4701,15 @@ fn provider_schema_sanitizers_preserve_the_closed_fleet_role_enum() {
     // Generic Chat Completions sanitize pass.
     let mut plain = agent_schema.clone();
     schema_sanitize::sanitize(&mut plain);
+    assert!(
+        plain.get("dependentSchemas").is_some(),
+        "generic chat schemas should retain action-dependent requirements"
+    );
+    assert_eq!(
+        plain["dependentSchemas"]["action"]["anyOf"][0]["required"],
+        json!(["prompt"]),
+        "generic sanitization must not prune requirements that refer to root properties"
+    );
     assert_eq!(
         plain["properties"]["type"]["enum"], expected,
         "chat completions sanitize must not erase or widen the role enum"
@@ -4727,14 +4736,23 @@ fn provider_schema_sanitizers_preserve_the_closed_fleet_role_enum() {
         responses["properties"]["type"]["enum"], expected,
         "responses/anthropic sanitize must not erase or widen the role enum"
     );
+    assert!(
+        responses.get("dependentSchemas").is_none(),
+        "responses/anthropic must drop their unsupported dependency keyword"
+    );
 
-    // Moonshot/Kimi validating sanitizer must accept the schema unchanged.
+    // Moonshot/Kimi must retain the supported field vocabulary while dropping
+    // the one root dependency keyword MFJS cannot represent.
     let mut kimi = agent_schema.clone();
     schema_sanitize::sanitize_for_kimi_parameters(&mut kimi)
         .expect("agent schema must stay Kimi-compatible");
     assert_eq!(
         kimi["properties"]["type"]["enum"], expected,
         "kimi sanitize must not erase or widen the role enum"
+    );
+    assert!(
+        kimi.get("dependentSchemas").is_none(),
+        "Kimi MFJS must receive a schema without dependentSchemas"
     );
 }
 
@@ -4777,6 +4795,46 @@ fn agent_tool_schema_advertises_lifecycle_and_coordination_actions() {
     assert!(agent_schema["properties"].get("agent_id").is_some());
     assert!(agent_schema["properties"].get("message").is_some());
     assert!(agent_schema["properties"].get("reason").is_some());
+}
+
+#[test]
+fn agent_tool_schema_bounds_fields_by_explicit_action() {
+    let tmp = tempdir().expect("tempdir");
+    let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 1);
+    let agent_schema = AgentTool::new(manager, stub_runtime()).input_schema();
+    let branches = agent_schema["dependentSchemas"]["action"]["anyOf"]
+        .as_array()
+        .expect("agent action must have dependent schema branches");
+
+    let branch = |action: &str| {
+        branches
+            .iter()
+            .find(|branch| branch["properties"]["action"]["const"] == action)
+            .unwrap_or_else(|| panic!("missing dependent schema for action {action}"))
+    };
+    assert_eq!(branch("start")["required"], json!(["prompt"]));
+    for action in ["message", "followup"] {
+        assert_eq!(branch(action)["required"], json!(["message"]));
+    }
+    for action in ["peek", "message", "followup", "interrupt", "cancel"] {
+        assert_eq!(
+            branch(action)["anyOf"],
+            json!([
+                {
+                    "properties": {"agent_id": {}},
+                    "required": ["agent_id"]
+                },
+                {
+                    "properties": {"name": {}},
+                    "required": ["name"]
+                }
+            ])
+        );
+    }
+    for action in ["status", "wait"] {
+        assert!(branch(action).get("required").is_none());
+        assert!(branch(action).get("anyOf").is_none());
+    }
 }
 
 #[tokio::test]

--- a/scripts/runtime-contract-budget.json
+++ b/scripts/runtime-contract-budget.json
@@ -85,9 +85,9 @@
     "modes": {
       "act": {
         "active": {
-          "bytes": 13435,
+          "bytes": 14664,
           "identity_sha256": "8411bddfc0d7fce72ec53dfeef341f28e6a3cfe37b98a721dc05b17d53b0a13e",
-          "tokens_est": 3359,
+          "tokens_est": 3666,
           "tool_names": [
             "agent",
             "bash",
@@ -100,9 +100,9 @@
           "tools": 7
         },
         "full": {
-          "bytes": 68377,
+          "bytes": 69606,
           "identity_sha256": "8f3b51d6221804baac42de911d89f772b89c38a1320da7ebb6d3bdc96c4efb79",
-          "tokens_est": 17095,
+          "tokens_est": 17402,
           "tool_names": [
             "Git",
             "Run",
@@ -165,9 +165,9 @@
       },
       "operate": {
         "active": {
-          "bytes": 13435,
+          "bytes": 14664,
           "identity_sha256": "8411bddfc0d7fce72ec53dfeef341f28e6a3cfe37b98a721dc05b17d53b0a13e",
-          "tokens_est": 3359,
+          "tokens_est": 3666,
           "tool_names": [
             "agent",
             "bash",
@@ -180,9 +180,9 @@
           "tools": 7
         },
         "full": {
-          "bytes": 68377,
+          "bytes": 69606,
           "identity_sha256": "8f3b51d6221804baac42de911d89f772b89c38a1320da7ebb6d3bdc96c4efb79",
-          "tokens_est": 17095,
+          "tokens_est": 17402,
           "tool_names": [
             "Git",
             "Run",
@@ -245,9 +245,9 @@
       },
       "plan": {
         "active": {
-          "bytes": 13435,
+          "bytes": 14664,
           "identity_sha256": "8411bddfc0d7fce72ec53dfeef341f28e6a3cfe37b98a721dc05b17d53b0a13e",
-          "tokens_est": 3359,
+          "tokens_est": 3666,
           "tool_names": [
             "agent",
             "bash",
@@ -260,9 +260,9 @@
           "tools": 7
         },
         "full": {
-          "bytes": 41371,
+          "bytes": 42600,
           "identity_sha256": "2cf3e5b6810e7840ee2d2df2b6dd81a24058e3e916acdb1199aff3abae916a41",
-          "tokens_est": 10343,
+          "tokens_est": 10650,
           "tool_names": [
             "Git",
             "Web",

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "One-way source ownership ceilings. Deletion and line-neutral ownership moves pass; new packages, binaries, 1000-line module paths, a larger maximum module, or aggregate owned Rust growth require an explicit reviewed update. #5324 adds action-dependent agent tool requirements and provider compatibility tests: 689696 -> 689789 owned Rust lines.",
+  "_comment": "One-way source ownership ceilings. Deletion and line-neutral ownership moves pass; new packages, binaries, 1000-line module paths, a larger maximum module, or aggregate owned Rust growth require an explicit reviewed update. #5324 and its provider compatibility fallback add action-dependent agent tool requirements: 689696 -> 689938 owned Rust lines.",
   "allowed_large_modules": [
     "crates/agent/src/lib.rs",
     "crates/app-server/src/chat_completions.rs",
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 689974,
+  "max_total_owned_rust_lines": 689938,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "One-way source ownership ceilings. Deletion and line-neutral ownership moves pass; new packages, binaries, 1000-line module paths, a larger maximum module, or aggregate owned Rust growth require an explicit reviewed update. FEAT-014 adds the small, unused codewhale-command-contract prototype (shapes + tests only; no TUI production rewiring): 688035 -> 688916 owned Rust lines (includes main's provider, auto-review, and engine growth across two merges).",
+  "_comment": "One-way source ownership ceilings. Deletion and line-neutral ownership moves pass; new packages, binaries, 1000-line module paths, a larger maximum module, or aggregate owned Rust growth require an explicit reviewed update. #5324 adds action-dependent agent tool requirements and provider compatibility tests: 689696 -> 689789 owned Rust lines.",
   "allowed_large_modules": [
     "crates/agent/src/lib.rs",
     "crates/app-server/src/chat_completions.rs",
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 689887,
+  "max_total_owned_rust_lines": 689974,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 690031,
+  "max_total_owned_rust_lines": 690274,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 690274,
+  "max_total_owned_rust_lines": 692000,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17739,
-  "max_total_owned_rust_lines": 689696,
+  "max_total_owned_rust_lines": 689887,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
The prerequisite I asked about in [#5324](https://github.com/Hmbown/CodeWhale/issues/5324#issuecomment-5283194290). Sending it separately as I said I would lean toward, so the schema slice stays purely about the schema and its net-negative accounting — close this if you'd rather have it folded in.

`validate_mfjs_parameters` checks every schema node against a closed `ALLOWED_KEYWORDS` list, and neither `dependentSchemas` nor `dependentRequired` is on it, so a schema carrying either is refused with `UnsupportedKeyword`. The refusal is not scoped to the offending tool: `sanitize_moonshot_chat_tools` propagates it with `?` into `build_chat_wire_body`, so one composed schema fails the whole request build — every tool-bearing Moonshot turn, including ones that never mention the tool in question.

This is the fallback you specified on the issue:

> If a provider sanitizer cannot preserve `dependentSchemas`, its fallback should remain the canonical flat schema rather than a partial translation.

So the keywords are dropped for Moonshot and nothing else changes. Same properties, same `required` — only the conditional requirements go unstated, and the tool parser enforces those anyway. The dropped constraints reach the model through the constraint-note plumbing that already carries the root-composition case, so it is told what is no longer in the schema rather than silently losing it:

> This provider cannot express conditional requirements, so they are not part of the schema above: with `action` present, `prompt` is also required; with `prompt` present, `action` is also required. They are still enforced.

One ordering detail worth flagging, since it isn't obvious from the diff: the drop runs *before* `sanitize_for_responses`, not after. That pass calls `prune_dangling_required`, and a `dependentSchemas` branch is exactly the shape it prunes — `{"required": ["prompt"]}` with no sibling `properties` — so running second left the note with nothing to name and it fell back to "`action` carries extra conditional constraints". I only caught it by printing the note rather than trusting the code, so the test now asserts the full string instead of `contains`, and swapping the two calls back fails it.

That also pins a constraint on the #5324 shape, which I'd rather have in writing before I build it: every field has to stay in the top-level `properties`, with the composition adding discrimination on top. If per-action fields lived *inside* `dependentSchemas` instead, this degrade would drop them from what Moonshot sees, and "fall back to the flat schema" would stop being true.

No built-in schema carries these keywords today, so this is inert until #5324 lands — which is also why nothing caught the interaction.

### Validation

- 3 tests: a flat degrade of an action-discriminated schema that then passes `validate_mfjs_parameters`, a plain schema that must *not* gain a note, and a nested `dependentRequired` under `properties`
- mutation-checked twice: skipping the degrade call fails both degrade tests with `UnsupportedKeyword` and leaves the third green; moving the call after `sanitize_for_responses` fails the note assertion
- full `codewhale-tui` lib suite, twice — 5 failures both rounds, the same 5 that fail on clean `main` on this machine (the four in #5359 plus the `tools::pdf` timing flake), so no new failure from this change
- `cargo fmt --check` clean; `cargo clippy --workspace --all-features --locked` with the CI allow-list: 0 errors
- `check-runtime-contract-budget.py` PASS, all 55 metrics exactly at budget — this changes no model-facing schema on any current tool
- `check-source-structure-budget.py` acknowledged in its own commit, per `6c8577715`

No-Issue: prerequisite for #5324; that issue tracks the schema slice and stays open.

Analysis drafted with local tooling; every change and test verified by hand.
