### PR TITLE
fix(client): map canonical "ultra" reasoning effort, not only legacy "ultracode"

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -3366,7 +3366,7 @@ pub(super) fn apply_reasoning_effort(
             ApiProvider::Google => {}
             ApiProvider::Antigravity => {}
         },
-        "xhigh" | "max" | "highest" | "ultracode" => match provider {
+        "xhigh" | "max" | "highest" | "ultra" | "ultracode" => match provider {
             // Handled by the shared DeepSeek table above, before this match.
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => {}
             ApiProvider::Siliconflow

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -172,7 +172,7 @@ fn apply_inkling_reasoning_effort(
         "low" => "low",
         "medium" | "mid" | "" => "medium",
         "high" => "high",
-        "max" | "xhigh" | "highest" | "ultracode" => "max",
+        "max" | "xhigh" | "highest" | "ultra" | "ultracode" => "max",
         _ => return,
     };
     body["reasoning_effort"] = json!(wire_effort);
@@ -292,7 +292,7 @@ fn apply_zai_route_reasoning_controls(
         .as_deref()
     {
         Some("high") => body["reasoning_effort"] = json!("high"),
-        Some("xhigh") | Some("max") | Some("highest") | Some("ultracode") => {
+        Some("xhigh") | Some("max") | Some("highest") | Some("ultra") | Some("ultracode") => {
             body["reasoning_effort"] = json!("max");
         }
         // Off, lower tiers, omitted effort, and unknown legacy values retain
@@ -331,7 +331,7 @@ fn apply_minimax_route_reasoning_controls(
             body["thinking"] = json!({ "type": "disabled" });
         }
         Some(
-            "low" | "minimal" | "medium" | "mid" | "high" | "xhigh" | "max" | "highest"
+            "low" | "minimal" | "medium" | "mid" | "high" | "xhigh" | "max" | "highest" | "ultra"
             | "ultracode" | "",
         ) => {
             body["thinking"] = json!({ "type": "adaptive" });
@@ -530,7 +530,7 @@ fn modelstudio_reasoning_effort_for_model(effort: &str) -> Option<&'static str> 
     match effort.trim().to_ascii_lowercase().as_str() {
         // Model Studio documents low and medium as aliases for high.
         "minimal" | "low" | "medium" | "mid" | "high" | "" => Some("high"),
-        "xhigh" | "max" | "highest" | "ultracode" => Some("max"),
+        "xhigh" | "max" | "highest" | "ultra" | "ultracode" => Some("max"),
         _ => None,
     }
 }
@@ -713,7 +713,7 @@ fn mistral_model_supports_reasoning(model: &str) -> bool {
 fn mistral_reasoning_effort_wire_value(effort: &str) -> Option<&'static str> {
     match effort.trim().to_ascii_lowercase().as_str() {
         "off" | "disabled" | "none" | "false" => Some("none"),
-        "high" | "xhigh" | "max" | "highest" | "ultracode" => Some("high"),
+        "high" | "xhigh" | "max" | "highest" | "ultra" | "ultracode" => Some("high"),
         _ => None,
     }
 }
@@ -874,8 +874,8 @@ fn openai_compatible_reasoning_effort(
         "medium" | "mid" | "" => Some("medium"),
         "high" => Some("high"),
         "xhigh" => Some("xhigh"),
-        "max" | "highest" | "ultracode" if supports_max => Some("max"),
-        "max" | "highest" | "ultracode" => Some("xhigh"),
+        "max" | "highest" | "ultra" | "ultracode" if supports_max => Some("max"),
+        "max" | "highest" | "ultra" | "ultracode" => Some("xhigh"),
         _ => None,
     }
 }
@@ -6051,6 +6051,7 @@ mod mistral_reasoning_tests {
         assert_eq!(mistral_reasoning_effort_wire_value("high"), Some("high"));
         assert_eq!(mistral_reasoning_effort_wire_value("xhigh"), Some("high"));
         assert_eq!(mistral_reasoning_effort_wire_value("max"), Some("high"));
+        assert_eq!(mistral_reasoning_effort_wire_value("ultra"), Some("high"));
         assert_eq!(
             mistral_reasoning_effort_wire_value("ultracode"),
             Some("high")

--- a/crates/tui/src/client/deepseek_effort.rs
+++ b/crates/tui/src/client/deepseek_effort.rs
@@ -95,6 +95,7 @@ pub(super) const DEEPSEEK_EFFORT_ALIASES: &[(&str, DeepseekEffortTier)] = &[
     ("max", DeepseekEffortTier::Max),
     ("maximum", DeepseekEffortTier::Max),
     ("highest", DeepseekEffortTier::Max),
+    ("ultra", DeepseekEffortTier::Max),
     ("ultracode", DeepseekEffortTier::Max),
 ];
 
@@ -148,6 +149,19 @@ mod tests {
         assert_eq!(
             deepseek_effort_tier_or_default("auto"),
             DeepseekEffortTier::High
+        );
+    }
+
+    #[test]
+    fn ultra_and_legacy_ultracode_alias_resolve_to_max() {
+        assert_eq!(deepseek_effort_tier("ultra"), Some(DeepseekEffortTier::Max));
+        assert_eq!(
+            deepseek_effort_tier("ultracode"),
+            Some(DeepseekEffortTier::Max)
+        );
+        assert_eq!(
+            deepseek_effort_tier_or_default("ultra").responses_effort(),
+            "max"
         );
     }
 

--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -833,7 +833,7 @@ fn codex_responses_reasoning_effort(raw: &str) -> Option<&'static str> {
         "minimal" => Some("low"),
         "low" => Some("low"),
         "high" => Some("high"),
-        "xhigh" | "max" | "maximum" | "ultracode" => Some("xhigh"),
+        "xhigh" | "max" | "maximum" | "ultra" | "ultracode" => Some("xhigh"),
         _ => Some("medium"),
     }
 }

--- a/crates/tui/src/client/responses/tests.rs
+++ b/crates/tui/src/client/responses/tests.rs
@@ -513,6 +513,7 @@ fn codex_reasoning_effort_uses_responses_labels() {
     assert_eq!(codex_responses_reasoning_effort("max"), Some("xhigh"));
     assert_eq!(codex_responses_reasoning_effort("maximum"), Some("xhigh"));
     assert_eq!(codex_responses_reasoning_effort("xhigh"), Some("xhigh"));
+    assert_eq!(codex_responses_reasoning_effort("ultra"), Some("xhigh"));
     assert_eq!(codex_responses_reasoning_effort("ultracode"), Some("xhigh"));
     assert_eq!(codex_responses_reasoning_effort("high"), Some("high"));
     assert_eq!(codex_responses_reasoning_effort("medium"), Some("medium"));


### PR DESCRIPTION
---
## Summary

`ReasoningEffort::Ultra` canonicalizes to `"ultra"`, while `"ultracode"` is a legacy input alias that normalizes to it (see `crates/tui/src/tui/app/types.rs`, the `("ultracode", "ultra")` normalization in `settings.rs`, and the `normalize_cli_reasoning_effort` doc in `lib.rs`). The reasoning-effort mapping tables, however, only recognized `"ultracode"` — so selecting the Ultra tier (or setting `reasoning_effort = "ultra"`) was silently dropped:

- **DeepSeek Chat**: `deepseek_effort_tier("ultra")` returned `None`, writing no reasoning fields and falling back to the server default instead of max reasoning.
- **DeepSeek Responses**: downgraded `Ultra` to the default `High` tier.
- **Codex Responses**: fell through to `"medium"`.
- Several other provider shapers (Inkling, Z.ai, MiniMax, ModelStudio, Mistral, OpenAI-compatible) dropped or mis-mapped `"ultra"` the same way.

This PR adds `"ultra"` alongside `"ultracode"` in every mapping table and extends the unit tests to cover `"ultra"`. `"ultracode"` remains a working legacy alias; no behavior changes for any other tier.

## Testing

Ran (scoped to the touched crate `codewhale-tui`):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-tui --all-features --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants`
- [x] `cargo test -p codewhale-tui --lib --locked` — 10444 passed, 0 failed

I did not run the full `--workspace --all-targets` gate locally; CI will run it.

## Checklist

- [x] Updated docs or comments as needed (no doc changes required — the mapping tables are self-documenting)
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes (N/A — no UI changes)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A — single-author commit)

Refs: #5303
