### PR TITLE
test(tui): re-pin the thinking-ladder assertions

### DIFF
--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -3058,7 +3058,8 @@ mod tests {
 
         let result = set_config_value(&mut app, "reasoning_effort", "xhigh", false);
 
-        assert_eq!(app.reasoning_effort, ReasoningEffort::Max);
+        // `xhigh` stopped collapsing into `Max` when the ladder gave it a rung.
+        assert_eq!(app.reasoning_effort, ReasoningEffort::XHigh);
         assert_eq!(
             result.message.as_deref(),
             Some("reasoning_effort = xhigh (session only, add --save to persist)")

--- a/crates/tui/src/fleet/profile.rs
+++ b/crates/tui/src/fleet/profile.rs
@@ -969,7 +969,7 @@ mod tests {
             r#"
 id = "scout"
 role_hint = "scout"
-thinking = "xhigh"
+thinking = "ultracode"
 
 [instructions]
 text = "Scout deeply."
@@ -978,7 +978,12 @@ text = "Scout deeply."
 
         let profiles = load_agent_profiles_from_dir(dir.path()).expect("profile TOML loads");
         assert_eq!(profiles.len(), 1);
-        assert_eq!(profiles[0].profile.reasoning_effort.as_deref(), Some("max"));
+        // `xhigh` used to land here too; the thinking ladder made it a rung of
+        // its own, so `ultracode` is the alias left to exercise.
+        assert_eq!(
+            profiles[0].profile.reasoning_effort.as_deref(),
+            Some("ultra")
+        );
     }
 
     #[test]

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -14727,9 +14727,17 @@ mod terminal_mode_tests {
 
     #[test]
     fn cli_reasoning_effort_normalizes_aliases_and_rejects_typos() {
+        // The thinking ladder split these: `xhigh` is a tier the CLI can now
+        // name, `ultracode` is still an alias and resolves to `ultra`.
         assert_eq!(
             normalize_cli_reasoning_effort("xhigh").unwrap().as_deref(),
-            Some("max")
+            Some("xhigh")
+        );
+        assert_eq!(
+            normalize_cli_reasoning_effort("ultracode")
+                .unwrap()
+                .as_deref(),
+            Some("ultra")
         );
         assert_eq!(normalize_cli_reasoning_effort("default").unwrap(), None);
         assert!(normalize_cli_reasoning_effort("expensive").is_err());

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -3431,14 +3431,20 @@ mod tests {
     #[test]
     fn reasoning_effort_setting_normalizes_and_clears() {
         let mut settings = Settings::default();
-        settings
-            .set("reasoning_effort", "xhigh")
-            .expect("normalize xhigh");
-        assert_eq!(settings.reasoning_effort.as_deref(), Some("max"));
-        settings
-            .set("reasoning_effort", "ultracode")
-            .expect("normalize ultracode");
-        assert_eq!(settings.reasoning_effort.as_deref(), Some("max"));
+        // `xhigh` and `ultra` are their own rungs since the thinking ladder,
+        // so normalizing collapses spellings *within* a tier instead of
+        // folding the top three tiers into `max`.
+        for (input, stored) in [
+            ("xhigh", "xhigh"),
+            ("ultracode", "ultra"),
+            ("maximum", "max"),
+            ("minimal", "low"),
+        ] {
+            settings
+                .set("reasoning_effort", input)
+                .unwrap_or_else(|error| panic!("normalize {input}: {error}"));
+            assert_eq!(settings.reasoning_effort.as_deref(), Some(stored));
+        }
         settings
             .set("reasoning_effort", "default")
             .expect("clear effort");

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -6027,13 +6027,14 @@ fn reasoning_cycle_persists_through_the_same_owner_as_the_picker() {
     // `apply_reasoning_effort_cycle`.
     app.apply_reasoning_effort_cycle();
 
-    assert_eq!(app.reasoning_effort, ReasoningEffort::High);
+    // One step up DeepSeek's ladder from Off is Low, not the old shortcut's High.
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
     assert_eq!(
         Settings::load()
             .expect("reload settings")
             .reasoning_effort
             .as_deref(),
-        Some("high"),
+        Some("low"),
         "a restart must restore the last thinking choice"
     );
 }
@@ -6174,15 +6175,20 @@ async fn fixed_route_thinking_cycle_persists_raw_preference() {
     app.apply_reasoning_effort_cycle();
     app.startup_defaults.flush();
 
-    assert_eq!(app.reasoning_effort, ReasoningEffort::Off);
-    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Off));
+    // Cycling off the top of K3's ladder wraps to Auto rather than Off now
+    // that the cycle walks `picker_efforts_for_route`. What this test is
+    // about is unchanged: whatever tier the cycle lands on is the raw
+    // preference that has to survive a restart, not whatever the route
+    // executes.
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Auto);
+    assert_eq!(app.reasoning_effort_preference, Some(ReasoningEffort::Auto));
     assert_eq!(
         Settings::load()
             .expect("reload")
             .reasoning_effort
             .as_deref(),
-        Some("off"),
-        "the always-thinking route may execute Low, but the raw Off preference must survive restart"
+        Some("auto"),
+        "the raw preference the cycle landed on must survive restart"
     );
 }
 

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -5775,8 +5775,12 @@ mod tests {
     }
 
     #[test]
-    fn picker_keeps_default_when_catalog_has_no_reasoning_options() {
-        // grok-4.5 is reasoning-capable but ships no reasoning_options list.
+    fn picker_walks_the_catalogued_ladder_for_grok_4_5() {
+        // grok-4.5 shipped without a `reasoning_options` list until the
+        // thinking-ladder change gave it one, so this stopped being a
+        // DEFAULT_PICKER_EFFORTS fallback case. That fallback still has
+        // coverage in `picker_normalizes_low_medium_to_high`, which reaches it
+        // through a generic Moonshot base URL.
         let labels: Vec<&str> = picker_efforts_for_route(
             crate::config::ApiProvider::Xai,
             crate::config::ApiProvider::Xai.default_base_url(),
@@ -5788,8 +5792,8 @@ mod tests {
         .collect();
         assert_eq!(
             labels,
-            vec!["auto", "off", "high", "max"],
-            "absent reasoning_options must keep DEFAULT_PICKER_EFFORTS, not invent Low/Medium"
+            vec!["auto", "low", "medium", "high"],
+            "grok-4.5's documented ladder, not the generic DEFAULT_PICKER_EFFORTS"
         );
     }
 

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -209,7 +209,9 @@ fn ctrl_t_key_event_reaches_reasoning_effort_cycle() {
         &mut app,
         &KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
     ));
-    assert_eq!(app.reasoning_effort, ReasoningEffort::High);
+    // Ctrl+T walks DeepSeek's real ladder now, not the off/high/max shortcut,
+    // and DeepSeek's first-party route documents a Low tier above Off.
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Low);
     assert!(
         !handle_reasoning_effort_key(
             &mut app,

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -6299,6 +6299,9 @@ context_window = 262144
         assert_eq!(
             visible_row_keys(&view),
             vec![
+                // `reasoning_effort` joined this filter when the thinking
+                // ladder gave it a config row.
+                "reasoning_effort",
                 "show_thinking",
                 "thinking_default_expanded",
                 "thinking_highlight"

--- a/scripts/source-structure-budget.json
+++ b/scripts/source-structure-budget.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "One-way source ownership ceilings. Deletion and line-neutral ownership moves pass; new packages, binaries, 1000-line module paths, a larger maximum module, or aggregate owned Rust growth require an explicit reviewed update. The v0.9.8 direct-main reconciliation adds child receipts, persisted setup readiness, multiline composer and approval behavior, output-ceiling receipts, sub-agent lifecycle/identity, and provider truth boundaries: 691562 -> 692588 owned Rust lines; restoring the child spawn-route receipt seam adds 28 lines to 692616; largest module 17745 -> 17785 lines. /rc observed-git plus the 0.9.8 output-ceiling reservation/test repair: 692616 -> 692736 owned Rust lines. Thinking-ladder + dsh consent: 692736 -> 693113 owned Rust lines; largest module 17785 -> 17786.",
+  "_comment": "One-way source ownership ceilings. Deletion and line-neutral ownership moves pass; new packages, binaries, 1000-line module paths, a larger maximum module, or aggregate owned Rust growth require an explicit reviewed update. The v0.9.8 direct-main reconciliation adds child receipts, persisted setup readiness, multiline composer and approval behavior, output-ceiling receipts, sub-agent lifecycle/identity, and provider truth boundaries: 691562 -> 692588 owned Rust lines; restoring the child spawn-route receipt seam adds 28 lines to 692616; largest module 17745 -> 17785 lines. /rc observed-git plus the 0.9.8 output-ceiling reservation/test repair: 692616 -> 692736 owned Rust lines. Thinking-ladder + dsh consent: 692736 -> 693113 owned Rust lines; largest module 17785 -> 17786. Re-pinning the nine thinking-ladder tests the same change left asserting the old off/high/max shortcut (#5377): 693113 -> 693137 owned Rust lines; largest module 17786 -> 17794.",
   "allowed_large_modules": [
     "crates/agent/src/lib.rs",
     "crates/app-server/src/chat_completions.rs",
@@ -187,8 +187,8 @@
   "document_kind": "codewhale.source_structure_budget",
   "large_module_threshold_lines": 1000,
   "max_large_module_count": 178,
-  "max_module_lines": 17786,
-  "max_total_owned_rust_lines": 693113,
+  "max_module_lines": 17794,
+  "max_total_owned_rust_lines": 693137,
   "schema_version": 1,
   "workspace_packages": [
     "codewhale-agent",


### PR DESCRIPTION
Closes #5377

Nine tests, no production changes. Each one asserted the off/high/max shortcut that `6f6c35183` set out to replace, so `main` has been red on macOS and Windows since it landed — its own run [31778394006](https://github.com/Hmbown/CodeWhale/actions/runs/31778394006) fails exactly these.

Before touching anything I recorded what each one actually reports, and every left column is derivable from the new ladder:

| test | was | now |
| --- | --- | --- |
| `settings::…normalizes_and_clears` | `Some("max")` | `Some("xhigh")` |
| `fleet::profile::…normalizes_reasoning_aliases` | `Some("max")` | `Some("ultra")` |
| `terminal_mode_tests::cli_…rejects_typos` | `Some("max")` | `Some("xhigh")` + `Some("ultra")` |
| `…config_reasoning_effort_uses_codex_provider_labels` | `Max` | `XHigh` |
| `tui::ui::ctrl_t_key_event_reaches_reasoning_effort_cycle` | `High` | `Low` |
| `tui::app::reasoning_cycle_persists_through_the_same_owner_as_the_picker` | `High` | `Low` |
| `tui::app::fixed_route_thinking_cycle_persists_raw_preference` | `Off` | `Auto` |
| `tui::model_picker::picker_…grok_4_5` | `["auto","off","high","max"]` | `["auto","low","medium","high"]` |
| `tui::views::config_view_filter_…` | list without it | `reasoning_effort` joins the `thinking` filter |

Where a test's *name* was the point, I kept the name true rather than just flipping a number. `profile_loader_normalizes_reasoning_aliases` would have been asserting `xhigh → xhigh`, which is not an alias normalizing, so it uses `ultracode` — still an alias. Same for the CLI one, which now pins both halves of the split.

## The one that isn't a value change

`picker_keeps_default_when_catalog_has_no_reasoning_options` used grok-4.5 because it "ships no reasoning_options list". The same commit gave it one:

```json
"reasoning_options": [
  { "type": "effort", "values": ["low", "medium", "high"], "default": "high" }
]
```

So the name described a case that no longer applied to its own fixture. Renamed to `picker_walks_the_catalogued_ladder_for_grok_4_5`.

That leaves the question of whether the `DEFAULT_PICKER_EFFORTS` fallback lost coverage. It didn't — `picker_normalizes_low_medium_to_high` reaches it through a generic Moonshot base URL and asserts `DEFAULT_PICKER_EFFORTS` directly. I checked that before renaming rather than after, because dropping the only test of a fallback while making CI green is exactly the trade this kind of PR makes by accident.

## Two spots where I followed the code

Flagged in #5377 and repeated here so they're easy to reject in review:

- **`ultracode` now lands on `ultra`, not `max`.** `parse_strict` sends `"ultra" | "ultracode"` to `Ultra`, so I followed it. If the alias was meant to keep pointing at the ceiling, that's a one-line change in `types.rs` and I'll redo the assertions instead.
- **`fixed_route_thinking_cycle_persists_raw_preference` moves `Off` to `Auto`.** That changes what a fixed K3 route wraps to, not just what it's called. The test's actual subject — the raw preference surviving a restart — is unchanged, and I rewrote its message to say that rather than the old off-specific wording.

## Verification

`cargo fmt --check` clean. Workspace clippy with CI's exact allow-list: exit 0.

`cargo test -p codewhale-tui --lib`, same machine, two rounds:

| | passed | failed |
| --- | --- | --- |
| `main` c9b9559a7 | 10382 | 10 |
| this branch, round 1 | 10391 | 1 |
| this branch, round 2 | 10391 | 1 |

The remaining one is `tools::pdf::tests::shared_adapter_forwards_page_window_and_returns_stdout`, which fails on clean `main` here too and is not in CI's failure set — a local environment thing, not part of this.

Also ran CI's own command rather than only the crate: `cargo test --workspace --all-features --locked` gives 10406 passed, 1 failed, and the one is that same pdf test.

Budget: +24 owned Rust lines and `lib.rs` 17786 → 17794, both acknowledged in a separate commit. It is all comments and the extra alias assertions; I'd rather leave a line saying why each expectation moved than have someone flip them back next time the ladder shifts.

Analysis drafted with local tooling; every change and test verified by hand.
