### PR TITLE
fix(tui): canonicalize agy_credentials fixtures for macOS (#5392)

### DIFF
--- a/crates/tui/src/agy_credentials.rs
+++ b/crates/tui/src/agy_credentials.rs
@@ -248,7 +248,13 @@ mod tests {
 
     fn fixture_db(token_value: Option<&str>) -> (tempfile::TempDir, std::path::PathBuf) {
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("state.vscdb");
+        // Canonicalize: production open_secure_regular_file uses O_NOFOLLOW on
+        // every path component, so macOS TempDir paths under `/var` (symlink
+        // to `private/var`) would fail the secure open for an unrelated reason.
+        // Resolving the fixture root keeps the suite focused on credential
+        // parsing while preserving the production no-follow boundary.
+        let root = dir.path().canonicalize().expect("canonical temp root");
+        let path = root.join("state.vscdb");
         let connection = rusqlite::Connection::open(&path).expect("create fixture database");
         connection
             .execute_batch(
@@ -280,22 +286,6 @@ mod tests {
         assert_eq!(
             antigravity_oauth_token_from_grant(&grant).unwrap(),
             Some("ya29.test-token".to_string())
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn symlink_leaf_state_db_is_rejected() {
-        use std::os::unix::fs::symlink;
-
-        let (_dir, real) = fixture_db(Some("ya29.test-token"));
-        let link_dir = tempfile::tempdir().expect("link tempdir");
-        let link = link_dir.path().join("state.vscdb");
-        symlink(&real, &link).expect("leaf symlink");
-        let grant = grant_for(&link);
-        assert!(
-            antigravity_oauth_token_from_grant(&grant).is_err(),
-            "a symlink leaf must fail closed even when the target is a valid store"
         );
     }
 

--- a/crates/tui/src/agy_credentials.rs
+++ b/crates/tui/src/agy_credentials.rs
@@ -283,6 +283,22 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn symlink_leaf_state_db_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let (_dir, real) = fixture_db(Some("ya29.test-token"));
+        let link_dir = tempfile::tempdir().expect("link tempdir");
+        let link = link_dir.path().join("state.vscdb");
+        symlink(&real, &link).expect("leaf symlink");
+        let grant = grant_for(&link);
+        assert!(
+            antigravity_oauth_token_from_grant(&grant).is_err(),
+            "a symlink leaf must fail closed even when the target is a valid store"
+        );
+    }
+
     #[test]
     fn extracts_access_token_member_from_json_value() {
         let (_dir, path) = fixture_db(Some(

--- a/crates/tui/src/external_credentials.rs
+++ b/crates/tui/src/external_credentials.rs
@@ -1,10 +1,12 @@
 //! Capability-gated I/O for credentials owned by another CLI.
 //!
 //! Every external open/read stays behind an opaque grant. Consumption opens
-//! one absolute regular file through a no-follow traversal, validates that
-//! same handle, and reads a bounded payload from it. This prevents a consented
-//! path from being redirected through a leaf or parent symlink/reparse point
-//! and avoids the old exists-then-read race.
+//! one absolute regular file, validates that same handle, and reads a bounded
+//! payload from it. Intermediate path components may be ordinary system
+//! directory symlinks (macOS `/var` → `private/var`, a home on an external
+//! volume); the leaf itself must be a regular file with no symlink/reparse
+//! redirection. That leaf no-follow boundary avoids the old exists-then-read
+//! race without rejecting legitimate relocated ambient paths.
 
 use std::fs::File;
 use std::io::{self, Read};
@@ -208,10 +210,13 @@ fn open_secure_regular_file(path: &Path, require_owner_only: bool) -> io::Result
                 }
             });
         }
+        // Follow ordinary intermediate directory symlinks (for example macOS
+        // `/var` → `private/var`). Refuse only a symlink/reparse leaf so the
+        // granted file cannot be redirected after consent.
         let flags = if leaf {
             libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK
         } else {
-            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_DIRECTORY
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY
         };
         use std::os::fd::AsRawFd;
         // SAFETY: the directory fd and component C string are valid for this
@@ -276,11 +281,10 @@ fn open_secure_regular_file(path: &Path, require_owner_only: bool) -> io::Result
         ));
     }
 
-    // Reject every reparse-point component before the final open. The final
-    // handle is opened as the reparse point itself, checked again, and its
-    // kernel-resolved path is compared below. A second component pass catches
-    // replacement during the open window.
-    reject_windows_reparse_components(path)?;
+    // Intermediate reparse points (volume mounts, redirected homes) are
+    // allowed. Reject only a reparse-point leaf: open it as the reparse point
+    // itself, check attributes, and re-check after open to catch a swap.
+    reject_windows_reparse_leaf(path)?;
     let file = std::fs::OpenOptions::new()
         .read(true)
         .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
@@ -294,15 +298,15 @@ fn open_secure_regular_file(path: &Path, require_owner_only: bool) -> io::Result
             "external credential path must name a non-reparse regular file",
         ));
     }
-    reject_windows_reparse_components(path)?;
+    reject_windows_reparse_leaf(path)?;
 
     let handle = file.as_raw_handle();
     // Compare the spelling Windows actually opened rather than asking it to
     // expand the path into its normalized long form. A valid caller path can
     // contain an 8.3 component such as `RUNNER~1`; normalizing only the handle
     // side would make that exact path look redirected. FILE_NAME_OPENED keeps
-    // the comparison handle-relative while the pre/post component checks above
-    // continue to reject reparse points and swaps.
+    // the comparison handle-relative while the leaf reparse checks above
+    // continue to reject a redirected credential file.
     let flags = FILE_NAME_OPENED | VOLUME_NAME_DOS;
     // SAFETY: the handle remains owned by `file`; null output asks Windows for
     // the required UTF-16 buffer length.
@@ -608,29 +612,19 @@ impl Drop for WindowsLocalAllocation {
 }
 
 #[cfg(windows)]
-fn reject_windows_reparse_components(path: &Path) -> io::Result<()> {
+fn reject_windows_reparse_leaf(path: &Path) -> io::Result<()> {
     use std::os::windows::fs::MetadataExt;
     use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
 
-    let mut current = std::path::PathBuf::new();
-    for component in path.components() {
-        current.push(component.as_os_str());
-        if matches!(
-            component,
-            std::path::Component::Prefix(_) | std::path::Component::RootDir
-        ) {
-            continue;
-        }
-        let metadata = std::fs::symlink_metadata(&current)?;
-        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!(
-                    "external credential path contains reparse point {}",
-                    codewhale_config::quote_os_path(&current)
-                ),
-            ));
-        }
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "external credential path leaf is a reparse point {}",
+                codewhale_config::quote_os_path(path)
+            ),
+        ));
     }
     Ok(())
 }
@@ -704,11 +698,9 @@ mod tests {
     fn secure_read_accepts_one_bounded_regular_file() {
         let _env = crate::test_support::lock_test_env();
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir
-            .path()
-            .canonicalize()
-            .expect("canonical temp root")
-            .join("auth.json");
+        // Use the ambient TempDir spelling (often `/var/folders/...` on macOS).
+        // Intermediate system directory symlinks must not fail the open.
+        let path = dir.path().join("auth.json");
         std::fs::write(&path, "{\"token\":\"ok\"}").expect("fixture");
         assert_eq!(
             read_to_string(&grant(&path))
@@ -720,12 +712,12 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn secure_read_rejects_leaf_and_parent_symlinks_and_non_regular_files() {
+    fn secure_read_rejects_leaf_symlink_and_non_regular_files() {
         let _env = crate::test_support::lock_test_env();
         use std::os::unix::fs::symlink;
 
         let dir = tempfile::tempdir().expect("tempdir");
-        let root = dir.path().canonicalize().expect("canonical temp root");
+        let root = dir.path();
         let real_dir = root.join("real");
         std::fs::create_dir(&real_dir).expect("real dir");
         let real = real_dir.join("auth.json");
@@ -733,13 +725,38 @@ mod tests {
 
         let leaf = root.join("leaf.json");
         symlink(&real, &leaf).expect("leaf symlink");
-        assert!(read_to_string(&grant(&leaf)).is_err());
-
-        let parent = root.join("linked-parent");
-        symlink(&real_dir, &parent).expect("parent symlink");
-        assert!(read_to_string(&grant(&parent.join("auth.json"))).is_err());
+        assert!(
+            read_to_string(&grant(&leaf)).is_err(),
+            "a symlink leaf must fail closed"
+        );
 
         assert!(read_to_string(&grant(&real_dir)).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secure_read_allows_intermediate_directory_symlink() {
+        let _env = crate::test_support::lock_test_env();
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let real_dir = root.join("real");
+        std::fs::create_dir(&real_dir).expect("real dir");
+        let real = real_dir.join("auth.json");
+        std::fs::write(&real, "secret").expect("fixture");
+
+        // Simulate macOS `/var` → `private/var`: an ordinary directory symlink
+        // above the credential leaf must still open the regular file.
+        let parent = root.join("linked-parent");
+        symlink(&real_dir, &parent).expect("parent symlink");
+        let via_parent = parent.join("auth.json");
+        assert_eq!(
+            read_to_string(&grant(&via_parent))
+                .expect("intermediate directory symlink")
+                .as_deref(),
+            Some("secret")
+        );
     }
 
     #[cfg(unix)]
@@ -749,7 +766,7 @@ mod tests {
         use std::os::unix::fs::symlink;
 
         let dir = tempfile::tempdir().expect("tempdir");
-        let root = dir.path().canonicalize().expect("canonical temp root");
+        let root = dir.path();
         let path = root.join("auth.json");
         let moved = root.join("auth-before-swap.json");
         let attacker = root.join("attacker.json");
@@ -773,11 +790,7 @@ mod tests {
     fn secure_read_rejects_oversized_regular_file() {
         let _env = crate::test_support::lock_test_env();
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir
-            .path()
-            .canonicalize()
-            .expect("canonical temp root")
-            .join("oversized.json");
+        let path = dir.path().join("oversized.json");
         let file = File::create(&path).expect("fixture");
         file.set_len(MAX_EXTERNAL_CREDENTIAL_BYTES + 1)
             .expect("oversize fixture");
@@ -792,7 +805,7 @@ mod tests {
 
         let _env = crate::test_support::lock_test_env();
         let dir = tempfile::tempdir().expect("tempdir");
-        let root = dir.path().canonicalize().expect("canonical temp root");
+        let root = dir.path();
         let path = root.join("owned.json");
         std::fs::write(&path, "owned-secret").expect("fixture");
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
@@ -831,11 +844,7 @@ mod tests {
 
         let _env = crate::test_support::lock_test_env();
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir
-            .path()
-            .canonicalize()
-            .unwrap()
-            .join("oversized-owned.json");
+        let path = dir.path().join("oversized-owned.json");
         let file = File::create(&path).expect("fixture");
         file.set_len(MAX_EXTERNAL_CREDENTIAL_BYTES + 1).unwrap();
         file.set_permissions(std::fs::Permissions::from_mode(0o600))

--- a/crates/tui/src/external_credentials.rs
+++ b/crates/tui/src/external_credentials.rs
@@ -1,12 +1,10 @@
 //! Capability-gated I/O for credentials owned by another CLI.
 //!
 //! Every external open/read stays behind an opaque grant. Consumption opens
-//! one absolute regular file, validates that same handle, and reads a bounded
-//! payload from it. Intermediate path components may be ordinary system
-//! directory symlinks (macOS `/var` → `private/var`, a home on an external
-//! volume); the leaf itself must be a regular file with no symlink/reparse
-//! redirection. That leaf no-follow boundary avoids the old exists-then-read
-//! race without rejecting legitimate relocated ambient paths.
+//! one absolute regular file through a no-follow traversal, validates that
+//! same handle, and reads a bounded payload from it. This prevents a consented
+//! path from being redirected through a leaf or parent symlink/reparse point
+//! and avoids the old exists-then-read race.
 
 use std::fs::File;
 use std::io::{self, Read};
@@ -210,13 +208,10 @@ fn open_secure_regular_file(path: &Path, require_owner_only: bool) -> io::Result
                 }
             });
         }
-        // Follow ordinary intermediate directory symlinks (for example macOS
-        // `/var` → `private/var`). Refuse only a symlink/reparse leaf so the
-        // granted file cannot be redirected after consent.
         let flags = if leaf {
             libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK
         } else {
-            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_DIRECTORY
         };
         use std::os::fd::AsRawFd;
         // SAFETY: the directory fd and component C string are valid for this
@@ -281,10 +276,11 @@ fn open_secure_regular_file(path: &Path, require_owner_only: bool) -> io::Result
         ));
     }
 
-    // Intermediate reparse points (volume mounts, redirected homes) are
-    // allowed. Reject only a reparse-point leaf: open it as the reparse point
-    // itself, check attributes, and re-check after open to catch a swap.
-    reject_windows_reparse_leaf(path)?;
+    // Reject every reparse-point component before the final open. The final
+    // handle is opened as the reparse point itself, checked again, and its
+    // kernel-resolved path is compared below. A second component pass catches
+    // replacement during the open window.
+    reject_windows_reparse_components(path)?;
     let file = std::fs::OpenOptions::new()
         .read(true)
         .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
@@ -298,15 +294,15 @@ fn open_secure_regular_file(path: &Path, require_owner_only: bool) -> io::Result
             "external credential path must name a non-reparse regular file",
         ));
     }
-    reject_windows_reparse_leaf(path)?;
+    reject_windows_reparse_components(path)?;
 
     let handle = file.as_raw_handle();
     // Compare the spelling Windows actually opened rather than asking it to
     // expand the path into its normalized long form. A valid caller path can
     // contain an 8.3 component such as `RUNNER~1`; normalizing only the handle
     // side would make that exact path look redirected. FILE_NAME_OPENED keeps
-    // the comparison handle-relative while the leaf reparse checks above
-    // continue to reject a redirected credential file.
+    // the comparison handle-relative while the pre/post component checks above
+    // continue to reject reparse points and swaps.
     let flags = FILE_NAME_OPENED | VOLUME_NAME_DOS;
     // SAFETY: the handle remains owned by `file`; null output asks Windows for
     // the required UTF-16 buffer length.
@@ -612,19 +608,29 @@ impl Drop for WindowsLocalAllocation {
 }
 
 #[cfg(windows)]
-fn reject_windows_reparse_leaf(path: &Path) -> io::Result<()> {
+fn reject_windows_reparse_components(path: &Path) -> io::Result<()> {
     use std::os::windows::fs::MetadataExt;
     use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
 
-    let metadata = std::fs::symlink_metadata(path)?;
-    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!(
-                "external credential path leaf is a reparse point {}",
-                codewhale_config::quote_os_path(path)
-            ),
-        ));
+    let mut current = std::path::PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        if matches!(
+            component,
+            std::path::Component::Prefix(_) | std::path::Component::RootDir
+        ) {
+            continue;
+        }
+        let metadata = std::fs::symlink_metadata(&current)?;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "external credential path contains reparse point {}",
+                    codewhale_config::quote_os_path(&current)
+                ),
+            ));
+        }
     }
     Ok(())
 }
@@ -698,9 +704,11 @@ mod tests {
     fn secure_read_accepts_one_bounded_regular_file() {
         let _env = crate::test_support::lock_test_env();
         let dir = tempfile::tempdir().expect("tempdir");
-        // Use the ambient TempDir spelling (often `/var/folders/...` on macOS).
-        // Intermediate system directory symlinks must not fail the open.
-        let path = dir.path().join("auth.json");
+        let path = dir
+            .path()
+            .canonicalize()
+            .expect("canonical temp root")
+            .join("auth.json");
         std::fs::write(&path, "{\"token\":\"ok\"}").expect("fixture");
         assert_eq!(
             read_to_string(&grant(&path))
@@ -712,12 +720,12 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn secure_read_rejects_leaf_symlink_and_non_regular_files() {
+    fn secure_read_rejects_leaf_and_parent_symlinks_and_non_regular_files() {
         let _env = crate::test_support::lock_test_env();
         use std::os::unix::fs::symlink;
 
         let dir = tempfile::tempdir().expect("tempdir");
-        let root = dir.path();
+        let root = dir.path().canonicalize().expect("canonical temp root");
         let real_dir = root.join("real");
         std::fs::create_dir(&real_dir).expect("real dir");
         let real = real_dir.join("auth.json");
@@ -725,38 +733,13 @@ mod tests {
 
         let leaf = root.join("leaf.json");
         symlink(&real, &leaf).expect("leaf symlink");
-        assert!(
-            read_to_string(&grant(&leaf)).is_err(),
-            "a symlink leaf must fail closed"
-        );
+        assert!(read_to_string(&grant(&leaf)).is_err());
 
-        assert!(read_to_string(&grant(&real_dir)).is_err());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn secure_read_allows_intermediate_directory_symlink() {
-        let _env = crate::test_support::lock_test_env();
-        use std::os::unix::fs::symlink;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let root = dir.path();
-        let real_dir = root.join("real");
-        std::fs::create_dir(&real_dir).expect("real dir");
-        let real = real_dir.join("auth.json");
-        std::fs::write(&real, "secret").expect("fixture");
-
-        // Simulate macOS `/var` → `private/var`: an ordinary directory symlink
-        // above the credential leaf must still open the regular file.
         let parent = root.join("linked-parent");
         symlink(&real_dir, &parent).expect("parent symlink");
-        let via_parent = parent.join("auth.json");
-        assert_eq!(
-            read_to_string(&grant(&via_parent))
-                .expect("intermediate directory symlink")
-                .as_deref(),
-            Some("secret")
-        );
+        assert!(read_to_string(&grant(&parent.join("auth.json"))).is_err());
+
+        assert!(read_to_string(&grant(&real_dir)).is_err());
     }
 
     #[cfg(unix)]
@@ -766,7 +749,7 @@ mod tests {
         use std::os::unix::fs::symlink;
 
         let dir = tempfile::tempdir().expect("tempdir");
-        let root = dir.path();
+        let root = dir.path().canonicalize().expect("canonical temp root");
         let path = root.join("auth.json");
         let moved = root.join("auth-before-swap.json");
         let attacker = root.join("attacker.json");
@@ -790,7 +773,11 @@ mod tests {
     fn secure_read_rejects_oversized_regular_file() {
         let _env = crate::test_support::lock_test_env();
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("oversized.json");
+        let path = dir
+            .path()
+            .canonicalize()
+            .expect("canonical temp root")
+            .join("oversized.json");
         let file = File::create(&path).expect("fixture");
         file.set_len(MAX_EXTERNAL_CREDENTIAL_BYTES + 1)
             .expect("oversize fixture");
@@ -805,7 +792,7 @@ mod tests {
 
         let _env = crate::test_support::lock_test_env();
         let dir = tempfile::tempdir().expect("tempdir");
-        let root = dir.path();
+        let root = dir.path().canonicalize().expect("canonical temp root");
         let path = root.join("owned.json");
         std::fs::write(&path, "owned-secret").expect("fixture");
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
@@ -844,7 +831,11 @@ mod tests {
 
         let _env = crate::test_support::lock_test_env();
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("oversized-owned.json");
+        let path = dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .join("oversized-owned.json");
         let file = File::create(&path).expect("fixture");
         file.set_len(MAX_EXTERNAL_CREDENTIAL_BYTES + 1).unwrap();
         file.set_permissions(std::fs::Permissions::from_mode(0o600))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #5392.

The four `agy_credentials` tests failed on every macOS run because `TempDir` returns `/var/folders/…` and `/var` is a symlink to `private/var`. Production `open_secure_regular_file` correctly applies `O_NOFOLLOW` to every path component (including intermediates); the suite was tripping that boundary for an unrelated path-shape reason.

**Fixture-only fix:** canonicalize the `agy_credentials` TempDir root before building `state.vscdb`. Production no-follow walk is unchanged (an earlier leaf-only production relaxation on this branch was reverted).

Diagnosis credit: @Lstarsky0.

## Testing

<!-- Exact gate commands (including the clippy allow list) are in
     CONTRIBUTING.md → "Pre-push verification". -->

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [ ] `cargo test --workspace --all-features --locked`
- [x] `cargo test -p codewhale-tui --lib --locked agy_credentials`
- [x] `cargo test -p codewhale-tui --lib --locked external_credentials` (parent/leaf symlink rejection still enforced)

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4d2054d-6e86-4f30-b41c-b08ef9231fc8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4d2054d-6e86-4f30-b41c-b08ef9231fc8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

