### PR TITLE
fix(tui): fill transcript to full terminal width (#5322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- Wide terminals and tmux panes fill the full available width again for the
+  transcript and composer (#5322). The brief v0.9 session-shell side gutter is
+  gone so expanding a pane rematerializes layout the same way shrinking does.
 
 ## [0.9.8] - 2026-08-14
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- Wide terminals and tmux panes fill the full available width again for the
+  transcript and composer (#5322). The brief v0.9 session-shell side gutter is
+  gone so expanding a pane rematerializes layout the same way shrinking does.
 
 ## [0.9.8] - 2026-08-14
 

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -5,24 +5,15 @@
 
 use super::*;
 
-/// Keep compact terminals fully fluid, then introduce only a modest symmetric
-/// gutter as the canvas grows. One cell per twelve columns beyond the compact
-/// breakpoint gives wide sessions breathing room without turning the product
-/// into a narrow centered rail; the cap prevents ultra-wide terminals from
-/// accumulating large dead margins.
-const SESSION_SHELL_FLUID_WIDTH: u16 = 112;
-const SESSION_SHELL_GUTTER_STEP: u16 = 12;
-const SESSION_SHELL_MAX_SIDE_GUTTER: u16 = 16;
-
+/// Map the host terminal rect onto the session shell canvas.
+///
+/// Wide terminals use the full available width (v0.8.65 behavior; #5322). A
+/// brief v0.9 gutter capped usable columns beyond 112 and left dead margins on
+/// large displays / tmux panes; that cap is gone. Keep this helper so layout
+/// and PTY oracles share one geometry entry point if a future setting wants a
+/// configurable measure again.
 pub(crate) fn session_shell_area(area: Rect) -> Rect {
-    let side_gutter = (area.width.saturating_sub(SESSION_SHELL_FLUID_WIDTH)
-        / SESSION_SHELL_GUTTER_STEP)
-        .min(SESSION_SHELL_MAX_SIDE_GUTTER);
-    Rect {
-        x: area.x.saturating_add(side_gutter),
-        width: area.width.saturating_sub(side_gutter.saturating_mul(2)),
-        ..area
-    }
+    area
 }
 
 /// Snapshot the posture a real `Op::SendMessage` would carry, and — when the

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -36,31 +36,28 @@ use crate::tui::selection::{SelectionAutoscroll, TranscriptSelectionPoint};
 use tempfile::TempDir;
 
 #[test]
-fn session_shell_area_keeps_compact_geometry_and_uses_most_of_wide_terminals() {
-    for (width, height) in [(40, 12), (60, 16), (80, 24), (100, 32), (112, 40)] {
-        let fluid = Rect::new(4, 3, width, height);
-        assert_eq!(frame::session_shell_area(fluid), fluid);
-    }
-
-    for (width, height, side_gutter) in [(140, 40, 2), (200, 50, 7), (240, 60, 10)] {
+fn session_shell_area_fills_the_host_terminal_at_every_width() {
+    // #5322: transcript / composer share the full host width — no wide-terminal
+    // side gutters. Shrinking and expanding must both rematerialize at `area`.
+    for (width, height) in [
+        (40, 12),
+        (60, 16),
+        (80, 24),
+        (100, 32),
+        (112, 40),
+        (140, 40),
+        (160, 32),
+        (200, 50),
+        (240, 60),
+        (400, 60),
+    ] {
         let host = Rect::new(4, 3, width, height);
-        let shell = frame::session_shell_area(host);
-        assert_eq!(shell.x, host.x + side_gutter, "{width} columns");
         assert_eq!(
-            shell.right() + side_gutter,
-            host.right(),
-            "{width} columns must retain symmetric gutters"
-        );
-        assert_eq!(shell.height, host.height);
-        assert!(
-            u32::from(shell.width) * 100 >= u32::from(host.width) * 85,
-            "{width} columns left only {}% usable",
-            u32::from(shell.width) * 100 / u32::from(host.width)
+            frame::session_shell_area(host),
+            host,
+            "{width}x{height} must fill the host terminal"
         );
     }
-
-    let ultra_wide = frame::session_shell_area(Rect::new(0, 0, 400, 60));
-    assert_eq!(ultra_wide, Rect::new(16, 0, 368, 60));
 }
 
 #[test]
@@ -3532,8 +3529,9 @@ fn wide_underwater_shell_aligns_transcript_and_composer_on_the_shared_canvas() {
 
     let transcript = app.viewport.last_transcript_area.expect("transcript area");
     let composer = app.viewport.last_composer_area.expect("composer area");
-    assert_eq!((transcript.x, transcript.width), (4, 152));
-    assert_eq!((composer.x, composer.width), (4, 152));
+    // Full host width (#5322) — transcript and composer share one canvas edge.
+    assert_eq!((transcript.x, transcript.width), (0, 160));
+    assert_eq!((composer.x, composer.width), (0, 160));
 }
 
 #[test]
@@ -3549,16 +3547,18 @@ fn wide_underwater_canvas_carries_the_ocean_to_both_terminal_edges() {
         .expect("render wide ocean canvas");
     let buffer = terminal.backend().buffer();
 
-    let mut ocean_tint_seen = false;
+    // Full-width shell (#5322): both terminal edges stay in the water column.
+    // Ombre may tint left and right differently; what must not happen is a flat
+    // surface-bg dead margin on either side.
+    let mut left_ocean = false;
+    let mut right_ocean = false;
     for y in 0..buffer.area.height {
-        let left = buffer[(0, y)].bg;
-        let right = buffer[(buffer.area.width - 1, y)].bg;
-        assert_eq!(left, right, "row {y} split into mismatched outer banks");
-        ocean_tint_seen |= left != surface_bg;
+        left_ocean |= buffer[(0, y)].bg != surface_bg;
+        right_ocean |= buffer[(buffer.area.width - 1, y)].bg != surface_bg;
     }
     assert!(
-        ocean_tint_seen,
-        "wide gutters retained the flat terminal floor instead of the shared ocean"
+        left_ocean && right_ocean,
+        "wide terminal edges retained the flat terminal floor instead of the shared ocean"
     );
 }
 

--- a/crates/tui/tests/pty/qa_pty.rs
+++ b/crates/tui/tests/pty/qa_pty.rs
@@ -28,31 +28,28 @@ const KEY_TIMEOUT: Duration = Duration::from_secs(5);
 const SKILL_SCAN_TIMEOUT: Duration = Duration::from_secs(15);
 const COMPOSER_READY_TEXT: &str = "Write a task";
 // Keep this geometry oracle in step with `tui::ui::frame::session_shell_area`.
-// Integration tests cannot import that private renderer helper, so the PTY
-// contract repeats only its three public-facing constants.
-const SESSION_SHELL_FLUID_WIDTH: u16 = 112;
-const SESSION_SHELL_GUTTER_STEP: u16 = 12;
-const SESSION_SHELL_MAX_SIDE_GUTTER: u16 = 16;
-
-fn expected_session_shell_side_gutter(cols: u16) -> u16 {
-    (cols.saturating_sub(SESSION_SHELL_FLUID_WIDTH) / SESSION_SHELL_GUTTER_STEP)
-        .min(SESSION_SHELL_MAX_SIDE_GUTTER)
+// Integration tests cannot import that private renderer helper. The session
+// shell fills the host terminal (#5322); side gutters are gone.
+fn expected_session_shell_side_gutter(_cols: u16) -> u16 {
+    0
 }
 
 fn expected_session_shell_width(cols: u16) -> u16 {
-    cols.saturating_sub(expected_session_shell_side_gutter(cols).saturating_mul(2))
+    cols
 }
 
 #[test]
-fn pty_geometry_oracle_keeps_wide_canvas_above_the_release_floor() {
-    for (cols, expected_gutter) in [(140, 2), (200, 7), (240, 10)] {
-        let gutter = expected_session_shell_side_gutter(cols);
-        let width = expected_session_shell_width(cols);
-        assert_eq!(gutter, expected_gutter, "{cols} columns");
-        assert!(
-            u32::from(width) * 100 >= u32::from(cols) * 85,
-            "{cols} columns left only {}% usable",
-            u32::from(width) * 100 / u32::from(cols)
+fn pty_geometry_oracle_fills_the_host_terminal_width() {
+    for cols in [80u16, 112, 140, 160, 200, 240, 400] {
+        assert_eq!(
+            expected_session_shell_side_gutter(cols),
+            0,
+            "{cols} columns"
+        );
+        assert_eq!(
+            expected_session_shell_width(cols),
+            cols,
+            "{cols} columns must remain fully usable"
         );
     }
 }
@@ -3950,8 +3947,8 @@ fn horizontal_rule_fills_session_shell(
     let shell_width = expected_session_shell_width(cols);
     let shell_end = shell_start.saturating_add(shell_width);
     let chars = text.chars().collect::<Vec<_>>();
-    // Frame rows omit trailing blank cells. A responsive canvas therefore ends
-    // at `shell_end`, including its modest symmetric wide-terminal gutters.
+    // Frame rows omit trailing blank cells. A full-width session shell (#5322)
+    // therefore ends at `shell_end` with no side gutters.
     UnicodeWidthStr::width(text.as_str()) == usize::from(shell_end)
         && chars
             .iter()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #5322.

Wide terminals / tmux panes no longer lose usable columns to the v0.9 session-shell side gutters. `session_shell_area` is an identity again so the transcript and composer fill the host width (v0.8.65 behavior). Expanding rematerializes the same way shrinking does.

No new settings UI — kept the single geometry entry point so a future `transcript_max_width` could plug in without inventing chrome.

### What changed

- `crates/tui/src/tui/ui/frame.rs`: remove `SESSION_SHELL_*` gutter math; `session_shell_area(area) -> area`
- Unit + PTY oracles updated for full-width geometry
- CHANGELOG notes under `[Unreleased]`

### Exec vs transcript

Both paths go through the same shell canvas from `render()` → `session_shell_area`. The prior asymmetry (shell/exec looking wider while normal transcript stayed bound) was the guttered shell wrapping normal cells while some tool receipts already looked full-bleed relative to that measure. With no gutter, both fill the terminal.

## Testing

- [x] `cargo fmt`
- [x] `cargo test -p codewhale-tui --lib --locked session_shell_area_fills`
- [x] `cargo test -p codewhale-tui --lib --locked wide_underwater`
- [x] `cargo test -p codewhale-tui --test pty --locked pty_geometry_oracle_fills`
- [ ] Full workspace clippy/test gate left to CI (local `-D warnings` still hits pre-existing allow-listed lints unrelated to this change)

Geometry check: host width `W` → shell `(0, W)` (was e.g. 160 → `(4, 152)`, 400 → `(16, 368)`).

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] No bot/tool Co-authored-by trailers

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-816f9e88-d72d-4439-ab5e-90fdd0ee308e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-816f9e88-d72d-4439-ab5e-90fdd0ee308e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

