### PR TITLE
fix(tui): clear two marketplace clippy lints blocking Lint on main

### DIFF
--- a/crates/tui/src/commands/groups/plugins/marketplace.rs
+++ b/crates/tui/src/commands/groups/plugins/marketplace.rs
@@ -47,11 +47,11 @@ pub(super) fn dispatch(app: &mut App, words: &[&str]) -> CommandResult {
     }
 }
 
-fn open_store(app: &App) -> Result<MarketplaceStore, CommandResult> {
+fn open_store(app: &App) -> Result<MarketplaceStore, Box<CommandResult>> {
     MarketplaceStore::open(app.plugin_registry.state_path()).ok_or_else(|| {
-        CommandResult::error(
+        Box::new(CommandResult::error(
             "This plugin registry has no persistence store, so marketplace catalogs cannot be saved.",
-        )
+        ))
     })
 }
 
@@ -73,7 +73,7 @@ fn add(app: &mut App, name: &str, raw_path: &str) -> CommandResult {
     }
     let store = match open_store(app) {
         Ok(store) => store,
-        Err(result) => return result,
+        Err(result) => return *result,
     };
     let path = PathBuf::from(raw_path.trim());
     let path = if path.is_absolute() {
@@ -141,7 +141,7 @@ fn add(app: &mut App, name: &str, raw_path: &str) -> CommandResult {
 fn list(app: &mut App) -> CommandResult {
     let store = match open_store(app) {
         Ok(store) => store,
-        Err(result) => return result,
+        Err(result) => return *result,
     };
     let state = match store.load() {
         Ok(state) => state,
@@ -174,7 +174,7 @@ fn list(app: &mut App) -> CommandResult {
 fn show(app: &mut App, name: &str) -> CommandResult {
     let store = match open_store(app) {
         Ok(store) => store,
-        Err(result) => return result,
+        Err(result) => return *result,
     };
     let state = match store.load() {
         Ok(state) => state,
@@ -204,7 +204,7 @@ fn show(app: &mut App, name: &str) -> CommandResult {
 fn remove(app: &mut App, name: &str) -> CommandResult {
     let store = match open_store(app) {
         Ok(store) => store,
-        Err(result) => return result,
+        Err(result) => return *result,
     };
     match store.remove(name) {
         Ok(true) => CommandResult::message(format!(
@@ -222,7 +222,7 @@ fn remove(app: &mut App, name: &str) -> CommandResult {
 fn install(app: &mut App, catalog_name: &str, candidate_name: &str) -> CommandResult {
     let store = match open_store(app) {
         Ok(store) => store,
-        Err(result) => return result,
+        Err(result) => return *result,
     };
     let state = match store.load() {
         Ok(state) => state,

--- a/crates/tui/src/plugins/marketplace/parsers/codex.rs
+++ b/crates/tui/src/plugins/marketplace/parsers/codex.rs
@@ -238,7 +238,7 @@ fn parse_codex_entry(
         Some("INSTALLED_BY_DEFAULT") => {
             entry_diags.push(MarketplaceDiagnostic::warning(
                 "NO_AUTO_INSTALL",
-                format!("Codex policy `INSTALLED_BY_DEFAULT` is ignored: Codewhale installs only on an explicit operator action"),
+                "Codex policy `INSTALLED_BY_DEFAULT` is ignored: Codewhale installs only on an explicit operator action".to_string(),
                 Some(name.clone()),
                 Some(index),
             ));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unblocks CI Lint on `main` and on PRs that inherit the two v0.9.8 marketplace clippy defects (including #5384). This PR only touches those two defects — no provider-count assertion changes in `crates/cli`.

1. `marketplace.rs` `open_store`: `CommandResult` as `Err` tripped `clippy::result_large_err`. Box the error and dereference at call sites (same pattern as `prefix_cache.rs`).
2. `parsers/codex.rs`: no-arg `format!(...)` for the `INSTALLED_BY_DEFAULT` warning tripped `clippy::useless_format`. Use `.to_string()` instead.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants` (the failing CI Lint command)
- [x] `cargo test -p codewhale-tui --lib --locked marketplace` (21 passed)
- [ ] `cargo test --workspace --all-features --locked` (not required for this lint-only change)

## Checklist

- [x] Updated docs or comments as needed (N/A — lint-only)
- [x] Added or updated tests where relevant (existing marketplace coverage sufficient)
- [x] Verified TUI behavior manually if UI changes (N/A — no UI change)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A — agent-only work; no human co-authors)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-150aebaf-bfdd-4dfb-885e-5f2b0caa8354?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-150aebaf-bfdd-4dfb-885e-5f2b0caa8354&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

