### PR TITLE
feat: register Eden AI as a named provider

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -110,6 +110,8 @@ enum ProviderArg {
     Mistral,
     /// Google Gemini (official OpenAI-compatible endpoint).
     Google,
+    #[value(alias = "eden-ai", alias = "eden_ai")]
+    Edenai,
 }
 
 impl From<ProviderArg> for ProviderKind {
@@ -151,6 +153,7 @@ impl From<ProviderArg> for ProviderKind {
             ProviderArg::Xai => ProviderKind::Xai,
             ProviderArg::Mistral => ProviderKind::Mistral,
             ProviderArg::Google => ProviderKind::Google,
+            ProviderArg::Edenai => ProviderKind::Edenai,
         }
     }
 }
@@ -7849,8 +7852,8 @@ mod tests {
             .map(|provider| provider.kind())
             .collect();
         // Full registry keeps legacy dialect/plan kinds; ALL is the catalog surface.
-        assert_eq!(registry_kinds.len(), 45);
-        assert_eq!(ProviderKind::ALL.len(), 40);
+        assert_eq!(registry_kinds.len(), 46);
+        assert_eq!(ProviderKind::ALL.len(), 41);
         for kind in ProviderKind::ALL {
             assert!(
                 registry_kinds.contains(&kind),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -441,6 +441,14 @@ pub struct ProvidersToml {
         alias = "tokenhub"
     )]
     pub telecomjs: ProviderConfigToml,
+    /// Eden AI — OpenAI-compatible AI gateway (aggregator).
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "eden-ai",
+        alias = "eden_ai"
+    )]
+    pub edenai: ProviderConfigToml,
     /// Alibaba Cloud Model Studio — Token Plan (OpenAI-compatible endpoint).
     #[serde(
         default,
@@ -663,6 +671,7 @@ impl ProvidersToml {
             ProviderKind::Google => &self.google,
             ProviderKind::Antigravity => &self.antigravity,
             ProviderKind::Telecomjs => &self.telecomjs,
+            ProviderKind::Edenai => &self.edenai,
             ProviderKind::ModelstudioTokenPlan => &self.modelstudio_token_plan,
             ProviderKind::ModelstudioTokenPlanAnthropic => &self.modelstudio_token_plan_anthropic,
             ProviderKind::ModelstudioCodingPlan => &self.modelstudio_coding_plan,
@@ -713,6 +722,7 @@ impl ProvidersToml {
             ProviderKind::Google => &mut self.google,
             ProviderKind::Antigravity => &mut self.antigravity,
             ProviderKind::Telecomjs => &mut self.telecomjs,
+            ProviderKind::Edenai => &mut self.edenai,
             ProviderKind::ModelstudioTokenPlan => &mut self.modelstudio_token_plan,
             ProviderKind::ModelstudioTokenPlanAnthropic => {
                 &mut self.modelstudio_token_plan_anthropic
@@ -3235,6 +3245,7 @@ impl ConfigToml {
                 ProviderKind::Google => DEFAULT_GOOGLE_BASE_URL.to_string(),
                 ProviderKind::Antigravity => DEFAULT_ANTIGRAVITY_BASE_URL.to_string(),
                 ProviderKind::Telecomjs => DEFAULT_TELECOMJS_BASE_URL.to_string(),
+                ProviderKind::Edenai => DEFAULT_EDENAI_BASE_URL.to_string(),
                 ProviderKind::ModelstudioTokenPlan
                 | ProviderKind::ModelstudioTokenPlanAnthropic
                 | ProviderKind::ModelstudioCodingPlan
@@ -4328,6 +4339,7 @@ fn default_model_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Google => DEFAULT_GOOGLE_MODEL,
         ProviderKind::Antigravity => DEFAULT_ANTIGRAVITY_MODEL,
         ProviderKind::Telecomjs => DEFAULT_TELECOMJS_MODEL,
+        ProviderKind::Edenai => DEFAULT_EDENAI_MODEL,
         ProviderKind::ModelstudioTokenPlan
         | ProviderKind::ModelstudioTokenPlanAnthropic
         | ProviderKind::ModelstudioCodingPlan
@@ -4379,6 +4391,7 @@ fn default_base_url_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Google => DEFAULT_GOOGLE_BASE_URL,
         ProviderKind::Antigravity => DEFAULT_ANTIGRAVITY_BASE_URL,
         ProviderKind::Telecomjs => DEFAULT_TELECOMJS_BASE_URL,
+        ProviderKind::Edenai => DEFAULT_EDENAI_BASE_URL,
         ProviderKind::ModelstudioTokenPlan => DEFAULT_MODELSTUDIO_TOKEN_PLAN_BASE_URL,
         ProviderKind::ModelstudioTokenPlanAnthropic => MODELSTUDIO_TOKEN_PLAN_ANTHROPIC_BASE_URL,
         ProviderKind::ModelstudioCodingPlan => DEFAULT_MODELSTUDIO_CODING_PLAN_BASE_URL,
@@ -6643,6 +6656,8 @@ struct EnvRuntimeOverrides {
     antigravity_model: Option<String>,
     telecomjs_base_url: Option<String>,
     telecomjs_model: Option<String>,
+    edenai_base_url: Option<String>,
+    edenai_model: Option<String>,
     modelstudio_token_plan_base_url: Option<String>,
     modelstudio_token_plan_model: Option<String>,
     modelstudio_coding_plan_base_url: Option<String>,
@@ -6985,6 +7000,12 @@ impl EnvRuntimeOverrides {
             telecomjs_model: std::env::var("TELECOMJS_MODEL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
+            edenai_base_url: std::env::var("EDENAI_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            edenai_model: std::env::var("EDENAI_MODEL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
             modelstudio_token_plan_base_url: std::env::var("MODELSTUDIO_TOKEN_PLAN_BASE_URL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
@@ -7084,6 +7105,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::Google => self.google_base_url.clone(),
             ProviderKind::Antigravity => self.antigravity_base_url.clone(),
             ProviderKind::Telecomjs => self.telecomjs_base_url.clone(),
+            ProviderKind::Edenai => self.edenai_base_url.clone(),
             ProviderKind::ModelstudioTokenPlan | ProviderKind::ModelstudioTokenPlanAnthropic => {
                 self.modelstudio_token_plan_base_url.clone()
             }
@@ -7130,6 +7152,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::Google => self.google_model.clone(),
             ProviderKind::Antigravity => self.antigravity_model.clone(),
             ProviderKind::Telecomjs => self.telecomjs_model.clone(),
+            ProviderKind::Edenai => self.edenai_model.clone(),
             ProviderKind::ModelstudioTokenPlan | ProviderKind::ModelstudioTokenPlanAnthropic => {
                 self.modelstudio_token_plan_model.clone()
             }

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -9,9 +9,10 @@ use super::{
     DEFAULT_ARCEE_MODEL, DEFAULT_ATLASCLOUD_BASE_URL, DEFAULT_ATLASCLOUD_MODEL,
     DEFAULT_DEEPINFRA_BASE_URL, DEFAULT_DEEPINFRA_MODEL, DEFAULT_DEEPSEEK_ANTHROPIC_BASE_URL,
     DEFAULT_DEEPSEEK_ANTHROPIC_MODEL, DEFAULT_DEEPSEEK_BASE_URL, DEFAULT_DEEPSEEK_MODEL,
-    DEFAULT_FIREWORKS_BASE_URL, DEFAULT_FIREWORKS_MODEL, DEFAULT_GOOGLE_BASE_URL,
-    DEFAULT_GOOGLE_MODEL, DEFAULT_HUGGINGFACE_BASE_URL, DEFAULT_HUGGINGFACE_MODEL,
-    DEFAULT_LONGCAT_BASE_URL, DEFAULT_LONGCAT_MODEL, DEFAULT_META_BASE_URL, DEFAULT_META_MODEL,
+    DEFAULT_EDENAI_BASE_URL, DEFAULT_EDENAI_MODEL, DEFAULT_FIREWORKS_BASE_URL,
+    DEFAULT_FIREWORKS_MODEL, DEFAULT_GOOGLE_BASE_URL, DEFAULT_GOOGLE_MODEL,
+    DEFAULT_HUGGINGFACE_BASE_URL, DEFAULT_HUGGINGFACE_MODEL, DEFAULT_LONGCAT_BASE_URL,
+    DEFAULT_LONGCAT_MODEL, DEFAULT_META_BASE_URL, DEFAULT_META_MODEL,
     DEFAULT_MINIMAX_ANTHROPIC_BASE_URL, DEFAULT_MINIMAX_BASE_URL, DEFAULT_MINIMAX_MODEL,
     DEFAULT_MISTRAL_BASE_URL, DEFAULT_MISTRAL_MODEL, DEFAULT_MODELSTUDIO_CODING_PLAN_BASE_URL,
     DEFAULT_MODELSTUDIO_TOKEN_PLAN_BASE_URL, DEFAULT_MODELSTUDIO_TOKEN_PLAN_MODEL,
@@ -411,6 +412,12 @@ pub const fn credential_help(kind: ProviderKind) -> CredentialHelp {
             credential_url: Some("https://aigw.telecomjs.com/"),
             docs_url: None,
             guidance: "Create a TelecomJS TokenHub API key, then use the provider's live model catalog to discover the models available to that key.",
+        },
+        ProviderKind::Edenai => CredentialHelp {
+            acquisition: ApiKey,
+            credential_url: Some("https://app.edenai.run/settings/api-keys"),
+            docs_url: Some("https://www.edenai.co/docs"),
+            guidance: "Create an Eden AI API key from the Eden AI dashboard, then select models by their provider/model namespaced id.",
         },
         ProviderKind::ModelstudioTokenPlan
         | ProviderKind::ModelstudioTokenPlanAnthropic
@@ -1326,6 +1333,17 @@ provider!(
     "telecomjs",
     aliases: ["telecom-js", "telecom_js", "telecomjs-cn", "tokenhub"]
 );
+provider!(
+    Edenai,
+    Edenai,
+    "edenai",
+    "Eden AI",
+    DEFAULT_EDENAI_BASE_URL,
+    DEFAULT_EDENAI_MODEL,
+    ["EDENAI_API_KEY"],
+    "edenai",
+    aliases: ["eden-ai", "eden_ai"]
+);
 
 /// Alibaba Cloud Model Studio — Token Plan (OpenAI-compatible Chat Completions).
 ///
@@ -1610,6 +1628,7 @@ static XAI: Xai = Xai;
 static MISTRAL: Mistral = Mistral;
 static ANTIGRAVITY: Antigravity = Antigravity;
 static TELECOMJS: Telecomjs = Telecomjs;
+static EDENAI: Edenai = Edenai;
 static MODELSTUDIO_TOKEN_PLAN: ModelstudioTokenPlan = ModelstudioTokenPlan;
 static MODELSTUDIO_TOKEN_PLAN_ANTHROPIC: ModelstudioTokenPlanAnthropic =
     ModelstudioTokenPlanAnthropic;
@@ -1618,7 +1637,7 @@ static MODELSTUDIO_CODING_PLAN_ANTHROPIC: ModelstudioCodingPlanAnthropic =
     ModelstudioCodingPlanAnthropic;
 static CUSTOM: Custom = Custom;
 
-static PROVIDER_REGISTRY: [&dyn Provider; 45] = [
+static PROVIDER_REGISTRY: [&dyn Provider; 46] = [
     &DEEPSEEK,
     &DEEPSEEK_ANTHROPIC,
     &NVIDIA_NIM,
@@ -1657,6 +1676,7 @@ static PROVIDER_REGISTRY: [&dyn Provider; 45] = [
     &XAI,
     &MISTRAL,
     &TELECOMJS,
+    &EDENAI,
     &MODELSTUDIO_TOKEN_PLAN,
     &MODELSTUDIO_TOKEN_PLAN_ANTHROPIC,
     &MODELSTUDIO_CODING_PLAN,

--- a/crates/config/src/provider_defaults.rs
+++ b/crates/config/src/provider_defaults.rs
@@ -178,6 +178,9 @@ pub(crate) const DEFAULT_MISTRAL_BASE_URL: &str = "https://api.mistral.ai/v1";
 // TelecomJS (Jiangsu Telecom TokenHub) defaults
 pub(crate) const DEFAULT_TELECOMJS_MODEL: &str = "deepseek-v4-pro";
 pub(crate) const DEFAULT_TELECOMJS_BASE_URL: &str = "https://aigw.telecomjs.com/v1";
+// Eden AI (OpenAI-compatible AI gateway) defaults
+pub(crate) const DEFAULT_EDENAI_MODEL: &str = "deepseek/deepseek-v4-pro";
+pub(crate) const DEFAULT_EDENAI_BASE_URL: &str = "https://api.edenai.run/v3";
 // Alibaba Cloud Model Studio (DashScope) defaults
 // Token Plan (Personal / Team): shared endpoint, OpenAI + Anthropic dialects
 pub(crate) const DEFAULT_MODELSTUDIO_TOKEN_PLAN_MODEL: &str = "qwen3.8-max";

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -207,6 +207,12 @@ pub enum ProviderKind {
         alias = "aistudio"
     )]
     Google,
+    /// Eden AI — OpenAI-compatible AI gateway (aggregator).
+    ///
+    /// Serves a broad catalog of upstream models under `provider/model`
+    /// namespaced wire ids over the OpenAI Chat Completions protocol.
+    #[serde(alias = "eden-ai", alias = "eden_ai", alias = "edenai")]
+    Edenai,
     /// User-defined OpenAI-compatible endpoint (#1519).
     ///
     /// A single dynamic identity for arbitrary `[providers.<name>]
@@ -224,7 +230,7 @@ impl ProviderKind {
     /// stay on the enum for serde and `provider_for_kind`, but they are not
     /// first-class catalog rows. Plan is `mode` / base_url; dialect is
     /// `wire = openai|anthropic` on the primary provider config.
-    pub const ALL: [Self; 40] = [
+    pub const ALL: [Self; 41] = [
         Self::Deepseek,
         Self::NvidiaNim,
         Self::Openai,
@@ -264,6 +270,7 @@ impl ProviderKind {
         Self::ModelstudioTokenPlan,
         Self::Google,
         Self::Antigravity,
+        Self::Edenai,
         Self::Custom,
     ];
 

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -4811,9 +4811,9 @@ fn meta_model_api_scopes_both_documented_key_names_to_official_endpoint() {
 fn provider_metadata_registry_covers_every_provider_kind_once() {
     let providers = provider::all_providers();
     // Full registry keeps legacy dialect/plan kinds for provider_for_kind.
-    assert_eq!(providers.len(), 45);
+    assert_eq!(providers.len(), 46);
     // Catalog surface is one identity per vendor (no dual-wire / plan rows).
-    assert_eq!(ProviderKind::ALL.len(), 40);
+    assert_eq!(ProviderKind::ALL.len(), 41);
     assert!(ProviderKind::ALL.len() < providers.len());
 
     let mut ids = std::collections::BTreeSet::new();

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -1162,6 +1162,7 @@ impl Secrets {
 /// | `meta` / `muse-spark` | `META_MODEL_API_KEY`, `MODEL_API_KEY` |
 /// | `xai` / `grok` | `XAI_API_KEY` |
 /// | `telecomjs` / `tokenhub` | `TELECOMJS_API_KEY` |
+/// | `edenai` / `eden-ai` | `EDENAI_API_KEY` |
 ///
 /// Returns `None` if the provider is not recognised or none of its
 /// candidate environment variables are set to a non-empty value.
@@ -1217,6 +1218,7 @@ pub fn env_for(name: &str) -> Option<String> {
         "telecomjs" | "telecom-js" | "telecom_js" | "telecomjs-cn" | "tokenhub" => {
             &["TELECOMJS_API_KEY"]
         }
+        "edenai" | "eden-ai" | "eden_ai" => &["EDENAI_API_KEY"],
         // One Alibaba Cloud Model Studio account authenticates every plan /
         // dialect variant; all four names share one env convention.
         "modelstudio-token-plan"

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -3166,6 +3166,7 @@ pub(super) fn apply_reasoning_effort(
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => {}
             ApiProvider::Openrouter
             | ApiProvider::Orcarouter
+            | ApiProvider::Edenai
             | ApiProvider::XiaomiMimo
             | ApiProvider::Novita
             | ApiProvider::Siliconflow
@@ -3285,6 +3286,7 @@ pub(super) fn apply_reasoning_effort(
             // accept those directly.
             ApiProvider::Openrouter
             | ApiProvider::Orcarouter
+            | ApiProvider::Edenai
             | ApiProvider::Novita
             | ApiProvider::Together => {
                 let value = match normalized.as_str() {
@@ -3389,6 +3391,7 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::ModelstudioCodingPlanAnthropic => {}
             ApiProvider::Openrouter
             | ApiProvider::Orcarouter
+            | ApiProvider::Edenai
             | ApiProvider::Novita
             | ApiProvider::Together => {
                 body["reasoning_effort"] = json!("xhigh");

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -98,6 +98,8 @@ pub enum ApiProvider {
     Antigravity,
     /// Jiangsu Telecom TokenHub — OpenAI-compatible AI gateway.
     Telecomjs,
+    /// Eden AI — OpenAI-compatible AI gateway (aggregator).
+    Edenai,
     /// Alibaba Cloud Model Studio — Token Plan (OpenAI-compatible Chat Completions).
     ModelstudioTokenPlan,
     /// Alibaba Cloud Model Studio — Token Plan Anthropic-compatible endpoint.
@@ -325,7 +327,7 @@ impl ApiProvider {
 
     /// `ApiProvider` discriminant → `ProviderKind` lookup.
     /// Index 1 is `None` for the legacy `DeepseekCN` variant.
-    const KIND_LOOKUP: [Option<codewhale_config::ProviderKind>; 46] = [
+    const KIND_LOOKUP: [Option<codewhale_config::ProviderKind>; 47] = [
         Some(codewhale_config::ProviderKind::Deepseek),
         None, // DeepseekCN
         Some(codewhale_config::ProviderKind::DeepseekAnthropic),
@@ -367,6 +369,7 @@ impl ApiProvider {
         Some(codewhale_config::ProviderKind::Google),
         Some(codewhale_config::ProviderKind::Antigravity),
         Some(codewhale_config::ProviderKind::Telecomjs),
+        Some(codewhale_config::ProviderKind::Edenai),
         Some(codewhale_config::ProviderKind::ModelstudioTokenPlan),
         Some(codewhale_config::ProviderKind::ModelstudioTokenPlanAnthropic),
         Some(codewhale_config::ProviderKind::ModelstudioCodingPlan),
@@ -375,7 +378,7 @@ impl ApiProvider {
     ];
 
     /// `ProviderKind` discriminant → `ApiProvider` lookup.
-    const FROM_KIND_LOOKUP: [Self; 45] = [
+    const FROM_KIND_LOOKUP: [Self; 46] = [
         Self::Deepseek,
         Self::DeepseekAnthropic,
         Self::NvidiaNim,
@@ -420,6 +423,7 @@ impl ApiProvider {
         Self::ModelstudioCodingPlanAnthropic,
         Self::Antigravity,
         Self::Google,
+        Self::Edenai,
         Self::Custom,
     ];
 
@@ -487,6 +491,7 @@ fn subagent_provider_key_matches(key: &str, provider: ApiProvider) -> bool {
         ),
         ApiProvider::Openrouter => matches!(normalized.as_str(), "openrouter" | "open_router"),
         ApiProvider::Orcarouter => matches!(normalized.as_str(), "orcarouter" | "orca_router"),
+        ApiProvider::Edenai => matches!(normalized.as_str(), "edenai" | "eden_ai"),
         ApiProvider::OpenaiCodex => matches!(
             normalized.as_str(),
             "openai_codex" | "codex" | "chatgpt" | "openai_chatgpt"
@@ -1573,6 +1578,7 @@ pub fn model_completion_names_for_provider(provider: ApiProvider) -> Vec<&'stati
         // The cloud-code wire protocol is not implemented; no model is
         // advertised for the credential-import-only route.
         ApiProvider::Antigravity => Vec::new(),
+        ApiProvider::Edenai => vec![DEFAULT_EDENAI_MODEL],
         // Custom endpoints expose no built-in completion names; the user
         // supplies their own model id (#1519).
         ApiProvider::Custom => Vec::new(),
@@ -3483,6 +3489,9 @@ pub struct ProvidersConfig {
         alias = "tokenhub"
     )]
     pub telecomjs: ProviderConfig,
+    /// Eden AI — OpenAI-compatible AI gateway (aggregator).
+    #[serde(default, alias = "eden-ai", alias = "eden_ai")]
+    pub edenai: ProviderConfig,
     /// Alibaba Cloud Model Studio — Token Plan (OpenAI-compatible Chat Completions).
     #[serde(default, alias = "modelstudio-token-plan")]
     pub modelstudio_token_plan: ProviderConfig,
@@ -4935,6 +4944,7 @@ impl Config {
             ApiProvider::Google => &providers.google,
             ApiProvider::Antigravity => &providers.antigravity,
             ApiProvider::Telecomjs => &providers.telecomjs,
+            ApiProvider::Edenai => &providers.edenai,
             ApiProvider::ModelstudioTokenPlan => &providers.modelstudio_token_plan,
             ApiProvider::ModelstudioTokenPlanAnthropic => {
                 &providers.modelstudio_token_plan_anthropic
@@ -5014,6 +5024,7 @@ impl Config {
             ApiProvider::Google => &mut providers.google,
             ApiProvider::Antigravity => &mut providers.antigravity,
             ApiProvider::Telecomjs => &mut providers.telecomjs,
+            ApiProvider::Edenai => &mut providers.edenai,
             ApiProvider::ModelstudioTokenPlan => &mut providers.modelstudio_token_plan,
             ApiProvider::ModelstudioTokenPlanAnthropic => {
                 &mut providers.modelstudio_token_plan_anthropic
@@ -5378,6 +5389,7 @@ impl Config {
             ApiProvider::Google => DEFAULT_GOOGLE_MODEL,
             ApiProvider::Antigravity => DEFAULT_ANTIGRAVITY_MODEL,
             ApiProvider::Telecomjs => DEFAULT_TELECOMJS_MODEL,
+            ApiProvider::Edenai => DEFAULT_EDENAI_MODEL,
             ApiProvider::ModelstudioTokenPlan
             | ApiProvider::ModelstudioTokenPlanAnthropic
             | ApiProvider::ModelstudioCodingPlan
@@ -5499,6 +5511,7 @@ impl Config {
             | ApiProvider::Google
             | ApiProvider::Antigravity
             | ApiProvider::Telecomjs
+            | ApiProvider::Edenai
             | ApiProvider::ModelstudioTokenPlan
             | ApiProvider::ModelstudioTokenPlanAnthropic
             | ApiProvider::ModelstudioCodingPlan
@@ -5607,6 +5620,7 @@ impl Config {
                         ApiProvider::Google => DEFAULT_GOOGLE_BASE_URL,
                         ApiProvider::Antigravity => DEFAULT_ANTIGRAVITY_BASE_URL,
                         ApiProvider::Telecomjs => DEFAULT_TELECOMJS_BASE_URL,
+                        ApiProvider::Edenai => DEFAULT_EDENAI_BASE_URL,
                         ApiProvider::ModelstudioTokenPlan
                         | ApiProvider::ModelstudioTokenPlanAnthropic
                         | ApiProvider::ModelstudioCodingPlan
@@ -7215,6 +7229,7 @@ fn provider_env_base_url_override(provider: ApiProvider) -> Option<String> {
         ApiProvider::Google => &["GOOGLE_BASE_URL", "GEMINI_BASE_URL"],
         ApiProvider::Antigravity => &["ANTIGRAVITY_BASE_URL"],
         ApiProvider::Telecomjs => &["TELECOMJS_BASE_URL"],
+        ApiProvider::Edenai => &["EDENAI_BASE_URL"],
         ApiProvider::ModelstudioTokenPlan | ApiProvider::ModelstudioTokenPlanAnthropic => {
             &["MODELSTUDIO_TOKEN_PLAN_BASE_URL"]
         }
@@ -7579,6 +7594,13 @@ fn apply_env_overrides_unlocked(config: &mut Config, policy: ConfigEnvironmentPo
                     .telecomjs
                     .base_url = Some(value);
             }
+            ApiProvider::Edenai => {
+                config
+                    .providers
+                    .get_or_insert_with(ProvidersConfig::default)
+                    .edenai
+                    .base_url = Some(value);
+            }
             ApiProvider::ModelstudioTokenPlan => {
                 config
                     .providers
@@ -7826,6 +7848,16 @@ fn apply_env_overrides_unlocked(config: &mut Config, policy: ConfigEnvironmentPo
             .telecomjs
             .base_url = Some(value);
     }
+    if matches!(config.api_provider(), ApiProvider::Edenai)
+        && let Ok(value) = std::env::var("EDENAI_BASE_URL")
+        && !value.trim().is_empty()
+    {
+        config
+            .providers
+            .get_or_insert_with(ProvidersConfig::default)
+            .edenai
+            .base_url = Some(value);
+    }
     if matches!(
         config.api_provider(),
         ApiProvider::ModelstudioTokenPlan | ApiProvider::ModelstudioTokenPlanAnthropic
@@ -7936,6 +7968,7 @@ fn apply_env_overrides_unlocked(config: &mut Config, policy: ConfigEnvironmentPo
                 ApiProvider::Google => &mut providers.google,
                 ApiProvider::Antigravity => &mut providers.antigravity,
                 ApiProvider::Telecomjs => &mut providers.telecomjs,
+                ApiProvider::Edenai => &mut providers.edenai,
                 ApiProvider::ModelstudioTokenPlan => &mut providers.modelstudio_token_plan,
                 ApiProvider::ModelstudioTokenPlanAnthropic => {
                     &mut providers.modelstudio_token_plan_anthropic
@@ -8148,6 +8181,16 @@ fn apply_env_overrides_unlocked(config: &mut Config, policy: ConfigEnvironmentPo
             .telecomjs
             .model = Some(value);
     }
+    if matches!(config.api_provider(), ApiProvider::Edenai)
+        && let Ok(value) = std::env::var("EDENAI_MODEL")
+        && !value.trim().is_empty()
+    {
+        config
+            .providers
+            .get_or_insert_with(ProvidersConfig::default)
+            .edenai
+            .model = Some(value);
+    }
     if matches!(
         config.api_provider(),
         ApiProvider::ModelstudioTokenPlan | ApiProvider::ModelstudioTokenPlanAnthropic
@@ -8283,6 +8326,7 @@ fn apply_env_overrides_unlocked(config: &mut Config, policy: ConfigEnvironmentPo
                 ApiProvider::Google => &mut providers.google,
                 ApiProvider::Antigravity => &mut providers.antigravity,
                 ApiProvider::Telecomjs => &mut providers.telecomjs,
+                ApiProvider::Edenai => &mut providers.edenai,
                 ApiProvider::ModelstudioTokenPlan => &mut providers.modelstudio_token_plan,
                 ApiProvider::ModelstudioTokenPlanAnthropic => {
                     &mut providers.modelstudio_token_plan_anthropic
@@ -9683,6 +9727,7 @@ fn merge_providers(
             google: merge_provider_config(base.google, override_cfg.google),
             antigravity: merge_provider_config(base.antigravity, override_cfg.antigravity),
             telecomjs: merge_provider_config(base.telecomjs, override_cfg.telecomjs),
+            edenai: merge_provider_config(base.edenai, override_cfg.edenai),
             modelstudio_token_plan: merge_provider_config(
                 base.modelstudio_token_plan,
                 override_cfg.modelstudio_token_plan,

--- a/crates/tui/src/config/models.rs
+++ b/crates/tui/src/config/models.rs
@@ -229,6 +229,8 @@ pub const DEFAULT_GOOGLE_BASE_URL: &str =
     "https://generativelanguage.googleapis.com/v1beta/openai/";
 pub const DEFAULT_TELECOMJS_MODEL: &str = "deepseek-v4-pro";
 pub const DEFAULT_TELECOMJS_BASE_URL: &str = "https://aigw.telecomjs.com/v1";
+pub const DEFAULT_EDENAI_MODEL: &str = "deepseek/deepseek-v4-pro";
+pub const DEFAULT_EDENAI_BASE_URL: &str = "https://api.edenai.run/v3";
 // Alibaba Cloud Model Studio (DashScope) defaults
 pub const DEFAULT_MODELSTUDIO_TOKEN_PLAN_MODEL: &str = "qwen3.8-max";
 pub const DEFAULT_MODELSTUDIO_TOKEN_PLAN_BASE_URL: &str =

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -317,6 +317,7 @@ fn provider_base_url_table_key(provider: ApiProvider) -> anyhow::Result<&'static
         ApiProvider::Google => Ok("google"),
         ApiProvider::Antigravity => Ok("antigravity"),
         ApiProvider::Telecomjs => Ok("telecomjs"),
+        ApiProvider::Edenai => Ok("edenai"),
         ApiProvider::ModelstudioTokenPlan => Ok("modelstudio_token_plan"),
         ApiProvider::ModelstudioTokenPlanAnthropic => Ok("modelstudio_token_plan_anthropic"),
         ApiProvider::ModelstudioCodingPlan => Ok("modelstudio_coding_plan"),

--- a/crates/tui/src/tui/ui/session_state.rs
+++ b/crates/tui/src/tui/ui/session_state.rs
@@ -876,6 +876,7 @@ pub(crate) fn mirror_saved_api_key_in_config(
         ApiProvider::Google => &mut providers.google,
         ApiProvider::Antigravity => &mut providers.antigravity,
         ApiProvider::Telecomjs => &mut providers.telecomjs,
+        ApiProvider::Edenai => &mut providers.edenai,
         ApiProvider::ModelstudioTokenPlan => &mut providers.modelstudio_token_plan,
         ApiProvider::ModelstudioTokenPlanAnthropic => {
             &mut providers.modelstudio_token_plan_anthropic

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -31,7 +31,7 @@ Sources to keep in sync:
 
 ## Provider Selection
 
-The canonical provider IDs are the 38 entries of `ProviderKind::ALL`
+The canonical provider IDs are the 39 entries of `ProviderKind::ALL`
 (`crates/config/src/provider_kind.rs:198-234`), in that order:
 
 `deepseek`, `nvidia-nim`, `openai`, `atlascloud`, `wanjie-ark`, `volcengine`,
@@ -40,7 +40,7 @@ The canonical provider IDs are the 38 entries of `ProviderKind::ALL`
 `together`, `qianfan`, `openai-codex`, `anthropic`, `openmodel`, `zai`,
 `stepfun`, `minimax`, `deepinfra`, `sakana`, `longcat`, `opencode-go`,
 `opencode-zen`, `meta`, `xai`, `mistral`, `telecomjs`, `modelstudio-token-plan`,
-and `custom`.
+`edenai`, and `custom`.
 
 `deepseek-anthropic` is *not* on this list — it is a wire dialect of
 `deepseek`, reached with `wire = "anthropic"`, not a separate route to select.
@@ -133,6 +133,7 @@ the listed provider env vars.
 | `mistral` | `[providers.mistral]` | OpenAI Chat Completions | `MISTRAL_API_KEY` |
 | `google` | `[providers.google]` | OpenAI Chat Completions (official Gemini OpenAI-compat route; captures and replays thought signatures on tool calls) | `GOOGLE_API_KEY`, `GEMINI_API_KEY` |
 | `antigravity` | `[providers.antigravity]` | none — requests fail closed; credential import only | `ANTIGRAVITY_API_KEY` (key plane); `AGY_ADC_AUTH` (process env) |
+| `edenai` | `[providers.edenai]` | OpenAI Chat Completions | `EDENAI_API_KEY` |
 | `modelstudio-token-plan` | `[providers.modelstudio_token_plan]` | OpenAI Chat Completions | `MODELSTUDIO_API_KEY`, `DASHSCOPE_API_KEY` |
 | `modelstudio-token-plan-anthropic` | `[providers.modelstudio_token_plan_anthropic]` | Anthropic Messages | `MODELSTUDIO_API_KEY`, `DASHSCOPE_API_KEY` |
 | `modelstudio-coding-plan` | `[providers.modelstudio_coding_plan]` | OpenAI Chat Completions | `MODELSTUDIO_API_KEY`, `DASHSCOPE_API_KEY` |
@@ -457,6 +458,7 @@ configuration path instead of guessing a vendor page.
 | `mistral` | [Mistral Console (la Plateforme)](https://console.mistral.ai/api-keys) |
 | `google` | [Google AI Studio](https://aistudio.google.com/apikey) — Codewhale uses the official Gemini OpenAI-compatible endpoint and never reads Google OAuth files. |
 | `antigravity` | Sign in with the official `agy` CLI (1.1.13). Codewhale can read that login's OAuth token read-only from the exact pinned `state.vscdb` after `codewhale auth external-consent`; it never writes or refreshes the file. An `ANTIGRAVITY_API_KEY` or the process's `AGY_ADC_AUTH` wins over the file. The cloud-code wire protocol is not implemented: requests fail closed with an actionable message — use `google` for Gemini models. |
+| `edenai` | [Eden AI API keys](https://app.edenai.run/settings/api-keys) |
 | `modelstudio-token-plan`, `modelstudio-token-plan-anthropic`, `modelstudio-coding-plan`, `modelstudio-coding-plan-anthropic` | [Alibaba Cloud Model Studio (Bailian console)](https://bailian.console.aliyun.com/) — create or copy a Model Studio API key. |
 | `custom` | Set the named provider's `base_url` and `api_key_env` or `api_key`; no canonical vendor credential page exists. |
 
@@ -548,6 +550,7 @@ Kimi remains API-key-only; external consent for Kimi is rejected.
 | `meta` | `[providers.meta]` | `META_MODEL_API_KEY`, `MODEL_API_KEY` | `META_MODEL_API_BASE_URL`, `MODEL_API_BASE_URL`; default `https://api.meta.ai/v1` | `muse-spark-1.2` (default) | [Meta Model API](https://developer.meta.com/ai/resources/blog/build-with-muse-spark/) public-preview route using OpenAI-compatible Chat Completions. Muse Spark 1.2 keeps its wire ID, tool support, 1M context, 32K output metadata, and `none` through `xhigh` reasoning effort. `META_MODEL_API_MODEL` and `MODEL_API_MODEL` are accepted. Provider aliases: `meta-ai`, `meta_model_api`, `muse`, `muse-spark`. |
 | `telecomjs` | `[providers.telecomjs]` | `TELECOMJS_API_KEY` | `TELECOMJS_BASE_URL`; default `https://aigw.telecomjs.com/v1` | `deepseek-v4-pro` conservative fallback; authenticated `/models` rows when a key is configured | TelecomJS TokenHub OpenAI-compatible Chat Completions route. Live catalogs are isolated by provider and key fingerprint, stale rows survive transient refresh failures, and unsupported reasoning request fields are omitted. `TELECOMJS_MODEL` is accepted. Provider aliases: `telecom-js`, `telecom_js`, `telecomjs-cn`, `tokenhub`. |
 | `mistral` | `[providers.mistral]` | `MISTRAL_API_KEY` | `MISTRAL_BASE_URL`; default `https://api.mistral.ai/v1` | `mistral-code-latest` (default; `codestral-latest` accepted as alias), `mistral-medium-latest` (aliases: `mistral-medium-3-5`), `mistral-small-latest` (aliases: `mistral-small-2603`), `mistral-large-latest` | Mistral AI (la Plateforme) OpenAI-compatible Chat route. On the documented first-party HTTPS `/v1` hosts, Medium and Small send adjustable `reasoning_effort` (`none` or `high` only), parse Mistral's polymorphic thinking/text blocks, and replay stored thinking in that same wire shape. Deprecated native Magistral IDs remain explicit-configuration compatibility routes: they are always-reasoning and never receive the adjustable effort field. Code and Large are non-reasoning. A custom `MISTRAL_BASE_URL` keeps generic Chat semantics unless it is one of the documented first-party hosts. `MISTRAL_MODEL` is accepted. Provider aliases: `mistral-ai`, `mistralai`, `la-plateforme`. |
+| `edenai` | `[providers.edenai]` | `EDENAI_API_KEY` | `EDENAI_BASE_URL`; default `https://api.edenai.run/v3` | `deepseek/deepseek-v4-pro` (default); any `provider/model` namespaced id from the Eden AI catalog | Eden AI OpenAI-compatible aggregation gateway. Serves a broad upstream catalog under `provider/model` wire ids over the OpenAI Chat Completions protocol. `EDENAI_MODEL` is accepted. Provider aliases: `eden-ai`, `eden_ai`. |
 | `xai` | `[providers.xai]` | `XAI_API_KEY`, Codewhale-owned device OAuth, or explicit read-only Grok CLI consent | `XAI_BASE_URL`; default `https://api.x.ai/v1` | `grok-4.6` (default), `grok-4.5`, `grok-4.3`, `grok-build`, `grok-composer-2.5-fast`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning` | xAI/Grok OpenAI-compatible Chat Completions route. Grok 4.6 has a 500K context window, text/image input, function calls, structured output, server-side web search, and `low`/`medium`/`high`/`xhigh` reasoning (default `high`). Its standard rates double when the prompt reaches 200K tokens. There is no documented `latest`/`fast` alias and no published numeric output limit. **API-key** (default): Bearer token from console.x.ai via `XAI_API_KEY` / keyring / `api_key`. **OAuth**: `codewhale auth xai-device` uses SSH-friendly device login and Codewhale-owned storage, which may refresh itself. Existing Grok CLI credentials require `codewhale auth external-consent --provider xai --mode read-only`; the granted external file is never refreshed or rewritten. OAuth may return HTTP 403 on some SuperGrok tiers — keep API-key as the reliable fallback. `XAI_MODEL` is accepted. Provider aliases: `x-ai`, `x_ai`, `grok`. |
 | `modelstudio-token-plan` | `[providers.modelstudio_token_plan]` | `MODELSTUDIO_API_KEY`, `DASHSCOPE_API_KEY` | `MODELSTUDIO_TOKEN_PLAN_BASE_URL`; default `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` | `qwen3.8-max` (default), `qwen3.8-max-preview`, `qwen3.7-plus`, `qwen3.7-max`, `qwen3.6-flash`, `deepseek-v4-pro`, `deepseek-v4-flash-0731`, `glm-5.2` | Alibaba Cloud Model Studio Token Plan OpenAI-compatible Chat Completions route. Token Plan Personal and Team share this endpoint. All listed models are reasoning-capable text/coding models. DeepSeek and GLM entries are provider-scoped and do not collide with first-party routes. `MODELSTUDIO_TOKEN_PLAN_MODEL` is accepted. Provider aliases: `modelstudio-token-plan`, `alibaba-token-plan`, `dashscope-token-plan`. |
 | `modelstudio-token-plan-anthropic` | `[providers.modelstudio_token_plan_anthropic]` | `MODELSTUDIO_API_KEY`, `DASHSCOPE_API_KEY` | default `https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic` | Same model catalog as `modelstudio-token-plan` | Token Plan Anthropic-compatible Messages route (`/apps/anthropic`). Same API key as the OpenAI dialect. Provider aliases: `modelstudio-token-plan-anthropic`, `alibaba-token-plan-anthropic`. |


### PR DESCRIPTION
## Summary

This registers [Eden AI](https://www.edenai.co/) the same way the existing OpenRouter provider is wired.
Eden AI is an OpenAI-compatible gateway, which gives developers access to 500+ models from OpenAI, Mistral, Gemini, Claude, and more. Eden AI also provides a regional EU endpoint, which routes requets only through providers and models cleared for European processing.

I do not work for Eden AI.

Changes: registers Eden AI as a new ProviderKind ("edenai", aliases eden-ai/eden_ai) with default base URL https://api.edenai.run/v3 and model deepseek/deepseek-v4-pro; reads EDENAI_API_KEY, EDENAI_BASE_URL, and EDENAI_MODEL; and wires the OpenAI-compatible route through the TUI config/client, CLI provider argument, secret-store env mapping, credential help, and provider docs.

This PR was created with the help of CodeWhale and deepseek-v4-pro model.

## Testing

<!-- Exact gate commands (including the clippy allow list) are in
     CONTRIBUTING.md → "Pre-push verification". -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [x] `cargo test --workspace --all-features --locked` (There are 2 failures which are also in the base `main` branch.)

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
