### PR TITLE
fix(release): asset freshness vs the successful release job's started_at (#5429)

### DIFF
--- a/npm/codewhale/scripts/verify-release-assets.js
+++ b/npm/codewhale/scripts/verify-release-assets.js
@@ -229,7 +229,11 @@ async function findReleaseWorkflowRun(repo, tag, tagSha, api = githubApi) {
       (job) => job.name === "release" && job.conclusion === "success",
     );
     if (releaseJob) {
-      return candidate;
+      // #5429: pin asset freshness to the successful release job's own
+      // started_at, not the run-level run_started_at. A job-level rerun
+      // (`gh run rerun --failed`) bumps run_started_at past the asset upload
+      // timestamps even though this release job produced those assets.
+      return { ...candidate, release_job_started_at: releaseJob.started_at || null };
     }
   }
 
@@ -260,7 +264,12 @@ function assertReleaseAssetsFresh(release, expectedAssets, run) {
     throw new Error(`GitHub Release is missing required release asset(s): ${missing.join(", ")}`);
   }
 
-  const runStartedAt = parseGitHubTime(run.run_started_at || run.created_at, "workflow run start");
+  // #5429: compare against the successful release job's started_at when the
+  // run record carries it; fall back to the run-level timestamp only when a
+  // job baseline is unavailable.
+  const baseline = run.release_job_started_at || run.run_started_at || run.created_at;
+  const baselineLabel = run.release_job_started_at ? "release job start" : "workflow run start";
+  const freshnessBaseline = parseGitHubTime(baseline, baselineLabel);
   const stale = [];
   for (const expected of expectedAssets) {
     const asset = assetsByName.get(expected);
@@ -269,7 +278,7 @@ function assertReleaseAssetsFresh(release, expectedAssets, run) {
       continue;
     }
     const updatedAt = parseGitHubTime(asset.updated_at || asset.created_at, `${expected} update`);
-    if (updatedAt < runStartedAt) {
+    if (updatedAt < freshnessBaseline) {
       stale.push(`${expected} updated at ${asset.updated_at || asset.created_at}`);
     }
   }

--- a/npm/codewhale/test/release-assets.test.js
+++ b/npm/codewhale/test/release-assets.test.js
@@ -120,6 +120,38 @@ test("assertReleaseAssetsFresh accepts assets updated by the release workflow ru
   );
 });
 
+test("assertReleaseAssetsFresh accepts assets uploaded before a job-level rerun bumped run_started_at (#5429)", () => {
+  assert.doesNotThrow(() =>
+    assertReleaseAssetsFresh(
+      { assets: [{ name: "codewhale-linux-x64", state: "uploaded", updated_at: "2026-08-15T02:00:00Z" }] },
+      ["codewhale-linux-x64"],
+      {
+        database_id: 123,
+        // `gh run rerun --failed` moves the run-level start forward…
+        run_started_at: "2026-08-15T10:00:00Z",
+        // …but the release job that actually uploaded the assets is unchanged.
+        release_job_started_at: "2026-08-15T01:00:00Z",
+      },
+    ),
+  );
+});
+
+test("assertReleaseAssetsFresh still rejects assets older than the successful release job", () => {
+  assert.throws(
+    () =>
+      assertReleaseAssetsFresh(
+        { assets: [{ name: "codewhale-linux-x64", state: "uploaded", updated_at: "2026-08-15T00:30:00Z" }] },
+        ["codewhale-linux-x64"],
+        {
+          database_id: 123,
+          run_started_at: "2026-08-15T10:00:00Z",
+          release_job_started_at: "2026-08-15T01:00:00Z",
+        },
+      ),
+    /asset set is stale/,
+  );
+});
+
 test("findReleaseWorkflowRun accepts a successful release job when a downstream job failed", async () => {
   const run = {
     id: 123,
@@ -136,13 +168,16 @@ test("findReleaseWorkflowRun accepts a successful release job when a downstream 
     assert.equal(endpoint, "/actions/runs/123/jobs?per_page=100");
     return {
       jobs: [
-        { name: "release", conclusion: "success" },
+        { name: "release", conclusion: "success", started_at: "2026-08-12T07:30:00Z" },
         { name: "npm", conclusion: "failure" },
       ],
     };
   };
 
-  assert.equal(await findReleaseWorkflowRun("owner/repo", "v0.9.6", "abc123", api), run);
+  assert.deepEqual(await findReleaseWorkflowRun("owner/repo", "v0.9.6", "abc123", api), {
+    ...run,
+    release_job_started_at: "2026-08-12T07:30:00Z",
+  });
 });
 
 test("findReleaseWorkflowRun rejects runs without a successful release job", async () => {

--- a/scripts/release/verify-release-assets.sh
+++ b/scripts/release/verify-release-assets.sh
@@ -122,6 +122,10 @@ while IFS=$'\t' read -r run_id head_branch run_event run_url; do
       --jq '.jobs[] | select(.name == "release" and .conclusion == "success") | .databaseId' \
       | head -n 1
   )"
+  # Freshness vs the release job's own started_at (not the run-level
+  # run_started_at, which job-level reruns bump past the uploads) is enforced
+  # in npm/codewhale/scripts/verify-release-assets.js — see #5429. This check
+  # only proves a successful release job exists for the tag SHA.
   if [[ -n "${release_job_id}" ]]; then
     run_summary="${run_id}\t${head_branch}\t${run_event}\t${run_url}\trelease job ${release_job_id}"
     break


### PR DESCRIPTION
Closes #5429.

Job-level reruns (`gh run rerun --failed`) bump the run-level `run_started_at` past the asset upload timestamps, so every rerun of a failed downstream job failed the freshness gate with 'asset set is stale' even though the assets belong to that exact run and SHA (cost three attempts on the v0.9.8 publish).

## Change

- `findReleaseWorkflowRun` now carries `release_job_started_at` (the successful release job's own `started_at`) on the returned run record.
- `assertReleaseAssetsFresh` compares asset `updated_at` against that job baseline, falling back to `run_started_at` / `created_at` only when the job baseline is unavailable.
- The local `scripts/release/verify-release-assets.sh` path delegates freshness to the same JS verifier, so operator repairs after reruns are protected too (comment added there pointing at the enforcement site).

## Tests

- New: rerun-shifted `run_started_at` with an unchanged job `started_at` is judged fresh.
- New: assets older than the release job are still rejected.
- Updated the `findReleaseWorkflowRun` stubs to carry job `started_at` and assert the plumbed baseline.
- Full npm suite: 49/49 pass (`npm test` in npm/codewhale).