### PR TITLE
fix(session): let /rename and /title apply mid-first-turn (#5430)

### DIFF
--- a/crates/tui/src/commands/groups/session/rename.rs
+++ b/crates/tui/src/commands/groups/session/rename.rs
@@ -81,6 +81,14 @@ pub(crate) fn rename_with_manager(
     }
     let mut session = match manager.load_session(session_id) {
         Ok(s) => s,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            match live_session_before_first_snapshot(manager, session_id, app) {
+                Some(s) => s,
+                None => {
+                    return CommandResult::error(format!("Could not load session: {err}"));
+                }
+            }
+        }
         Err(e) => return CommandResult::error(format!("Could not load session: {e}")),
     };
 
@@ -126,6 +134,39 @@ pub(crate) fn rename_with_manager(
         }
         Err(e) => CommandResult::error(format!("Could not save session: {e}")),
     }
+}
+
+/// Recover the session document for a live turn that has not completed (and
+/// therefore persisted) its first snapshot yet (#5430).
+///
+/// Until a turn completes, `sessions/<id>.json` does not exist — only the
+/// crash checkpoint written at dispatch does — so a mid-first-turn
+/// `/rename` or `/title` used to fail outright with "Could not load
+/// session". Prefer the durable checkpoint; if even that has not been
+/// flushed yet, rebuild the document from the same in-memory `App` state the
+/// checkpoint itself was built from. Everything rename needs to preserve
+/// (id, created_at, fork lineage, journal) is either in the checkpoint or
+/// has never existed, and `update_session` re-syncs the conversation from
+/// `App` state immediately afterwards in both cases.
+fn live_session_before_first_snapshot(
+    manager: &SessionManager,
+    session_id: &str,
+    app: &App,
+) -> Option<crate::session_manager::SavedSession> {
+    if let Ok(Some(checkpoint)) = manager.load_session_checkpoint(session_id) {
+        return Some(checkpoint);
+    }
+    Some(
+        crate::session_manager::create_saved_session_with_id_and_mode(
+            session_id.to_string(),
+            &app.api_messages,
+            &app.model_selection_for_persistence(),
+            &app.workspace,
+            u64::from(app.session.total_tokens),
+            app.system_prompt.as_ref(),
+            Some(app.mode.as_setting()),
+        ),
+    )
 }
 
 #[cfg(test)]
@@ -290,5 +331,65 @@ mod tests {
 
         let reloaded = manager.load_session(&session_id).unwrap();
         assert_eq!(reloaded.metadata.title, max_title);
+    }
+
+    // #5430: until a session's first turn completes, only the crash
+    // checkpoint written at dispatch exists — `sessions/<id>.json` does not.
+    // A mid-first-turn `/rename`/`/title` must apply from that checkpoint
+    // instead of failing with "Could not load session".
+    #[test]
+    fn rename_mid_first_turn_recovers_from_checkpoint_when_snapshot_missing() {
+        let tmp = TempDir::new().unwrap();
+        let manager = make_session_manager(&tmp);
+        let mut app = make_app(&tmp);
+
+        let checkpoint =
+            create_saved_session_with_mode(&[], "deepseek-v4-pro", tmp.path(), 0, None, None);
+        let session_id = checkpoint.metadata.id.clone();
+        manager.save_checkpoint(&checkpoint).unwrap();
+        app.current_session_id = Some(session_id.clone());
+        app.api_messages = vec![user_message("first turn still streaming")];
+
+        let result = rename_with_manager("Midturn Rename", &session_id, &manager, &mut app);
+        assert!(!result.is_error, "{result:?}");
+        assert_eq!(app.session_title.as_deref(), Some("Midturn Rename"));
+
+        // The rename promotes the checkpoint record to the durable session
+        // file, so the listing and the next launch see the new title.
+        let persisted = manager.load_session(&session_id).unwrap();
+        assert_eq!(persisted.metadata.title, "Midturn Rename");
+        assert_eq!(persisted.messages.len(), 1);
+    }
+
+    // Worst case of the same window: the user renames before even the
+    // dispatch checkpoint has been flushed. The document is then built from
+    // the same in-memory App state the checkpoint itself would carry.
+    #[test]
+    fn rename_mid_first_turn_builds_from_app_state_when_nothing_persisted() {
+        let tmp = TempDir::new().unwrap();
+        let manager = make_session_manager(&tmp);
+        let mut app = make_app(&tmp);
+
+        let session_id = "live-before-first-checkpoint";
+        app.current_session_id = Some(session_id.to_string());
+        app.api_messages = vec![user_message("turn one, nothing persisted yet")];
+
+        let result = rename_with_manager("Earliest Rename", session_id, &manager, &mut app);
+        assert!(!result.is_error, "{result:?}");
+        assert_eq!(app.session_title.as_deref(), Some("Earliest Rename"));
+
+        let persisted = manager.load_session(session_id).unwrap();
+        assert_eq!(persisted.metadata.title, "Earliest Rename");
+        assert_eq!(persisted.messages.len(), 1);
+    }
+
+    fn user_message(text: &str) -> crate::models::Message {
+        crate::models::Message {
+            role: "user".to_string(),
+            content: vec![crate::models::ContentBlock::Text {
+                text: text.to_string(),
+                cache_control: None,
+            }],
+        }
     }
 }

--- a/crates/tui/tests/pty/release_runtime_qa.rs
+++ b/crates/tui/tests/pty/release_runtime_qa.rs
@@ -528,6 +528,213 @@ fn compaction_tui_builder(
         .env("NO_ANIMATIONS", "1")
 }
 
+/// Loopback responder whose streaming turns each complete with a distinct
+/// marker after a fixed hold, so a PTY scenario can issue commands while the
+/// turn is provably still in flight and then wait for that turn's own
+/// completion marker.
+#[derive(Clone)]
+struct HeldTurnTextResponder {
+    requests: Arc<AtomicUsize>,
+    hold: Duration,
+}
+
+impl HeldTurnTextResponder {
+    fn new(hold: Duration) -> Self {
+        Self {
+            requests: Arc::new(AtomicUsize::new(0)),
+            hold,
+        }
+    }
+}
+
+impl Respond for HeldTurnTextResponder {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        let turn = self.requests.fetch_add(1, Ordering::SeqCst) + 1;
+        sse_response(text_sse(
+            DEEPSEEK_TEST_MODEL,
+            &format!("rename-qa turn {turn} complete"),
+        ))
+        .set_delay(self.hold)
+    }
+}
+
+/// Every OSC 0 (window title) sequence body the child has emitted so far.
+fn osc0_titles(transcript: &[u8]) -> Vec<String> {
+    let text = String::from_utf8_lossy(transcript);
+    let mut titles = Vec::new();
+    let mut rest = text.as_ref();
+    while let Some(start) = rest.find("\x1b]0;") {
+        rest = &rest[start + 4..];
+        let Some(end) = rest.find('\x07') else {
+            break;
+        };
+        titles.push(rest[..end].to_string());
+        rest = &rest[end + 1..];
+    }
+    titles
+}
+
+/// Assert the terminal tab (OSC 0) has been repainted with `prefix` as the
+/// `[prefix]` identity decoration.
+fn expect_osc0_prefix(harness: &Harness, prefix: &str) -> Result<()> {
+    let needle = format!("[{prefix}]");
+    let titles = osc0_titles(&harness.transcript());
+    anyhow::ensure!(
+        titles.iter().any(|title| title.starts_with(&needle)),
+        "OSC 0 window title was never repainted with {needle:?}; observed titles: {titles:?}"
+    );
+    Ok(())
+}
+
+/// The persisted `metadata.title` of the single saved session in the sealed
+/// home's sessions directory (checkpoints and sidecars excluded).
+fn persisted_session_title(ws: &SealedWorkspace) -> Result<(String, String)> {
+    let sessions_dir = ws.home().join(".codewhale/sessions");
+    let mut found: Vec<(String, String)> = Vec::new();
+    for entry in std::fs::read_dir(&sessions_dir)? {
+        let path = entry?.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let value: Value = serde_json::from_slice(&std::fs::read(&path)?)
+            .map_err(|err| anyhow!("session {path:?} is not valid JSON: {err}"))?;
+        let Some(id) = value["metadata"]["id"].as_str() else {
+            continue;
+        };
+        let title = value["metadata"]["title"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        found.push((id.to_string(), title));
+    }
+    anyhow::ensure!(
+        found.len() == 1,
+        "expected exactly one saved session, found {found:?}"
+    );
+    Ok(found.pop().expect("len checked"))
+}
+
+/// #5430: `/rename` and `/title` during a live turn must apply immediately
+/// (receipt + OSC 0 tab repaint while the stream is still open) and survive
+/// the turn's own autosave, the session listing, and the next launch. Both
+/// commands share one implementation, so one scenario drives both entry
+/// points: mid-turn on the session's first turn, mid-turn on a later turn,
+/// and at rest between turns.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn release_rename_title_mid_turn_and_mid_session_apply_and_survive() -> Result<()> {
+    let _guard = RELEASE_RUNTIME_QA_LOCK.lock().await;
+    let server = MockServer::start().await;
+    let responder = HeldTurnTextResponder::new(Duration::from_secs(3));
+    mount_models(&server, &[DEEPSEEK_TEST_MODEL]).await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(responder.clone())
+        .mount(&server)
+        .await;
+
+    let ws = make_sealed_workspace()?;
+    let mut tui = compaction_tui_builder(&ws, &server).spawn()?;
+    enter_launch_session(&mut tui)?;
+
+    // --- Phase 1: /rename mid-turn, during the session's FIRST turn (before
+    // any completed-turn autosave has ever written the session file). ---
+    type_and_submit(&mut tui, "rename qa first turn")?;
+    wait_for_counter(&mut tui, &responder.requests, 1, INTERACTION_TIMEOUT)?;
+    type_and_submit(&mut tui, "/rename PTY Midturn One")?;
+    tui.wait_for_text(
+        "Session and terminal tab renamed to \"PTY Midturn One\"",
+        INTERACTION_TIMEOUT,
+    )?;
+    // The tab repaint must land while the turn is still streaming: the
+    // responder holds every response for three seconds.
+    expect_osc0_prefix(&tui, "PTY Midturn One")?;
+    tui.wait_for_text("rename-qa turn 1 complete", INTERACTION_TIMEOUT)?;
+    let (session_id, title) = persisted_session_title(&ws)?;
+    assert_eq!(
+        title, "PTY Midturn One",
+        "first-turn mid-turn rename did not survive the turn's own autosave"
+    );
+
+    // --- Phase 2: /rename mid-turn on a later turn of the same session. ---
+    type_and_submit(&mut tui, "rename qa second turn")?;
+    wait_for_counter(&mut tui, &responder.requests, 2, INTERACTION_TIMEOUT)?;
+    type_and_submit(&mut tui, "/rename PTY Midturn Two")?;
+    tui.wait_for_text(
+        "Session and terminal tab renamed to \"PTY Midturn Two\"",
+        INTERACTION_TIMEOUT,
+    )?;
+    expect_osc0_prefix(&tui, "PTY Midturn Two")?;
+    tui.wait_for_text("rename-qa turn 2 complete", INTERACTION_TIMEOUT)?;
+    let (id2, title2) = persisted_session_title(&ws)?;
+    assert_eq!(
+        id2, session_id,
+        "a mid-turn rename must not fork a new session"
+    );
+    assert_eq!(
+        title2, "PTY Midturn Two",
+        "later-turn mid-turn rename did not survive the turn's own autosave"
+    );
+
+    // --- Phase 3: /title (the alias entry point) mid-turn. ---
+    type_and_submit(&mut tui, "title qa third turn")?;
+    wait_for_counter(&mut tui, &responder.requests, 3, INTERACTION_TIMEOUT)?;
+    type_and_submit(&mut tui, "/title PTY Midturn Title")?;
+    tui.wait_for_text(
+        "Session and terminal tab renamed to \"PTY Midturn Title\"",
+        INTERACTION_TIMEOUT,
+    )?;
+    expect_osc0_prefix(&tui, "PTY Midturn Title")?;
+    tui.wait_for_text("rename-qa turn 3 complete", INTERACTION_TIMEOUT)?;
+    let (_, title3) = persisted_session_title(&ws)?;
+    assert_eq!(
+        title3, "PTY Midturn Title",
+        "mid-turn /title did not survive the turn's own autosave"
+    );
+
+    // --- Phase 4: at rest (mid-session, no turn in flight), both commands. ---
+    type_and_submit(&mut tui, "/rename PTY Resting Rename")?;
+    tui.wait_for_text(
+        "Session and terminal tab renamed to \"PTY Resting Rename\"",
+        INTERACTION_TIMEOUT,
+    )?;
+    expect_osc0_prefix(&tui, "PTY Resting Rename")?;
+    let (_, title4) = persisted_session_title(&ws)?;
+    assert_eq!(title4, "PTY Resting Rename");
+
+    type_and_submit(&mut tui, "/title PTY Resting Title")?;
+    tui.wait_for_text(
+        "Session and terminal tab renamed to \"PTY Resting Title\"",
+        INTERACTION_TIMEOUT,
+    )?;
+    expect_osc0_prefix(&tui, "PTY Resting Title")?;
+    let (_, title5) = persisted_session_title(&ws)?;
+    assert_eq!(title5, "PTY Resting Title");
+
+    // --- Phase 5: the session listing shows the live title. ---
+    type_and_submit(&mut tui, "/sessions")?;
+    tui.wait_for_text("PTY Resting Title", INTERACTION_TIMEOUT)?;
+    tui.send(keys::key::esc())?;
+    // The picker's action rail ("all workspaces") is picker chrome, never
+    // transcript text, so its disappearance proves the overlay closed — the
+    // renamed title itself legitimately stays in the transcript behind it.
+    tui.wait_for(
+        |frame| !frame.contains("all workspaces"),
+        INTERACTION_TIMEOUT,
+    )?;
+
+    // --- Phase 6: next launch — a fresh process over the same sealed home
+    // lists the renamed session. ---
+    let _ = tui.shutdown();
+    let mut next = compaction_tui_builder(&ws, &server).spawn()?;
+    enter_launch_session(&mut next)?;
+    type_and_submit(&mut next, "/sessions")?;
+    next.wait_for_text("PTY Resting Title", INTERACTION_TIMEOUT)?;
+    let (_, title6) = persisted_session_title(&ws)?;
+    assert_eq!(title6, "PTY Resting Title");
+    let _ = next.shutdown();
+    Ok(())
+}
+
 /// The session metrics strip on the phase row after exactly one completed
 /// turn: `1 turn`, `Input 12` (the mock usage's prompt_tokens), and an
 /// `LLM` time — sourced from the engine's usage receipt and its own model-call


### PR DESCRIPTION
Closes #5430

## Summary

Until a session's first turn completes, only the crash checkpoint written at dispatch exists — `sessions/<id>.json` is not created until that turn's autosave. `rename_with_manager` (shared by `/rename` and `/title`) loaded only the main session file, so a mid-turn rename during the first turn failed with `Could not load session: No such file or directory`, leaving name, tab title, and listing untouched.

- On `NotFound`, recover the document: prefer the durable per-session checkpoint; if it has not been flushed yet, rebuild from the same in-memory `App` state the checkpoint is built from. The rename then promotes it to the durable session file, which the turn's autosave respects (disk-authoritative title merge).
- Two unit tests in `rename.rs` (checkpoint-only, nothing-persisted).
- One real-PTY regression test (`release_rename_title_mid_turn_and_mid_session_apply_and_survive`) driving both entry points through the live event loop: `/rename` mid-first-turn, `/rename` mid-later-turn, `/title` mid-turn, both at rest, asserting the OSC 0 tab repaint while the stream is still held open, the persisted session JSON, the `/sessions` listing, and a fresh relaunch over the same sealed home.

## Verification

Run locally on macOS in the branch worktree:

- `cargo fmt --all -- --check` — clean
- `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- rename title` — 65 passed, 0 failed
- `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --test pty -- release_rename_title` — 1 passed, 0 failed (12.5s)
- Negative check: with `rename.rs` reverted to `origin/main`, the same PTY test FAILS with `Could not load session: No such file or directory (os error 2)` (the exact issue symptom); restored afterwards.

## Not verified

- Full workspace test suite, clippy, Linux/bwrap behaviour, CI.
