### PR TITLE
fix(web): regenerate facts.generated.ts for the two v0.9.8 providers

### DIFF
--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -27,7 +27,7 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-08-14T15:23:06.794Z",
+  "generatedAt": "2026-08-15T05:57:01.838Z",
   "sourceRevision": null,
   "sourceCommittedAt": null,
   "version": "0.9.8",
@@ -243,6 +243,16 @@ export const FACTS: RepoFacts = {
       "id": "mistral",
       "label": "Mistral AI",
       "env": "MISTRAL_API_KEY"
+    },
+    {
+      "id": "google",
+      "label": "Google Gemini",
+      "env": "GOOGLE_API_KEY / GEMINI_API_KEY"
+    },
+    {
+      "id": "antigravity",
+      "label": "Google Antigravity",
+      "env": "ANTIGRAVITY_API_KEY / AGY_ADC_AUTH"
     },
     {
       "id": "telecomjs",


### PR DESCRIPTION
`check:facts` has been failing on `main` since v0.9.8, and it sits inside **Lint & Type Check** — a required check, so every web pull request inherits the red no matter what it touches. My #5397 is currently red on exactly this and nothing else.

`53af08ce3` registered Google Gemini and `531b64ed9` registered Google Antigravity; `web/lib/facts.generated.ts` was never regenerated. Same pair that left the CLI assertion counts behind in #5383, and the same family as the `docs/PROVIDERS.md` row #5394 refreshed — this looks like the remaining artifact from those two commits.

This is the output of `cd web && npm run prebuild`, which is what the checker prints as the remedy. `derive-facts.mjs` reads the Rust sources directly and needs no build.

```
[derive-facts] version=0.9.8 crates=21 providers=44 sandboxes=2 default-model=deepseek-v4-pro node=>=18 tools=74 license=MIT
```

The diff is the two provider rows plus `generatedAt`. The script deliberately preserves that stamp when no *checked* fact has moved, so it changing here is the signal that one did.

### Checks

Branched from `ad102ec44`. Gates run twice, identical both rounds:

| Gate | exit |
| --- | --- |
| `npm run check:facts` | 0 — was 1 on the unmodified head |
| `npm run check:locales` | 0 |
| `npm run check:docs` | 0 |
| `npm run lint` | 0 |

`npx vitest run` stays at 10 failed / 250 passed, and the failing set is byte-identical to the same suite on an unmodified `ad102ec44` — seven Cloudflare deploy-preflight tests that need credentials, plus one `public-copy` and two `public-surface-contract` parity tests. This regeneration does not address those three; they look like the changelog/release-facts side of the same v0.9.8 drift, and I did not want to bundle a guess with a mechanical regeneration.

Analysis drafted with local tooling; every change and test verified by hand.

No-Issue: unbreaks the `check:facts` gate on main; the drift itself is already covered by the v0.9.8 follow-ups.