### PR TITLE
fix(ci): stop cancel-in-progress from killing concurrent main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ permissions:
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # PRs: cancel superseded head runs. Push/schedule/dispatch on main must not
+  # cancel each other — they share github.ref with no pull_request.number, and
+  # canceling mid-run hid assertion failures that shipped in v0.9.8 (#5383).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -30,7 +30,8 @@ permissions:
 
 concurrency:
   group: ohos-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Same as ci.yml: cancel superseded PR heads only; never cancel main pushes.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Main-branch CI was sharing one concurrency group (`ci-${{ github.ref }}`) whenever `pull_request.number` was absent. With `cancel-in-progress: true`, a later push to `main` canceled the previous run mid-flight — so failing assertions never turned red. That is the failure mode behind the v0.9.8 assertion regressions documented in #5383 (already closed; this PR does not close it).

Change `cancel-in-progress` to `${{ github.event_name == 'pull_request' }}` in:

- `.github/workflows/ci.yml`
- `.github/workflows/ohos.yml` (same `pr.number || github.ref` group pattern)

PR events still cancel superseded heads. Push / schedule / `workflow_dispatch` on `main` no longer cancel each other.

Other workflows checked: `claude-review.yml` is PR-only (unchanged); `nightly.yml` is schedule/dispatch only and not the main-push cancellation bug; remaining workflows already use `cancel-in-progress: false`.

## Testing

- [x] Parsed both workflow YAML files with PyYAML
- [x] Confirmed expression semantics: `pull_request` → cancel true; `push` / `schedule` / `workflow_dispatch` → cancel false
- [x] Audited `.github/workflows/` for the same concurrency pattern
- [ ] `cargo fmt` / clippy / test — N/A (workflow YAML only)

## Checklist

- [x] Updated docs or comments as needed (inline workflow comments)
- [ ] Added or updated tests where relevant (N/A)
- [ ] Verified TUI behavior manually if UI changes (N/A)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A — agent-assisted; no Co-authored-by trailer)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33c873f3-c314-4f22-bc28-9586d01a3446?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33c873f3-c314-4f22-bc28-9586d01a3446&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

