### PR TITLE
fix(tui): truncate session titles by char count, not byte offset

### DIFF
--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Session titles truncate by character count, not byte offset, so
+  multi-byte titles (CJK, emoji) cut at the intended width and word
+  boundary instead of past the limit (#5415).
 - Wide terminals and tmux panes fill the full available width again for the
   transcript and composer (#5322). The brief v0.9 session-shell side gutter is
   gone so expanding a pane rematerializes layout the same way shrinking does.

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -1203,11 +1203,14 @@ pub(crate) fn short_title_truncate(text: &str, max_chars: usize) -> String {
     if text.chars().count() <= max_chars {
         return text.to_string();
     }
-    // Look for a natural boundary within the allowed range.
-    let candidate: String = text.chars().take(max_chars).collect();
+    // Find the boundary as a character index. `str::rfind` returns a byte
+    // offset, which mis-counts multi-byte UTF-8 text when fed back into
+    // `chars().take()`, so operate on `Vec<char>` instead.
+    let candidate: Vec<char> = text.chars().take(max_chars).collect();
     let boundary = candidate
-        .rfind(['.', ',', ':', ';', '—', '-'])
-        .or_else(|| candidate.rfind(' '))
+        .iter()
+        .rposition(|&c| matches!(c, '.' | ',' | ':' | ';' | '—' | '-'))
+        .or_else(|| candidate.iter().rposition(|&c| c == ' '))
         .unwrap_or(max_chars.min(candidate.len()).saturating_sub(1));
     let cut: String = text.chars().take(boundary.max(1)).collect();
     format!("{cut}…")
@@ -1329,4 +1332,39 @@ pub(crate) fn workflow_tool_is_running(app: &App) -> bool {
             .active_cell
             .as_ref()
             .is_some_and(|active| active.entries().iter().any(is_running_workflow))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::short_title_truncate;
+
+    #[test]
+    fn truncates_at_ascii_word_boundary() {
+        assert_eq!(short_title_truncate("hello world foo", 10), "hello…");
+    }
+
+    #[test]
+    fn truncates_non_ascii_titles_by_char_count_not_bytes() {
+        // `str::rfind` returns a byte offset; using it as a char count used to
+        // cut past the limit and mid-word on multi-byte input.
+        assert_eq!(
+            short_title_truncate("你好 world and more", 10),
+            "你好 world…"
+        );
+    }
+
+    #[test]
+    fn truncates_at_punctuation_boundary() {
+        assert_eq!(short_title_truncate("hello, world", 8), "hello…");
+    }
+
+    #[test]
+    fn truncates_mid_word_when_no_boundary_exists() {
+        assert_eq!(short_title_truncate("abcdefghij", 5), "abcd…");
+    }
+
+    #[test]
+    fn leaves_short_titles_untouched() {
+        assert_eq!(short_title_truncate("short", 10), "short");
+    }
 }


### PR DESCRIPTION
---
## Summary

`short_title_truncate` (used by `derive_session_title` to name sessions) located its natural phrase boundary with `str::rfind`, which returns a **byte** offset, then fed that offset to `chars().take()` as a **character** count. That is harmless for ASCII, but for non-ASCII first prompts the byte offset exceeds the character count, so the cut landed past the requested limit and mid-word.

This computes the boundary as a character index by scanning a `Vec<char>` instead, and adds unit tests for ASCII, non-ASCII (CJK), punctuation, and no-boundary cases.

## Testing

Ran (scoped to the touched crate `codewhale-tui`):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-tui --all-features --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants`
- [x] `cargo test -p codewhale-tui --lib --locked frame::tests::` — 5 passed, 0 failed

I did not run the full `--workspace --all-targets` gate locally; CI will run it.

## Checklist

- [x] Updated docs or comments as needed (comment explains the byte/char distinction)
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes (N/A — no UI changes)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A — single-author commit)
