### PR TITLE
test(cli): re-pin the provider-count assertions to the v0.9.8 registry

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -7849,8 +7849,8 @@ mod tests {
             .map(|provider| provider.kind())
             .collect();
         // Full registry keeps legacy dialect/plan kinds; ALL is the catalog surface.
-        assert_eq!(registry_kinds.len(), 43);
-        assert_eq!(ProviderKind::ALL.len(), 38);
+        assert_eq!(registry_kinds.len(), 45);
+        assert_eq!(ProviderKind::ALL.len(), 40);
         for kind in ProviderKind::ALL {
             assert!(
                 registry_kinds.contains(&kind),


### PR DESCRIPTION
Closes #5383.

Two integers. `cli_provider_helpers_follow_config_metadata` asserted 43 registry kinds and 38 catalog kinds; v0.9.8 shipped 45 and 40.

| commit | registry | `ProviderKind::ALL` |
| --- | --- | --- |
| `c9b9559a7` (pre-v0.9.8) | 43 | 38 |
| `53af08ce3` Google Gemini as its own backend | 44 | 39 |
| `531b64ed9` Antigravity credential plane | **45** | **40** |

The run panics on the first assertion, so the second only becomes visible once the first is fixed — both had to move.

`crates/config/src/tests.rs:4816` asserts the same catalog count and was already updated to 40. The registry's own crate kept its test in step; this copy in the CLI crate was the one left behind.

## Verification

Full `cargo test --workspace --all-features --locked --no-fail-fast`, twice on this branch and once on the unmodified head in the same session:

| | failures |
| --- | --- |
| unmodified head `3f3cbafe8` | 10 |
| this branch, round 1 | 9 |
| this branch, round 2 | 9 |

Both branch rounds produce the identical failure set, and the set difference against the clean head is exactly `tests::cli_provider_helpers_follow_config_metadata`. Nothing else moves; passed counts go 12646 → 12647.

`cargo fmt --all --check` exits 0.

The nine that remain are pre-existing on the unmodified head and none are touched here — four `agy_credentials`, `plugin_e2e_acceptance`, `prompts::changelog_entry_exists_for_current_package_version`, `qa_pty::legacy_work_ctrl_t_save_export_and_restart_are_consistent`, and the `exec_persistent_service` / `tools::pdf` pair already written up on #5355. I haven't characterized the first four; they arrived with v0.9.8 and are a separate thread.

## One thing to expect on this PR's own checks

`main` currently fails the clippy gate, and it has nothing to do with this change. Running CI's exact command on the unmodified head:

```
cargo clippy --workspace --all-features --locked -- -D warnings -A clippy::uninlined_format_args \
  -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if \
  -A clippy::assertions_on_constants
```

exits 101 with two errors in `codewhale-tui`, both in v0.9.8's marketplace code:

- `crates/tui/src/commands/groups/plugins/marketplace.rs:50` — `result_large_err`
- `crates/tui/src/plugins/marketplace/parsers/codex.rs:241` — `useless_format`

So if Lint is red here, that is inherited. I left it out of #5383 because it's a different defect in different files — say the word and I'll open it separately, or fold it in.
