### PR TITLE
fix: rebuild the model settings feature surface

### DIFF
--- a/web/app/[locale]/models/page.tsx
+++ b/web/app/[locale]/models/page.tsx
@@ -106,6 +106,93 @@ export default async function ModelsPage({ params }: { params: Promise<{ locale:
         </div>
       </section>
 
+      <section className="portal-section settings-preview" aria-labelledby="settings-preview-title">
+        <div className="portal-container">
+          <div className="settings-preview-heading">
+            <div>
+              <span>{isZh ? "设置界面" : "Settings surface"}</span>
+              <h2 id="settings-preview-title">
+                {isZh ? "只读设置预览" : "Read-only settings preview"}
+              </h2>
+            </div>
+            <p>
+              {isZh
+                ? "这是 Codewhale 本地配置界面的只读说明，不会更改你的本地配置。"
+                : "This is a read-only guide to Codewhale's local configuration and does not change your local configuration."}
+            </p>
+          </div>
+
+          <div className="settings-shell">
+            <aside className="settings-rail" aria-label={isZh ? "设置区域" : "Settings areas"}>
+              <div className="settings-rail-title">{isZh ? "设置" : "Settings"}</div>
+              <ul>
+                <li className="settings-rail-item settings-rail-item-active">
+                  <span>{isZh ? "模型与提供商" : "Models & providers"}</span>
+                  <span>{isZh ? "当前" : "Current"}</span>
+                </li>
+                <li className="settings-rail-item">{isZh ? "运行时" : "Runtime"}</li>
+                <li className="settings-rail-item">{isZh ? "模式" : "Modes"}</li>
+                <li className="settings-rail-item">{isZh ? "权限" : "Permissions"}</li>
+                <li className="settings-rail-item">{isZh ? "工具与 MCP" : "Tools & MCP"}</li>
+              </ul>
+            </aside>
+
+            <div className="settings-pane">
+              <div className="settings-pane-heading">
+                <div>
+                  <span>{isZh ? "本地工具链" : "Local harness"}</span>
+                  <h3>{isZh ? "模型与提供商" : "Models & providers"}</h3>
+                </div>
+                <span className="settings-readonly-badge">{isZh ? "只读" : "Read only"}</span>
+              </div>
+
+              <dl className="settings-default-model">
+                <div>
+                  <dt>{isZh ? "默认模型" : "Default model"}</dt>
+                  <dd>
+                    <code className="settings-provider-code">{facts.defaultModel ?? "—"}</code>
+                  </dd>
+                </div>
+                <div>
+                  <dt>{isZh ? "提供商路由" : "Provider routes"}</dt>
+                  <dd>{facts.providers.length}</dd>
+                </div>
+              </dl>
+
+              <div className="settings-provider-heading">
+                <span>{isZh ? "仓库注册表" : "Repository registry"}</span>
+                <span>{isZh ? "认证环境变量" : "Authentication environment"}</span>
+              </div>
+              <ul className="settings-provider-list">
+                {facts.providers.map((provider) => (
+                  <li key={provider.id}>
+                    <div>
+                      <strong>{provider.label}</strong>
+                      <code className="settings-provider-code">{provider.id}</code>
+                    </div>
+                    <div className="settings-provider-auth">
+                      <span className="settings-registry-marker" aria-hidden="true" />
+                      <code className="settings-provider-code">{provider.env}</code>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="settings-docs-action">
+                <p>
+                  {isZh
+                    ? "要在你的机器上选择路由、模型、端点或凭据，请按照配置文档操作。"
+                    : "To choose a route, model, endpoint, or credentials on your machine, follow the configuration documentation."}
+                </p>
+                <Link href={p("/docs/configuration")}>
+                  {isZh ? "打开配置文档 ↗" : "Open configuration docs ↗"}
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section className="portal-section portal-section-muted">
         <div className="portal-container">
           <div className="portal-docs-heading">

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -39,6 +39,9 @@
   --jade: #08766d;
   --seafoam: #4fd1c5;
   --cobalt: #315fd8;
+  --settings-state-active: var(--indigo-deep);
+  --settings-state-ready: var(--jade);
+  --settings-state-muted: var(--ink-mute);
   --ocean-deep: #03070d;
   --ocean-mid: #0e1729;
   --ocean-current: #d1ebf4;
@@ -1173,6 +1176,314 @@ a.body-link:hover { background-size: 100% 6px; color: var(--ink); }
 
 .portal-section-muted {
   background: var(--paper-deep);
+}
+
+/* ---------- read-only settings reference ---------- */
+.settings-preview {
+  background: color-mix(in srgb, var(--paper-deep) 52%, var(--paper));
+}
+
+.settings-preview-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+  gap: 32px;
+  align-items: end;
+  width: min(100%, 800px);
+  margin: 0 auto 24px;
+}
+
+.settings-preview-heading span,
+.settings-pane-heading > div > span,
+.settings-provider-heading {
+  color: var(--settings-state-muted);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-preview-heading h2 {
+  margin-top: 8px;
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.settings-preview-heading p {
+  color: var(--ink-soft);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+}
+
+.settings-shell {
+  display: grid;
+  grid-template-columns: 188px minmax(0, 1fr);
+  width: min(100%, 800px);
+  margin-inline: auto;
+  overflow: hidden;
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  background: var(--paper-card);
+  box-shadow: 0 16px 40px rgba(5, 12, 24, 0.08);
+}
+
+.settings-rail {
+  min-width: 0;
+  padding: 20px 12px;
+  border-right: 1px solid var(--hairline);
+  background: var(--paper-deep);
+}
+
+.settings-rail-title {
+  padding: 0 8px 16px;
+  color: var(--ink);
+  font-family: var(--font-display), "Fraunces", "Noto Serif SC", Georgia, serif;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.settings-rail ul {
+  display: grid;
+  gap: 4px;
+}
+
+.settings-rail-item {
+  min-width: 0;
+  padding: 12px 8px;
+  border-radius: 4px;
+  color: var(--settings-state-muted);
+  font-size: 0.75rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.settings-rail-item-active {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--indigo-pale);
+  color: var(--settings-state-active);
+  font-weight: 600;
+}
+
+.settings-rail-item-active > span:last-child {
+  color: var(--settings-state-muted);
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: 0.5625rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.settings-pane {
+  min-width: 0;
+  padding: 24px;
+}
+
+.settings-pane-heading {
+  display: flex;
+  gap: 16px;
+  align-items: start;
+  justify-content: space-between;
+}
+
+.settings-pane-heading h3 {
+  margin-top: 4px;
+  font-size: 1.125rem;
+  letter-spacing: -0.02em;
+}
+
+.settings-readonly-badge {
+  flex: none;
+  padding: 4px 8px;
+  border: 1px solid var(--paper-line-soft);
+  border-radius: 4px;
+  color: var(--settings-state-muted);
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: 0.625rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.settings-default-model {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(120px, 0.4fr);
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.settings-default-model > div {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--hairline);
+  border-radius: 4px;
+  background: var(--paper);
+}
+
+.settings-default-model dt {
+  color: var(--settings-state-muted);
+  font-size: 0.6875rem;
+  font-weight: 600;
+}
+
+.settings-default-model dd {
+  margin-top: 8px;
+  color: var(--ink);
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.settings-provider-heading {
+  display: grid;
+  grid-template-columns: minmax(144px, 0.8fr) minmax(0, 1fr);
+  gap: 16px;
+  margin-top: 24px;
+  padding: 0 12px 8px;
+}
+
+.settings-provider-list {
+  border-top: 1px solid var(--hairline);
+}
+
+.settings-provider-list li {
+  display: grid;
+  grid-template-columns: minmax(144px, 0.8fr) minmax(0, 1fr);
+  gap: 16px;
+  min-width: 0;
+  padding: 12px;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.settings-provider-list li > div {
+  min-width: 0;
+}
+
+.settings-provider-list strong {
+  display: block;
+  color: var(--ink);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.settings-provider-code {
+  display: block;
+  min-width: 0;
+  margin-top: 4px;
+  color: var(--ink-mute);
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: 0.625rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.settings-provider-auth {
+  display: flex;
+  min-width: 0;
+  gap: 8px;
+  align-items: start;
+}
+
+.settings-registry-marker {
+  flex: 0 0 8px;
+  width: 8px;
+  height: 8px;
+  margin-top: 8px;
+  border-radius: 50%;
+  background: var(--settings-state-muted);
+}
+
+.settings-docs-action {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 24px;
+  padding-top: 16px;
+}
+
+.settings-docs-action p {
+  max-width: 360px;
+  color: var(--ink-soft);
+  font-size: 0.75rem;
+  line-height: 1.6;
+}
+
+.settings-preview a {
+  display: inline-flex;
+  min-height: 44px;
+  flex: none;
+  align-items: center;
+  padding: 8px 12px;
+  border: 1px solid var(--settings-state-active);
+  border-radius: 4px;
+  color: var(--settings-state-active);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.settings-preview a:hover {
+  background: var(--indigo-pale);
+}
+
+.settings-preview a:focus-visible {
+  outline: 2px solid var(--settings-state-active);
+  outline-offset: 2px;
+}
+
+@media (max-width: 720px) {
+  .settings-preview-heading {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .settings-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-rail {
+    padding: 16px 12px;
+    border-right: 0;
+    border-bottom: 1px solid var(--hairline);
+  }
+
+  .settings-rail-title {
+    padding-bottom: 12px;
+  }
+
+  .settings-rail ul {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .settings-pane {
+    padding: 20px 16px;
+  }
+
+  .settings-provider-heading,
+  .settings-provider-list li {
+    grid-template-columns: minmax(128px, 0.8fr) minmax(0, 1fr);
+    gap: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .settings-default-model,
+  .settings-provider-list li {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-provider-heading {
+    display: none;
+  }
+
+  .settings-docs-action {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .settings-preview a {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 .portal-section-grid {

--- a/web/lib/public-copy.test.ts
+++ b/web/lib/public-copy.test.ts
@@ -142,6 +142,33 @@ describe("public website copy contracts", () => {
     expect(community).not.toContain("Today's dispatch");
   });
 
+  it("keeps the models settings preview read-only, repository-driven, and responsive", () => {
+    const models = pageSource("models/page.tsx");
+    const styles = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+    expect(models).toContain('className="portal-section settings-preview"');
+    expect(models).toContain('isZh ? "只读设置预览" : "Read-only settings preview"');
+    expect(models).toContain("facts.defaultModel");
+    expect(models).toContain("facts.providers.map((provider)");
+    expect(models).toContain('href={p("/docs/configuration")}');
+    expect(models).toContain("does not change your local configuration");
+    expect(models).toContain("不会更改你的本地配置");
+    expect(models).toContain('className="settings-registry-marker"');
+    expect(models).not.toContain('className="settings-status-dot"');
+    expect(models).not.toMatch(/Save settings|Save changes|Apply changes|Create account|Sign up/);
+
+    expect(styles).toContain("--settings-state-active: var(--indigo-deep);");
+    expect(styles).toContain("--settings-state-ready: var(--jade);");
+    expect(styles).toContain("--settings-state-muted: var(--ink-mute);");
+    expect(styles).toMatch(/\.settings-shell\s*\{[^}]*width: min\(100%, 800px\);/s);
+    expect(styles).toMatch(/\.settings-shell\s*\{[^}]*grid-template-columns: 188px minmax\(0, 1fr\);/s);
+    expect(styles).toMatch(/\.settings-preview a:focus-visible\s*\{[^}]*outline:/s);
+    expect(styles).toMatch(/\.settings-preview a\s*\{[^}]*min-height: 44px;/s);
+    expect(styles).toMatch(/\.settings-provider-code\s*\{[^}]*overflow-wrap: anywhere;/s);
+    expect(styles).toMatch(/\.settings-registry-marker\s*\{[^}]*background: var\(--settings-state-muted\);/s);
+    expect(styles).toMatch(/@media \(max-width: 720px\)[\s\S]*?\.settings-shell\s*\{[^}]*grid-template-columns: 1fr;/);
+  });
+
   it("keeps current-release website credits in exact changelog parity", () => {
     expect(FACTS.version).toBeTruthy();
     const changelog = readFileSync(new URL("../../CHANGELOG.md", import.meta.url), "utf8");


### PR DESCRIPTION
## Summary

Extend `web/app/[locale]/models/page.tsx` with a read-only settings preview that uses the existing `facts.defaultModel` and `facts.providers` data for the model/provider pane, adds clearly labeled rail sections for the real settings areas, and links configuration actions to the existing documentation instead of rendering inert or deceptive controls. Add scoped styles in `web/app/globals.css` for the 800px shell, 188px desktop rail, 4px-multiple spacing, existing palette-backed state aliases, visible focus treatment, and a narrow-screen stacked layout with no horizontal overflow or zero-size interactive targets. Update `web/lib/public-copy.test.ts` to pin the data wiring, read-only framing, documentation target, reference dimensions, responsive behavior, and absence of unsupported hosted-account or live-edit claims.

The public site now shares one layout and already exposes repository-derived model and runtime facts, but it still lacks the settings/harness presentation explicitly left outstanding by the maintainer. The remaining visual reference is concrete: an 800px settings shell, a 188px navigation rail, a 4px-based spacing rhythm, and semantic state-color aliases modeled after the pinned DeepSeek Harness reference. This slice belongs on the existing models page, where provider routes and the default model already come from `getFacts()`, rather than in a separate managed-product dashboard. It must present real Codewhale capabilities without implying that website controls edit a visitor's local configuration.

Fixes #5370

## Testing

- [ ] `cargo fmt --all -- --check`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `cargo test --workspace --all-features --locked`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- The English and Chinese models route renders the settings preview with localized read-only framing, the repository-derived default model, and provider rows sourced from `facts.providers` rather than a duplicated provider list. - The model/provider view exposes a real link to the existing configuration documentation and does not render fake save/apply controls, account requirements, or claims that the public site changes local settings. - The desktop stylesheet preserves the 800px panel and 188px rail reference dimensions while all spacing values use the intended 4px rhythm and state colors alias existing Codewhale palette tokens.

## Checklist

- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
  Not verified: this needs a person on the named hardware or environment.
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
