### PR TITLE
fix(fleet): answer the #5426 containment question — delegation never widens authority

### DIFF
--- a/crates/tui/src/fleet/exact.rs
+++ b/crates/tui/src/fleet/exact.rs
@@ -2031,6 +2031,71 @@ mod shell_ceiling_tests {
         );
     }
 
+    /// #5426 acceptance 2, made mechanical: delegation moves work, never
+    /// authority. A read-only scout's own runtime posture is the "session"
+    /// its children clamp against, so a `builder` member dispatched from a
+    /// read-only parent lands read-only — raw shell gone, ceiling-derived
+    /// posture, mutating tools denied — while the delegation itself stays
+    /// available (the depth budget is the parent's, not zero). The escape
+    /// hatch is work capacity, never a wider envelope.
+    #[test]
+    fn a_read_only_parents_delegation_never_widens_authority() {
+        // The scout's live runtime posture, expressed as the session ceiling
+        // a child clamps against: no writes, read-only shell, network kept,
+        // one level of delegation budget left.
+        let scout_runtime = PermissionCeiling {
+            write: false,
+            network_tool: true,
+            shell: ShellCeiling::ReadOnly,
+            delegation_depth: 1,
+            tools: true,
+        };
+        let builder_member = PermissionCeiling {
+            write: true,
+            network_tool: true,
+            shell: ShellCeiling::Full,
+            delegation_depth: 1,
+            tools: true,
+        };
+        assert!(builder_member.write && builder_member.shell == ShellCeiling::Full);
+
+        let authority =
+            ChildAuthority::clamp_for_role("builder", builder_member, scout_runtime);
+
+        // Authority does not widen through delegation: the child is read-only.
+        assert!(!authority.ceiling.write);
+        assert_eq!(authority.ceiling.shell, ShellCeiling::ReadOnly);
+        assert_eq!(authority.write_authority, "read_only");
+        assert_eq!(
+            authority.posture_role, "scout",
+            "a write-capable role name must not smuggle write through delegation"
+        );
+        assert!(denies_raw_shell(&authority));
+        for mutating in ["write_file", "apply_patch"] {
+            assert!(
+                authority.disallowed_tools.iter().any(|rule| rule == mutating),
+                "{mutating} must stay denied for a scout-delegated builder: {:?}",
+                authority.disallowed_tools
+            );
+        }
+
+        // The escape hatch itself stays open: delegation is still possible
+        // (the parent's budget is intact). But it is useless for shell:
+        // canonical Bash is denied to a delegated child (it is not a bounded
+        // inspection role), so a scout can never obtain bash by spawning —
+        // the scout's own bounded read-only Bash from #5428 is the only shell
+        // path a read-only parent has.
+        assert_eq!(authority.max_depth, 1);
+        assert!(
+            authority
+                .disallowed_tools
+                .iter()
+                .any(|name| name.eq_ignore_ascii_case("Bash")),
+            "a scout-delegated child must not gain canonical Bash: {:?}",
+            authority.disallowed_tools
+        );
+    }
+
     /// The deny list feeds the fingerprint, so a ceiling that now denies more
     /// must fingerprint differently from one that does not. Two postures that
     /// install different surfaces may never share a fingerprint.

--- a/crates/tui/src/fleet/exact.rs
+++ b/crates/tui/src/fleet/exact.rs
@@ -2059,8 +2059,7 @@ mod shell_ceiling_tests {
         };
         assert!(builder_member.write && builder_member.shell == ShellCeiling::Full);
 
-        let authority =
-            ChildAuthority::clamp_for_role("builder", builder_member, scout_runtime);
+        let authority = ChildAuthority::clamp_for_role("builder", builder_member, scout_runtime);
 
         // Authority does not widen through delegation: the child is read-only.
         assert!(!authority.ceiling.write);
@@ -2073,7 +2072,10 @@ mod shell_ceiling_tests {
         assert!(denies_raw_shell(&authority));
         for mutating in ["write_file", "apply_patch"] {
             assert!(
-                authority.disallowed_tools.iter().any(|rule| rule == mutating),
+                authority
+                    .disallowed_tools
+                    .iter()
+                    .any(|rule| rule == mutating),
                 "{mutating} must stay denied for a scout-delegated builder: {:?}",
                 authority.disallowed_tools
             );

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -82,6 +82,24 @@ its explicit tool list or the spawning call. The focused worker's header
 states the effective posture (`scout · read-only · network · read-only
 shell`) from the runtime's own permission snapshot.
 
+**Delegation moves work, never authority** (the containment answer for
+#5426). A read-only role delegating to a write-capable role (scout →
+builder) is a supported escape hatch for *work capacity* — the child brings
+its own model, route, and step budget — but the child's authority is clamped
+against the delegating parent's live posture, not the operator's: a scout's
+builder child lands read-only with raw shell and mutating tools denied, and
+canonical `Bash` is denied to it too (only bounded-inspection roles keep the
+classified read-only shell). Delegating to obtain shell is therefore
+mechanically useless — the scout's own bounded shell (`git -C … log`,
+`find … | head`, `npm view …`, classifier-gated) is the only shell path a
+read-only parent has. Read-only is transitive through any delegation chain:
+the clamp (`ChildAuthority::clamp` in `fleet/exact.rs`) intersects every
+field with the narrower side, the deny-list union means a descendant can
+never drop an ancestor's restriction, and `inherit_disallowed_tools: false`
+cannot drop a posture denial (`is_posture_denial`). This is pinned by
+`a_read_only_parents_delegation_never_widens_authority` in
+`crates/tui/src/fleet/exact.rs` tests.
+
 The session's **permission posture** applies inside every child exactly as
 it applies to the parent turn: under Auto-Review the same deterministic
 floor and one-shot model guardian decide a worker's held calls (never a


### PR DESCRIPTION
Closes #5426 (acceptance point 2; point 1 lands via #5428 + the behavioral dogfood check).

The acceptance criteria on #5426 ask for two things 0.9.9 must prove. This PR delivers the second:

**Policy, written down** (docs/SUBAGENTS.md): delegation moves work, never authority. scout → builder is an intended escape hatch for work *capacity* (model/route/budget), but the child's authority clamps against the delegating parent's live posture — read-only is transitive through any delegation chain. A delegated child cannot obtain canonical Bash, so spawning just for shell is mechanically useless; the scout's own bounded read-only shell (#5428) is the only shell path a read-only parent has.

**Pinned by test** (fleet/exact.rs): `a_read_only_parents_delegation_never_widens_authority` — a write-capable builder member dispatched from a read-only scout lands `write=false`, `shell=ReadOnly`, `posture_role=scout`, raw shell + Bash + mutating tools denied, while `max_depth` survives so the escape hatch stays open for capacity, never for authority.

Verified: `cargo test -p codewhale-tui --lib fleet::exact::shell_ceiling_tests` (7/7) and `cargo test -p codewhale-tui --lib command_safety` (64/64) with RUST_MIN_STACK=16777216.