### PR TITLE
fix: unred v0.9.8 provider-count assertions and google ModelRegistry drift

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -7849,8 +7849,8 @@ mod tests {
             .map(|provider| provider.kind())
             .collect();
         // Full registry keeps legacy dialect/plan kinds; ALL is the catalog surface.
-        assert_eq!(registry_kinds.len(), 43);
-        assert_eq!(ProviderKind::ALL.len(), 38);
+        assert_eq!(registry_kinds.len(), 45);
+        assert_eq!(ProviderKind::ALL.len(), 40);
         for kind in ProviderKind::ALL {
             assert!(
                 registry_kinds.contains(&kind),

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -732,6 +732,7 @@ endpoint when the endpoint supports model listing.
 | `opencode-go` | `deepseek-v4-pro`, `grok-4.5`, `glm-5.2`, `glm-5.1`, `kimi-k3`, `kimi-k2.7-code`, `kimi-k2.6`, `deepseek-v4-flash`, `mimo-v2.5`, `mimo-v2.5-pro` | yes | yes |
 | `meta` | `muse-spark-1.2` | yes | yes |
 | `xai` | `grok-4.6`, `grok-4.5`, `grok-4.3`, `grok-build`, `grok-composer-2.5-fast`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning` | yes | yes for `grok-4.6`, `grok-4.5`, `grok-4.3`, `grok-build`, and `grok-4.20-0309-reasoning` |
+| `google` | `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-2.5-pro`, `gemini-2.5-flash` | yes | yes except `gemini-3.5-flash-lite` |
 | `mistral` | `mistral-code-latest`, `mistral-medium-latest`, `mistral-small-latest`, `mistral-large-latest` | yes | yes for Medium and Small (`reasoning_effort` `none` or `high` on exact first-party routes); deprecated native Magistral remains an always-on explicit compatibility ID; no for Code and Large |
 | `modelstudio-token-plan`, `modelstudio-coding-plan` | `qwen3.8-max`, `qwen3.8-max-preview`, `qwen3.7-plus`, `qwen3.7-max`, `qwen3.6-flash`, `deepseek-v4-pro`, `deepseek-v4-flash-0731`, `glm-5.2` | yes | yes |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unreds #5383 and the Lint provider-registry drift check left red after #5393 (marketplace clippy) landed. Two v0.9.8 leftovers on one concern; #5384 can close as superseded once this lands.

1. **CLI provider-count assertions** — `cli_provider_helpers_follow_config_metadata` still pinned pre-v0.9.8 counts (43 / 38). Live `PROVIDER_REGISTRY` is 45 and `ProviderKind::ALL` is 40 after Gemini (`53af08ce3`) and Antigravity (`531b64ed9`). Same two integers as #5384 (credit Lstarsky0); `crates/config/src/tests.rs` already asserted 40/45.

2. **Static ModelRegistry docs drift** — Lint's `scripts/check-provider-registry.py` failed with `static ModelRegistry rows missing: google`. The Rust registry already has seven `ProviderKind::Google` rows; `docs/PROVIDERS.md` "## Static Model Registry" was missing the matching `google` table row.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [x] Targeted: `cargo test -p codewhale-cli --lib cli_provider_helpers_follow_config_metadata`
- [x] Targeted: `cargo test -p codewhale-config provider_metadata_registry_covers_every_provider_kind_once`
- [x] `python3 scripts/check-provider-registry.py` (passes; no longer reports `google` missing)
- [ ] `cargo test --workspace --all-features --locked`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ecf6e53-1f4d-4e3c-bec2-0f81c9073e30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ecf6e53-1f4d-4e3c-bec2-0f81c9073e30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

