### PR TITLE
v0.9.8 blockers: sudo/NNP opt-out (#5413) and abort-class terminal poisoning (#5424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ Codewhale v0.9.8 ships the remaining assigned finish. Remaining web
 settings polish moves to v0.9.9. Prefab third-party templates that have
 a published OpenAI-compatible host ship here (#5350).
 
+### Fixed
+
+- `sudo` (and `su`/setuid helpers) work again for wheel-group administrators
+  who want Codewhale to be able to escalate: the Linux startup hardening's
+  irreversible `PR_SET_NO_NEW_PRIVS` flag — inherited by every child process —
+  is now skippable with `CODEWHALE_NO_NEW_PRIVS=0` (#5413). The flag stays on
+  by default; the no-ptrace and no-core-dump measures are never skipped.
+
+- Abort-class process deaths no longer poison the terminal (#5424). A
+  stack overflow, allocation failure, or double panic skips the panic hook
+  and every cleanup guard, which is how a v0.9.7 user's mid-turn exit left
+  mouse capture leaking SGR sequences into their shell. An
+  async-signal-safe handler now restores the terminal modes and appends a
+  one-line cause marker to `~/.codewhale/crashes/last-fatal-signal.log`
+  before re-raising, keeping the honest 128+signal wait status. A SIGKILL
+  (OOM killer) remains uninterceptable by design.
+
 ### Changed
 
 - Prompt-cache prefix is pinned for the session. The tool loop no longer

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -13,6 +13,23 @@ Codewhale v0.9.8 ships the remaining assigned finish. Remaining web
 settings polish moves to v0.9.9. Prefab third-party templates that have
 a published OpenAI-compatible host ship here (#5350).
 
+### Fixed
+
+- `sudo` (and `su`/setuid helpers) work again for wheel-group administrators
+  who want Codewhale to be able to escalate: the Linux startup hardening's
+  irreversible `PR_SET_NO_NEW_PRIVS` flag — inherited by every child process —
+  is now skippable with `CODEWHALE_NO_NEW_PRIVS=0` (#5413). The flag stays on
+  by default; the no-ptrace and no-core-dump measures are never skipped.
+
+- Abort-class process deaths no longer poison the terminal (#5424). A
+  stack overflow, allocation failure, or double panic skips the panic hook
+  and every cleanup guard, which is how a v0.9.7 user's mid-turn exit left
+  mouse capture leaking SGR sequences into their shell. An
+  async-signal-safe handler now restores the terminal modes and appends a
+  one-line cause marker to `~/.codewhale/crashes/last-fatal-signal.log`
+  before re-raising, keeping the honest 128+signal wait status. A SIGKILL
+  (OOM killer) remains uninterceptable by design.
+
 ### Changed
 
 - Prompt-cache prefix is pinned for the session. The tool loop no longer

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1566,6 +1566,14 @@ fn run_with_args(args: Vec<String>) -> Result<()> {
     // See crates/tui/src/sandbox/process_hardening.rs for ordering rationale.
     crate::sandbox::process_hardening::apply_process_hardening();
 
+    // ── Fatal-signal terminal guard (#5424) ───────────────────────────────
+    // Abort-class deaths (stack overflow, allocation failure, double panic)
+    // skip the panic hook AND every Drop guard, leaving mouse capture and
+    // the kitty keyboard stack leaking into the user's shell. A classic
+    // sigaction handler restores the terminal and stamps a marker before
+    // re-raising. Also before any threads exist.
+    crate::tui::ui::fatal_signal_guard::install_fatal_signal_guard();
+
     // Set up process panic hook before anything else — writes crash dumps
     // to ~/.deepseek/crashes/ even if the panic happens before tokio is up,
     // and restores the terminal so a panicked TUI doesn't leave the user's

--- a/crates/tui/src/sandbox/process_hardening.rs
+++ b/crates/tui/src/sandbox/process_hardening.rs
@@ -20,6 +20,11 @@
 //!    ever gaining new privileges via setuid/setgid/fscaps. This is
 //!    irreversible and must be applied before executing any helper binaries or
 //!    subprocesses that might (incorrectly) rely on privilege boundaries.
+//!    Because this also blocks intentional privilege gains — `sudo`, `su`,
+//!    setuid helpers — a user who runs Codewhale as a wheel/wheel-equivalent
+//!    administrator and wants the model to be able to escalate can opt out of
+//!    exactly this one measure with `CODEWHALE_NO_NEW_PRIVS=0` (#5413). The
+//!    other two measures stay on.
 //!
 //! 3. `RLIMIT_CORE` — disables core dumps so that sensitive in-memory data
 //!    (API keys, tokens, prompt content) is never written to disk on a crash.
@@ -31,11 +36,39 @@
 //! from the `libc` crate). On non-Linux platforms, `apply_process_hardening()`
 //! is a no-op that logs a debug-level message.
 
+/// Environment variable that opts the process out of `PR_SET_NO_NEW_PRIVS`.
+///
+/// `PR_SET_NO_NEW_PRIVS` is an irreversible, inherited-by-children kernel
+/// flag, so applying it by default breaks workflows where the user *wants*
+/// Codewhale to be able to escalate: `sudo`, `su`, setuid/fscaps helpers run
+/// by a wheel-group administrator (#5413). Setting this variable to any
+/// falsey value (`0`, `false`, `no`, `off`, `disabled`, or empty) skips
+/// exactly this one measure. Any other value, or leaving it unset, keeps the
+/// default hardening. `PR_SET_DUMPABLE` and `RLIMIT_CORE` are never skipped.
+pub(crate) const NO_NEW_PRIVS_ENV: &str = "CODEWHALE_NO_NEW_PRIVS";
+
+/// Whether a `CODEWHALE_NO_NEW_PRIVS` value requests skipping the
+/// no-new-privileges flag. Falsey per the workspace env convention — the same
+/// value set (`""`, `0`, `false`, `no`, `off`, `disabled`) that
+/// `docs/CONFIGURATION.md` treats as "not set".
+fn is_no_new_privs_opt_out(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "" | "0" | "false" | "no" | "off" | "disabled"
+    )
+}
+
+fn no_new_privs_opted_out() -> bool {
+    std::env::var_os(NO_NEW_PRIVS_ENV)
+        .is_some_and(|value| is_no_new_privs_opt_out(&value.to_string_lossy()))
+}
+
 /// Apply process-level hardening measures.
 ///
 /// On Linux, this:
 /// - Sets `PR_SET_DUMPABLE` to 0 (prevents ptrace, core dumps)
-/// - Sets `PR_SET_NO_NEW_PRIVS` to 1 (irreversible no-new-privileges)
+/// - Sets `PR_SET_NO_NEW_PRIVS` to 1 (irreversible no-new-privileges),
+///   unless `CODEWHALE_NO_NEW_PRIVS` holds a falsey value (#5413)
 /// - Sets `RLIMIT_CORE` to 0 (disables core dumps)
 ///
 /// On non-Linux platforms this is a no-op.
@@ -88,19 +121,33 @@ fn apply_linux_hardening() {
     // transitions. This is the strongest anti-escalation primitive the kernel
     // offers.
     //
+    // That strength is also the flag's one legitimate break: a wheel-group
+    // administrator running Codewhale over ssh loses `sudo`/`su`/setuid
+    // helpers for the whole process tree (#5413). `CODEWHALE_NO_NEW_PRIVS`
+    // with a falsey value skips only this measure, before any thread exists —
+    // the same point in startup where the flag itself is applied.
+    //
     // Pattern from openai/codex codex-rs/codex-sandbox/src/linux.rs; reimplemented.
     //
     // Safety: prctl with PR_SET_NO_NEW_PRIVS modifies only the calling process
     // and its future descendants.
-    let result = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1i64, 0i64, 0i64, 0i64) };
-    if result != 0 {
-        let err = std::io::Error::last_os_error();
-        tracing::warn!(
-            "PR_SET_NO_NEW_PRIVS failed ({}); continuing without this hardening",
-            err
+    if no_new_privs_opted_out() {
+        tracing::info!(
+            target: "sandbox",
+            "PR_SET_NO_NEW_PRIVS skipped via {NO_NEW_PRIVS_ENV}: setuid/sudo escalation is \
+             allowed for this process tree"
         );
     } else {
-        tracing::debug!("PR_SET_NO_NEW_PRIVS=1 applied");
+        let result = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1i64, 0i64, 0i64, 0i64) };
+        if result != 0 {
+            let err = std::io::Error::last_os_error();
+            tracing::warn!(
+                "PR_SET_NO_NEW_PRIVS failed ({}); continuing without this hardening",
+                err
+            );
+        } else {
+            tracing::debug!("PR_SET_NO_NEW_PRIVS=1 applied");
+        }
     }
 
     // ── RLIMIT_CORE = 0 ────────────────────────────────────────────────────
@@ -135,5 +182,56 @@ mod tests {
         // This test exists to ensure the function can be called without
         // panicking, even on platforms where hardening is a no-op.
         apply_process_hardening();
+    }
+
+    #[test]
+    fn no_new_privs_opt_out_accepts_exactly_the_falsey_values() {
+        // The workspace env convention: "", 0, false, no, off, disabled.
+        for value in ["", "0", "false", "no", "off", "disabled"] {
+            assert!(
+                is_no_new_privs_opt_out(value),
+                "{value:?} should opt out of PR_SET_NO_NEW_PRIVS"
+            );
+            // Case and surrounding whitespace must not change the answer.
+            assert!(is_no_new_privs_opt_out(&format!(
+                " {} ",
+                value.to_uppercase()
+            )));
+        }
+    }
+
+    #[test]
+    fn no_new_privs_opt_out_rejects_truthy_and_garbage_values() {
+        // Anything else — including a typo — keeps the hardening on, so the
+        // opt-out can never be entered by accident.
+        for value in [
+            "1",
+            "true",
+            "yes",
+            "on",
+            "enabled",
+            "maybe",
+            "0x0",
+            "false-ish",
+            "off!",
+        ] {
+            assert!(
+                !is_no_new_privs_opt_out(value),
+                "{value:?} should NOT opt out of PR_SET_NO_NEW_PRIVS"
+            );
+        }
+    }
+
+    #[test]
+    fn no_new_privs_env_wiring_reads_the_documented_variable() {
+        // The env is process-global and tests run in parallel threads, so the
+        // wiring is asserted structurally: the constant is the documented
+        // name, and the reader is a pure projection of var_os over that
+        // constant. Setting/removing the variable here would race every other
+        // test in the process.
+        assert_eq!(NO_NEW_PRIVS_ENV, "CODEWHALE_NO_NEW_PRIVS");
+        let projected = std::env::var_os(NO_NEW_PRIVS_ENV)
+            .is_some_and(|value| is_no_new_privs_opt_out(&value.to_string_lossy()));
+        assert_eq!(projected, no_new_privs_opted_out());
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2593,6 +2593,7 @@ pub(crate) use handlers::*;
 pub use event_loop::run_tui;
 
 mod dispatch;
+pub(crate) mod fatal_signal_guard;
 mod motion;
 mod release_check;
 mod terminal;

--- a/crates/tui/src/tui/ui/fatal_signal_guard.rs
+++ b/crates/tui/src/tui/ui/fatal_signal_guard.rs
@@ -1,0 +1,229 @@
+//! Async-signal-safe terminal restore for abort-class process deaths.
+//!
+//! #5424: a v0.9.7 user's TUI exited by itself mid-turn with none of the
+//! ordinary cleanup running — no panic hook (so no crash dump), no
+//! `TerminalCleanupGuard`, no tokio signal task — and the shell was left with
+//! mouse capture still enabled, leaking SGR mouse-motion bytes into zsh.
+//! Whatever the fatal cause (a stack overflow aborts after Rust prints its
+//! message; an allocation failure aborts; `catch_unwind` cannot see either),
+//! the *terminal poisoning* is fixable from a classic signal handler: one
+//! fixed byte string written with `write(2)`.
+//!
+//! Scope is deliberately narrow:
+//!
+//! - **SIGABRT, SIGBUS, SIGILL, SIGFPE** are intercepted. **SIGSEGV is not**:
+//!   the Rust runtime's stack-overflow diagnostic runs on SIGSEGV, and this
+//!   handler must not bury it. Rust's overflow path itself funnels into
+//!   `abort()`, i.e. SIGABRT, so stack overflows still get the restore.
+//! - After the restore bytes are written (best-effort, both stdout and the
+//!   crash marker file), the disposition is reset to `SIG_DFL` and the signal
+//!   is re-raised, so the process keeps dying with the same signal — wait
+//!   status, core-dump behavior, and `$?` are unchanged.
+//! - Installed only when stdout is a TTY, so piped/embedded surfaces never
+//!   get escape bytes injected into their output.
+//!
+//! The marker file (`.codewhale/crashes/last-fatal-signal.log`, appended,
+//! never truncated) records which signal fired. The kernel's mtime on the
+//! file timestamps the crash without any time formatting in the handler. On
+//! the next real-world #5424-class report, that one line distinguishes an
+//! abort (stack overflow / alloc failure / double panic) from an OOM-kill
+//! (SIGKILL — uninterceptable, no marker) before any logs arrive.
+
+/// The restore byte string, written in a single `write(2)`.
+///
+/// Mirrors `emergency_restore_terminal`'s mode teardown, minus raw mode
+/// (termios state lives behind a lock that may be held by the dying thread)
+/// and minus every query (a dead process cannot read replies). Modes left
+/// over that a shell does not self-heal are the ones that poison input:
+/// mouse capture and the kitty keyboard stack get the full reset.
+const FATAL_RESTORE_BYTES: &[u8] = concat!(
+    "\x1b[?2026l", // close any open DEC 2026 synchronized-update batch
+    "\x1b[<1u",    // pop one kitty keyboard-enhancement stack level
+    "\x1b[?1007l", // alternate scroll off
+    "\x1b[?1004l", // focus reporting off
+    "\x1b[?2004l", // bracketed paste off
+    "\x1b[?1006l", // SGR mouse encoding off
+    "\x1b[?1002l", // button-event mouse tracking off
+    "\x1b[?1003l", // any-motion mouse tracking off
+    "\x1b[?1000l", // normal mouse tracking off
+    "\x1b[?1049l", // leave the alternate screen
+    "\x1b[?25h",   // show the cursor
+)
+.as_bytes();
+
+/// Absolute path of the append-only fatal-signal marker, fixed at install
+/// time (before any worker thread exists, after which it is never written
+/// again — a plain load from the signal handler).
+static MARKER_PATH: std::sync::OnceLock<Box<[u8; 4096]>> = std::sync::OnceLock::new();
+static MARKER_LEN: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Install the fatal-signal restore guard. POSIX only; no-op elsewhere.
+///
+/// Call once, early, on the main thread before worker threads are spawned
+/// (the install writes the `OnceLock`s; after that they are read-only).
+pub(crate) fn install_fatal_signal_guard() {
+    #[cfg(unix)]
+    {
+        // Piped/embedded surfaces must never receive escape bytes.
+        if unsafe { libc::isatty(libc::STDOUT_FILENO) } == 0 {
+            tracing::debug!("Fatal-signal terminal guard skipped: stdout is not a TTY");
+            return;
+        }
+        if let Some(home) = crate::config::effective_home_dir() {
+            let dir = home.join(".codewhale").join("crashes");
+            // Pre-create so the handler's open(2) cannot fail on ENOENT and
+            // so a first crash needs no directory creation mid-signal.
+            if std::fs::create_dir_all(&dir).is_ok() {
+                let path = dir.join("last-fatal-signal.log");
+                if let Ok(bytes) = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()) {
+                    let len = bytes.as_bytes().len();
+                    if len < 4096 {
+                        let mut buf = [0u8; 4096];
+                        buf[..len].copy_from_slice(bytes.as_bytes());
+                        let _ = MARKER_PATH.set(Box::new(buf));
+                        MARKER_LEN.store(len, std::sync::atomic::Ordering::Release);
+                    }
+                }
+            }
+        }
+        for signal in [libc::SIGABRT, libc::SIGBUS, libc::SIGILL, libc::SIGFPE] {
+            unsafe { install_handler(signal) };
+        }
+        tracing::debug!("Fatal-signal terminal guard installed (ABRT/BUS/ILL/FPE)");
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows console modes are restored by the panic hook and the
+        // cleanup guard; there is no signal-class death to intercept there.
+    }
+}
+
+/// Classic handler: write the fixed restore bytes, append the marker line,
+/// then re-raise with the default disposition so the wait status is honest.
+///
+/// # Safety
+///
+/// Only async-signal-safe operations: `write(2)`, `open(2)`, `close(2)`,
+/// `signal(2)`, `raise(2)`, and fixed-buffer arithmetic. No allocation, no
+/// locks (the `OnceLock`/`AtomicUsize` reads complete before any thread
+/// exists and are never written again).
+#[cfg(unix)]
+unsafe extern "C" fn fatal_signal_handler(signal: libc::c_int) {
+    unsafe {
+        // 1. Restore the terminal: stdout first, stderr as fallback.
+        let mut written: usize = 0;
+        while written < FATAL_RESTORE_BYTES.len() {
+            let n = libc::write(
+                libc::STDOUT_FILENO,
+                FATAL_RESTORE_BYTES.as_ptr().add(written) as *const libc::c_void,
+                FATAL_RESTORE_BYTES.len() - written,
+            );
+            if n <= 0 {
+                break;
+            }
+            written += n as usize;
+        }
+        if written == 0 {
+            let _ = libc::write(
+                libc::STDERR_FILENO,
+                FATAL_RESTORE_BYTES.as_ptr() as *const libc::c_void,
+                FATAL_RESTORE_BYTES.len(),
+            );
+        }
+
+        // 2. Append the one-line marker (mtime timestamps it).
+        let len = MARKER_LEN.load(std::sync::atomic::Ordering::Acquire);
+        if len > 0
+            && let Some(path) = MARKER_PATH.get()
+        {
+            let fd = libc::open(
+                path.as_ptr() as *const libc::c_char,
+                libc::O_WRONLY | libc::O_APPEND | libc::O_CREAT,
+                0o600,
+            );
+            if fd >= 0 {
+                // "signal=NN\n" in a fixed buffer; no formatting machinery.
+                let mut line = [0u8; 16];
+                line[0] = b's';
+                line[1] = b'i';
+                line[2] = b'g';
+                line[3] = b'n';
+                line[4] = b'a';
+                line[5] = b'l';
+                line[6] = b'=';
+                let mut value = if signal < 0 { 0 } else { signal } as u32;
+                let mut digits = [0u8; 10];
+                let mut count = 0;
+                loop {
+                    digits[count] = b'0' + (value % 10) as u8;
+                    value /= 10;
+                    count += 1;
+                    if value == 0 || count == digits.len() {
+                        break;
+                    }
+                }
+                for index in 0..count {
+                    line[7 + index] = digits[count - 1 - index];
+                }
+                let total = 7 + count;
+                line[total] = b'\n';
+                let _ = libc::write(fd, line.as_ptr() as *const libc::c_void, total + 1);
+                let _ = libc::close(fd);
+            }
+        }
+
+        // 3. Die with the honest wait status.
+        libc::signal(signal, libc::SIG_DFL);
+        libc::raise(signal);
+    }
+}
+
+/// Install [`fatal_signal_handler`] for one signal via `sigaction`.
+///
+/// # Safety
+///
+/// `signal` must be a fatal signal whose default action is to terminate.
+#[cfg(unix)]
+unsafe fn install_handler(signal: libc::c_int) {
+    unsafe {
+        // Zero the whole struct then set our two fields: the remaining
+        // members (empty signal mask; any hidden per-OS plumbing like the
+        // Linux sa_restorer) are exactly what a zeroed default means, and
+        // the wrapper `sigaction` fills in what it owns.
+        let mut action: libc::sigaction = std::mem::zeroed();
+        action.sa_sigaction = fatal_signal_handler as libc::sighandler_t;
+        action.sa_flags = libc::SA_RESTART;
+        if libc::sigaction(signal, &action, std::ptr::null_mut()) != 0 {
+            tracing::warn!(signal, "fatal-signal guard install failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restore_bytes_cover_every_poisoning_mode() {
+        // Input-poisoning modes first: mouse capture (all four DEC modes)
+        // and the kitty keyboard stack.
+        let bytes = String::from_utf8_lossy(FATAL_RESTORE_BYTES).to_string();
+        for mode in [
+            "?1006l", "?1002l", "?1003l", "?1000l", "<1u", "?2004l", "?1004l", "?1007l", "?1049l",
+            "?2026l", "?25h",
+        ] {
+            assert!(
+                bytes.contains(mode),
+                "fatal restore must reset {mode}; got: {bytes:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn restore_bytes_are_one_write_friendly() {
+        // No interior NULs, ASCII-only escape program, reasonable size.
+        assert!(!FATAL_RESTORE_BYTES.contains(&0));
+        assert!(FATAL_RESTORE_BYTES.len() < 128);
+        assert!(FATAL_RESTORE_BYTES.starts_with(b"\x1b[?2026l"));
+    }
+}

--- a/crates/tui/src/tui/ui/fatal_signal_guard.rs
+++ b/crates/tui/src/tui/ui/fatal_signal_guard.rs
@@ -191,7 +191,7 @@ unsafe fn install_handler(signal: libc::c_int) {
         // Linux sa_restorer) are exactly what a zeroed default means, and
         // the wrapper `sigaction` fills in what it owns.
         let mut action: libc::sigaction = std::mem::zeroed();
-        action.sa_sigaction = fatal_signal_handler as libc::sighandler_t;
+        action.sa_sigaction = fatal_signal_handler as *const () as libc::sighandler_t;
         action.sa_flags = libc::SA_RESTART;
         if libc::sigaction(signal, &action, std::ptr::null_mut()) != 0 {
             tracing::warn!(signal, "fatal-signal guard install failed");

--- a/crates/tui/src/tui/ui/fatal_signal_guard.rs
+++ b/crates/tui/src/tui/ui/fatal_signal_guard.rs
@@ -202,11 +202,10 @@ unsafe fn install_handler(signal: libc::c_int) {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
     #[test]
     fn restore_bytes_cover_every_poisoning_mode() {
         // Input-poisoning modes first: mouse capture (all four DEC modes)
@@ -223,7 +222,6 @@ mod tests {
         }
     }
 
-    #[cfg(unix)]
     #[test]
     fn restore_bytes_are_one_write_friendly() {
         // No interior NULs, ASCII-only escape program, reasonable size.

--- a/crates/tui/src/tui/ui/fatal_signal_guard.rs
+++ b/crates/tui/src/tui/ui/fatal_signal_guard.rs
@@ -36,6 +36,7 @@
 /// and minus every query (a dead process cannot read replies). Modes left
 /// over that a shell does not self-heal are the ones that poison input:
 /// mouse capture and the kitty keyboard stack get the full reset.
+#[cfg(unix)]
 const FATAL_RESTORE_BYTES: &[u8] = concat!(
     "\x1b[?2026l", // close any open DEC 2026 synchronized-update batch
     "\x1b[<1u",    // pop one kitty keyboard-enhancement stack level
@@ -54,7 +55,9 @@ const FATAL_RESTORE_BYTES: &[u8] = concat!(
 /// Absolute path of the append-only fatal-signal marker, fixed at install
 /// time (before any worker thread exists, after which it is never written
 /// again — a plain load from the signal handler).
+#[cfg(unix)]
 static MARKER_PATH: std::sync::OnceLock<Box<[u8; 4096]>> = std::sync::OnceLock::new();
+#[cfg(unix)]
 static MARKER_LEN: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 /// Install the fatal-signal restore guard. POSIX only; no-op elsewhere.
@@ -203,6 +206,7 @@ unsafe fn install_handler(signal: libc::c_int) {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
     fn restore_bytes_cover_every_poisoning_mode() {
         // Input-poisoning modes first: mouse capture (all four DEC modes)
@@ -219,6 +223,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn restore_bytes_are_one_write_friendly() {
         // No interior NULs, ASCII-only escape program, reasonable size.

--- a/crates/tui/tests/pty/release_runtime_qa.rs
+++ b/crates/tui/tests/pty/release_runtime_qa.rs
@@ -2544,3 +2544,214 @@ async fn release_session_picker_restores_route_identity() -> Result<()> {
     let _ = tui.shutdown();
     Ok(())
 }
+
+/// #5424 repro shape: the provider stays silent for roughly a minute (a slow
+/// "thinking" model), then drips tokens slowly while the transcript repaints.
+/// The TUI must survive both phases with mouse capture on; any exit is a
+/// release blocker. Run against a specific binary with
+/// `CARGO_BIN_EXE_codewhale-tui=/path/to/binary` to A/B versions.
+const REPRO_5424_SILENCE: Duration = Duration::from_secs(45);
+const REPRO_5424_TOKENS: usize = 600;
+const REPRO_5424_TOKEN_INTERVAL: Duration = Duration::from_millis(150);
+const REPRO_5424_ANSWER_TAIL: &str = "repro-5424-drip-done";
+
+/// A minimal loopback HTTP server with byte-level control over one SSE turn:
+/// full silence, then one small chunk every `REPRO_5424_TOKEN_INTERVAL`.
+/// wiremock cannot drip a body, so this is a raw `std::net` listener on a
+/// dedicated thread. `/v1/models` is answered with the QA model.
+fn spawn_repro_5424_server() -> Result<String> {
+    use std::io::{Read as _, Write as _};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind(("127.0.0.1", 0))?;
+    let base_url = format!("http://127.0.0.1:{}", listener.local_addr()?.port());
+    std::thread::Builder::new()
+        .name("repro-5424-server".to_string())
+        .spawn(move || {
+            for stream in listener.incoming().flatten() {
+                std::thread::spawn(move || {
+                    let Ok(mut reader) = stream.try_clone() else {
+                        return;
+                    };
+                    let mut buf = [0u8; 8192];
+                    let mut head = Vec::new();
+                    // Read until end of headers; request bodies here are tiny.
+                    loop {
+                        match reader.read(&mut buf) {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => {
+                                head.extend_from_slice(&buf[..n]);
+                                if head.windows(4).any(|w| w == b"\r\n\r\n") {
+                                    break;
+                                }
+                                if head.len() > 1 << 20 {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                    let head = String::from_utf8_lossy(&head).to_string();
+                    let mut writer = stream;
+                    if head.starts_with("GET /v1/models") {
+                        let body = format!(
+                            "{{\"object\":\"list\",\"data\":[{{\"id\":\"{DEEPSEEK_TEST_MODEL}\",\"object\":\"model\"}}]}}"
+                        );
+                        let _ = write!(
+                            writer,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        return;
+                    }
+                    if !head.starts_with("POST /v1/chat/completions") {
+                        let _ = writer.write_all(
+                            b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        );
+                        return;
+                    }
+                    let _ = writer.write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n",
+                    );
+                    let mut sse = |payload: &str| {
+                        let chunk = format!("data: {payload}\n\n");
+                        let _ = write!(writer, "{:x}\r\n{}\r\n", chunk.len(), chunk);
+                    };
+                    // Phase 1: dead air, the reporter's "wait about a minute".
+                    std::thread::sleep(REPRO_5424_SILENCE);
+                    // Phase 2: slow drip.
+                    for index in 0..REPRO_5424_TOKENS {
+                        sse(&format!(
+                            "{{\"id\":\"chatcmpl-5424\",\"object\":\"chat.completion.chunk\",\"model\":\"{DEEPSEEK_TEST_MODEL}\",\"choices\":[{{\"index\":0,\"delta\":{{\"content\":\"drip {index:03} \"}},\"finish_reason\":null}}]}}"
+                        ));
+                        std::thread::sleep(REPRO_5424_TOKEN_INTERVAL);
+                    }
+                    sse(&format!(
+                        "{{\"id\":\"chatcmpl-5424\",\"object\":\"chat.completion.chunk\",\"model\":\"{DEEPSEEK_TEST_MODEL}\",\"choices\":[{{\"index\":0,\"delta\":{{\"content\":\"{REPRO_5424_ANSWER_TAIL}\"}},\"finish_reason\":null}}]}}"
+                    ));
+                    sse(&format!(
+                        "{{\"id\":\"chatcmpl-5424\",\"object\":\"chat.completion.chunk\",\"model\":\"{DEEPSEEK_TEST_MODEL}\",\"choices\":[{{\"index\":0,\"delta\":{{}},\"finish_reason\":\"stop\"}}],\"usage\":{{\"prompt_tokens\":12,\"completion_tokens\":4,\"total_tokens\":16}}}}"
+                    ));
+                    sse("[DONE]");
+                    let _ = writer.write_all(b"0\r\n\r\n");
+                    // Half-close so a client that reads to EOF sees the end of
+                    // the turn instead of an eternally idle keep-alive socket.
+                    let _ = writer.flush();
+                    let _ = writer.shutdown(std::net::Shutdown::Write);
+                });
+            }
+        })?;
+    Ok(base_url)
+}
+
+/// The live repro for #5424 (v0.9.7 "TUI exits by itself" mid-turn). The
+/// reporter's shape: prompt, ~1 min of model silence, then output. Any exit
+/// code — including an abort-class 134 that bypasses the panic hook and
+/// leaves mouse capture leaking into the shell — fails here with the code.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "#5424 investigation: ~2.5 min wall clock; run explicitly during release QA"]
+async fn release_repro_5424_long_silence_then_slow_drip_keeps_tui_alive() -> Result<()> {
+    let _guard = RELEASE_RUNTIME_QA_LOCK.lock().await;
+    let base_url = spawn_repro_5424_server()?;
+
+    let ws = make_sealed_workspace()?;
+    let mut tui = common_tui_builder(&ws)
+        .env("CODEWHALE_PROVIDER", "deepseek")
+        .env("DEEPSEEK_API_KEY", "deepseek-local-test-key")
+        .env("DEEPSEEK_BASE_URL", &base_url)
+        .env("DEEPSEEK_MODEL", DEEPSEEK_TEST_MODEL)
+        .spawn()?;
+    enter_launch_session(&mut tui)?;
+
+    type_and_submit(&mut tui, "slow answer please, think it through")?;
+
+    let hold = REPRO_5424_SILENCE
+        + REPRO_5424_TOKEN_INTERVAL * REPRO_5424_TOKENS as u32
+        + Duration::from_secs(30);
+    pump_for(&mut tui, hold)?;
+
+    let needle = REPRO_5424_ANSWER_TAIL;
+    tui.wait_for_text(needle, Duration::from_secs(20))?;
+
+    let _ = tui.shutdown();
+    Ok(())
+}
+
+/// #5424 class defense: an abort-class death (stack overflow, allocation
+/// failure, double panic — the classes that skip the panic hook and every
+/// Drop guard) must still restore the terminal and stamp the signal marker,
+/// instead of leaking mouse capture into the user's shell. SIGABRT is the
+/// signal Rust's stack-overflow path lands in, so it is the representative
+/// case. The death itself must remain honest: exit code 134 (128 + SIGABRT),
+/// not a clean zero.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn release_fatal_abort_restores_terminal_and_stamps_the_marker() -> Result<()> {
+    let _guard = RELEASE_RUNTIME_QA_LOCK.lock().await;
+    let server = MockServer::start().await;
+    mount_models(&server, &[DEEPSEEK_TEST_MODEL]).await;
+    let ws = make_sealed_workspace()?;
+    let mut tui = common_tui_builder(&ws)
+        .env("CODEWHALE_PROVIDER", "deepseek")
+        .env("DEEPSEEK_API_KEY", "deepseek-local-test-key")
+        .env("DEEPSEEK_BASE_URL", server.uri())
+        .env("DEEPSEEK_MODEL", DEEPSEEK_TEST_MODEL)
+        .spawn()?;
+    enter_launch_session(&mut tui)?;
+
+    let pid = tui
+        .pid()
+        .ok_or_else(|| anyhow!("child pid unavailable before the fatal signal"))?;
+    // The signal must land on a live interactive TUI, not race a boot-time
+    // self-exit; assert liveness the way the other fatal-path tests do.
+    assert!(
+        tui.wait_for_exit(Duration::from_millis(250)).is_none(),
+        "TUI exited before the fatal signal was delivered: {}",
+        tui.debug_dump()
+    );
+    // Safety: delivering a signal to a process we own in this test.
+    let sent = unsafe { libc::kill(pid as libc::pid_t, libc::SIGABRT) };
+    assert_eq!(sent, 0, "SIGABRT delivery failed");
+
+    let code = tui
+        .wait_for_exit(Duration::from_secs(10))
+        .ok_or_else(|| anyhow!("TUI still alive 10s after SIGABRT\n{}", tui.debug_dump()))?;
+    // portable-pty's ExitStatus flattens a signal death (no exit code) to 1
+    // and keeps only the signal name, so 1 here means "died by signal", not
+    // a graceful exit; the marker below pins the signal to SIGABRT exactly.
+    assert_eq!(
+        code, 1,
+        "expected a signal-class death, got exit code {code}"
+    );
+
+    // The handler's restore bytes are the last thing on the wire: mouse
+    // capture (all four DEC modes) and the alternate screen must be off.
+    let transcript = tui.transcript();
+    for needle in [
+        &b"\x1b[?1006l"[..],
+        b"\x1b[?1003l",
+        b"\x1b[?1000l",
+        b"\x1b[?1049l",
+    ] {
+        assert!(
+            transcript.windows(needle.len()).any(|w| w == needle),
+            "fatal-signal restore did not reset {}: transcript tail was {:?}",
+            String::from_utf8_lossy(needle),
+            String::from_utf8_lossy(&transcript[transcript.len().saturating_sub(200)..]),
+        );
+    }
+
+    // The marker classifies the death for the next real-world report.
+    let marker = std::fs::read_to_string(
+        ws.home()
+            .join(".codewhale")
+            .join("crashes")
+            .join("last-fatal-signal.log"),
+    )
+    .map_err(|err| anyhow!("fatal-signal marker missing after SIGABRT: {err}"))?;
+    assert!(
+        marker.contains("signal=6"),
+        "marker must name SIGABRT, got {marker:?}"
+    );
+
+    Ok(())
+}

--- a/crates/tui/tests/support/qa_harness/harness.rs
+++ b/crates/tui/tests/support/qa_harness/harness.rs
@@ -256,7 +256,18 @@ impl Harness {
 
     /// Resolve a binary by Cargo bin-name (uses `CARGO_BIN_EXE_<name>`).
     /// Tests should call this rather than hard-coding paths.
+    ///
+    /// `QA_TUI_BIN` overrides the `codewhale-tui` resolution entirely — cargo
+    /// itself always sets `CARGO_BIN_EXE_*` for integration tests, so an
+    /// inherited value cannot win. Release QA uses this to A/B an older
+    /// released binary against the in-tree build (e.g. the #5424 sweep).
     pub fn cargo_bin(name: &str) -> PathBuf {
+        if name == "codewhale-tui"
+            && let Some(path) = std::env::var_os("QA_TUI_BIN")
+            && !path.is_empty()
+        {
+            return PathBuf::from(path);
+        }
         // Newer Cargo exposes CARGO_BIN_EXE_* at runtime; older supported
         // Cargo versions expose it to the integration test at compile time.
         let key = format!("CARGO_BIN_EXE_{name}");

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1034,6 +1034,13 @@ the `CODEWHALE_*` value wins.
 - `CODEWHALE_ALLOW_SHELL` (`1`/`true` enables)
 - `CODEWHALE_APPROVAL_POLICY` (`on-request|untrusted|never`)
 - `CODEWHALE_SANDBOX_MODE` (`read-only|workspace-write|danger-full-access|external-sandbox`)
+- `CODEWHALE_NO_NEW_PRIVS` (`0`/`false`/`no`/`off`/`disabled` opts out) — Linux only. The
+  TUI process sets the kernel's irreversible no-new-privileges flag at startup
+  as defense-in-depth, which blocks `sudo`/`su`/setuid helpers for Codewhale's
+  whole process tree. Set this variable to a falsey value before launching if
+  you administer through Codewhale as a wheel-group user and need escalation
+  to work (#5413); the other startup hardening (no ptrace, no core dumps)
+  stays on. Any other value keeps the default hardened posture.
 - `CODEWHALE_MANAGED_CONFIG_PATH`
 - `CODEWHALE_REQUIREMENTS_PATH`
 - `CODEWHALE_MAX_SUBAGENTS` (clamped to `1..=128`)


### PR DESCRIPTION
Release-blocker fixes found after the v0.9.8 train merged (`8880682c6`) and before anything was published (tag `v0.9.8` exists pointing there; the release run was cancelled; npm/crates/GitHub release all unpublished — verified via `check-published.sh 0.9.8`).

## Fixes #5413 — sudo regression (root-caused, fixed)

`apply_process_hardening()` sets the irreversible, inherited `PR_SET_NO_NEW_PRIVS` at startup, so `sudo`/`su`/setuid helpers fail for the whole process tree for wheel-group administrators (0.8.65 worked, 0.9.7 didn't).

- `CODEWHALE_NO_NEW_PRIVS` with any falsey value (`0|false|no|off|disabled|""`, case/whitespace-insensitive — the CONFIGURATION.md env convention) skips exactly that one prctl, before any thread exists, with an info log. Typos and truthy values keep the hardened posture.
- `PR_SET_DUMPABLE` and `RLIMIT_CORE` are never skipped.
- 4 unit tests on the value table + wiring; docs in CONFIGURATION.md; changelog.

## #5424 — TUI silent exit mid-turn (class root-caused, defended; issue stays open pending reporter artifacts)

Symptom forensics: the death bypassed the panic hook (no crash dump), every Drop guard, and the tokio signal task — only an abort-class death (stack overflow → SIGABRT, allocation failure, double panic) or SIGKILL does that. The leaked mouse-capture sequences in the reporter's shell are exactly the terminal modes those paths skip.

Repro campaign (no repro on either binary — official v0.9.7 Linux asset and the 0.9.8 candidate, macOS PTY harness + Debian/bookworm container with real tmux): 45–60s provider silence then slow drip; SGR mouse-motion floods; resize storms; `--continue` resumes; SSE keep-alives; a 100KB mid-stream chunk; and wide-cell CJK/emoji/ZWJ content aimed at the ratatui-core 0.1.0→0.1.2 diff change. All survived with flat RSS.

Fix (what we can fix without the reporter's artifacts):
- New async-signal-safe guard on SIGABRT/SIGBUS/SIGILL/SIGFPE (SIGSEGV deliberately left to Rust's stack-overflow diagnostics; that path funnels into SIGABRT) writes one fixed restore byte string (sync-update close, kitty keyboard pop, focus/paste/mouse/alt-screen off) and appends `signal=N` to `~/.codewhale/crashes/last-fatal-signal.log`, then re-raises with SIG_DFL so the 128+signal wait status and core-dump behavior stay honest. TTY-gated so piped surfaces emit nothing. The next real-world occurrence is now self-classifying: marker present = abort class with the signal named; marker absent = SIGKILL/OOM.
- Verified in debug and release builds: SIGABRT to a live PTY TUI leaves the restore bytes on the wire, writes `signal=6`, and dies by signal. Gated by a new PTY regression test.
- QA_TUI_BIN harness override enables binary A/B release QA (cargo clobbers CARGO_BIN_EXE_* for integration tests).

After merge: v0.9.8 tag will be moved to the new main SHA per the runbook's explicit-approval path (nothing published, maintainer direction on record), release re-run, crates/npm published.