### PR TITLE
fix(web): call the constitution a charter on the website

### DIFF
--- a/web/app/[locale]/constitution/page.tsx
+++ b/web/app/[locale]/constitution/page.tsx
@@ -11,7 +11,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     locale,
     title: isZh ? "三层法 · Codewhale" : "Three layers of law · Codewhale",
     description: isZh
-      ? "Codewhale 的嵌套宪法：内置基础法、你的常备法（/constitution）、仓库自己的法（.codewhale/constitution.json）。位阶由执行框架强制生效，换掉模型也不失效。"
+      ? "Codewhale 的嵌套宪章：内置基础法、你的常备法（/constitution）、仓库自己的法（.codewhale/constitution.json）。位阶由执行框架强制生效，换掉模型也不失效。"
       : "Codewhale's nested constitution: bundled base law, your standing law (/constitution), and your repo's law (.codewhale/constitution.json). Rank is enforced in the harness and survives a model swap.",
   });
 }
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
 const LAYERS = [
   {
     n: "01",
-    name: { en: "Bundled Constitution", zh: "内置宪法" },
+    name: { en: "Bundled Constitution", zh: "内置宪章" },
     path: "compiled into every binary",
     pathZh: "编译进每一个二进制",
     en: "The base law. Its priority article fixes the authority order for any conflict, so a stale handoff can never outrank a fresh test result by accident.",
@@ -65,7 +65,7 @@ export default async function ConstitutionPage({ params }: { params: Promise<{ l
         </h1>
         <p className={`max-w-2xl text-ink-soft ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
           {isZh
-            ? "项目一变老，指令就开始堆积、彼此冲突：最初的规格、后来推翻它的重构、陈旧的记忆、上一个智能体的交接、你此刻的要求、刚跑出的与交接说法不符的测试结果。扁平的系统提示词让模型靠猜来化解；Codewhale 用一部嵌套的宪法给出明确的位阶。顺序由执行框架强制生效——有测试断言它不会漂移——换掉模型，结构依然完好。"
+            ? "项目一变老，指令就开始堆积、彼此冲突：最初的规格、后来推翻它的重构、陈旧的记忆、上一个智能体的交接、你此刻的要求、刚跑出的与交接说法不符的测试结果。扁平的系统提示词让模型靠猜来化解；Codewhale 用一部嵌套的宪章给出明确的位阶。顺序由执行框架强制生效——有测试断言它不会漂移——换掉模型，结构依然完好。"
             : "As a project ages, instructions pile up and conflict: the original spec, a refactor that contradicts it, stale memory, a previous agent's handoff, your current request, fresh test output that doesn't match what the handoff claimed. A flat system prompt makes the model resolve that by guess. Codewhale uses a nested constitution so there is a defined rank instead of vibes — the order is enforced in the harness, with tests asserting it can't drift, and it stays intact when you swap models."}
         </p>
 
@@ -74,7 +74,7 @@ export default async function ConstitutionPage({ params }: { params: Promise<{ l
           <span className="pill pill-new mr-2">{isZh ? "v0.9.0 新增" : "New in v0.9.0"}</span>
           <span className={`text-sm text-ink-soft ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
             {isZh
-              ? "宪法优先的初始设置——首次启动依次引导语言、模型、安全姿态和你的宪法；之后随时 /setup。模型可以起草，由你批准。"
+              ? "宪章优先的初始设置——首次启动依次引导语言、模型、安全姿态和你的宪章；之后随时 /setup。模型可以起草，由你批准。"
               : "Constitution-first setup — first launch walks language, model, posture, and your constitution; /setup any time. The model can draft it. You ratify it."}
           </span>
         </div>
@@ -113,7 +113,7 @@ export default async function ConstitutionPage({ params }: { params: Promise<{ l
           <div className="eyebrow mb-1.5">{isZh ? "诚实的边界" : "The honest boundary"}</div>
           <p className={`text-ink-soft ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
             {isZh
-              ? "审批、沙箱、网络与信任控制由代码强制执行——宪法文本永远越不过它们。"
+              ? "审批、沙箱、网络与信任控制由代码强制执行——宪章文本永远越不过它们。"
               : "Approval, sandbox, network, and trust controls are enforced in code — constitution text never overrides them."}
           </p>
         </div>

--- a/web/app/[locale]/docs/constitution/page.tsx
+++ b/web/app/[locale]/docs/constitution/page.tsx
@@ -7,9 +7,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return buildPageMetadata({
     path: "/docs/constitution",
     locale,
-    title: isZh ? "宪法与 /constitution · Codewhale 文档" : "Constitution and /constitution · Codewhale Docs",
+    title: isZh ? "宪章与 /constitution · Codewhale 文档" : "Constitution and /constitution · Codewhale Docs",
     description: isZh
-      ? "用户全局宪法、仓库本地法、项目说明和运行时边界。"
+      ? "用户全局宪章、仓库本地法、项目说明和运行时边界。"
       : "User-global constitution, repo-local law, project instructions, and runtime boundaries.",
   });
 }
@@ -22,15 +22,15 @@ export default async function ConstitutionPage({ params }: { params: Promise<{ l
     <section className="space-y-10">
       <section id="overview" className="scroll-mt-32">
         <h2 className="font-display text-3xl mb-1">
-          {isZh ? "宪法与 /constitution" : "Constitution and /constitution"}{" "}
+          {isZh ? "宪章与 /constitution" : "Constitution and /constitution"}{" "}
           <span className="font-cjk text-indigo text-2xl ml-2">
-            {isZh ? "Constitution" : "宪法与 /constitution"}
+            {isZh ? "Constitution" : "宪章与 /constitution"}
           </span>
         </h2>
         {isZh ? (
           <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
             Codewhale 先给 Agent 一个可追责的地址，再给上下文冲突一套法律。
-            <code className="inline">/constitution</code> 是管理个人常驻宪法的主入口：
+            <code className="inline">/constitution</code> 是管理个人常驻宪章的主入口：
             它把结构化的用户全局设置保存在 <code className="inline">$CODEWHALE_HOME/constitution.json</code>，
             再渲染成模型可读的 prose block。仓库仍可通过{" "}
             <code className="inline">.codewhale/constitution.json</code> 增加本地 law；runtime
@@ -65,7 +65,7 @@ export default async function ConstitutionPage({ params }: { params: Promise<{ l
               name: "Runtime",
               cn: "运行时",
               en: "Constitution text may express preferences, but approval, sandbox, shell, network, trust, and MCP permissions remain enforced config.",
-              zh: "宪法文本可以表达偏好；审批、沙箱、Shell、网络、信任和 MCP 权限仍由运行时配置强制执行。",
+              zh: "宪章文本可以表达偏好；审批、沙箱、Shell、网络、信任和 MCP 权限仍由运行时配置强制执行。",
             },
           ].map((row) => (
             <div key={row.name} className="p-5">
@@ -80,7 +80,7 @@ export default async function ConstitutionPage({ params }: { params: Promise<{ l
         </div>
         <p className={`mt-4 text-sm text-ink-soft ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
           {isZh
-            ? "普通项目说明仍放在 AGENTS.md；记忆和交接低于宪法与项目说明；完整 base prompt Markdown 覆盖只是专家逃生口，不是普通设置路径。详见 "
+            ? "普通项目说明仍放在 AGENTS.md；记忆和交接低于宪章与项目说明；完整 base prompt Markdown 覆盖只是专家逃生口，不是普通设置路径。详见 "
             : "Standard project instructions still live in AGENTS.md; memory and handoffs rank below constitutions and project instructions; the full base-prompt Markdown override is an expert escape hatch, not the normal setup path. See "}
           <Link
             href="https://github.com/Hmbown/CodeWhale/blob/main/docs/CONFIGURATION.md#constitution-project-instructions-and-repo-authority"

--- a/web/lib/content/getting-started.ts
+++ b/web/lib/content/getting-started.ts
@@ -48,7 +48,7 @@ export const GETTING_STARTED_STEPS: GuideStep[] = [
     title: { en: "Open a first session — no key needed", zh: "打开第一个会话——无需密钥" },
     body: {
       en: "Launches without any API key: short constitution-first setup, then the full interface. Explore in Plan mode — always read-only. Model replies need a provider; that's the next step.",
-      zh: "无需任何 API 密钥即可启动：简短的宪法优先设置，然后进入完整界面。在 Plan 模式中探索——始终只读。模型回复需要提供商；这正是下一步。",
+      zh: "无需任何 API 密钥即可启动：简短的宪章优先设置，然后进入完整界面。在 Plan 模式中探索——始终只读。模型回复需要提供商；这正是下一步。",
     },
     commands: ["codewhale"],
     link: {

--- a/web/lib/docs-map.ts
+++ b/web/lib/docs-map.ts
@@ -96,7 +96,7 @@ export const DOC_TOPICS: DocTopic[] = [
   {
     id: "constitution",
     slug: "constitution",
-    label: { en: "Constitution", zh: "嵌套宪法" },
+    label: { en: "Constitution", zh: "嵌套宪章" },
     description: {
       en: "Agent identity, authority hierarchy, evidence rules, and the nested law system.",
       zh: "Agent 自我模型、权威层次、证据规则和嵌套法律系统。",


### PR DESCRIPTION
Follows the outcome of #4949, which @SparkofSpike closed today after three weeks of discussion with 宪章 as the settled term.

The TUI settled on 宪章 for Simplified Chinese back in `cf08cb6af`, and `zh_hans_constitution_copy_uses_charter_term` (`crates/tui/src/localization.rs`) keeps it there — 宪法 is a banned literal in the zh-Hans pack. The website never followed, so the same feature reads as 宪章 in the TUI and 宪法 on codewhale.net. The worst spot is `getting-started.ts`, which is the copy that walks a new Chinese user from the site straight into `/setup`, where the term flips.

This replaces all 15 occurrences across the four files that carry them:

| File | occurrences |
| --- | --- |
| `web/app/[locale]/constitution/page.tsx` | 6 |
| `web/app/[locale]/docs/constitution/page.tsx` | 7 |
| `web/lib/content/getting-started.ts` | 1 |
| `web/lib/docs-map.ts` | 1 |

The compound forms match what the pack already ships rather than being invented here — `用户全局宪章` and `内置宪章` line up with `SetupCheckpointLayerOrder` in `zh-Hans.json` ("内置基础宪章 -> 用户全局宪章 -> 仓库宪章 -> ..."). `web/` has no occurrences of 宪法 left after this.

Copy only. No structural changes, no English-side changes, no zh-Hant changes — @SparkofSpike's point in #4949 that the Traditional Chinese pack should be left to its own users applies, and the one remaining 憲法 in `zh-Hant.json` is out of scope here.

### Checks

Rebased onto `dd0fbed81`. Every gate below was also run on an unmodified `dd0fbed81` in the same session, so the reds are attributable rather than guessed at.

| Gate | this branch | unmodified `dd0fbed81` |
| --- | --- | --- |
| `npm run check:locales` | 0 | — |
| `npm run check:docs` | 0 | — |
| `npm run lint` | 0 | — |
| `npm run check:facts` | 1 | **1, same failure** |
| `npx vitest run` | 1 — 10 failed, 250 passed | **1 — same 10, same names** |

The two reds are inherited, and both trace back to v0.9.8:

- **`check:facts`** reports `facts.generated.ts` is stale, missing `google` (Google Gemini) and `antigravity` (Google Antigravity) — the two providers `53af08ce3` and `531b64ed9` registered. Same pair that left the CLI assertion counts behind in #5383. #5394 refreshed `docs/PROVIDERS.md` for that drift; `web/lib/facts.generated.ts` looks like the copy that didn't get regenerated. `cd web && npm run prebuild` is what the checker suggests. I left it out of this PR because it isn't a copy change and would bury a one-line terminology diff — happy to send it separately, or fold it in if you'd rather have one commit.
- **`vitest`** — 7 in `lib/deploy-preflight.test.ts` (Cloudflare credentials, environmental), 1 in `lib/public-copy.test.ts` and 2 in `lib/public-surface-contract.test.ts` (changelog/release-facts parity, same v0.9.8 drift). Byte-identical set on the unmodified head; only the millisecond timings differ.

Analysis drafted with local tooling; every change and test verified by hand.

No-Issue: copy-only follow-up to the #4949 discussion, which is now closed; this PR closes nothing on its own.
