### PR TITLE
fix(integrations): carry Responses-dialect DSH routes via pi-ai openai-responses (#5434)

### DIFF
--- a/crates/tui/src/integrations/cli.rs
+++ b/crates/tui/src/integrations/cli.rs
@@ -8,8 +8,8 @@ use anyhow::{Context, Result};
 
 use crate::config::Config;
 use crate::integrations::dsh::{
-    self, CLI_COMMAND, DetectEnv, DshIntegrationState, DshPaths, DshPlan, DshReceiptEvent,
-    DshStatusReport, ProcessRunner, RELATIONSHIP_LABEL,
+    self, CLI_COMMAND, DetectEnv, DshAdapter, DshIntegrationState, DshPaths, DshPlan,
+    DshReceiptEvent, DshStatusReport, ProcessRunner, RELATIONSHIP_LABEL,
 };
 use crate::{DshIntegrationCommand, IntegrationsCommand};
 
@@ -167,13 +167,21 @@ fn print_status(report: &DshStatusReport) {
         }
     }
     match (&report.current_identity, &report.current_identity_error) {
-        (Some(now), _) => println!(
+        (Some(now), _) if now.mappable() => println!(
             "  current Codewhale route: {}/{} · {} · would map via {}",
             now.source.provider_id,
             now.source.model,
             now.source.base_url,
             now.dsh_provider().unwrap_or("(not mappable)")
         ),
+        (Some(now), _) => {
+            if let DshAdapter::Unsupported { reason } = &now.adapter {
+                println!(
+                    "  current Codewhale route: {}/{} · {} · cannot be carried by DSH: {reason}",
+                    now.source.provider_id, now.source.model, now.source.base_url
+                );
+            }
+        }
         (None, Some(error)) => println!("  current Codewhale route: unresolved ({error})"),
         (None, None) => {}
     }

--- a/crates/tui/src/integrations/dsh/identity.rs
+++ b/crates/tui/src/integrations/dsh/identity.rs
@@ -71,7 +71,9 @@ impl DshPermissionMode {
 pub(crate) enum DshAdapter {
     /// `@deepseek-ai/dsh-llm-deepseek`, route id `deepseek-official`.
     DeepseekNative,
-    /// `@deepseek-ai/dsh-llm-pi-ai` hand-declared `openai-completions` route.
+    /// `@deepseek-ai/dsh-llm-pi-ai` hand-declared route. The route names the
+    /// provider's own wire dialect (`openai-completions`, `openai-responses`,
+    /// or `anthropic-messages`); see [`pi_ai_api_for`].
     PiAiOpenAiCompatible { route_id: String },
     /// DSH cannot carry this route; nothing is written for it.
     Unsupported { reason: String },
@@ -187,6 +189,27 @@ fn base_url_is_structural(url: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// The `api:` dialect a hand-declared `dsh-llm-pi-ai` route names for a
+/// Codewhale wire protocol — identity-preserving, never an approximation.
+///
+/// Verified against the installed `@deepseek-ai/dsh@0.1.0-rc.6`:
+/// `@deepseek-ai/dsh-llm-pi-ai`'s exported profile schema accepts exactly
+/// `openai-completions | openai-responses | anthropic-messages` for `api:`
+/// (`lib/index.js`: `const PROTOCOLS = { "openai-completions": …,
+/// "openai-responses": openAIResponsesApi, "anthropic-messages": … }`),
+/// while `@deepseek-ai/dsh-llm-deepseek` (the `deepseek-official` route)
+/// speaks chat completions only — its single wire call posts to
+/// `<baseURL>/chat/completions` with no protocol switch — so
+/// Responses-dialect DeepSeek routes (e.g. `deepseek-v4-flash`) ride the
+/// pi-ai hand-declared route instead.
+pub(crate) fn pi_ai_api_for(protocol: WireProtocol) -> &'static str {
+    match protocol {
+        WireProtocol::ChatCompletions => "openai-completions",
+        WireProtocol::Responses => "openai-responses",
+        WireProtocol::AnthropicMessages => "anthropic-messages",
+    }
+}
+
 fn route_id_for(provider_id: &str) -> String {
     let mut out = String::from("codewhale-");
     for ch in provider_id.chars() {
@@ -241,30 +264,15 @@ pub(crate) fn map_identity(
         };
     }
 
-    match identity.protocol {
-        WireProtocol::ChatCompletions => {}
-        WireProtocol::Responses => {
-            return MappedIdentity {
-                source: identity.clone(),
-                adapter: DshAdapter::Unsupported {
-                    reason: "route speaks the OpenAI Responses protocol; this adapter only declares openai-completions DSH routes".to_string(),
-                },
-                dsh_reasoning_effort: None,
-                permission_mode,
-                disclosures,
-            };
-        }
-        WireProtocol::AnthropicMessages => {
-            return MappedIdentity {
-                source: identity.clone(),
-                adapter: DshAdapter::Unsupported {
-                    reason: "route speaks the Anthropic Messages protocol; this adapter only declares openai-completions DSH routes".to_string(),
-                },
-                dsh_reasoning_effort: None,
-                permission_mode,
-                disclosures,
-            };
-        }
+    // Every wire dialect Codewhale can speak, `dsh-llm-pi-ai` declares a
+    // hand-declared route for (see `pi_ai_api_for`), so the route is carried
+    // in its own dialect rather than refused or approximated as completions.
+    if identity.protocol != WireProtocol::ChatCompletions {
+        disclosures.push(format!(
+            "Route speaks the {} dialect; DSH carries it through the `@deepseek-ai/dsh-llm-pi-ai` hand-declared route (`api: {}`) — the wire dialect is preserved, never approximated as chat completions.",
+            dialect_label(identity.protocol),
+            pi_ai_api_for(identity.protocol)
+        ));
     }
 
     if identity.reasoning_effort.is_some() {
@@ -296,6 +304,14 @@ pub(crate) fn map_identity(
         dsh_reasoning_effort: None,
         permission_mode,
         disclosures,
+    }
+}
+
+fn dialect_label(protocol: WireProtocol) -> &'static str {
+    match protocol {
+        WireProtocol::ChatCompletions => "OpenAI Chat Completions",
+        WireProtocol::Responses => "OpenAI Responses",
+        WireProtocol::AnthropicMessages => "Anthropic Messages",
     }
 }
 
@@ -354,7 +370,7 @@ pub(crate) fn render_overlay(mapped: &MappedIdentity) -> Option<String> {
             {
                 out.push_str(&format!("        apiKeyEnv: {}\n", yaml_str(env)));
             }
-            out.push_str("        api: openai-completions\n");
+            out.push_str(&format!("        api: {}\n", pi_ai_api_for(src.protocol)));
             out.push_str(&format!("        baseURL: {}\n", yaml_str(&src.base_url)));
             out.push_str("        models:\n");
             out.push_str(&format!("          - id: {}\n", yaml_str(&src.model)));

--- a/crates/tui/src/integrations/dsh/mod.rs
+++ b/crates/tui/src/integrations/dsh/mod.rs
@@ -325,9 +325,11 @@ pub(crate) fn plan(
 ) -> Result<DshPlan> {
     let mapped = map_identity(identity, allow_full_access);
     let overlay_text = render_overlay(&mapped).ok_or_else(|| match &mapped.adapter {
-        DshAdapter::Unsupported { reason } => {
-            anyhow::anyhow!("current Codewhale route cannot be carried by DSH: {reason}")
-        }
+        DshAdapter::Unsupported { reason } => anyhow::anyhow!(
+            "current Codewhale route {}/{} cannot be carried by DSH: {reason}",
+            identity.provider_id,
+            identity.model
+        ),
         _ => anyhow::anyhow!("overlay could not be rendered"),
     })?;
     let overlay_sha256 = sha256_hex(overlay_text.as_bytes());
@@ -899,9 +901,34 @@ pub(crate) fn status_line(report: &DshStatusReport) -> String {
         DshIntegrationState::Incompatible { reason, .. } => {
             format!("incompatible — dsh {version}: {reason}")
         }
-        DshIntegrationState::Detected { .. } => format!(
-            "detected — dsh {version}, not connected; `{CLI_COMMAND} plan` explains what would be written"
-        ),
+        DshIntegrationState::Detected { .. } => {
+            // Surface route carry-ability before `plan` is ever run, so a
+            // refuse-at-plan-time surprise is visible in `status`/doctor.
+            let carry = match report.current_identity.as_ref() {
+                Some(now) if now.mappable() => format!(
+                    "current route {}/{} is carryable via {}",
+                    now.source.provider_id,
+                    now.source.model,
+                    now.dsh_provider().unwrap_or("(unknown adapter)")
+                ),
+                Some(now) => match &now.adapter {
+                    DshAdapter::Unsupported { reason } => format!(
+                        "current route {}/{} cannot be carried by DSH: {reason}",
+                        now.source.provider_id, now.source.model
+                    ),
+                    _ => String::new(),
+                },
+                None => String::new(),
+            };
+            let carry = if carry.is_empty() {
+                String::new()
+            } else {
+                format!("; {carry}")
+            };
+            format!(
+                "detected — dsh {version}, not connected{carry}; `{CLI_COMMAND} plan` explains what would be written"
+            )
+        }
         DshIntegrationState::Connected { .. } => {
             let identity = report
                 .record

--- a/crates/tui/src/integrations/dsh/tests.rs
+++ b/crates/tui/src/integrations/dsh/tests.rs
@@ -313,23 +313,7 @@ fn keyed_openai_compatible_route_names_only_the_env_var() {
 }
 
 #[test]
-fn unsupported_protocols_and_credentialed_urls_are_refused() {
-    let id = identity(
-        "anthropic",
-        "claude",
-        "https://api.anthropic.com",
-        WireProtocol::AnthropicMessages,
-    );
-    let mapped = map_identity(&id, false);
-    assert!(matches!(mapped.adapter, DshAdapter::Unsupported { .. }));
-    assert!(render_overlay(&mapped).is_none());
-    let id = identity(
-        "openai-codex",
-        "gpt",
-        "https://x/responses",
-        WireProtocol::Responses,
-    );
-    assert!(!map_identity(&id, false).mappable());
+fn credentialed_base_urls_are_refused_and_the_error_names_the_route() {
     let id = identity(
         "custom",
         "m",
@@ -348,6 +332,118 @@ fn unsupported_protocols_and_credentialed_urls_are_refused() {
         WireProtocol::ChatCompletions,
     );
     assert!(!map_identity(&id, false).mappable());
+    // A Responses-dialect route with a credentialed URL is still refused —
+    // carrying the dialect never relaxes the structural-URL guard.
+    let id = identity(
+        "custom",
+        "m",
+        "https://user:token@gateway/v1",
+        WireProtocol::Responses,
+    );
+    assert!(!map_identity(&id, false).mappable());
+
+    // The plan refusal names the current route so it is actionable.
+    let (_dir, paths) = lab_paths();
+    let detection = detection_ok();
+    let id = identity(
+        "custom",
+        "secret-gateway-model",
+        "https://user:token@gateway/v1",
+        WireProtocol::ChatCompletions,
+    );
+    let error = super::plan(&paths, &detection, &id, "web", false, false)
+        .expect_err("credentialed URL must refuse");
+    let text = format!("{error:#}");
+    assert!(text.contains("custom/secret-gateway-model"), "{text}");
+    assert!(text.contains("userinfo"), "{text}");
+}
+
+#[test]
+fn responses_dialect_route_is_carried_not_approximated() {
+    // The default DeepSeek route from #5434: deepseek-v4-flash speaks the
+    // Responses dialect at https://api.deepseek.com/beta.
+    let id = identity(
+        "deepseek",
+        "deepseek-v4-flash",
+        "https://api.deepseek.com/beta",
+        WireProtocol::Responses,
+    );
+    let mapped = map_identity(&id, false);
+    assert_eq!(
+        mapped.adapter,
+        DshAdapter::PiAiOpenAiCompatible {
+            route_id: "codewhale-deepseek".to_string()
+        }
+    );
+    assert_eq!(mapped.dsh_provider(), Some("codewhale-deepseek"));
+    let overlay = render_overlay(&mapped).unwrap();
+    assert!(overlay.contains("provider: 'codewhale-deepseek'"));
+    assert!(overlay.contains("api: openai-responses"));
+    assert!(!overlay.contains("api: openai-completions"));
+    assert!(overlay.contains("baseURL: 'https://api.deepseek.com/beta'"));
+    assert!(overlay.contains("apiKeyEnv: 'DEEPSEEK_API_KEY'"));
+    assert!(overlay.contains("model: 'deepseek-v4-flash'"));
+    assert!(
+        mapped
+            .disclosures
+            .iter()
+            .any(|d| d.contains("openai-responses") && d.contains("never approximated"))
+    );
+
+    // And it plans cleanly end-to-end.
+    let (_dir, paths) = lab_paths();
+    let detection = detection_ok();
+    let plan = super::plan(&paths, &detection, &id, "web", false, false).unwrap();
+    assert!(plan.overlay_text.contains("api: openai-responses"));
+    assert_eq!(plan.mapped.dsh_provider(), Some("codewhale-deepseek"));
+}
+
+#[test]
+fn anthropic_messages_route_is_carried_in_its_own_dialect() {
+    let id = identity(
+        "anthropic",
+        "claude-sonnet-5",
+        "https://api.anthropic.com",
+        WireProtocol::AnthropicMessages,
+    );
+    let mapped = map_identity(&id, false);
+    assert!(matches!(
+        mapped.adapter,
+        DshAdapter::PiAiOpenAiCompatible { .. }
+    ));
+    let overlay = render_overlay(&mapped).unwrap();
+    assert!(overlay.contains("api: anthropic-messages"));
+    assert!(overlay.contains("apiKeyEnv: 'ANTHROPIC_API_KEY'"));
+    assert!(overlay.contains("baseURL: 'https://api.anthropic.com'"));
+}
+
+#[test]
+fn status_surfaces_route_carryability_before_plan() {
+    let (_dir, paths) = lab_paths();
+    let detection = detection_ok();
+    let id = identity(
+        "deepseek",
+        "deepseek-v4-flash",
+        "https://api.deepseek.com/beta",
+        WireProtocol::Responses,
+    );
+    let report = compute_status(&paths, detection.clone(), Ok(id), false, avail()).unwrap();
+    let line = status_line(&report);
+    assert!(
+        line.contains("deepseek/deepseek-v4-flash is carryable via codewhale-deepseek"),
+        "{line}"
+    );
+
+    let id = identity(
+        "custom",
+        "m",
+        "https://user:token@gateway/v1",
+        WireProtocol::ChatCompletions,
+    );
+    let report = compute_status(&paths, detection, Ok(id), false, avail()).unwrap();
+    let line = status_line(&report);
+    assert!(line.contains("custom/m cannot be carried by DSH"), "{line}");
+    assert!(line.contains("userinfo"), "{line}");
 }
 
 #[test]

--- a/docs/INTEGRATIONS_DSH.md
+++ b/docs/INTEGRATIONS_DSH.md
@@ -29,11 +29,13 @@ with the opt-in plugin path below, whatever `dsh plugin` itself writes into
 the dedicated `codewhale` DSH profile):
 
 - `codewhale.patch.yml` — the overlay. Identity only: provider route, model,
-  base URL, and (native DeepSeek route) `reasoningEffort`. For
-  OpenAI-compatible providers it declares a `codewhale-<provider>` route on
-  DSH's `llm-pi-ai` adapter with `apiKeyEnv` naming the provider's canonical
-  environment variable — the *name*, never the value. Keyless local routes
-  (loopback Ollama / LM Studio / vLLM / SGLang) carry no credential reference.
+  base URL, and (native DeepSeek route) `reasoningEffort`. For every
+  non-native route it declares a `codewhale-<provider>` route on DSH's
+  `llm-pi-ai` adapter, naming that route's own wire dialect under `api:`
+  (`openai-completions`, `openai-responses`, or `anthropic-messages`) and
+  `apiKeyEnv` naming the provider's canonical environment variable — the
+  *name*, never the value. Keyless local routes (loopback Ollama / LM Studio
+  / vLLM / SGLang) carry no credential reference.
 - `receipt.json` — the current connection record plus an append-only history
   of `connect` / `update` / `disable` / `enable` / `remove` events with the
   overlay SHA-256, dsh version, `$DSH_HOME`, mapped identity, permission mode,
@@ -102,8 +104,24 @@ sessions, and profiles remain theirs.
   cleared in DSH; `status`/`plan` list them.
 - Reasoning tiers are mapped only for the native DeepSeek route
   (`off|high|max`); hand-declared routes send no effort parameter.
-- Anthropic Messages and OpenAI Responses routes cannot be carried and are
-  refused rather than approximated.
+- Wire dialects are carried, never approximated: a Chat Completions route
+  declares `api: openai-completions`, an OpenAI Responses route (e.g. the
+  default `deepseek/deepseek-v4-flash`) declares `api: openai-responses`,
+  and an Anthropic Messages route declares `api: anthropic-messages`. This
+  follows the installed adapters' own declarations (verified against
+  `@deepseek-ai/dsh@0.1.0-rc.6`): `@deepseek-ai/dsh-llm-deepseek` — the
+  `deepseek-official` route — speaks chat completions only (its single wire
+  call posts to `<baseURL>/chat/completions`, with no protocol switch),
+  while `@deepseek-ai/dsh-llm-pi-ai`'s hand-declared route schema accepts
+  exactly `openai-completions | openai-responses | anthropic-messages` for
+  `api:`. So DeepSeek chat routes ride the native adapter (with reasoning
+  tiers), and every other dialect — including DeepSeek's own
+  Responses-dialect models — rides a hand-declared `codewhale-*` pi-ai
+  route in its own dialect.
+- What is refused: base URLs that embed credentials (userinfo or
+  query/fragment material) are never copied into the overlay; `plan` fails
+  naming the current `provider/model` and the reason, and `status` shows
+  carry-ability for the current route before `plan` is ever run.
 
 ## The DSH plugin path (`install-bundle`)
 


### PR DESCRIPTION
Closes #5434

## Summary

`codewhale integrations dsh plan` refused the default DeepSeek route (`deepseek/deepseek-v4-flash`, `endpoint_key: "responses"`) with "this adapter only declares openai-completions DSH routes". That is true for `@deepseek-ai/dsh-llm-deepseek` (its single wire call posts to `<baseURL>/chat/completions`) but not for `@deepseek-ai/dsh-llm-pi-ai`, whose hand-declared route schema accepts `openai-completions | openai-responses | anthropic-messages` for `api:`.

- `map_identity` now carries every Codewhale wire dialect via the pi-ai hand-declared route in its own dialect (`pi_ai_api_for`): Chat Completions -> `openai-completions`, Responses -> `openai-responses`, Anthropic Messages -> `anthropic-messages`. Nothing is approximated; DeepSeek chat routes still prefer `deepseek-official`.
- Credentialed base URLs (userinfo / query / fragment) still refuse; the `plan` error now names `provider/model`.
- `status` / `status_line` surface route carry-ability before `plan` is run.
- `docs/INTEGRATIONS_DSH.md` updated: overlay shape (`api:` dialect), what is carried vs. refused.
- Tests: `responses_dialect_route_is_carried_not_approximated` (the #5434 route plans end-to-end with `api: openai-responses`), `anthropic_messages_route_is_carried_in_its_own_dialect`, `status_surfaces_route_carryability_before_plan`, and the credentialed-URL refusal test now asserts the actionable error text.

## Verification

Run on macOS in the branch worktree (1 commit on top of `origin/main`):

- `cargo fmt --all -- --check` -> exit 0
- `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- integrations::dsh` -> `25 passed; 0 failed; 0 ignored`
- Cross-checked the adapter claims against the locally installed `@deepseek-ai/dsh@0.1.0-rc.6`: `dsh-llm-pi-ai/lib/index.js` `PROTOCOLS` table includes `"openai-responses": openAIResponsesApi`; `dsh-llm-deepseek/lib/index.js` posts only to `${connection.baseURL}/chat/completions`.

## Not verified

- Full workspace test suite, `cargo clippy`, and Linux/bwrap behaviour (reviewed on macOS only).
- A live `dsh --patch <overlay> --dump-config` / real DeepSeek Responses round-trip was not re-run in this review (the commit message reports it composed with exit 0).
