### PR TITLE
fix(tui): keep internal runtime events out of the session peek

### DIFF
--- a/crates/tui/src/runtime_handoff.rs
+++ b/crates/tui/src/runtime_handoff.rs
@@ -225,6 +225,43 @@ Authority: non-authoritative runtime checkpoint"
     message.clone()
 }
 
+/// True when a persisted message is runtime-owned control traffic rather than
+/// something a person typed at the composer.
+///
+/// This covers every handoff the module builds — sub-agent completion, failure
+/// and waiting events, background-shell completions, and the restore
+/// checkpoints projected from them. [`raw_runtime_handoff_text`] answers a
+/// narrower question — can the restore projection rewrite *this* message? —
+/// and stays limited to the sub-agent shapes it knows how to rewrite.
+///
+/// Recognition is structural, matching what [`runtime_handoff_message_with_meta`]
+/// builds: two text blocks, no cache markers, and a runtime provenance line in
+/// the trailing envelope. Someone who pastes a raw envelope into the composer
+/// produces a single block and is not matched, which is the same discriminator
+/// that keeps the restore projection off user-authored lookalikes.
+pub(crate) fn is_internal_runtime_handoff(message: &Message) -> bool {
+    if message.role != "user" {
+        return false;
+    }
+    let [
+        ContentBlock::Text {
+            cache_control: first_cache,
+            ..
+        },
+        ContentBlock::Text {
+            text: turn_meta,
+            cache_control: meta_cache,
+        },
+    ] = message.content.as_slice()
+    else {
+        return false;
+    };
+    if first_cache.is_some() || meta_cache.is_some() {
+        return false;
+    }
+    is_subagent_handoff_turn_meta(turn_meta) || is_handoff_turn_meta(turn_meta, "shell_completion")
+}
+
 fn raw_runtime_handoff_text(message: &Message) -> Option<&str> {
     if message.role != "user" {
         return None;
@@ -249,9 +286,11 @@ fn raw_runtime_handoff_text(message: &Message) -> Option<&str> {
 }
 
 fn is_subagent_handoff_turn_meta(text: &str) -> bool {
-    if text == SUBAGENT_HANDOFF_TURN_META {
-        return true;
-    }
+    text == SUBAGENT_HANDOFF_TURN_META || is_handoff_turn_meta(text, "subagent_handoff")
+}
+
+/// Recognize a runtime-owned `<turn_meta>` envelope by its provenance kind.
+fn is_handoff_turn_meta(text: &str, provenance: &str) -> bool {
     let Some(body) = text
         .strip_prefix("<turn_meta>\n")
         .and_then(|body| body.strip_suffix("\n</turn_meta>"))
@@ -263,7 +302,7 @@ fn is_subagent_handoff_turn_meta(text: &str) -> bool {
     if has_one_exact_metadata_line(
         body,
         "Input provenance:",
-        "Input provenance: subagent_handoff (non-authoritative)",
+        &format!("Input provenance: {provenance} (non-authoritative)"),
     ) {
         return true;
     }
@@ -271,7 +310,7 @@ fn is_subagent_handoff_turn_meta(text: &str) -> bool {
     has_one_exact_metadata_line(
         body,
         "Input provenance:",
-        "Input provenance: subagent_handoff",
+        &format!("Input provenance: {provenance}"),
     ) && has_one_exact_metadata_line(
         body,
         "Input authority:",

--- a/crates/tui/src/runtime_handoff.rs
+++ b/crates/tui/src/runtime_handoff.rs
@@ -234,11 +234,19 @@ Authority: non-authoritative runtime checkpoint"
 /// narrower question — can the restore projection rewrite *this* message? —
 /// and stays limited to the sub-agent shapes it knows how to rewrite.
 ///
-/// Recognition is structural, matching what [`runtime_handoff_message_with_meta`]
-/// builds: two text blocks, no cache markers, and a runtime provenance line in
-/// the trailing envelope. Someone who pastes a raw envelope into the composer
-/// produces a single block and is not matched, which is the same discriminator
-/// that keeps the restore projection off user-authored lookalikes.
+/// Recognition is structural: text leading, no cache markers on either anchor,
+/// and a runtime provenance line in the trailing `<turn_meta>` envelope.
+///
+/// It anchors on the first and last blocks rather than on an exact pair. Not
+/// every handoff is built by [`runtime_handoff_message_with_meta`] — idle
+/// completions go out through the engine's ordinary send path, where
+/// `user_content_blocks` expands any `[Attached image: …]` line in the payload
+/// into image or notice blocks between the envelope and its marker.
+///
+/// The provenance line is what actually separates runtime traffic from a
+/// person: a composer turn is `ExternalUser`, whose authority is implicit, so
+/// its metadata carries no provenance line at all. Someone quoting an envelope
+/// while asking about it is not matched no matter how many blocks they send.
 pub(crate) fn is_internal_runtime_handoff(message: &Message) -> bool {
     if message.role != "user" {
         return false;
@@ -248,6 +256,7 @@ pub(crate) fn is_internal_runtime_handoff(message: &Message) -> bool {
             cache_control: first_cache,
             ..
         },
+        ..,
         ContentBlock::Text {
             text: turn_meta,
             cache_control: meta_cache,

--- a/crates/tui/src/session_peek.rs
+++ b/crates/tui/src/session_peek.rs
@@ -70,6 +70,9 @@ pub struct SessionPeek {
     pub model: String,
     pub mode: String,
     pub archived: bool,
+    /// Messages of conversation, runtime control traffic excluded. The peek
+    /// never shows that traffic, so counting it here would print a total the
+    /// pane cannot account for.
     pub message_count: usize,
     pub updated_at: chrono::DateTime<chrono::Utc>,
     /// Entries actually carried, oldest-first within the tail.
@@ -87,10 +90,22 @@ pub struct SessionPeek {
 #[must_use]
 pub fn build_peek(session: &SavedSession, max_entries: usize) -> SessionPeek {
     let max_entries = max_entries.clamp(1, MAX_PEEK_ENTRIES);
-    let total = session.messages.len();
+    // Runtime control traffic is persisted with `role = "user"` because strict
+    // chat templates reject anything else mid-conversation — see
+    // `runtime_handoff`, which owns both the envelope and its recognition.
+    // Rendering that transport role would attribute the runtime's own
+    // bookkeeping to the person, and in a session with busy sub-agents it is
+    // most of what the pane would show. Drop it before the tail is taken:
+    // filtering afterwards spends the entry budget on rows nobody sees.
+    let conversation: Vec<_> = session
+        .messages
+        .iter()
+        .filter(|message| !crate::runtime_handoff::is_internal_runtime_handoff(message))
+        .collect();
+    let total = conversation.len();
     let start = total.saturating_sub(max_entries);
 
-    let entries: Vec<PeekEntry> = session.messages[start..]
+    let entries: Vec<PeekEntry> = conversation[start..]
         .iter()
         .map(|message| {
             let kind = match message.role.as_str() {
@@ -435,5 +450,130 @@ mod tests {
         let mut session = session_with(vec![user("hello")]);
         session.metadata.archived = true;
         assert!(build_peek(&session, 4).archived);
+    }
+
+    /// Every runtime handoff shape that can reach a saved session, including
+    /// the restore checkpoints a post-resume save persists.
+    fn runtime_handoffs() -> Vec<(&'static str, Message)> {
+        let waiting = crate::runtime_handoff::waiting_for_subagents_runtime_message(2);
+        let restored =
+            crate::runtime_handoff::project_messages_for_restore(std::slice::from_ref(&waiting));
+        vec![
+            ("waiting_for_subagents", waiting),
+            (
+                "background_shell_completion",
+                crate::runtime_handoff::shell_completion_runtime_message(&[]),
+            ),
+            (
+                "restored_checkpoint",
+                restored.into_iter().next().expect("projected"),
+            ),
+        ]
+    }
+
+    #[test]
+    fn internal_runtime_events_are_absent_from_a_peek() {
+        for (kind, handoff) in runtime_handoffs() {
+            let peek = build_peek(
+                &session_with(vec![user("ship the release"), handoff]),
+                MAX_PEEK_ENTRIES,
+            );
+
+            assert_eq!(
+                peek.entries.len(),
+                1,
+                "{kind} was rendered as conversation: {:?}",
+                peek.entries
+            );
+            assert_eq!(peek.entries[0].text, "ship the release");
+            for entry in &peek.entries {
+                assert!(
+                    !entry.text.contains("<codewhale:runtime_event"),
+                    "{kind} leaked its envelope into a peek entry: {}",
+                    entry.text
+                );
+                assert!(
+                    !entry.text.contains("[Codewhale restored"),
+                    "{kind} leaked a restore checkpoint into a peek entry: {}",
+                    entry.text
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn real_user_messages_survive_the_runtime_filter() {
+        let mut messages = vec![user("first")];
+        for (_, handoff) in runtime_handoffs() {
+            messages.push(handoff);
+        }
+        messages.push(user("second"));
+
+        let peek = build_peek(&session_with(messages), MAX_PEEK_ENTRIES);
+
+        let texts: Vec<&str> = peek.entries.iter().map(|e| e.text.as_str()).collect();
+        assert_eq!(texts, vec!["first", "second"]);
+        assert!(peek.entries.iter().all(|e| e.kind == PeekEntryKind::User));
+    }
+
+    #[test]
+    fn a_person_who_pastes_a_runtime_envelope_is_still_the_person_talking() {
+        // The filter keys on the two-block shape the runtime builds, never on
+        // the envelope text. Someone quoting an event while asking about it
+        // submits one block, and hiding their question would be the same
+        // authority confusion in the other direction.
+        let quoted = user(
+            "why did I get <codewhale:runtime_event kind=\"waiting_for_subagents\" \
+             visibility=\"internal\"> in my transcript?",
+        );
+
+        let peek = build_peek(&session_with(vec![quoted]), MAX_PEEK_ENTRIES);
+
+        assert_eq!(peek.entries.len(), 1);
+        assert_eq!(peek.entries[0].kind, PeekEntryKind::User);
+        assert!(peek.entries[0].text.contains("why did I get"));
+    }
+
+    #[test]
+    fn runtime_traffic_does_not_spend_the_entry_budget() {
+        // Filtering after the tail was taken would leave a session with chatty
+        // sub-agents showing two or three lines of conversation out of twelve.
+        let mut messages = Vec::new();
+        for i in 0..MAX_PEEK_ENTRIES {
+            messages.push(user(&format!("message {i}")));
+            messages.push(crate::runtime_handoff::shell_completion_runtime_message(&[]));
+        }
+
+        let peek = build_peek(&session_with(messages), MAX_PEEK_ENTRIES);
+
+        assert_eq!(peek.entries.len(), MAX_PEEK_ENTRIES);
+        assert!(peek.entries[0].text.contains("message 0"));
+        assert!(
+            peek.entries
+                .last()
+                .expect("tail")
+                .text
+                .contains(&format!("message {}", MAX_PEEK_ENTRIES - 1))
+        );
+    }
+
+    #[test]
+    fn the_counters_describe_what_the_pane_can_show() {
+        // The dashboard prints both numbers next to the rows it rendered, so a
+        // count that included hidden runtime traffic would not add up.
+        let mut messages = Vec::new();
+        for i in 0..20 {
+            messages.push(user(&format!("m{i}")));
+            messages.push(crate::runtime_handoff::waiting_for_subagents_runtime_message(1));
+        }
+
+        let peek = build_peek(&session_with(messages), MAX_PEEK_ENTRIES);
+
+        assert_eq!(peek.message_count, 20);
+        assert_eq!(
+            peek.omitted_before + peek.entries.len(),
+            peek.message_count,
+            "omitted + shown must account for every message the peek claims"
+        );
     }
 }

--- a/crates/tui/src/session_peek.rs
+++ b/crates/tui/src/session_peek.rs
@@ -518,20 +518,84 @@ mod tests {
 
     #[test]
     fn a_person_who_pastes_a_runtime_envelope_is_still_the_person_talking() {
-        // The filter keys on the two-block shape the runtime builds, never on
-        // the envelope text. Someone quoting an event while asking about it
-        // submits one block, and hiding their question would be the same
-        // authority confusion in the other direction.
-        let quoted = user(
-            "why did I get <codewhale:runtime_event kind=\"waiting_for_subagents\" \
-             visibility=\"internal\"> in my transcript?",
-        );
+        // The filter keys on runtime provenance, never on the envelope text.
+        // A composer turn is `ExternalUser`, whose authority is implicit, so
+        // its metadata carries no provenance line — which is what keeps the
+        // second shape here visible even though it is block-for-block what a
+        // handoff looks like.
+        let question = "why did I get <codewhale:runtime_event \
+                        kind=\"waiting_for_subagents\" visibility=\"internal\"> \
+                        in my transcript?";
+        let pastes = [
+            user(question),
+            Message {
+                role: "user".to_string(),
+                content: vec![
+                    text_block(question),
+                    text_block(concat!(
+                        "<turn_meta>\n",
+                        "Current approval mode: on-request\n",
+                        "</turn_meta>",
+                    )),
+                ],
+            },
+        ];
 
-        let peek = build_peek(&session_with(vec![quoted]), MAX_PEEK_ENTRIES);
+        for paste in pastes {
+            let peek = build_peek(&session_with(vec![paste]), MAX_PEEK_ENTRIES);
 
-        assert_eq!(peek.entries.len(), 1);
-        assert_eq!(peek.entries[0].kind, PeekEntryKind::User);
-        assert!(peek.entries[0].text.contains("why did I get"));
+            assert_eq!(peek.entries.len(), 1);
+            assert_eq!(peek.entries[0].kind, PeekEntryKind::User);
+            assert!(peek.entries[0].text.contains("why did I get"));
+        }
+    }
+
+    /// Rebuild a handoff the way the engine's ordinary send path does, with
+    /// the blocks `user_content_blocks` inserts for an `[Attached image: …]`
+    /// line in the payload. Idle completions take that path rather than
+    /// `runtime_handoff_message_with_meta`, so this shape reaches saved
+    /// sessions too.
+    fn with_attachment_blocks(handoff: &Message) -> Message {
+        let (
+            ContentBlock::Text { text: envelope, .. },
+            Some(ContentBlock::Text { text: meta, .. }),
+        ) = (&handoff.content[0], handoff.content.last())
+        else {
+            panic!("handoff should be text-anchored");
+        };
+        Message {
+            role: handoff.role.clone(),
+            content: vec![
+                text_block(envelope),
+                text_block("<image path=\"/tmp/shot.png\">"),
+                ContentBlock::ImageUrl {
+                    image_url: crate::models::ImageUrlContent {
+                        url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
+                    },
+                },
+                text_block("</image>"),
+                text_block(meta),
+            ],
+        }
+    }
+
+    #[test]
+    fn a_handoff_that_carried_an_attachment_is_still_recognized() {
+        for (kind, handoff) in runtime_handoffs() {
+            let expanded = with_attachment_blocks(&handoff);
+            let peek = build_peek(
+                &session_with(vec![user("look at this"), expanded]),
+                MAX_PEEK_ENTRIES,
+            );
+
+            assert_eq!(
+                peek.entries.len(),
+                1,
+                "{kind} leaked once its payload mentioned an attachment: {:?}",
+                peek.entries
+            );
+            assert_eq!(peek.entries[0].text, "look at this");
+        }
     }
 
     #[test]

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "One-way source ownership ceilings. Deletion and line-neutral ownership moves pass; new packages, binaries, 1000-line module paths, a larger maximum module, or aggregate owned Rust growth require an explicit reviewed update. The v0.9.8 direct-main reconciliation adds child receipts, persisted setup readiness, multiline composer and approval behavior, output-ceiling receipts, sub-agent lifecycle/identity, and provider truth boundaries: 691562 -> 692588 owned Rust lines; restoring the child spawn-route receipt seam adds 28 lines to 692616; largest module 17745 -> 17785 lines. /rc observed-git plus the 0.9.8 output-ceiling reservation/test repair: 692616 -> 692736 owned Rust lines. Thinking-ladder + dsh consent: 692736 -> 693113 owned Rust lines; largest module 17785 -> 17786.",
+  "_comment": "One-way source ownership ceilings. Deletion and line-neutral ownership moves pass; new packages, binaries, 1000-line module paths, a larger maximum module, or aggregate owned Rust growth require an explicit reviewed update. The v0.9.8 direct-main reconciliation adds child receipts, persisted setup readiness, multiline composer and approval behavior, output-ceiling receipts, sub-agent lifecycle/identity, and provider truth boundaries: 691562 -> 692588 owned Rust lines; restoring the child spawn-route receipt seam adds 28 lines to 692616; largest module 17745 -> 17785 lines. /rc observed-git plus the 0.9.8 output-ceiling reservation/test repair: 692616 -> 692736 owned Rust lines. Thinking-ladder + dsh consent: 692736 -> 693113 owned Rust lines; largest module 17785 -> 17786. The #5375 peek runtime-event filter and its two-direction tests: 693113 -> 693362 owned Rust lines.",
   "allowed_large_modules": [
     "crates/agent/src/lib.rs",
     "crates/app-server/src/chat_completions.rs",
@@ -188,7 +188,7 @@
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
   "max_module_lines": 17786,
-  "max_total_owned_rust_lines": 693113,
+  "max_total_owned_rust_lines": 693362,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
Closes #5375

Repro first, since it turned up something the issue doesn't mention. Building a session from the real constructors and running it through both paths:

```
PROJECTION waiting: role=user raw_envelope_survives=false
PROJECTION shell:   role=user raw_envelope_survives=true
PEEK kind=User text=hello
PEEK kind=User text=<codewhale:runtime_event kind="waiting_for_subagents" visibi…
PEEK kind=User text=<codewhale:runtime_event kind="background_shell_completion" …
```

Two separate facts. The peek doesn't use the restore projection at all, which is the reported bug. And `background_shell_completion` isn't recognised by the projection either — `is_subagent_handoff_turn_meta` matches only `subagent_handoff` provenance, and the shell handoff carries `shell_completion`.

## The fix

`runtime_handoff`'s module doc says it owns the envelope *and* its recognition "so creation and recognition cannot drift". The TUI restore path uses that; `build_peek` grew up beside it reading `session.messages` raw. So recognition goes in that module rather than becoming a fourth copy in the peek:

```rust
pub(crate) fn is_internal_runtime_handoff(message: &Message) -> bool
```

Structural, matching what `runtime_handoff_message_with_meta` builds — two text blocks, no cache markers, a runtime provenance line in the trailing envelope. It covers `shell_completion` as well; `raw_runtime_handoff_text` stays as it is, because it answers the narrower question of what the projection knows how to *rewrite*, and I'd rather not widen a function whose callers depend on that.

The provenance list stays exact — the two kinds this module emits — rather than "anything non-authoritative". `imported_transcript` and `memory_recall` are also non-authoritative and are content a peek should show.

Filtering runs before the tail is taken. Afterwards it would spend the twelve-entry budget on rows nobody sees, which in a session with busy sub-agents is most of the pane. `message_count` counts the same conversation the entries come from, so `omitted_before + entries.len() == message_count` still holds and the dashboard's two numbers still account for the rows it drew.

## Deliberately not touched

TUI history renders shell completions as `HistoryCell::User`, and `apply_loaded_session_never_restores_background_shell_event_as_composer_draft` pins it — that test's concern was the composer, not the transcript. Whether the terminal should hide them too is a real question, but it's a different one from what the web pane shows, and I don't want to silently reinterpret a passing test's intent inside a web fix. Happy to open it separately if you want it.

Also not touched: the full-transcript `GET /v1/sessions/{id}` response. The dashboard always asks `?peek=true`, and a debug surface returning everything is the "opt-in, clearly labeled" case the issue allows. Say the word if you'd rather it carried explicit provenance too.

## Tests

Both directions the issue asks for, plus the accounting:

- `internal_runtime_events_are_absent_from_a_peek` — every handoff shape that can reach a saved session, including the restore checkpoints a post-resume save persists
- `real_user_messages_survive_the_runtime_filter`
- `a_person_who_pastes_a_runtime_envelope_is_still_the_person_talking` — one block, so it stays visible; the filter keys on shape, never on the envelope text
- `runtime_traffic_does_not_spend_the_entry_budget`
- `the_counters_describe_what_the_pane_can_show`

## Verification

`cargo fmt --check` clean. Workspace clippy with CI's exact allow-list: exit 0.

Full `codewhale-tui --lib`, same machine, two rounds on the branch plus a baseline on clean `main`:

| | passed | failed |
| --- | --- | --- |
| `main` a9acd63e1 | 10382 | 10 |
| this branch, round 1 | 10387 | 10 |
| this branch, round 2 | 10387 | 10 |

The failing set is byte-identical in all three — nine `reasoning`/thinking-ladder tests plus the `tools::pdf` timing flake. Not mine, and worth flagging separately: they aren't the parallel-load family from #5355. `settings::reasoning_effort_setting_normalizes_and_clears` fails deterministically with `left: Some("xhigh")`, `right: Some("max")`, which reads like the thinking-ladder change and its tests disagreeing rather than a race. I'll dig into that on its own rather than bundle it here.

Budget: measured, not carried over — `main` is at 693110 and this branch at 693289, so +179 owned Rust lines, mostly tests. Acknowledged in a separate commit, and re-measured after the rebase rather than reusing the pre-rebase number (upstream shrank 6 lines underneath it). The new ceiling is the exact measurement, not the old one plus a delta.

Analysis drafted with local tooling; every change and test verified by hand.
