### PR TITLE
test(tui): isolate background verifier from rustup

### DIFF
--- a/crates/tui/src/tools/verifier.rs
+++ b/crates/tui/src/tools/verifier.rs
@@ -1490,18 +1490,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
     async fn run_verifiers_background_starts_shell_jobs_and_returns_task_ids() {
-        if !crate::dependencies::RustC::available() {
-            return;
-        }
-        // The spawned `rustc` is usually the rustup shim, which resolves its
-        // toolchain through $HOME. Hold the process-wide env mutex so tests
-        // that temporarily swap HOME cannot break the child process.
-        let _env_lock = crate::test_support::lock_test_env();
         let tmp = tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path());
         let tool = RunVerifiersTool;
+        let test_executable = std::env::current_exe().expect("test executable");
         let result = tool
             .execute(
                 json!({
@@ -1509,9 +1502,9 @@ mod tests {
                     "background": true,
                     "commands": [
                         {
-                            "name": "rustc-version",
-                            "program": crate::dependencies::RustC::resolve().expect("rustc"),
-                            "args": ["--version"]
+                            "name": "test-list",
+                            "program": test_executable,
+                            "args": ["--list"]
                         }
                     ]
                 }),
@@ -1572,8 +1565,8 @@ mod tests {
             output.stderr
         );
         assert!(
-            output.stdout.contains("rustc"),
-            "stdout should include rustc version: {:?}",
+            output.stdout.lines().any(|line| line.ends_with(": test")),
+            "stdout should include the test listing: {:?}",
             output.stdout
         );
     }


### PR DESCRIPTION
## Summary

Addresses one narrow verifier-test slice from #5056.

`run_verifiers_background_starts_shell_jobs_and_returns_task_ids` used an external `rustc` command, usually through the rustup shim, and held the process-wide test environment lock across an async wait. That coupled the test to `$HOME`, rustup state, and unrelated environment-mutating tests under full-suite parallelism.

The test now invokes the current libtest executable with `--list`. It still verifies detached verifier startup, task-id creation, completion, and captured output without external tool discovery or process-global environment locking.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --lib 'tools::verifier::tests::run_verifiers_background_starts_shell_jobs_and_returns_task_ids' --locked -- --exact --nocapture`
- 20 repeated runs of the exact test
- `cargo test -p codewhale-tui --lib 'tools::verifier::tests::' --locked -- --test-threads=32` (8 passed)
- `cargo test -p codewhale-tui --lib --locked` (full library suite passed)
- `git diff --check`

The strict clippy run also reports pre-existing diagnostics outside this diff; no clippy diagnostic points to `crates/tui/src/tools/verifier.rs` or the changed lines.

No-Issue: This is one narrow follow-up slice of #5056; the broader reliability tracking issue remains open.
