### PR TITLE
feat(fleet): usable read-only shell for scouts/reviewers (#5426)

### DIFF
--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -1606,8 +1606,6 @@ mod tests {
         }
     }
 
-    use super::*;
-
     #[test]
     fn test_safe_commands() {
         assert_eq!(analyze_command("ls -la").level, SafetyLevel::Safe);

--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -434,6 +434,14 @@ pub fn is_parallel_readonly_command(command: &str) -> bool {
         return false;
     }
 
+    readonly_tokens_admitted(trimmed)
+}
+
+/// The token-level decision shared by every machine-authority read-only
+/// classifier: the charset filters above have already run for the caller's
+/// posture. Keys on the arity-aware canonical form, the literal-program
+/// hardener, the env-prefix rejection, and the per-command option tables.
+fn readonly_tokens_admitted(trimmed: &str) -> bool {
     let tokens = shell_words(trimmed);
     let Some(start) = primary_token_index(&tokens) else {
         return false;
@@ -484,6 +492,168 @@ pub fn is_parallel_readonly_command(command: &str) -> bool {
         .iter()
         .chain(GITHUB_READONLY_PREFIXES.iter())
         .any(|prefix| *prefix == canonical)
+}
+
+/// Read-only shell surface for `ShellPolicy::ReadOnly` agents (fleet scouts
+/// and reviewers, #5356 follow-up): the parallel auto-approve table widened by
+/// exactly the shapes real repo reconnaissance needs, still
+/// mutation-proof-by-construction.
+///
+/// Relaxations relative to [`is_parallel_readonly_command`] (which stays
+/// untouched for the parent's parallel auto-approve chunks, where its
+/// tightness is load-bearing):
+///
+/// - pipelines `a | b`, where **every** segment must itself be an admitted
+///   read-only command (an empty segment — including `||` — rejects);
+/// - glob `*` arguments, expanded by the shell only against workspace paths
+///   the operand gate already confines;
+/// - `git -C <dir> <subcommand>` and `git --no-pager <subcommand>`, whose
+///   remainder re-enters the existing per-subcommand option tables;
+/// - `find` without any mutating primary (`-delete`, `-exec`, `-execdir`,
+///   `-ok`, `-okdir`, `-fprintf`, `-fls`, `-fprint`, `-fprint0`);
+/// - `sed -n '<range>p` — numeric line-range print only, no script verbs
+///   (`w`/`r`/`e`/`s`) can appear in a two-token range script;
+/// - `npm view|show|info <pkg>` — registry reads, matching the scout role's
+///   network-capable read-only posture;
+/// - pure text filters `sort`, `uniq`, `cut`, `tr`, `comm` as pipeline
+///   stages.
+///
+/// Everything else keeps the parallel classifier's posture: no separators,
+/// redirects, backgrounding, command/parameter expansion, subshells, or
+/// env-assignment prefixes.
+pub fn is_agent_readonly_shell_command(command: &str) -> bool {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.chars().any(|ch| {
+        matches!(
+            ch,
+            '\n' | '\r'
+                | ';'
+                | '&'
+                | '>'
+                | '<'
+                | '`'
+                | '$'
+                | '?'
+                | '['
+                | ']'
+                | '{'
+                | '}'
+                | '('
+                | ')'
+        )
+    }) {
+        return false;
+    }
+    // A pipeline is admitted only when every segment is: `a | b` is two
+    // read-only commands, while `a | | b`, `a |`, and `||` all carry an empty
+    // segment and reject. Quoted pipes inside an argument mis-split here,
+    // which only ever makes a segment fail classification (fail closed).
+    trimmed.split('|').all(is_agent_readonly_segment)
+}
+
+fn is_agent_readonly_segment(segment: &str) -> bool {
+    let segment = segment.trim();
+    if segment.is_empty() {
+        return false;
+    }
+    let tokens = shell_words(segment);
+    let Some(program) = tokens.first() else {
+        return false;
+    };
+    // No `env ...`/`KEY=value ...` prefix — same rule as the parallel table.
+    if primary_token_index(&tokens) != Some(0) || program.contains('=') {
+        return false;
+    }
+    match program.as_str() {
+        "git" => is_agent_readonly_git(&tokens),
+        "find" => is_agent_readonly_find(&tokens),
+        "sed" => is_agent_readonly_sed(&tokens),
+        "npm" => is_agent_readonly_npm(&tokens),
+        "sort" | "uniq" | "cut" | "tr" | "comm" => true,
+        // Everything else re-uses the parallel table verbatim (including the
+        // gh families and per-command option allowlists); its glob-free
+        // charset is enforced by the caller having already rejected every
+        // metacharacter this classifier permits except `|` and `*`, and the
+        // shared token logic re-checks the rest.
+        _ => readonly_tokens_admitted(segment),
+    }
+}
+
+fn is_agent_readonly_git(tokens: &[String]) -> bool {
+    // Skip the two safe global preambles; anything else before the
+    // subcommand (e.g. `--git-dir`, `-c`) leaves it unclassified and
+    // rejected, exactly like the parallel table.
+    let mut rest = &tokens[1..];
+    loop {
+        match rest.first().map(String::as_str) {
+            Some("--no-pager") => rest = &rest[1..],
+            Some("-C") if rest.len() >= 2 => rest = &rest[2..],
+            _ => break,
+        }
+    }
+    let Some(subcommand) = rest.first().map(String::as_str) else {
+        return false;
+    };
+    if !matches!(
+        subcommand,
+        "status" | "log" | "diff" | "show" | "ls-files" | "blame" | "grep"
+    ) {
+        return false;
+    }
+    // Re-enter the parallel option tables with the preamble stripped so
+    // `git -C dir log --oneline -n 5` is judged as `git log --oneline -n 5`.
+    let mut reduced = vec![tokens[0].clone()];
+    reduced.extend(rest.iter().cloned());
+    readonly_tokens_admitted(&reduced.join(" "))
+}
+
+fn is_agent_readonly_find(tokens: &[String]) -> bool {
+    const MUTATING_PRIMARIES: &[&str] = &[
+        "-delete",
+        "-exec",
+        "-execdir",
+        "-ok",
+        "-okdir",
+        "-fprintf",
+        "-fls",
+        "-fprint",
+        "-fprint0",
+        "-truncate",
+    ];
+    tokens
+        .iter()
+        .skip(1)
+        .all(|token| !MUTATING_PRIMARIES.contains(&token.as_str()))
+}
+
+fn is_agent_readonly_sed(tokens: &[String]) -> bool {
+    if tokens.len() < 3 || tokens[1] != "-n" {
+        return false;
+    }
+    // Numeric line-range print scripts only: `10p`, `1,5p`, `p`. Script
+    // verbs that write or execute (`w`, `r`, `e`, `s///w`) cannot appear in
+    // a two-token range script, and separators like `;` were already
+    // rejected at the charset gate.
+    let script = tokens[2].as_str();
+    let Some(head) = script.strip_suffix(['p', 'P']) else {
+        return false;
+    };
+    let numeric = |part: &str| !part.is_empty() && part.chars().all(|ch| ch.is_ascii_digit());
+    head.is_empty()
+        || numeric(head)
+        || head
+            .split_once(',')
+            .is_some_and(|(a, b)| numeric(a) && numeric(b))
+}
+
+fn is_agent_readonly_npm(tokens: &[String]) -> bool {
+    matches!(
+        tokens.get(1).map(String::as_str),
+        Some("view" | "show" | "info")
+    )
 }
 
 /// Return `true` only for the networked GitHub CLI subset admitted by
@@ -1320,6 +1490,106 @@ pub fn extract_primary_command(command: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_readonly_shell_admits_real_reconnaissance_shapes() {
+        for command in [
+            "git log",
+            "git -C crates/tui log --oneline -n 5",
+            "git --no-pager log --stat",
+            "git -C ../sibling status --short",
+            "grep TODO crates/ | head -5",
+            "git log --oneline | head -20",
+            "cat Cargo.toml | wc -l",
+            "rg enum crates/ | sort | uniq -c | head",
+            "find . -name *.rs -maxdepth 3",
+            "find crates -type f -name *.toml | head",
+            "sed -n 10p Cargo.toml",
+            "sed -n 1,5p README.md",
+            "npm view codewhale version",
+            "sort deps.txt | uniq -c",
+            "ls -la *.md",
+        ] {
+            assert!(
+                is_agent_readonly_shell_command(command),
+                "{command} should be agent read-only"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_readonly_shell_rejects_mutation_and_injection() {
+        for command in [
+            "git log; rm -rf /",
+            "git log && rm -rf /",
+            "git log | rm -rf /",
+            "git log | | head",
+            "git log |",
+            "|| head",
+            "cat a > b",
+            "cat a >> b",
+            "echo hi < a",
+            "cat $(which sh)",
+            "cat `which sh`",
+            "echo ${IFS}",
+            "find . -delete",
+            "find . -exec rm {} +",
+            "find . -execdir sh -c true ;",
+            "sed -n 1,5w /tmp/out Cargo.toml",
+            "sed -i s/a/b/ file",
+            "sed -n e true Cargo.toml",
+            "npm install left-pad",
+            "npm run build",
+            "FOO=1 git log",
+            "env PAGER=cat git log",
+            "git --git-dir=/tmp/x.git log",
+            "git -c core.fsmonitor=./hook log",
+            "git log (modified)",
+            "git log | (head)",
+            "git push origin main",
+            "awk BEGIN{system(rm)} file",
+            "python3 -c print(1)",
+        ] {
+            assert!(
+                !is_agent_readonly_shell_command(command),
+                "{command} must stay denied for agents"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_readonly_pipeline_needs_every_segment_readonly() {
+        // The final segment is the classifier-rejected one in each pair.
+        assert!(!is_agent_readonly_shell_command("git log | tee out"));
+        assert!(!is_agent_readonly_shell_command("cat f | xargs rm"));
+        assert!(!is_agent_readonly_shell_command("sort f | tail -1 | sh"));
+        // A denied segment anywhere in the chain denies the whole pipeline.
+        assert!(!is_agent_readonly_shell_command(
+            "head f | rm -rf / | wc -l"
+        ));
+    }
+
+    #[test]
+    fn parallel_classifier_stays_unchanged_for_parent_auto_approve() {
+        // The relaxations belong to the agent surface only; the parent's
+        // parallel auto-approve chunks keep rejecting them.
+        for command in [
+            "git log | head -5",
+            "grep TODO crates/ | head",
+            "find . -name *.rs",
+            "git -C crates/tui log",
+            "sed -n 10p Cargo.toml",
+            "npm view codewhale version",
+        ] {
+            assert!(
+                !is_parallel_readonly_command(command),
+                "{command} must stay parallel-strict"
+            );
+            assert!(is_agent_readonly_shell_command(command));
+        }
+    }
+
     use super::*;
 
     #[test]

--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -728,6 +728,13 @@ fn readonly_options_are_allowed(canonical: &str, tokens: &[&str]) -> bool {
         && (!canonical.starts_with("gh ") || !github_command_targets_unsupported_host(tokens))
 }
 
+fn is_numeric_count_shorthand(token: &str) -> bool {
+    let Some(digits) = token.strip_prefix('-') else {
+        return false;
+    };
+    !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+}
+
 fn options_match_allowlist(tokens: &[&str], switches: &str, values: &str) -> bool {
     let mut index = 0;
     let mut options = true;
@@ -738,6 +745,15 @@ fn options_match_allowlist(tokens: &[&str], switches: &str, values: &str) -> boo
         } else if options && token.starts_with('-') && token != "-" {
             if switches.split_ascii_whitespace().any(|name| name == token) {
                 // exact, no-value switch
+            } else if is_numeric_count_shorthand(token)
+                && values
+                    .split_ascii_whitespace()
+                    .any(|name| name == "-n" || name == "--lines")
+            {
+                // `head -5` / `tail -20` are the ubiquitous shorthand for
+                // `-n 5` / `-n 20`; only commands whose value flags include a
+                // line-count accept them, and the digit-only form can carry no
+                // attached path or value injection.
             } else if values.split_ascii_whitespace().any(|name| name == token) {
                 index += 1;
                 if index >= tokens.len() || tokens[index].starts_with('-') {

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -1681,16 +1681,26 @@ impl ShellManager {
 
         // Create command spec and prepare sandboxed environment
         let spec = if let Some(workspace) = readonly_workspace {
-            let (program, args) = hardened_readonly_argv(command)?;
-            let program = resolve_readonly_program(&program, workspace)?;
-            CommandSpec::program(
-                program
-                    .to_str()
-                    .ok_or_else(|| anyhow!("read-only executable path is not valid UTF-8"))?,
-                args,
-                work_dir.clone(),
-                Duration::from_millis(timeout_ms),
-            )
+            if command.contains('|') {
+                // An agent read-only pipeline: every segment was admitted by
+                // `is_agent_readonly_shell_command` (no separators, redirects,
+                // expansions, or subshells — only `|` between validated
+                // segments), so a shell is needed solely to bind the segments
+                // and report a failed stage through pipefail.
+                let piped = format!("set -o pipefail; {command}");
+                CommandSpec::shell(&piped, work_dir.clone(), Duration::from_millis(timeout_ms))
+            } else {
+                let (program, args) = hardened_readonly_argv(command)?;
+                let program = resolve_readonly_program(&program, workspace)?;
+                CommandSpec::program(
+                    program
+                        .to_str()
+                        .ok_or_else(|| anyhow!("read-only executable path is not valid UTF-8"))?,
+                    args,
+                    work_dir.clone(),
+                    Duration::from_millis(timeout_ms),
+                )
+            }
         } else {
             CommandSpec::shell(command, work_dir.clone(), Duration::from_millis(timeout_ms))
         };
@@ -2750,8 +2760,8 @@ pub fn new_shared_shell_manager(workspace: PathBuf) -> SharedShellManager {
 // === ToolSpec Implementations ===
 
 use crate::command_safety::{
-    SafetyLevel, analyze_command, extract_primary_command, is_github_readonly_command,
-    is_parallel_readonly_command,
+    SafetyLevel, analyze_command, extract_primary_command, is_agent_readonly_shell_command,
+    is_github_readonly_command, is_parallel_readonly_command,
 };
 use crate::execpolicy::{ExecPolicyDecision, load_default_policy};
 use crate::features::Feature;
@@ -3070,7 +3080,34 @@ fn enforce_readonly_github_network_policy(
     }
 }
 
+/// `exec_shell_input_is_parallel_readonly` with the agent-posture classifier:
+/// same input-shape restrictions (run action only, no background/tty/stdin),
+/// but commands are judged by [`is_agent_readonly_shell_command`] so
+/// `ShellPolicy::ReadOnly` agents keep a usable inspection surface
+/// (pipelines, globs, `git -C`, `find`, `sed -n`, `npm view`).
+fn exec_shell_input_agent_readonly(input: &serde_json::Value) -> bool {
+    if !exec_shell_input_is_parallel_readonly_shape(input) {
+        return false;
+    }
+    let command = input
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .expect("shape check established a command string");
+    is_agent_readonly_shell_command(command)
+}
+
 fn exec_shell_input_is_parallel_readonly(input: &serde_json::Value) -> bool {
+    if !exec_shell_input_is_parallel_readonly_shape(input) {
+        return false;
+    }
+    let command = input
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .expect("shape check established a command string");
+    is_parallel_readonly_command(command)
+}
+
+fn exec_shell_input_is_parallel_readonly_shape(input: &serde_json::Value) -> bool {
     let Some(fields) = input.as_object() else {
         return false;
     };
@@ -3085,9 +3122,6 @@ fn exec_shell_input_is_parallel_readonly(input: &serde_json::Value) -> bool {
         Some(serde_json::Value::String(action)) if action == "run" => {}
         Some(_) => return false,
     }
-    let Some(command) = input.get("command").and_then(serde_json::Value::as_str) else {
-        return false;
-    };
     if ["background", "interactive", "tty", "combined_output"]
         .iter()
         .any(|key| {
@@ -3112,7 +3146,10 @@ fn exec_shell_input_is_parallel_readonly(input: &serde_json::Value) -> bool {
         return false;
     }
 
-    is_parallel_readonly_command(command)
+    input
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .is_some()
 }
 
 fn hardened_readonly_argv(command: &str) -> Result<(String, Vec<String>)> {
@@ -3125,19 +3162,37 @@ fn hardened_readonly_argv(command: &str) -> Result<(String, Vec<String>)> {
     // Even when repository/user configuration names a diff or signature
     // helper, these flags make Git keep the read inside its own process.
     if argv.first().is_some_and(|program| program == "git") {
-        let subcommand = argv.get(1).map(String::as_str).ok_or_else(|| {
-            anyhow!("classifier-approved Git read was missing its literal subcommand")
-        })?;
+        // The agent read-only classifier admits `git -C <dir>` and
+        // `git --no-pager` before the subcommand; keep the preamble but
+        // locate the subcommand after it so the hardening flags splice in
+        // the right place. `-C` targets were already workspace-checked by
+        // `enforce_readonly_workspace_operands`.
+        let mut subcommand_index = 1;
+        while let Some(flag) = argv.get(subcommand_index) {
+            match flag.as_str() {
+                "--no-pager" => subcommand_index += 1,
+                "-C" => subcommand_index += 2,
+                _ => break,
+            }
+        }
+        let subcommand = argv
+            .get(subcommand_index)
+            .map(String::as_str)
+            .ok_or_else(|| {
+                anyhow!("classifier-approved Git read was missing its literal subcommand")
+            })?;
         match subcommand {
             "diff" => {
+                let at = subcommand_index + 1;
                 argv.splice(
-                    2..2,
+                    at..at,
                     ["--no-ext-diff".to_string(), "--no-textconv".to_string()],
                 );
             }
             "log" | "show" => {
+                let at = subcommand_index + 1;
                 argv.splice(
-                    2..2,
+                    at..at,
                     [
                         "--no-ext-diff".to_string(),
                         "--no-textconv".to_string(),
@@ -3935,7 +3990,7 @@ impl ToolSpec for BashTool {
                     "Shell tools are disabled by the active permission profile.",
                 ));
             }
-            ShellPolicy::ReadOnly if !exec_shell_input_is_parallel_readonly(&input) => {
+            ShellPolicy::ReadOnly if !exec_shell_input_agent_readonly(&input) => {
                 return Ok(ToolResult::error(
                     "Shell command blocked by read-only shell policy. Use a non-mutating, non-background inspection command, or switch to Work mode (`/mode work`) for write-capable shell work.",
                 ));


### PR DESCRIPTION
Fixes #5426. Splits the read-only shell classifier so `ShellPolicy::ReadOnly` agents keep the #5356 bounded shell usable, without touching the parent's parallel auto-approve posture.

- New `is_agent_readonly_shell_command`: pipelines (every segment validated), globs, `git -C`/`--no-pager`, `find` (mutating primaries denied), `sed -n <range>p`, `npm view|show|info`, `sort/uniq/cut/tr/comm`.
- `head/tail -N` recognized as `-n N` (digit-only, line-count commands only) — shared, still read-only.
- Single commands exec direct-argv as before (`-C`-aware splice); pipelines exec via `set -o pipefail` over pre-validated segments; workspace operand confinement unchanged.
- Gates: command_safety 64/64, shell 113/113, fleet exact 42/42, readonly-tagged 34/34.

Merge AFTER the v0.9.8 publish completes (release lane frozen at tag).