### PR TITLE
docs(i18n): add fr/de/zh-TW/hi/tr/it/pl/ar README translations

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -1,0 +1,139 @@
+<!-- source: README.md sha256:4fc19c5f9596 -->
+# Codewhale
+
+وكيل برمجة مفتوح المصدر لطرفيّتك — أحضر نموذجك بنفسك.
+
+بدأ Codewhale تجربة أصلية لـ DeepSeek. ومنذ ذلك الحين نما إلى مشروع تقوده
+المجتمع: حزمة برمجة واحدة تناسب مجتمعًا دوليًا متناميًا وتدعم أكبر عدد ممكن من
+النماذج والمزوّدين — النماذج المفتوحة أولًا، مستضافة أو محلية، بلا امتياز لأحد
+على البقية.
+
+أعطه مزوّدًا ونموذجًا ومهمة. يقرأ شفرتك، يعدّل الملفات، يشغّل الأوامر ويراجع
+عمله، ثم يتوقف عندما تكتمل المهمة أو يحتاجك. بدّل النموذج أثناء المهمة بـ
+`/model`. اعمل تفاعليًا في TUI، أو شغّل `codewhale exec` في السكربتات وCI.
+مكتوب بـ Rust، مرخّص بـ MIT، ويعمل على جهازك.
+
+ما يميّزه عن الحزم الأخرى: **أنت تختار النموذج لكل دور، ولا يلزم أن تتطابق.**
+يثبّت الـ fleet مزوّدًا ونموذجًا وطبقة استدلال لكل دور — فيقدر نموذج رخيص سريع
+أن يوجّه نموذج استدلال مكلفًا، أو يعمل builder على GLM في المهمة نفسها مع
+reviewer على Kimi. اكتب أدوارك ودستور constitution خاصًا بك، فتصبح الحزمة لك لا
+لنا.
+
+نبحث دائمًا عن مساهمين وسبل للتحسين. إن غاب نموذج أو مزوّد تستخدمه، أو تعطل
+شيء، فإخبارنا من أكثر ما يمكنك فعله نفعًا — انظر [المساهمة](#المساهمة).
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+
+[![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
+[![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/37gfS3ksug)
+
+![Codewhale يعمل في طرفية](assets/screenshot.png)
+
+## التثبيت
+
+```bash
+npm install -g codewhale
+```
+
+Cargo وDocker وNix وScoop والأرشيفات المبنية مسبقًا وAndroid/Termux ومرآة CNB
+لمن لا يصل إلى GitHub مشروحة في
+[docs/INSTALL.md](docs/INSTALL.md). قادم من `deepseek-tui`؟ إعدادك وجلساتك
+تنتقل معك — انظر [docs/REBRAND.md](docs/REBRAND.md).
+
+## الاستخدام
+
+```bash
+codewhale auth set --provider deepseek   # or export ANTHROPIC_API_KEY, etc.
+codewhale                                # open the TUI
+codewhale exec "fix the failing test"    # headless
+codewhale web                            # local browser client on 127.0.0.1
+```
+
+في TUI: `/model` يبدّل المزوّد والنموذج معًا، `/fleet` يبني الفريق ويشغّله —
+دور واحد في كل مرة، ولكلٍ نموذجه — و`/undo` يرجع آخر دور، و`/restore <N>` يعيد
+مساحة العمل إلى لقطة أقدم (`/restore` وحده يسردها). `Tab` يدور Plan / Work /
+Operate عندما يكون المحرّر فارغًا — ومع النص يكمّل أوامر الشرطة المائلة وإشارات
+`@`. `Shift+Tab` يدور في أي وقت وضع الأذونات Ask / Auto-Review / Full Access.
+`!` يشغّل أمر صدفة عبر مسار الموافقة المعتاد.
+
+## ماذا يفعل
+
+- **أي نموذج، أي مزوّد — وأي مزيج منهما.** DeepSeek وClaude وGPT وKimi وGLM وأكثر
+  من 30 مزوّدًا، إضافة إلى vLLM أو SGLang أو Ollama الخاص بك بلا مفتاح، كلها عبر
+  زمن تشغيل واحد ومجموعة أدوات واحدة. يتتبع الكتالوج تشكيلة كل مزوّد الحيّة —
+  يبقى خلفية DeepSeek V4 Pro (الموسومة `DeepSeek-V4-Pro-0813`) قابلة للاستدعاء
+  باسم `deepseek-v4-pro`، وGrok 4.6 هو الافتراضي المباشر لـ xAI، وOrcaRouter
+  يوجّه عبر `orcarouter/auto`. يسجّل الدور المحفوظ `provider` و`model` وطبقة
+  الاستدلال صراحة، فيقدر الـ fleet أن يعبر بائعين عدة في تشغيل واحد، ولا تعتمد
+  مسار الدور على أي مزوّد صادف أنه نشط. حدود السياق والأسعار تأتي من المسار
+  الحقيقي، والسعر المجهول يظهر مجهولًا لا 0 $.
+- **حزمة تكتبها أنت.** الأدوار ملفات تقرأها وتعدّلها — نموذج ووضعية أدوات
+  وتعليمات ثابتة لكل دور — تُحفظ في المشروع ليشاركها الفريق، أو بجانب إعداداتك
+  الشخصية الأخرى لتتبعك بين المستودعات. يسجّل الدستور constitution كيف تريد
+  الوكيل أن يتصرف عبر كل الجلسات، فتتوافق الحزمة مع ممارستك لا ممارستنا.
+- **للقراءة فقط حتى تسمح بالمزيد.** وضع Plan لا يغيّر الملفات، والموافقات تقفل
+  الأوامر الخطرة. عندما يلفّ صندوق رمل نظام التشغيل أمرًا فعلًا، يصرّح Codewhale:
+  Seatbelt على macOS إن توفّر، وbubblewrap اختياري على Linux. يُترجم
+  `constitution.json` في المستودع إلى أقفال كتابة لا يتجاوزها حتى Full Access.
+- **عمل يمكنك استئنافه.** يسجّل الـ fleet كل خطوة في دفتر للإلحاق فقط، فيلتقط
+  `fleet resume` من حيث توقفت.
+
+## التكاملات
+
+- **DeepSeek Harness (dsh) — متصل عبر Codewhale.**
+  يربط `codewhale integrations dsh connect` تثبيت `@deepseek-ai/dsh` القائم
+  بمسار مزوّد Codewhale وأذوناتك ومساحة عملك، ويضيف `integrations dsh
+  install-bundle` حزمة إضافات DSH الاختيارية حتى يحمل `dsh --profile codewhale`
+  تلك الهوية وحده. يملك Codewhale الأذونات وسلطة دورة الحياة؛ ويُبقي dsh جلساته
+  وملفاته التعريفية وبيانات اعتماده كما هي. انظر
+  [docs/INTEGRATIONS_DSH.md](docs/INTEGRATIONS_DSH.md).
+- **VS Code.** يفتح هيكل الامتداد الرسمي (`extensions/vscode`) Codewhale في
+  طرفية مدمجة ويعرض Agent View للقراءة فقط فوق زمن التشغيل المحلي. هذه معاينة
+  تطوير محلية، وليست إصدار سوق بعد.
+
+## اعرف المزيد
+
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — كل مسار مزوّد: مستضاف وبوابة ومحلي
+- [docs/FLEET.md](docs/FLEET.md) — الأساطيل والدفتر والاستئناف
+- [docs/WORKFLOW_EXPERIMENTAL_SEARCH.md](docs/WORKFLOW_EXPERIMENTAL_SEARCH.md) — بحث تجريبي مجمّد ومحايد تجاه المزوّد داخل Workflow
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml` والخطافات
+  والدستور constitution
+- [docs/AUTHORIZATION_ORDER.md](docs/AUTHORIZATION_ORDER.md) — كيف تتركب
+  الأوضاع والخطافات وقواعد الأذونات وأرضيات السلامة وقانون المستودع والموافقات
+  والصندوق الرملي
+- [docs/HOOKS.md](docs/HOOKS.md) — أحداث الخطاف الأحد عشر في دورة حياة TUI
+  وحمولاتها، وأي ثلاثة منها تستطيع توجيه دور (`codewhale exec` وأوامر CLI
+  الفرعية لا تطلق خطافات)
+- [docs/WEB.md](docs/WEB.md) — عميل المتصفح على العروة المحلية فقط وحدّ
+  المصادقة لمرة واحدة
+
+كل ما تبقّى — الأوضاع واختصارات المفاتيح وتفاصيل الصندوق الرملي وMCP وواجهة
+زمن التشغيل والعمارة — يعيش في [docs](docs) وعلى
+[codewhale.net](https://codewhale.net/).
+
+## المساهمة
+
+المسائل وطلبات السحب وخطوات إعادة الإنتاج والسجلات وطلبات الميزات كلها عمل
+مشروع حقيقي، وأول المساهمات مرحّب بها. عندما يتعذّر دمج طلب سحب كما هو، يحصد
+المصونون ما يعمل ويبقى المؤلف منسوبًا — في الالتزام وسجل التغييرات و
+[docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md).
+
+- [المسائل المفتوحة](https://github.com/Hmbown/CodeWhale/issues) — مساهمات أولى
+  جيدة هنا
+- [CONTRIBUTING.md](CONTRIBUTING.md) — إعداد التطوير ومسار طلبات السحب
+- [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) — كل من شكّل هذا المشروع
+- [اشترِ لي قهوة](https://www.buymeacoffee.com/hmbown)
+
+شكرًا لـ [DeepSeek](https://github.com/deepseek-ai) على النماذج والدعم الذي بدأ
+المشروع، ولـ [DataWhale](https://github.com/datawhalechina) 🐋 على الترحيب بنا
+في عائلة Whale Brother، ولـ [OpenWarp](https://github.com/zerx-lab/warp) و
+[Open Design](https://github.com/nexu-io/open-design) على التعاون في تجربة
+الوكيل في الطرفية.
+
+## الرخصة
+
+[MIT](LICENSE). مشروع مجتمعي مستقل، غير مرتبط بأي مزوّد نماذج.
+
+![Codewhale يفتح ثلاثة وكلاء فرعيين scout للقراءة فقط في طرفية](assets/fanout.gif)

--- a/README.ca.md
+++ b/README.ca.md
@@ -1,0 +1,158 @@
+<!-- source: README.md sha256:4fc19c5f9596 -->
+# Codewhale
+
+Un agent de programació de codi obert per al teu terminal — porta el teu propi model.
+
+El Codewhale va començar com una experiència nativa per al DeepSeek. Des d'aleshores
+s'ha convertit en un projecte impulsat per la comunitat: un harness de programació
+que encaixa amb una comunitat internacional en creixement i admet tants models i
+proveïdors com sigui possible — els models oberts primer, allotjats o locals, sense
+privilegiar-ne cap.
+
+Dona-li un proveïdor, un model i una tasca. Llegeix el teu codi, edita fitxers,
+executa ordres i comprova la seva pròpia feina, i s'atura quan la tasca s'ha acabat
+o et necessita. Canvia de model a mig camí amb `/model`. Treballa de forma
+interactiva a la TUI, o executa `codewhale exec` en scripts i CI. Està escrit en
+Rust, amb llicència MIT, i corre a la teva màquina.
+
+El que no s'assembla als altres harnessos: **tu tries el model de cada rol, i no
+cal que coincideixin.** Una fleet fixa un proveïdor, un model i un nivell de
+raonament per rol — així un model barat i ràpid pot dirigir-ne un de raonament car,
+o un builder GLM pot treballar en la mateixa tasca que un reviewer Kimi. Escriu els
+teus propis rols i la teva pròpia constitution, i el harness és teu en lloc de nostre.
+
+Sempre busquem persones que hi contribueixin i maneres de millorar. Si falta un
+model o un proveïdor que uses, o alguna cosa es trenca, dir-nos-ho és una de les
+coses més útils que pots fer — mira [Contribuir](#contribuir).
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+
+[![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
+[![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/37gfS3ksug)
+
+![Codewhale en execució en un terminal](assets/screenshot.png)
+
+## Instal·lació
+
+```bash
+npm install -g codewhale
+```
+
+Cargo, Docker, Nix, Scoop, arxius precompilats, Android/Termux i un mirall CNB
+per a qui no pot arribar a GitHub són a
+[docs/INSTALL.md](docs/INSTALL.md). Vens de `deepseek-tui`? La configuració i
+les sessions es conserven — mira [docs/REBRAND.md](docs/REBRAND.md).
+
+## Ús
+
+```bash
+codewhale auth set --provider deepseek   # or export ANTHROPIC_API_KEY, etc.
+codewhale                                # open the TUI
+codewhale exec "fix the failing test"    # headless
+codewhale web                            # local browser client on 127.0.0.1
+```
+
+A la TUI: `/model` canvia proveïdor i model alhora, `/fleet` construeix i
+executa l'equip — un rol cada vegada, cadascun amb el seu model —, `/undo`
+desfà l'últim torn i `/restore <N>` torna l'espai de treball a una instantània
+anterior (`/restore` sol els llista). `Tab` recorre Plan / Work / Operate quan
+el compositor és buit — amb text, `Tab` completa ordres slash i mencions `@`.
+`Shift+Tab` recorre en qualsevol moment la postura de permís Ask / Auto-Review /
+Full Access. `!` executa una ordre de l'intèrpret pel camí d'aprovació habitual.
+
+## Què fa
+
+- **Qualsevol model, qualsevol proveïdor — i qualsevol barreja.** DeepSeek,
+  Claude, GPT, Kimi, GLM i més de 30 proveïdors, a més del teu vLLM, SGLang o
+  Ollama sense clau, tot a través d'un sol runtime i un sol conjunt d'eines. El
+  catàleg segueix la línia en viu de cada proveïdor — el backend V4 Pro de
+  DeepSeek (etiquetat `DeepSeek-V4-Pro-0813`) continua sent invocable com
+  `deepseek-v4-pro`, Grok 4.6 és el predeterminat directe de xAI i OrcaRouter
+  enruta per `orcarouter/auto`. Un rol desat registra explícitament el
+  `provider`, el `model` i el nivell de raonament, de manera que una fleet pot
+  abastar diversos proveïdors en una sola execució i la ruta d'un rol no depèn
+  mai de quin proveïdor passa a estar actiu. Els límits de context i els preus
+  venen de la ruta real; un preu desconegut es mostra com a desconegut, no com
+  0 $.
+- **Un harness que escrius tu.** Els rols són fitxers que pots llegir i editar
+  — un model, una postura d'eines i instruccions permanents per rol — guardats
+  al projecte perquè l'equip els comparteixi, o al costat dels altres ajustos
+  personals perquè et segueixin entre repositoris. Una constitution registra com
+  vols que l'agent es comporti a cada sessió, de manera que el harness segueixi
+  la teva pràctica en lloc de la nostra.
+- **Només lectura fins que permetis més.** El mode Plan no pot canviar fitxers,
+  i les aprovacions tanquen les ordres arriscades. Quan un sandbox del sistema
+  operatiu envolta de debò una ordre, el Codewhale ho diu: Seatbelt a macOS
+  quan està disponible, bubblewrap opcional a Linux. El `constitution.json` d'un
+  repositori es compila en bloquejos d'escriptura que ni tan sols Full Access
+  pot saltar-se.
+- **Feina que pots reprendre.** Una fleet registra cada pas en un llibre major
+  de només afegir, així que `fleet resume` continua on et vas aturar.
+
+## Integracions
+
+- **DeepSeek Harness (dsh) — connectat a través de Codewhale.**
+  `codewhale integrations dsh connect` enllaça una instal·lació existent de
+  `@deepseek-ai/dsh` a la teva ruta de proveïdor, permisos i espai de treball
+  de Codewhale, i `integrations dsh install-bundle` afegeix el paquet de
+  connectors DSH opcional perquè `dsh --profile codewhale` porti aquesta
+  identitat tot sol. El Codewhale té els permisos i l'autoritat del cicle de
+  vida; el dsh conserva les seves sessions, perfils i credencials intactes.
+  Mira [docs/INTEGRATIONS_DSH.md](docs/INTEGRATIONS_DSH.md).
+- **VS Code.** L'entramat oficial de l'extensió (`extensions/vscode`) obre el
+  Codewhale en un terminal integrat i exposa una Agent View de només lectura
+  sobre el runtime local. És una previsualització de desenvolupament local, no
+  encara una publicació al marketplace.
+
+## Per saber-ne més
+
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — cada ruta de proveïdor: allotjada,
+  passarel·la i local
+- [docs/FLEET.md](docs/FLEET.md) — les fleets, el llibre major i la represa
+- [docs/WORKFLOW_EXPERIMENTAL_SEARCH.md](docs/WORKFLOW_EXPERIMENTAL_SEARCH.md) — cerca experimental congelada i neutral respecte al proveïdor dins de Workflow
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, ganxos i la
+  constitution
+- [docs/AUTHORIZATION_ORDER.md](docs/AUTHORIZATION_ORDER.md) — com es
+  combinen modes, ganxos, regles de permís, terres de seguretat, llei del
+  repositori, aprovacions i sandbox
+- [docs/HOOKS.md](docs/HOOKS.md) — els onze esdeveniments de ganxo del cicle
+  de vida de la TUI, les seves càrregues i quins tres poden orientar un torn
+  (`codewhale exec` i les subordres de la CLI no disparen ganxos)
+- [docs/WEB.md](docs/WEB.md) — el client de navegador només en loopback i el
+  seu límit d'autenticació d'un sol ús
+
+Tota la resta — modes, dreceres, detalls del sandbox, MCP, l'API del runtime
+i l'arquitectura — viu a [docs](docs) i a
+[codewhale.net](https://codewhale.net/).
+
+## Contribuir
+
+Els issues, els PR, els passos de reproducció, els registres i les peticions
+de funcionalitat són feina real de projecte, i les primeres contribucions són
+benvingudes. Quan un PR no es pot fusionar tal com està, els mantenidors
+recullen el que funciona i l'autor resta acreditat — al commit, al changelog i
+a [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md).
+
+- [Issues oberts](https://github.com/Hmbown/CodeWhale/issues) — les bones
+  primeres contribucions són aquí
+- [CONTRIBUTING.md](CONTRIBUTING.md) — configuració de desenvolupament i flux
+  de PR
+- [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) — tothom qui ha donat forma a
+  això
+- [Convida'm a un cafè](https://www.buymeacoffee.com/hmbown)
+
+Gràcies a [DeepSeek](https://github.com/deepseek-ai) pels models i el suport
+que van iniciar el projecte, a [DataWhale](https://github.com/datawhalechina)
+🐋 per acollir-nos a la família Whale Brother, i a
+[OpenWarp](https://github.com/zerx-lab/warp) i
+[Open Design](https://github.com/nexu-io/open-design) per col·laborar en
+l'experiència d'agent al terminal.
+
+## Llicència
+
+[MIT](LICENSE). Projecte comunitari independent, no afiliat a cap proveïdor de
+models.
+
+![Codewhale desplegant tres subagents scout de només lectura en un terminal](assets/fanout.gif)

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,168 @@
+<!-- source: README.md sha256:4fc19c5f9596 -->
+# Codewhale
+
+Ein Open-Source-Programmieragent für Ihr Terminal — bringen Sie Ihr eigenes Modell mit.
+
+Codewhale begann als native Erfahrung für DeepSeek. Daraus ist ein von der
+Community getragenes Projekt geworden: ein Coding-Harness, das zu einer
+wachsenden internationalen Community passt und so viele Modelle und Anbieter
+wie möglich unterstützt — offene Modelle zuerst, gehostet oder lokal, keines
+bevorzugt vor den anderen.
+
+Geben Sie ihm einen Anbieter, ein Modell und eine Aufgabe. Es liest Ihren
+Code, bearbeitet Dateien, führt Befehle aus und prüft die eigene Arbeit,
+und hält an, wenn die Aufgabe erledigt ist oder es Sie braucht. Wechseln
+Sie mitten in der Aufgabe das Modell mit `/model`. Arbeiten Sie interaktiv
+in der TUI, oder starten Sie `codewhale exec` in Skripten und CI.
+Geschrieben in Rust, lizenziert unter MIT, läuft es auf Ihrem Rechner.
+
+Was es von anderen Harnessen unterscheidet: **Sie wählen das Modell für
+jede Rolle, und sie müssen nicht übereinstimmen.** Eine Fleet legt
+Anbieter, Modell und Reasoning-Stufe pro Rolle fest — sodass ein günstiges,
+schnelles Modell ein teures Reasoning-Modell führen kann, oder ein
+GLM-Builder dieselbe Aufgabe bearbeitet wie ein Kimi-Reviewer. Schreiben
+Sie Ihre eigenen Rollen und Ihre eigene constitution, und der Harness
+gehört Ihnen, nicht uns.
+
+Wir suchen immer Mitwirkende und Wege, besser zu werden. Fehlt ein Modell
+oder ein Anbieter, den Sie nutzen, oder bricht etwas, uns das zu sagen ist
+eines der nützlichsten Dinge, die Sie tun können — siehe
+[Mitwirken](#mitwirken).
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+
+[![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
+[![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/37gfS3ksug)
+
+![Codewhale läuft in einem Terminal](assets/screenshot.png)
+
+## Installation
+
+```bash
+npm install -g codewhale
+```
+
+Cargo, Docker, Nix, Scoop, vorkompilierte Archive, Android/Termux und ein
+CNB-Spiegel für alle, die GitHub nicht erreichen, stehen in
+[docs/INSTALL.md](docs/INSTALL.md). Kommen Sie von `deepseek-tui`? Ihre
+Konfiguration und Sitzungen bleiben erhalten — siehe
+[docs/REBRAND.md](docs/REBRAND.md).
+
+## Verwendung
+
+```bash
+codewhale auth set --provider deepseek   # or export ANTHROPIC_API_KEY, etc.
+codewhale                                # open the TUI
+codewhale exec "fix the failing test"    # headless
+codewhale web                            # local browser client on 127.0.0.1
+```
+
+In der TUI: `/model` wechselt Anbieter und Modell gemeinsam, `/fleet` baut
+das Team auf und führt es — eine Rolle nach der anderen, jede mit eigenem
+Modell —, `/undo` macht den letzten Zug rückgängig, und `/restore <N>`
+setzt den Workspace auf einen früheren Snapshot zurück (bloßes `/restore`
+listet sie). `Tab` wechselt Plan / Work / Operate, wenn der Composer leer
+ist — mit Text darin vervollständigt `Tab` stattdessen Slash-Befehle und
+`@`-Erwähnungen. `Shift+Tab` wechselt jederzeit die
+Berechtigungshaltung Ask / Auto-Review / Full Access. `!` führt einen
+Shell-Befehl über den normalen Freigabepfad aus.
+
+## Was es tut
+
+- **Jedes Modell, jeder Anbieter — und jede Mischung.** DeepSeek, Claude,
+  GPT, Kimi, GLM und mehr als 30 Anbieter, plus Ihr eigenes vLLM, SGLang
+  oder Ollama ohne Schlüssel, alles über eine Runtime und einen
+  Werkzeugsatz. Der Katalog verfolgt die aktuelle Palette jedes Anbieters
+  — DeepSeeks V4-Pro-Backend (beschriftet `DeepSeek-V4-Pro-0813`) bleibt
+  als `deepseek-v4-pro` aufrufbar, Grok 4.6 ist der direkte xAI-Standard,
+  und OrcaRouter routet über `orcarouter/auto`. Eine gespeicherte Rolle
+  hält `provider`, `model` und Reasoning-Stufe ausdrücklich fest, sodass
+  eine Fleet in einem Lauf mehrere Anbieter umspannen kann und die Route
+  einer Rolle nie davon abhängt, welcher Anbieter gerade aktiv ist.
+  Kontextlimits und Preise kommen von der echten Route; ein unbekannter
+  Preis erscheint als unbekannt, nicht als 0 $.
+- **Ein Harness, den Sie schreiben.** Rollen sind Dateien, die Sie lesen
+  und bearbeiten können — ein Modell, eine Werkzeughaltung und stehende
+  Anweisungen pro Rolle — im Projekt, damit das Team sie teilt, oder
+  neben Ihren anderen persönlichen Einstellungen, damit sie Ihnen von
+  Repo zu Repo folgen. Eine constitution hält fest, wie sich der Agent
+  über alle Sitzungen verhalten soll, sodass der Harness Ihrer Praxis
+  folgt, nicht unserer.
+- **Nur lesen, bis Sie mehr erlauben.** Der Plan-Modus kann keine Dateien
+  ändern, und Freigaben sperren riskante Befehle. Wenn eine OS-Sandbox
+  einen Befehl tatsächlich umschließt, sagt Codewhale das: Seatbelt auf
+  macOS, sofern verfügbar, opt-in bubblewrap auf Linux. Das
+  `constitution.json` eines Repos kompiliert zu Schreibsperren, die selbst
+  Full Access nicht überspringt.
+- **Arbeit, die Sie fortsetzen können.** Eine Fleet schreibt jeden Schritt
+  in ein nur anhängendes Ledger, sodass `fleet resume` dort weitermacht,
+  wo Sie aufgehört haben.
+
+## Integrationen
+
+- **DeepSeek Harness (dsh) — über Codewhale verbunden.**
+  `codewhale integrations dsh connect` koppelt eine vorhandene
+  `@deepseek-ai/dsh`-Installation an Ihre Codewhale-Anbieterroute,
+  Berechtigungen und Ihren Workspace, und `integrations dsh
+  install-bundle` fügt das optionale DSH-Plugin-Bundle hinzu, damit
+  `dsh --profile codewhale` diese Identität selbst trägt. Codewhale
+  besitzt Berechtigungen und Lebenszyklus-Autorität; dsh behält eigene
+  Sitzungen, Profile und Anmeldedaten unangetastet. Siehe
+  [docs/INTEGRATIONS_DSH.md](docs/INTEGRATIONS_DSH.md).
+- **VS Code.** Das offizielle Extension-Gerüst (`extensions/vscode`) öffnet
+  Codewhale in einem integrierten Terminal und stellt eine schreibgeschützte
+  Agent View über die lokale Runtime bereit. Das ist eine lokale
+  Entwicklungsvorschau, noch keine Marketplace-Veröffentlichung.
+
+## Mehr erfahren
+
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — jede Anbieterroute: gehostet,
+  Gateway und lokal
+- [docs/FLEET.md](docs/FLEET.md) — Fleets, das Ledger und Fortsetzen
+- [docs/WORKFLOW_EXPERIMENTAL_SEARCH.md](docs/WORKFLOW_EXPERIMENTAL_SEARCH.md) — eingefrorene, anbieterneutrale experimentelle Suche in Workflow
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, Hooks
+  und die constitution
+- [docs/AUTHORIZATION_ORDER.md](docs/AUTHORIZATION_ORDER.md) — wie
+  Modi, Hooks, Berechtigungsregeln, Sicherheitsuntergrenzen, Repo-Recht,
+  Freigaben und Sandboxing zusammenwirken
+- [docs/HOOKS.md](docs/HOOKS.md) — die elf TUI-Lebenszyklus-Hook-Ereignisse,
+  ihre Payloads und welche drei davon einen Zug steuern können
+  (`codewhale exec` und die CLI-Unterbefehle feuern keine Hooks)
+- [docs/WEB.md](docs/WEB.md) — der nur-loopback Browser-Client und seine
+  einmalige Authentifizierungsgrenze
+
+Alles andere — Modi, Tastenkürzel, Sandbox-Details, MCP, die Runtime-API
+und die Architektur — lebt in [docs](docs) und auf
+[codewhale.net](https://codewhale.net/).
+
+## Mitwirken
+
+Issues, PRs, Reproduktionsschritte, Logs und Feature-Wünsche sind echte
+Projektarbeit, und erste Beiträge sind willkommen. Wenn ein PR so nicht
+gemergt werden kann, ernten die Maintainer, was funktioniert, und der
+Autor bleibt genannt — im Commit, im Changelog und in
+[docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md).
+
+- [Offene Issues](https://github.com/Hmbown/CodeWhale/issues) — gute
+  erste Beiträge liegen hier
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Dev-Setup und PR-Ablauf
+- [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) — alle, die das Projekt
+  mitgeformt haben
+- [Spendieren Sie mir einen Kaffee](https://www.buymeacoffee.com/hmbown)
+
+Danke an [DeepSeek](https://github.com/deepseek-ai) für die Modelle und
+die Unterstützung, mit denen das Projekt begann, an
+[DataWhale](https://github.com/datawhalechina) 🐋 für die Aufnahme in die
+Whale-Brother-Familie, und an
+[OpenWarp](https://github.com/zerx-lab/warp) und
+[Open Design](https://github.com/nexu-io/open-design) für die
+Zusammenarbeit an der Terminal-Agent-Erfahrung.
+
+## Lizenz
+
+[MIT](LICENSE). Ein unabhängiges Community-Projekt, nicht verbunden mit
+einem Modellanbieter.
+
+![Codewhale fächert drei schreibgeschützte Scout-Subagenten in einem Terminal auf](assets/fanout.gif)

--- a/README.es-419.md
+++ b/README.es-419.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:1569156eb887 -->
+<!-- source: README.md sha256:4fc19c5f9596 -->
 # Codewhale
 
 Un agente de programación de código abierto para tu terminal — trae tu propio modelo.
@@ -26,7 +26,7 @@ Siempre estamos buscando personas que contribuyan y formas de mejorar. Si falta
 un modelo o proveedor que usas, o algo se rompe, contárnoslo es una de las cosas
 más útiles que puedes hacer — mira [Contribuir](#contribuir).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,170 @@
+<!-- source: README.md sha256:4fc19c5f9596 -->
+# Codewhale
+
+Un agent de programmation open source pour votre terminal — apportez votre propre modèle.
+
+Codewhale a commencé comme une expérience native pour DeepSeek. Il est depuis
+devenu un projet porté par la communauté : un harness de programmation qui
+convient à une communauté internationale en croissance et prend en charge autant
+de modèles et de fournisseurs que possible — les modèles ouverts d'abord,
+hébergés ou locaux, sans en privilégier aucun.
+
+Donnez-lui un fournisseur, un modèle et une tâche. Il lit votre code, modifie
+des fichiers, exécute des commandes et vérifie son propre travail, puis
+s'arrête quand la tâche est terminée ou qu'il a besoin de vous. Changez de
+modèle en cours de tâche avec `/model`. Travaillez de façon interactive dans
+la TUI, ou lancez `codewhale exec` dans des scripts et en CI. Écrit en Rust,
+sous licence MIT, il tourne sur votre machine.
+
+Ce qui ne ressemble pas aux autres harnesses : **vous choisissez le modèle de
+chaque rôle, et ils n'ont pas à correspondre.** Une fleet fige un fournisseur,
+un modèle et un niveau de raisonnement par rôle — ainsi un modèle rapide et bon
+marché peut diriger un modèle de raisonnement coûteux, ou un builder GLM peut
+travailler sur la même tâche qu'un reviewer Kimi. Écrivez vos propres rôles et
+votre propre constitution, et le harness devient le vôtre plutôt que le nôtre.
+
+Nous cherchons toujours des contributeurs et des façons de nous améliorer. Si un
+modèle ou un fournisseur que vous utilisez manque, ou si quelque chose casse,
+nous le dire est l'une des choses les plus utiles que vous puissiez faire —
+voir [Contribuer](#contribuer).
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+
+[![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
+[![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/37gfS3ksug)
+
+![Codewhale en cours d'exécution dans un terminal](assets/screenshot.png)
+
+## Installation
+
+```bash
+npm install -g codewhale
+```
+
+Cargo, Docker, Nix, Scoop, les archives précompilées, Android/Termux et un
+miroir CNB pour ceux qui n'atteignent pas GitHub sont documentés dans
+[docs/INSTALL.md](docs/INSTALL.md). Vous venez de `deepseek-tui` ? Votre
+configuration et vos sessions sont reprises — voir
+[docs/REBRAND.md](docs/REBRAND.md).
+
+## Utilisation
+
+```bash
+codewhale auth set --provider deepseek   # or export ANTHROPIC_API_KEY, etc.
+codewhale                                # open the TUI
+codewhale exec "fix the failing test"    # headless
+codewhale web                            # local browser client on 127.0.0.1
+```
+
+Dans la TUI : `/model` change fournisseur et modèle ensemble, `/fleet`
+constitue et lance l'équipe — un rôle à la fois, chacun avec son propre
+modèle —, `/undo` annule le dernier tour, et `/restore <N>` ramène
+l'espace de travail à un instantané antérieur (`/restore` seul les
+liste). `Tab` fait défiler Plan / Work / Operate quand le compositeur est vide —
+s'il contient du texte, `Tab` complète les commandes slash et les mentions
+`@`. `Shift+Tab` fait défiler à tout moment la posture de permission Ask /
+Auto-Review / Full Access. `!` exécute une commande shell par le chemin
+d'approbation habituel.
+
+## Ce qu'il fait
+
+- **N'importe quel modèle, n'importe quel fournisseur — et n'importe quel
+  mélange.** DeepSeek, Claude, GPT, Kimi, GLM et plus de 30 fournisseurs,
+  plus votre propre vLLM, SGLang ou Ollama sans clé, le tout via un seul
+  runtime et un seul jeu d'outils. Le catalogue suit la gamme en direct de
+  chaque fournisseur — le backend V4 Pro de DeepSeek (libellé
+  `DeepSeek-V4-Pro-0813`) reste appelable en `deepseek-v4-pro`, Grok 4.6 est
+  le défaut xAI direct, et OrcaRouter route via `orcarouter/auto`. Un rôle
+  enregistré consigne explicitement son `provider`, son `model` et son
+  niveau de raisonnement, donc une fleet peut traverser plusieurs éditeurs
+  dans une même exécution, et la route d'un rôle ne dépend jamais du
+  fournisseur qui se trouve actif. Limites de contexte et prix viennent de
+  la vraie route ; un prix inconnu s'affiche comme inconnu, pas comme 0 $.
+- **Un harness que vous rédigez.** Les rôles sont des fichiers que vous
+  pouvez lire et modifier — un modèle, une posture d'outils et des
+  consignes permanentes par rôle — gardés dans le projet pour que l'équipe
+  les partage, ou à côté de vos autres réglages personnels pour qu'ils
+  vous suivent d'un dépôt à l'autre. Une constitution consigne comment
+  vous voulez que l'agent se comporte d'une session à l'autre, pour que le
+  harness suive votre pratique plutôt que la nôtre.
+- **Lecture seule jusqu'à ce que vous autorisiez davantage.** Le mode Plan
+  ne peut pas modifier de fichiers, et les approbations filtrent les
+  commandes risquées. Quand un sandbox OS enveloppe réellement une
+  commande, Codewhale le dit : Seatbelt sur macOS lorsqu'il est
+  disponible, bubblewrap en option sur Linux. Le `constitution.json` d'un
+  dépôt se compile en verrous d'écriture que même Full Access ne peut
+  contourner.
+- **Un travail que vous pouvez reprendre.** Une fleet consigne chaque
+  étape dans un registre en ajout seul, donc `fleet resume` reprend là où
+  vous vous étiez arrêté.
+
+## Intégrations
+
+- **DeepSeek Harness (dsh) — connecté via Codewhale.**
+  `codewhale integrations dsh connect` relie une installation existante de
+  `@deepseek-ai/dsh` à votre route de fournisseur Codewhale, vos
+  permissions et votre espace de travail, et `integrations dsh
+  install-bundle` ajoute le bundle de plugins DSH optionnel pour que
+  `dsh --profile codewhale` porte cette identité tout seul. Codewhale
+  détient les permissions et l'autorité de cycle de vie ; dsh garde ses
+  propres sessions, profils et identifiants intacts. Voir
+  [docs/INTEGRATIONS_DSH.md](docs/INTEGRATIONS_DSH.md).
+- **VS Code.** Le scaffold officiel de l'extension (`extensions/vscode`)
+  ouvre Codewhale dans un terminal intégré et expose une Agent View en
+  lecture seule sur le runtime local. C'est une préversion de
+  développement local, pas encore une publication marketplace.
+
+## En savoir plus
+
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — chaque route de fournisseur :
+  hébergée, passerelle et locale
+- [docs/FLEET.md](docs/FLEET.md) — les fleets, le registre et la reprise
+- [docs/WORKFLOW_EXPERIMENTAL_SEARCH.md](docs/WORKFLOW_EXPERIMENTAL_SEARCH.md) — recherche expérimentale figée et neutre vis-à-vis des fournisseurs dans Workflow
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, les
+  hooks et la constitution
+- [docs/AUTHORIZATION_ORDER.md](docs/AUTHORIZATION_ORDER.md) — comment
+  modes, hooks, règles de permission, planchers de sécurité, loi du
+  dépôt, approbations et sandbox se composent
+- [docs/HOOKS.md](docs/HOOKS.md) — les onze événements de hook du cycle
+  de vie TUI, leurs payloads, et lesquels parmi trois peuvent orienter un
+  tour (`codewhale exec` et les sous-commandes CLI ne déclenchent pas de
+  hooks)
+- [docs/WEB.md](docs/WEB.md) — le client navigateur en loopback uniquement
+  et sa frontière d'authentification à usage unique
+
+Tout le reste — modes, raccourcis, détails du sandbox, MCP, l'API runtime
+et l'architecture — vit dans [docs](docs) et sur
+[codewhale.net](https://codewhale.net/).
+
+## Contribuer
+
+Issues, PR, étapes de reproduction, journaux et demandes de
+fonctionnalités sont tous du vrai travail de projet, et les premières
+contributions sont les bienvenues. Quand une PR ne peut pas être fusionnée
+telle quelle, les mainteneurs récoltent ce qui fonctionne et gardent
+l'auteur crédité — dans le commit, le changelog et
+[docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md).
+
+- [Issues ouvertes](https://github.com/Hmbown/CodeWhale/issues) — les
+  bonnes premières contributions sont ici
+- [CONTRIBUTING.md](CONTRIBUTING.md) — installation de dev et flux de PR
+- [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) — toutes celles et ceux
+  qui ont façonné le projet
+- [Offrez-moi un café](https://www.buymeacoffee.com/hmbown)
+
+Merci à [DeepSeek](https://github.com/deepseek-ai) pour les modèles et le
+soutien qui ont lancé le projet, à
+[DataWhale](https://github.com/datawhalechina) 🐋 de nous avoir accueillis
+dans la famille Whale Brother, et à
+[OpenWarp](https://github.com/zerx-lab/warp) et
+[Open Design](https://github.com/nexu-io/open-design) pour la
+collaboration sur l'expérience d'agent dans le terminal.
+
+## Licence
+
+[MIT](LICENSE). Projet communautaire indépendant, non affilié à aucun
+fournisseur de modèles.
+
+![Codewhale déployant trois sous-agents scout en lecture seule dans un terminal](assets/fanout.gif)

--- a/README.hi.md
+++ b/README.hi.md
@@ -1,0 +1,146 @@
+<!-- source: README.md sha256:4fc19c5f9596 -->
+# Codewhale
+
+आपके टर्मिनल के लिए एक ओपन सोर्स कोडिंग एजेंट — मॉडल आप लाएँ।
+
+Codewhale की शुरुआत DeepSeek के लिए एक नेटिव अनुभव के रूप में हुई। तब से यह एक
+समुदाय-संचालित परियोजना बन गई है: एक ऐसा कोडिंग harness जो बढ़ते अंतरराष्ट्रीय
+समुदाय के साथ बैठता है और जितने संभव हो उतने मॉडल और प्रदाताओं को सहारा देता है —
+पहले ओपन मॉडल, होस्टेड या लोकल, किसी को बाकियों से विशेष अधिकार नहीं।
+
+इसे एक प्रदाता, एक मॉडल और एक कार्य दें। यह आपका कोड पढ़ता है, फ़ाइलें संपादित
+करता है, कमांड चलाता है और अपने काम की जाँच करता है, फिर रुक जाता है जब काम पूरा
+हो जाए या उसे आपकी ज़रूरत हो। कार्य के बीच में `/model` से मॉडल बदलें। TUI में
+इंटरैक्टिव काम करें, या स्क्रिप्ट और CI में `codewhale exec` चलाएँ। यह Rust में
+लिखा है, MIT लाइसेंस के तहत है, और आपकी मशीन पर चलता है।
+
+जो बात इसे दूसरे harnesses से अलग करती है: **हर भूमिका के लिए मॉडल आप चुनते हैं,
+और उन्हें एक जैसे होने की ज़रूरत नहीं।** एक fleet हर भूमिका के लिए प्रदाता, मॉडल
+और रीज़निंग स्तर पिन करता है — इसलिए एक सस्ता तेज़ मॉडल एक महंगे रीज़निंग मॉडल को
+निर्देशित कर सकता है, या एक GLM builder उसी काम पर एक Kimi reviewer के साथ काम कर
+सकता है। अपनी भूमिकाएँ लिखें, अपना constitution लिखें, और harness हमारा नहीं,
+आपका हो जाता है।
+
+हम हमेशा योगदानकर्ताओं और सुधार के रास्ते खोजते रहते हैं। अगर आप जिस मॉडल या
+प्रदाता का उपयोग करते हैं वह गायब है, या कुछ टूटता है, हमें बताना उन सबसे उपयोगी
+कामों में से एक है जो आप कर सकते हैं — देखें [योगदान](#योगदान)।
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+
+[![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
+[![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/37gfS3ksug)
+
+![टर्मिनल में चलता Codewhale](assets/screenshot.png)
+
+## इंस्टॉल
+
+```bash
+npm install -g codewhale
+```
+
+Cargo, Docker, Nix, Scoop, पहले से बने आर्काइव, Android/Termux, और उन लोगों के
+लिए एक CNB मिरर जो GitHub तक नहीं पहुँच सकते,
+[docs/INSTALL.md](docs/INSTALL.md) में हैं। `deepseek-tui` से आ रहे हैं? आपकी
+कॉन्फ़िग और सेशन साथ आते हैं — देखें [docs/REBRAND.md](docs/REBRAND.md)।
+
+## उपयोग
+
+```bash
+codewhale auth set --provider deepseek   # or export ANTHROPIC_API_KEY, etc.
+codewhale                                # open the TUI
+codewhale exec "fix the failing test"    # headless
+codewhale web                            # local browser client on 127.0.0.1
+```
+
+TUI में: `/model` प्रदाता और मॉडल एक साथ बदलता है, `/fleet` टीम बनाता और चलाता है
+— एक समय में एक भूमिका, प्रत्येक अपने मॉडल के साथ —, `/undo` पिछली बारी वापस लेता
+है, और `/restore <N>` वर्कस्पेस को पहले के स्नैपशॉट पर लौटाता है (बिना तर्क का
+`/restore` उन्हें सूचीबद्ध करता है)। कंपोज़र खाली होने पर `Tab` Plan / Work /
+Operate घुमाता है — उसमें टेक्स्ट हो तो `Tab` स्लैश कमांड और `@` उल्लेख पूरे करता
+है। `Shift+Tab` किसी भी समय Ask / Auto-Review / Full Access अनुमति मुद्रा घुमाता
+है। `!` एक शेल कमांड सामान्य अनुमोदन पथ से चलाता है।
+
+## यह क्या करता है
+
+- **कोई भी मॉडल, कोई भी प्रदाता — और उनका कोई भी मिश्रण।** DeepSeek, Claude, GPT,
+  Kimi, GLM और 30+ प्रदाता, साथ ही बिना कुंजी के आपका अपना vLLM, SGLang या Ollama,
+  सब एक ही रनटाइम और एक ही टूलसेट से। कैटलॉग हर प्रदाता की लाइव लाइनअप ट्रैक करता
+  है — DeepSeek का V4 Pro बैकएंड (लेबल `DeepSeek-V4-Pro-0813`) अब भी
+  `deepseek-v4-pro` के रूप में कॉल होता है, Grok 4.6 सीधा xAI डिफ़ॉल्ट है, और
+  OrcaRouter `orcarouter/auto` से रूट करता है। सहेजी गई भूमिका अपना `provider`,
+  `model` और रीज़निंग स्तर स्पष्ट रूप से दर्ज करती है, इसलिए एक fleet एक ही चलान
+  में कई विक्रेताओं तक फैल सकता है, और भूमिका का रूट इस पर निर्भर नहीं करता कि
+  कौन-सा प्रदाता उस समय सक्रिय हो। संदर्भ सीमाएँ और कीमतें असली रूट से आती हैं;
+  अज्ञात कीमत अज्ञात दिखती है, $0 नहीं।
+- **एक harness जिसे आप लिखते हैं।** भूमिकाएँ ऐसी फ़ाइलें हैं जिन्हें आप पढ़ और
+  संपादित कर सकते हैं — प्रति भूमिका एक मॉडल, एक टूल मुद्रा और स्थायी निर्देश —
+  प्रोजेक्ट में रखें ताकि टीम साझा करे, या अपनी दूसरी व्यक्तिगत सेटिंग्स के पास
+  रखें ताकि वे रेपो-दर-रेपो आपके साथ चलें। एक constitution दर्ज करता है कि आप
+  एजेंट को हर सेशन में कैसे व्यवहार कराना चाहते हैं, ताकि harness हमारी नहीं,
+  आपकी प्रथा से मेल खाए।
+- **जब तक आप और न दें, केवल पढ़ने योग्य।** Plan मोड फ़ाइलें नहीं बदल सकता, और
+  अनुमोदन जोखिम भरे कमांड रोकते हैं। जब कोई OS सैंडबॉक्स वास्तव में किसी कमांड को
+  लपेटता है, Codewhale कहता है: macOS पर उपलब्ध होने पर Seatbelt, Linux पर
+  ऑप्ट-इन bubblewrap। रेपो का `constitution.json` लेखन-रोक में कंपाइल होता है
+  जिन्हें Full Access भी नहीं छोड़ सकता।
+- **काम जिसे आप फिर से उठा सकते हैं।** एक fleet हर कदम को केवल-जोड़ वाले लेजर में
+  लिखता है, इसलिए `fleet resume` वहीं से चलता है जहाँ आप रुके थे।
+
+## इंटीग्रेशन
+
+- **DeepSeek Harness (dsh) — Codewhale के माध्यम से जुड़ा।**
+  `codewhale integrations dsh connect` मौजूदा `@deepseek-ai/dsh` इंस्टॉल को आपके
+  Codewhale प्रदाता रूट, अनुमतियों और वर्कस्पेस से जोड़ता है, और
+  `integrations dsh install-bundle` वैकल्पिक DSH प्लगइन बंडल जोड़ता है ताकि
+  `dsh --profile codewhale` वह पहचान खुद ले जाए। अनुमतियाँ और जीवनचक्र अधिकार
+  Codewhale के पास रहते हैं; dsh अपने सेशन, प्रोफ़ाइल और क्रेडेंशियल अछूते रखता
+  है। देखें [docs/INTEGRATIONS_DSH.md](docs/INTEGRATIONS_DSH.md)।
+- **VS Code.** आधिकारिक एक्सटेंशन स्कैफ़ोल्ड (`extensions/vscode`) Codewhale को
+  इंटीग्रेटेड टर्मिनल में खोलता है और लोकल रनटाइम पर केवल-पढ़ने योग्य Agent View
+  देता है। यह लोकल-डेवलपमेंट पूर्वावलोकन है, अभी मार्केटप्लेस रिलीज़ नहीं।
+
+## और जानें
+
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — हर प्रदाता रूट: होस्टेड, गेटवे और लोकल
+- [docs/FLEET.md](docs/FLEET.md) — fleet, लेजर और फिर से शुरू करना
+- [docs/WORKFLOW_EXPERIMENTAL_SEARCH.md](docs/WORKFLOW_EXPERIMENTAL_SEARCH.md) — Workflow के भीतर जमा, प्रदाता-तटस्थ प्रयोगात्मक खोज
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, hooks और
+  constitution
+- [docs/AUTHORIZATION_ORDER.md](docs/AUTHORIZATION_ORDER.md) — मोड, hooks,
+  अनुमति नियम, सुरक्षा तल, रेपो कानून, अनुमोदन और सैंडबॉक्सिंग कैसे जुड़ते हैं
+- [docs/HOOKS.md](docs/HOOKS.md) — ग्यारह TUI जीवनचक्र hook इवेंट, उनके payload,
+  और उनमें से कौन से तीन एक बारी मोड़ सकते हैं (`codewhale exec` और CLI
+  सबकमांड hooks नहीं चलाते)
+- [docs/WEB.md](docs/WEB.md) — केवल-लूपबैक ब्राउज़र क्लाइंट और उसकी एक-बार
+  प्रमाणीकरण सीमा
+
+बाकी सब — मोड, कीबाइंडिंग, सैंडबॉक्स विवरण, MCP, रनटाइम API और आर्किटेक्चर —
+[docs](docs) और [codewhale.net](https://codewhale.net/) पर है।
+
+## योगदान
+
+Issue, PR, पुनरुत्पादन चरण, लॉग और फ़ीचर अनुरोध सभी असली परियोजना कार्य हैं, और
+पहली बार योगदान स्वागतयोग्य हैं। जब कोई PR जैसा-का-तैसा मर्ज न हो सके, मेंटेनर
+जो काम करता है उसे सहेजते हैं और लेखक का श्रेय रहता है — कमिट में, changelog में
+और [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) में।
+
+- [खुले issue](https://github.com/Hmbown/CodeWhale/issues) — अच्छे पहले योगदान
+  यहीं हैं
+- [CONTRIBUTING.md](CONTRIBUTING.md) — डेव सेटअप और PR प्रवाह
+- [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) — जिन्होंने इसे आकार दिया
+- [मुझे एक कॉफ़ी पिलाएँ](https://www.buymeacoffee.com/hmbown)
+
+[DeepSeek](https://github.com/deepseek-ai) का धन्यवाद उन मॉडलों और सहयोग के लिए
+जिनसे परियोजना शुरू हुई, [DataWhale](https://github.com/datawhalechina) 🐋 का
+Whale Brother परिवार में स्वागत के लिए, और
+[OpenWarp](https://github.com/zerx-lab/warp) तथा
+[Open Design](https://github.com/nexu-io/open-design) का टर्मिनल-एजेंट अनुभव पर
+सहयोग के लिए।
+
+## लाइसेंस
+
+[MIT](LICENSE)। एक स्वतंत्र सामुदायिक परियोजना, किसी मॉडल प्रदाता से संबद्ध नहीं।
+
+![टर्मिनल में तीन केवल-पढ़ने योग्य scout सबएजेंट फैलाता Codewhale](assets/fanout.gif)

--- a/README.id.md
+++ b/README.id.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:1569156eb887 -->
+<!-- source: README.md sha256:4fc19c5f9596 -->
 # Codewhale
 
 Sebuah coding agent sumber terbuka untuk terminal Anda — bawa model pilihan Anda sendiri.
@@ -11,7 +11,7 @@ Yang membedakannya dari harness lain: **Anda memilih model untuk setiap peran, d
 
 Kami selalu membuka kesempatan bagi para kontributor dan cara untuk terus berkembang. Jika model atau penyedia yang Anda gunakan belum tersedia, atau ada hal yang tidak berjalan semestinya, memberi tahu kami adalah salah satu kontribusi paling berharga yang bisa Anda lakukan — lihat [Kontribusi](#kontribusi).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.it.md
+++ b/README.it.md
@@ -1,0 +1,158 @@
+<!-- source: README.md sha256:4fc19c5f9596 -->
+# Codewhale
+
+Un agente di programmazione open source per il tuo terminale — porta il tuo modello.
+
+Codewhale è nato come esperienza nativa per DeepSeek. Da allora è diventato un
+progetto guidato dalla comunità: un harness di programmazione che sta a una
+comunità internazionale in crescita e supporta quanti più modelli e fornitori
+possibile — prima i modelli aperti, ospitati o locali, nessuno privilegiato
+rispetto agli altri.
+
+Dagli un fornitore, un modello e un compito. Legge il tuo codice, modifica i
+file, esegue comandi e controlla il proprio lavoro, poi si ferma quando il
+compito è finito o ha bisogno di te. Cambia modello a metà compito con
+`/model`. Lavora in modo interattivo nella TUI, oppure esegui `codewhale exec`
+in script e CI. È scritto in Rust, con licenza MIT, e gira sulla tua macchina.
+
+Quello che non assomiglia agli altri harness: **scegli tu il modello di ogni
+ruolo, e non devono coincidere.** Una fleet fissa un fornitore, un modello e
+un livello di ragionamento per ruolo — così un modello economico e veloce può
+dirigere uno di ragionamento costoso, o un builder GLM può lavorare sullo
+stesso compito di un reviewer Kimi. Scrivi i tuoi ruoli e la tua constitution,
+e l'harness è tuo invece che nostro.
+
+Cerchiamo sempre contributori e modi per migliorare. Se manca un modello o un
+fornitore che usi, o qualcosa si rompe, dircelo è una delle cose più utili che
+tu possa fare — vedi [Contribuire](#contribuire).
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+
+[![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
+[![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/37gfS3ksug)
+
+![Codewhale in esecuzione in un terminale](assets/screenshot.png)
+
+## Installazione
+
+```bash
+npm install -g codewhale
+```
+
+Cargo, Docker, Nix, Scoop, archivi precompilati, Android/Termux e uno specchio
+CNB per chi non raggiunge GitHub sono in
+[docs/INSTALL.md](docs/INSTALL.md). Arrivi da `deepseek-tui`? Configurazione e
+sessioni restano — vedi [docs/REBRAND.md](docs/REBRAND.md).
+
+## Uso
+
+```bash
+codewhale auth set --provider deepseek   # or export ANTHROPIC_API_KEY, etc.
+codewhale                                # open the TUI
+codewhale exec "fix the failing test"    # headless
+codewhale web                            # local browser client on 127.0.0.1
+```
+
+Nella TUI: `/model` cambia fornitore e modello insieme, `/fleet` costruisce e
+avvia la squadra — un ruolo alla volta, ciascuno con il proprio modello —,
+`/undo` annulla l'ultimo turno e `/restore <N>` riporta lo spazio di lavoro a
+uno snapshot precedente (`/restore` da solo li elenca). `Tab` cicla Plan /
+Work / Operate quando il compositore è vuoto — con del testo, `Tab` completa
+invece i comandi slash e le menzioni `@`. `Shift+Tab` cicla in qualsiasi
+momento la postura di permesso Ask / Auto-Review / Full Access. `!` esegue un
+comando shell dal percorso di approvazione normale.
+
+## Cosa fa
+
+- **Qualsiasi modello, qualsiasi fornitore — e qualsiasi mix.** DeepSeek,
+  Claude, GPT, Kimi, GLM e oltre 30 fornitori, più il tuo vLLM, SGLang o
+  Ollama senza chiave, tutto attraverso un solo runtime e un solo set di
+  strumenti. Il catalogo segue la lineup dal vivo di ogni fornitore — il
+  backend V4 Pro di DeepSeek (etichettato `DeepSeek-V4-Pro-0813`) resta
+  chiamabile come `deepseek-v4-pro`, Grok 4.6 è il predefinito xAI diretto e
+  OrcaRouter instrada tramite `orcarouter/auto`. Un ruolo salvato registra in
+  modo esplicito `provider`, `model` e il livello di ragionamento, così una
+  fleet può attraversare più vendor in una sola esecuzione e la rotta di un
+  ruolo non dipende mai da quale fornitore capita di essere attivo. Limiti di
+  contesto e prezzi arrivano dalla rotta vera; un prezzo sconosciuto si mostra
+  come sconosciuto, non come 0 $.
+- **Un harness che scrivi tu.** I ruoli sono file che puoi leggere e
+  modificare — un modello, una postura degli strumenti e istruzioni permanenti
+  per ruolo — tenuti nel progetto perché la squadra li condivida, o accanto
+  alle altre impostazioni personali perché ti seguano tra i repo. Una
+  constitution registra come vuoi che l'agente si comporti in ogni sessione,
+  così l'harness segue la tua pratica invece della nostra.
+- **Sola lettura finché non concedi di più.** La modalità Plan non può
+  cambiare file e le approvazioni filtrano i comandi rischiosi. Quando una
+  sandbox del sistema operativo avvolge davvero un comando, Codewhale lo dice:
+  Seatbelt su macOS dove disponibile, bubblewrap opzionale su Linux. Il
+  `constitution.json` di un repo si compila in blocchi in scrittura che nemmeno
+  Full Access può saltare.
+- **Lavoro che puoi riprendere.** Una fleet registra ogni passo in un registro
+  in sola appendice, così `fleet resume` riparte da dove ti eri fermato.
+
+## Integrazioni
+
+- **DeepSeek Harness (dsh) — collegato tramite Codewhale.**
+  `codewhale integrations dsh connect` collega un'installazione esistente di
+  `@deepseek-ai/dsh` alla tua rotta fornitore Codewhale, ai permessi e allo
+  spazio di lavoro, e `integrations dsh install-bundle` aggiunge il bundle di
+  plugin DSH opzionale perché `dsh --profile codewhale` porti da solo quella
+  identità. Codewhale detiene permessi e autorità sul ciclo di vita; dsh
+  conserva sessioni, profili e credenziali intatti. Vedi
+  [docs/INTEGRATIONS_DSH.md](docs/INTEGRATIONS_DSH.md).
+- **VS Code.** Lo scaffold ufficiale dell'estensione (`extensions/vscode`)
+  apre Codewhale in un terminale integrato ed espone una Agent View in sola
+  lettura sul runtime locale. È un'anteprima di sviluppo locale, non ancora
+  una pubblicazione sul marketplace.
+
+## Per saperne di più
+
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — ogni rotta fornitore: ospitata,
+  gateway e locale
+- [docs/FLEET.md](docs/FLEET.md) — le fleet, il registro e il ripristino
+- [docs/WORKFLOW_EXPERIMENTAL_SEARCH.md](docs/WORKFLOW_EXPERIMENTAL_SEARCH.md) — ricerca sperimentale congelata e neutrale rispetto al fornitore in Workflow
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, hook e la
+  constitution
+- [docs/AUTHORIZATION_ORDER.md](docs/AUTHORIZATION_ORDER.md) — come si
+  compongono modalità, hook, regole di permesso, pavimenti di sicurezza,
+  legge del repo, approvazioni e sandbox
+- [docs/HOOKS.md](docs/HOOKS.md) — gli undici eventi hook del ciclo di vita
+  TUI, i loro payload e quali tre possono orientare un turno (`codewhale exec`
+  e i sottocomandi CLI non sparano hook)
+- [docs/WEB.md](docs/WEB.md) — il client browser solo in loopback e il suo
+  confine di autenticazione monouso
+
+Tutto il resto — modalità, scorciatoie, dettagli della sandbox, MCP, l'API
+runtime e l'architettura — vive in [docs](docs) e su
+[codewhale.net](https://codewhale.net/).
+
+## Contribuire
+
+Issue, PR, passi di riproduzione, log e richieste di funzionalità sono tutti
+lavoro reale di progetto, e i primi contributi sono benvenuti. Quando una PR
+non si può unire così com'è, i maintainer raccolgono ciò che funziona e
+l'autore resta accreditato — nel commit, nel changelog e in
+[docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md).
+
+- [Issue aperte](https://github.com/Hmbown/CodeWhale/issues) — i buoni primi
+  contributi stanno qui
+- [CONTRIBUTING.md](CONTRIBUTING.md) — setup di sviluppo e flusso PR
+- [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) — chi ha dato forma a questo
+- [Offrimi un caffè](https://www.buymeacoffee.com/hmbown)
+
+Grazie a [DeepSeek](https://github.com/deepseek-ai) per i modelli e il
+sostegno che hanno avviato il progetto, a
+[DataWhale](https://github.com/datawhalechina) 🐋 per averci accolto nella
+famiglia Whale Brother, e a [OpenWarp](https://github.com/zerx-lab/warp) e
+[Open Design](https://github.com/nexu-io/open-design) per la collaborazione
+sull'esperienza di agente nel terminale.
+
+## Licenza
+
+[MIT](LICENSE). Progetto comunitario indipendente, non affiliato ad alcun
+fornitore di modelli.
+
+![Codewhale che dispiega tre sottoagenti scout in sola lettura in un terminale](assets/fanout.gif)

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:1569156eb887 -->
+<!-- source: README.md sha256:4fc19c5f9596 -->
 # Codewhale
 
 ターミナルで動くオープンソースのコーディングエージェント — モデルはあなたが持ち込む。
@@ -11,7 +11,7 @@ Codewhale は DeepSeek のためのネイティブ体験として始まりまし
 
 私たちは常にコントリビューターと改善の方法を探しています。使っているモデルやプロバイダが見当たらないとき、あるいは何かが壊れたときは、それを知らせてもらえることが最も役に立つことのひとつです — [コントリビューション](#コントリビューション)を見てください。
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+[English](README.md) · [简体中文](README.zh-CN.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:1569156eb887 -->
+<!-- source: README.md sha256:4fc19c5f9596 -->
 # Codewhale
 
 터미널에서 쓰는 오픈소스 코딩 에이전트 — 모델은 당신이 가져옵니다.
@@ -11,7 +11,7 @@ Codewhale은 DeepSeek을 위한 네이티브 경험으로 시작했습니다. �
 
 우리는 항상 기여자와 개선할 방법을 찾고 있습니다. 사용하는 모델이나 프로바이더가 빠져 있거나 무언가가 깨진다면, 그것을 알려 주는 일이 할 수 있는 가장 유용한 일 중 하나입니다 — [기여](#기여)를 참고하세요.
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We're always looking for contributors and ways to improve. If a model or
 provider you use is missing, or something breaks, telling us is one of the most
 useful things you can do — see [Contributing](#contributing).
 
-[简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+[简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,0 +1,157 @@
+<!-- source: README.md sha256:4fc19c5f9596 -->
+# Codewhale
+
+Otwartoźródłowy agent programistyczny do Twojego terminala — model przynosisz sam.
+
+Codewhale zaczął jako natywne doświadczenie dla DeepSeek. Od tego czasu urósł
+do projektu prowadzonego przez społeczność: jednego harnessu programistycznego,
+który pasuje do rosnącej międzynarodowej społeczności i obsługuje tyle modeli
+i dostawców, ile się da — najpierw modele otwarte, hostowane albo lokalne,
+żaden nie jest uprzywilejowany wobec reszty.
+
+Daj mu dostawcę, model i zadanie. Czyta Twój kod, edytuje pliki, uruchamia
+polecenia i sprawdza własną pracę, a potem się zatrzymuje, gdy zadanie jest
+skończone albo potrzebuje Ciebie. W trakcie zadania zmień model przez
+`/model`. Pracuj interaktywnie w TUI albo uruchamiaj `codewhale exec` w
+skryptach i CI. Napisany w Rust, na licencji MIT, działa na Twojej maszynie.
+
+To, czym nie przypomina innych harnessów: **to Ty wybierasz model dla każdej
+roli i nie muszą się zgadzać.** Fleet przypina dostawcę, model i poziom
+rozumowania do roli — więc tani, szybki model może kierować drogim modelem
+rozumującym, a builder GLM może robić to samo zadanie co reviewer Kimi. Napisz
+własne role i własną constitution, a harness będzie Twój, nie nasz.
+
+Zawsze szukamy osób, które chcą się przyczynić, i sposobów na ulepszenia. Jeśli
+brakuje modelu albo dostawcy, z którego korzystasz, albo coś się psuje,
+powiedzenie nam o tym jest jedną z najpożyteczniejszych rzeczy, które możesz
+zrobić — zobacz [Współtworzenie](#współtworzenie).
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+
+[![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
+[![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/37gfS3ksug)
+
+![Codewhale działający w terminalu](assets/screenshot.png)
+
+## Instalacja
+
+```bash
+npm install -g codewhale
+```
+
+Cargo, Docker, Nix, Scoop, gotowe archiwa, Android/Termux oraz lustro CNB
+dla tych, którzy nie dochodzą do GitHuba, są w
+[docs/INSTALL.md](docs/INSTALL.md). Przychodzisz z `deepseek-tui`? Konfiguracja
+i sesje przechodzą — zobacz [docs/REBRAND.md](docs/REBRAND.md).
+
+## Użycie
+
+```bash
+codewhale auth set --provider deepseek   # or export ANTHROPIC_API_KEY, etc.
+codewhale                                # open the TUI
+codewhale exec "fix the failing test"    # headless
+codewhale web                            # local browser client on 127.0.0.1
+```
+
+W TUI: `/model` przełącza dostawcę i model razem, `/fleet` buduje i uruchamia
+zespół — jedna rola na raz, każda z własnym modelem —, `/undo` cofa ostatnią
+turę, a `/restore <N>` cofa przestrzeń roboczą do wcześniejszego zrzutu
+(gołe `/restore` je wypisuje). `Tab` przełącza Plan / Work / Operate, gdy
+kompozytor jest pusty — z tekstem `Tab` uzupełnia polecenia slash i wzmianki
+`@`. `Shift+Tab` w każdej chwili przełącza postawę uprawnień Ask /
+Auto-Review / Full Access. `!` uruchamia polecenie powłoki zwykłą ścieżką
+zatwierdzeń.
+
+## Co robi
+
+- **Dowolny model, dowolny dostawca — i dowolna mieszanka.** DeepSeek, Claude,
+  GPT, Kimi, GLM i ponad 30 dostawców, plus własne vLLM, SGLang albo Ollama
+  bez klucza, wszystko przez jedno środowisko uruchomieniowe i jeden zestaw
+  narzędzi. Katalog śledzi żywą ofertę każdego dostawcy — backend V4 Pro
+  DeepSeek (etykieta `DeepSeek-V4-Pro-0813`) nadal wywołuje się jako
+  `deepseek-v4-pro`, Grok 4.6 jest bezpośrednim domyślnym modelem xAI, a
+  OrcaRouter kieruje przez `orcarouter/auto`. Zapisana rola jawnie notuje
+  `provider`, `model` i poziom rozumowania, więc fleet może w jednym
+  uruchomieniu objąć wielu dostawców, a trasa roli nigdy nie zależy od tego,
+  który dostawca akurat jest aktywny. Limity kontekstu i ceny pochodzą z
+  prawdziwej trasy; nieznana cena pokazuje się jako nieznana, nie jako 0 $.
+- **Harness, który sam piszesz.** Role to pliki, które możesz czytać i
+  edytować — model, postawa narzędzi i stałe instrukcje na rolę — trzymane
+  w projekcie, żeby zespół je dzielił, albo obok innych ustawień osobistych,
+  żeby szły za Tobą między repozytoriami. Constitution zapisuje, jak agent
+  ma się zachowywać w każdej sesji, żeby harness pasował do Twojej praktyki,
+  nie do naszej.
+- **Tylko odczyt, dopóki nie pozwolisz na więcej.** Tryb Plan nie może
+  zmieniać plików, a zatwierdzenia pilnują ryzykownych poleceń. Gdy sandbox
+  systemu operacyjnego naprawdę otacza polecenie, Codewhale o tym mówi:
+  Seatbelt na macOS, gdy jest dostępny, opcjonalny bubblewrap na Linuksie.
+  `constitution.json` repozytorium kompiluje się do blokad zapisu, których
+  nawet Full Access nie przeskoczy.
+- **Praca, którą możesz wznowić.** Fleet zapisuje każdy krok w rejestrze
+  tylko do dopisywania, więc `fleet resume` podejmuje tam, gdzie skończyłeś.
+
+## Integracje
+
+- **DeepSeek Harness (dsh) — podłączony przez Codewhale.**
+  `codewhale integrations dsh connect` wiąże istniejącą instalację
+  `@deepseek-ai/dsh` z Twoją trasą dostawcy Codewhale, uprawnieniami i
+  przestrzenią roboczą, a `integrations dsh install-bundle` dodaje opcjonalny
+  pakiet wtyczek DSH, żeby `dsh --profile codewhale` nosił tę tożsamość sam.
+  Codewhale ma uprawnienia i władzę nad cyklem życia; dsh zostawia własne
+  sesje, profile i poświadczenia nietknięte. Zobacz
+  [docs/INTEGRATIONS_DSH.md](docs/INTEGRATIONS_DSH.md).
+- **VS Code.** Oficjalny szkielet rozszerzenia (`extensions/vscode`) otwiera
+  Codewhale w zintegrowanym terminalu i udostępnia Agent View tylko do odczytu
+  nad lokalnym środowiskiem. To lokalny podgląd deweloperski, jeszcze nie
+  wydanie na marketplace.
+
+## Dowiedz się więcej
+
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — każda trasa dostawcy: hostowana,
+  bramka i lokalna
+- [docs/FLEET.md](docs/FLEET.md) — fleety, rejestr i wznawianie
+- [docs/WORKFLOW_EXPERIMENTAL_SEARCH.md](docs/WORKFLOW_EXPERIMENTAL_SEARCH.md) — zamrożone, niezależne od dostawcy eksperymentalne wyszukiwanie w Workflow
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, hooki i
+  constitution
+- [docs/AUTHORIZATION_ORDER.md](docs/AUTHORIZATION_ORDER.md) — jak składają
+  się tryby, hooki, reguły uprawnień, podłogi bezpieczeństwa, prawo repo,
+  zatwierdzenia i sandbox
+- [docs/HOOKS.md](docs/HOOKS.md) — jedenaście zdarzeń hook cyklu życia TUI,
+  ich ładunki i które trzy mogą pokierować turą (`codewhale exec` i
+  podpolecenia CLI nie odpalają hooków)
+- [docs/WEB.md](docs/WEB.md) — przeglądarkowy klient tylko na loopback i jego
+  jednorazowa granica uwierzytelniania
+
+Wszystko inne — tryby, skróty, szczegóły sandboxa, MCP, API środowiska
+uruchomieniowego i architektura — żyje w [docs](docs) i na
+[codewhale.net](https://codewhale.net/).
+
+## Współtworzenie
+
+Zgłoszenia, PR-y, kroki odtworzenia, logi i prośby o funkcje to prawdziwa
+praca projektowa, a pierwsze wkłady są mile widziane. Gdy PR nie da się
+włączyć w obecnym kształcie, opiekunowie zbierają to, co działa, a autor
+zostaje wymieniony — w commicie, w changelogu i w
+[docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md).
+
+- [Otwarte zgłoszenia](https://github.com/Hmbown/CodeWhale/issues) — dobre
+  pierwsze wkłady są tutaj
+- [CONTRIBUTING.md](CONTRIBUTING.md) — środowisko deweloperskie i przepływ PR
+- [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) — wszyscy, którzy to ukształtowali
+- [Postaw mi kawę](https://www.buymeacoffee.com/hmbown)
+
+Dziękujemy [DeepSeek](https://github.com/deepseek-ai) za modele i wsparcie,
+które rozpoczęły projekt, [DataWhale](https://github.com/datawhalechina) 🐋
+za przyjęcie nas do rodziny Whale Brother oraz
+[OpenWarp](https://github.com/zerx-lab/warp) i
+[Open Design](https://github.com/nexu-io/open-design) za współpracę przy
+doświadczeniu agenta w terminalu.
+
+## Licencja
+
+[MIT](LICENSE). Niezależny projekt społecznościowy, niezwiązany z żadnym
+dostawcą modeli.
+
+![Codewhale rozsyła trzech podrzędnych agentów scout tylko do odczytu w terminalu](assets/fanout.gif)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:1569156eb887 -->
+<!-- source: README.md sha256:4fc19c5f9596 -->
 # Codewhale
 
 Um agente de programação de código aberto para o seu terminal — traga o seu próprio modelo.
@@ -26,7 +26,7 @@ Estamos sempre em busca de pessoas que contribuam e de formas de melhorar. Se um
 modelo ou provedor que você usa está faltando, ou se algo quebra, nos contar é
 uma das coisas mais úteis que você pode fazer — veja [Contribuindo](#contribuindo).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:1569156eb887 -->
+<!-- source: README.md sha256:4fc19c5f9596 -->
 # Codewhale
 
 Открытый агент для программирования в вашем терминале — модель приносите с собой.
@@ -28,7 +28,7 @@ harness станет вашим, а не нашим.
 одно из самых полезных действий с вашей стороны: см.
 [Участие в проекте](#участие-в-проекте).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,0 +1,160 @@
+<!-- source: README.md sha256:4fc19c5f9596 -->
+# Codewhale
+
+Terminaliniz için açık kaynak bir kodlama ajanı — modeli siz getirin.
+
+Codewhale, DeepSeek için yerel bir deneyim olarak başladı. O zamandan beri
+topluluk güdümlü bir projeye dönüştü: büyüyen uluslararası bir topluluğa uyan
+ve olabildiğince çok modeli ve sağlayıcıyı destekleyen tek bir kodlama
+harness'i — önce açık modeller, barındırılan veya yerel, hiçbiri diğerinden
+ayrıcalıklı değil.
+
+Ona bir sağlayıcı, bir model ve bir görev verin. Kodunuzu okur, dosyaları
+düzenler, komutları çalıştırır ve kendi işini denetler; iş bitince veya size
+ihtiyaç duyunca durur. Görev sırasında `/model` ile model değiştirin. TUI'de
+etkileşimli çalışın veya betiklerde ve CI'da `codewhale exec` çalıştırın. Rust
+ile yazılmıştır, MIT lisanslıdır ve sizin makinenizde çalışır.
+
+Diğer harness'lerden farkı şu: **her rol için modeli siz seçersiniz ve
+birbirleriyle aynı olmak zorunda değiller.** Bir fleet her rol için bir
+sağlayıcı, bir model ve bir akıl yürütme katmanı sabitler — böylece ucuz ve
+hızlı bir model pahalı bir akıl yürütme modelini yönetebilir veya bir GLM
+builder, bir Kimi reviewer ile aynı işte çalışabilir. Kendi rollerinizi, kendi
+constitution'ınızı yazın; harness bizim değil sizin olur.
+
+Her zaman katkıda bulunanlar ve iyileştirme yolları arıyoruz. Kullandığınız bir
+model veya sağlayıcı eksikse ya da bir şey bozulursa, bize söylemek
+yapabileceğiniz en yararlı şeylerden biridir — bkz.
+[Katkıda bulunma](#katkıda-bulunma).
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+
+[![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
+[![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/37gfS3ksug)
+
+![Terminalde çalışan Codewhale](assets/screenshot.png)
+
+## Kurulum
+
+```bash
+npm install -g codewhale
+```
+
+Cargo, Docker, Nix, Scoop, önceden derlenmiş arşivler, Android/Termux ve
+GitHub'a ulaşamayanlar için bir CNB aynası
+[docs/INSTALL.md](docs/INSTALL.md) içinde. `deepseek-tui`'den mi geliyorsunuz?
+Yapılandırmanız ve oturumlarınız taşınır — bkz.
+[docs/REBRAND.md](docs/REBRAND.md).
+
+## Kullanım
+
+```bash
+codewhale auth set --provider deepseek   # or export ANTHROPIC_API_KEY, etc.
+codewhale                                # open the TUI
+codewhale exec "fix the failing test"    # headless
+codewhale web                            # local browser client on 127.0.0.1
+```
+
+TUI'de: `/model` sağlayıcıyı ve modeli birlikte değiştirir, `/fleet` ekibi
+kurar ve çalıştırır — her seferinde bir rol, her biri kendi modeliyle —,
+`/undo` son turu geri alır ve `/restore <N>` çalışma alanını önceki bir
+anlık görüntüye döndürür (yalın `/restore` bunları listeler). Besteci boşken
+`Tab` Plan / Work / Operate arasında döner — içinde metin varken `Tab` slash
+komutlarını ve `@` bahsetmelerini tamamlar. `Shift+Tab` her an Ask /
+Auto-Review / Full Access izin duruşunu döngüler. `!` bir kabuk komutunu
+normal onay yolundan çalıştırır.
+
+## Ne yapar
+
+- **Herhangi bir model, herhangi bir sağlayıcı — ve herhangi bir karışım.**
+  DeepSeek, Claude, GPT, Kimi, GLM ve 30'dan fazla sağlayıcı, ayrıca anahtarsız
+  kendi vLLM, SGLang veya Ollama'nız, hepsi tek bir çalışma zamanı ve tek bir
+  araç setinden. Katalog her sağlayıcının canlı kadrosunu izler — DeepSeek'in
+  V4 Pro arka ucu (`DeepSeek-V4-Pro-0813` etiketli) hâlâ `deepseek-v4-pro`
+  olarak çağrılabilir, Grok 4.6 doğrudan xAI varsayılanıdır ve OrcaRouter
+  `orcarouter/auto` üzerinden yönlendirir. Kaydedilmiş bir rol `provider`,
+  `model` ve akıl yürütme katmanını açıkça kaydeder; böylece bir fleet tek bir
+  çalıştırmada birden çok satıcıya yayılabilir ve bir rolün rotası o anda
+  hangi sağlayıcının etkin olduğuna bağlı olmaz. Bağlam sınırları ve fiyatlar
+  gerçek rotadan gelir; bilinmeyen bir fiyat $0 değil, bilinmiyor olarak
+  görünür.
+- **Sizin yazdığınız bir harness.** Roller okuyup düzenleyebileceğiniz
+  dosyalardır — rol başına bir model, bir araç duruşu ve kalıcı yönergeler —
+  ekibin paylaşması için projede veya sizi depolar arasında izlemesi için
+  diğer kişisel ayarlarınızın yanında tutulur. Bir constitution, ajanın her
+  oturumda nasıl davranmasını istediğinizi kaydeder; böylece harness bizim
+  değil sizin pratiğinize uyar.
+- **Daha fazlasına izin verene kadar salt okunur.** Plan kipi dosyaları
+  değiştiremez ve onaylar riskli komutları kapılar. Bir işletim sistemi
+  sanal alanı bir komutu gerçekten sardığında Codewhale bunu söyler: macOS'ta
+  varsa Seatbelt, Linux'ta isteğe bağlı bubblewrap. Bir deponun
+  `constitution.json` dosyası, Full Access'in bile atlayamayacağı yazma
+  kilitlerine derlenir.
+- **Kaldığınız yerden sürebileceğiniz iş.** Bir fleet her adımı yalnızca
+  eklenen bir deftere yazar, böylece `fleet resume` kaldığınız yerden devam
+  eder.
+
+## Entegrasyonlar
+
+- **DeepSeek Harness (dsh) — Codewhale üzerinden bağlı.**
+  `codewhale integrations dsh connect` mevcut bir `@deepseek-ai/dsh`
+  kurulumunu Codewhale sağlayıcı rotanıza, izinlerinize ve çalışma alanınıza
+  bağlar; `integrations dsh install-bundle` isteğe bağlı DSH eklenti paketini
+  ekler ki `dsh --profile codewhale` bu kimliği kendi başına taşısın.
+  İzinler ve yaşam döngüsü yetkisi Codewhale'dedir; dsh kendi oturumlarını,
+  profillerini ve kimlik bilgilerini olduğu gibi bırakır. Bkz.
+  [docs/INTEGRATIONS_DSH.md](docs/INTEGRATIONS_DSH.md).
+- **VS Code.** Resmi eklenti iskelesi (`extensions/vscode`) Codewhale'i
+  tümleşik bir terminalde açar ve yerel çalışma zamanı üzerinde salt okunur
+  bir Agent View sunar. Bu yerel geliştirme önizlemesidir, henüz bir
+  marketplace sürümü değildir.
+
+## Daha fazla öğrenin
+
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — her sağlayıcı rotası: barındırılan,
+  ağ geçidi ve yerel
+- [docs/FLEET.md](docs/FLEET.md) — fleet'ler, defter ve devam ettirme
+- [docs/WORKFLOW_EXPERIMENTAL_SEARCH.md](docs/WORKFLOW_EXPERIMENTAL_SEARCH.md) — Workflow içinde dondurulmuş, sağlayıcıdan bağımsız deneysel arama
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, hook'lar ve
+  constitution
+- [docs/AUTHORIZATION_ORDER.md](docs/AUTHORIZATION_ORDER.md) — kipler,
+  hook'lar, izin kuralları, güvenlik tabanları, depo yasası, onaylar ve
+  sanal alanın nasıl birleştiği
+- [docs/HOOKS.md](docs/HOOKS.md) — on bir TUI yaşam döngüsü hook olayı,
+  yükleri ve bir turu yönlendirebilen üçü (`codewhale exec` ve CLI alt
+  komutları hook tetiklemez)
+- [docs/WEB.md](docs/WEB.md) — yalnızca döngü geri dönüşü tarayıcı istemcisi
+  ve tek kullanımlık kimlik doğrulama sınırı
+
+Geri kalan her şey — kipler, tuş bağları, sanal alan ayrıntıları, MCP,
+çalışma zamanı API'si ve mimari — [docs](docs) ve
+[codewhale.net](https://codewhale.net/) üzerinde yaşar.
+
+## Katkıda bulunma
+
+Issue'lar, PR'lar, yeniden üretim adımları, günlükler ve özellik istekleri
+gerçek proje işidir ve ilk katkılar hoş karşılanır. Bir PR olduğu gibi
+birleştirilemediğinde bakımcılar işe yarayanı alır ve yazarın kredisi kalır
+— commit'te, changelog'da ve
+[docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) içinde.
+
+- [Açık issue'lar](https://github.com/Hmbown/CodeWhale/issues) — iyi ilk
+  katkılar burada
+- [CONTRIBUTING.md](CONTRIBUTING.md) — geliştirme kurulumu ve PR akışı
+- [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) — bunu şekillendiren herkes
+- [Bana bir kahve ısmarla](https://www.buymeacoffee.com/hmbown)
+
+Projeyi başlatan modeller ve destek için [DeepSeek](https://github.com/deepseek-ai)'e,
+bizi Whale Brother ailesine kabul ettiği için
+[DataWhale](https://github.com/datawhalechina) 🐋'e ve terminal ajanı
+deneyiminde iş birliği için [OpenWarp](https://github.com/zerx-lab/warp) ile
+[Open Design](https://github.com/nexu-io/open-design)'a teşekkürler.
+
+## Lisans
+
+[MIT](LICENSE). Bağımsız bir topluluk projesi; hiçbir model sağlayıcısıyla
+bağlı değildir.
+
+![Codewhale bir terminalde üç salt okunur scout alt ajanını açıyor](assets/fanout.gif)

--- a/README.uk.md
+++ b/README.uk.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:1569156eb887 -->
+<!-- source: README.md sha256:4fc19c5f9596 -->
 # Codewhale
 
 Агент для програмування з відкритим кодом у вашому терміналі — модель приносите ви.
@@ -28,7 +28,7 @@ Codewhale починався як нативний інструмент для D
 це — одна з найкорисніших речей, які ви можете зробити — див.
 [Участь у проєкті](#участь-у-проєкті).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [codewhale.net](https://codewhale.net/) · [Документація](docs) · [Журнал змін](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Документація](docs) · [Журнал змін](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:1569156eb887 -->
+<!-- source: README.md sha256:4fc19c5f9596 -->
 # Codewhale
 
 Một coding agent mã nguồn mở cho terminal của bạn — mang theo model của riêng bạn.
@@ -26,7 +26,7 @@ Chúng tôi luôn tìm kiếm người đóng góp và cách cải thiện. Nế
 provider bạn dùng còn thiếu, hoặc có gì đó hỏng, báo cho chúng tôi biết là một
 trong những điều hữu ích nhất bạn có thể làm — xem [Đóng góp](#đóng-góp).
 
-[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Bahasa Indonesia](README.id.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Bahasa Indonesia](README.id.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:1569156eb887 -->
+<!-- source: README.md sha256:4fc19c5f9596 -->
 # Codewhale
 
 一个面向终端的开源编程智能体——模型由你自带。
@@ -11,7 +11,7 @@ Codewhale 最初是为 DeepSeek 打造的原生体验,如今已成长为一个�
 
 我们一直在寻找贡献者和改进的方式。如果你在用的某个模型或 provider 还不支持,或者有什么东西坏了,告诉我们就是你能做的最有用的事之一——见[贡献](#贡献)。
 
-[English](README.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord 社区](https://discord.gg/37gfS3ksug)
+[English](README.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [繁體中文](README.zh-TW.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord 社区](https://discord.gg/37gfS3ksug)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,90 @@
+<!-- source: README.md sha256:4fc19c5f9596 -->
+# Codewhale
+
+給終端機用的開源程式設計智能體——模型由你自備。
+
+Codewhale 起初是為 DeepSeek 打造的原生體驗，如今已成長為社群驅動的專案：一套契合持續擴大的國際社群、並盡可能支援更多模型與 provider 的程式設計 harness——開放模型優先，託管或本機皆可，彼此之間沒有誰被特別優待。
+
+給它一個 provider、一個模型和一項任務。它會讀你的程式碼、改檔案、跑指令、檢查自己的工作，並在任務完成或需要你介入時停下。任務進行中可用 `/model` 切換模型。互動式工作用 TUI，腳本和 CI 用 `codewhale exec`。以 Rust 撰寫，採 MIT 授權，跑在你自己的機器上。
+
+和其他 harness 不一樣的地方在於：**每個角色用哪個模型由你決定，而且不必相同。** 一個 Fleet 會為每個角色分別釘住 provider、模型和推論層級——所以又快又便宜的模型可以指揮昂貴的推論模型，GLM 的 builder 也可以和 Kimi 的 reviewer 做同一份工作。寫下你自己的角色、你自己的 constitution，這套 harness 就是你的，而不是我們的。
+
+我們一直在尋找貢獻者和改進的方式。如果你在用的某個模型或 provider 還沒支援，或有東西壞了，告訴我們就是你能做的最有用的事之一——見[貢獻](#貢獻)。
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Bahasa Indonesia](README.id.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [Русский](README.ru.md) · [Українська](README.uk.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [हिन्दी](README.hi.md) · [Türkçe](README.tr.md) · [Italiano](README.it.md) · [Polski](README.pl.md) · [العربية](README.ar.md) · [Català](README.ca.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md) · [Discord](https://discord.gg/37gfS3ksug)
+
+[![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
+[![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/37gfS3ksug)
+
+![Codewhale 在終端機中執行](assets/screenshot.png)
+
+## 安裝
+
+```bash
+npm install -g codewhale
+```
+
+Cargo、Docker、Nix、Scoop、預先建置的封存檔、Android/Termux，以及給無法連上 GitHub 的人用的 CNB 鏡像，都寫在
+[docs/INSTALL.md](docs/INSTALL.md)。從 `deepseek-tui` 過來？你的設定和工作階段會沿用——見
+[docs/REBRAND.md](docs/REBRAND.md)。
+
+## 使用
+
+```bash
+codewhale auth set --provider deepseek   # or export ANTHROPIC_API_KEY, etc.
+codewhale                                # open the TUI
+codewhale exec "fix the failing test"    # headless
+codewhale web                            # local browser client on 127.0.0.1
+```
+
+在 TUI 裡：`/model` 會同時切換 provider 與模型，`/fleet` 組建並執行團隊——一次一個角色，各自帶著自己的模型，`/undo` 還原上一回合，`/restore <N>` 把工作區捲回更早的快照（不帶參數的 `/restore` 只列出快照）。輸入區為空時，`Tab` 在 Plan / Work / Operate 之間循環；輸入區有文字時，`Tab` 改為補全斜線指令和 `@` 提及。`Shift+Tab` 隨時可循環切換 Ask / Auto-Review / Full Access 權限姿態。`!` 讓 shell 指令走一般的核准路徑。
+
+## 功能
+
+- **任意模型、任意 provider——也可以任意混搭。** DeepSeek、Claude、GPT、Kimi、GLM 等 30 多家 provider，以及你自己的 vLLM、SGLang 或 Ollama——不需要金鑰——全都跑在同一套執行環境和同一套工具上。目錄會追蹤每家 provider 的即時陣容——DeepSeek 的 V4 Pro 後端（標示為 `DeepSeek-V4-Pro-0813`）仍以 `deepseek-v4-pro` 呼叫，Grok 4.6 是 xAI 的直接預設，OrcaRouter 則經由 `orcarouter/auto` 路由。儲存下來的角色會明確記錄它的 `provider`、`model` 和推論層級，所以一個 Fleet 可以在同一次執行裡跨越多家廠商，角色的路由也不會取決於當時恰好啟用的是哪個 provider。上下文上限與價格取自真實路由；價格未知時顯示未知，而不是 $0。
+- **由你親手寫就的 harness。** 角色就是你能讀、能改的檔案——每個角色一個模型、一套工具姿態和一份常駐指示——放在專案裡讓團隊共用，或放在你的其他個人設定旁邊，跟著你在不同倉庫之間走。constitution 記錄你希望智能體在每一次工作階段中如何行事，讓這套 harness 貼合你的做法，而不是我們的。
+- **預設唯讀，你允許之後才再放寬。** Plan 模式不能改檔案，核准把關高風險指令。當作業系統沙箱確實包住一條指令時，Codewhale 會說出來：macOS 上是可用時啟用的 Seatbelt，Linux 上是需自行開啟的 bubblewrap。倉庫的 `constitution.json` 會編譯成寫入鎖定，連 Full Access 也無法略過。
+- **隨時可以續跑的工作。** Fleet 把每一步記在只追加的帳本裡，`fleet resume` 從你停下的地方繼續。
+
+## 整合
+
+- **DeepSeek Harness（dsh）——透過 Codewhale 連接。**
+  `codewhale integrations dsh connect` 會把既有的 `@deepseek-ai/dsh`
+  安裝接到你的 Codewhale provider 路由、權限和工作區，而
+  `integrations dsh install-bundle` 會加入可選的 DSH 外掛套件，讓
+  `dsh --profile codewhale` 能獨自帶上同一身分。權限與生命週期由
+  Codewhale 負責；dsh 保留自己的工作階段、設定檔和憑證，不會被改動。見
+  [docs/INTEGRATIONS_DSH.md](docs/INTEGRATIONS_DSH.md)。
+- **VS Code。** 官方擴充功能鷹架（`extensions/vscode`）會在整合式終端機中開啟
+  Codewhale，並透過本機執行環境提供唯讀的 Agent View。目前仍是本機開發預覽，尚未上架市集。
+
+## 了解更多
+
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — 每一條 provider 路由：託管、閘道與本機
+- [docs/FLEET.md](docs/FLEET.md) — Fleet、帳本與續跑
+- [docs/WORKFLOW_EXPERIMENTAL_SEARCH.md](docs/WORKFLOW_EXPERIMENTAL_SEARCH.md) — Workflow 內已凍結、對 provider 中立的實驗性搜尋
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`、hooks 與 constitution
+- [docs/AUTHORIZATION_ORDER.md](docs/AUTHORIZATION_ORDER.md) — 模式、hook、權限規則、安全下限、倉庫規範、核准和沙箱如何組合
+- [docs/HOOKS.md](docs/HOOKS.md) — 十一個 TUI 生命週期 hook 事件、其承載，以及其中可引導回合的三個事件（`codewhale exec` 和 CLI 子指令不會觸發 hooks）
+- [docs/WEB.md](docs/WEB.md) — 僅限回環位址的瀏覽器用戶端及其一次性驗證邊界
+
+其餘內容——模式、快捷鍵、沙箱細節、MCP、執行環境 API、架構——見 [docs](docs) 與 [codewhale.net](https://codewhale.net/)。
+
+## 貢獻
+
+Issue、PR、重現步驟、紀錄檔和功能請求，在這裡都算真實的專案工作，也歡迎第一次貢獻。當一個 PR 無法原樣合併時，維護者會擷取其中可用的部分，並保留作者的署名——在提交、變更紀錄和 [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) 中。
+
+- [開放的 issue](https://github.com/Hmbown/CodeWhale/issues) —— 適合入門的貢獻在這裡
+- [CONTRIBUTING.md](CONTRIBUTING.md) —— 開發環境建置與 PR 流程
+- [docs/CONTRIBUTORS.md](docs/CONTRIBUTORS.md) —— 每一位形塑過這個專案的人
+- [請我喝杯咖啡](https://www.buymeacoffee.com/hmbown)
+
+感謝 [DeepSeek](https://github.com/deepseek-ai) 提供讓專案起步的模型與支援，感謝 [DataWhale](https://github.com/datawhalechina) 🐋 歡迎我們加入「鯨兄弟」大家庭，也感謝 [OpenWarp](https://github.com/zerx-lab/warp) 與 [Open Design](https://github.com/nexu-io/open-design) 在終端機智能體體驗上的合作。
+
+## 授權
+
+[MIT](LICENSE)。獨立的社群專案，與任何模型 provider 均無隸屬關係。
+
+![Codewhale 在終端機中並行派出三個唯讀 scout 子代理](assets/fanout.gif)

--- a/docs/LOCALIZATION.id.md
+++ b/docs/LOCALIZATION.id.md
@@ -55,6 +55,15 @@ Paket TUI di bawah `crates/tui/locales/` adalah permukaan terjemahan terbesar di
 | Bahasa Portugis Brasil | `README.pt-BR.md` | **shipped** | Ditinjau per rilis |
 | Bahasa Rusia | `README.ru.md` | **shipped** | Ditinjau per rilis |
 | Bahasa Ukraina | `README.uk.md` | **shipped** | Ditinjau per rilis |
+| Bahasa Prancis | `README.fr.md` | **shipped** | Menunggu tinjauan penutur asli |
+| Bahasa Jerman | `README.de.md` | **shipped** | Menunggu tinjauan penutur asli |
+| Bahasa Mandarin Tradisional | `README.zh-TW.md` | **shipped** | Menunggu tinjauan penutur asli |
+| Bahasa Hindi | `README.hi.md` | **shipped** | Menunggu tinjauan penutur asli |
+| Bahasa Turki | `README.tr.md` | **shipped** | Menunggu tinjauan penutur asli |
+| Bahasa Italia | `README.it.md` | **shipped** | Menunggu tinjauan penutur asli |
+| Bahasa Polandia | `README.pl.md` | **shipped** | Menunggu tinjauan penutur asli |
+| Bahasa Arab | `README.ar.md` | **shipped** | Menunggu tinjauan penutur asli |
+| Bahasa Katalan | `README.ca.md` | **shipped** | Menunggu tinjauan penutur asli |
 
 ---
 

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -15,8 +15,8 @@ Customer-visible copy also follows the [Codewhale voice and terminal
 charter](VOICE.md); commands, key names, and glyphs remain code-owned around
 localized prose.
 
-Last updated: 2026-08-12 (retire the stale `zh-Hant` partial declaration
-left behind by #5143).
+Last updated: 2026-08-16 (README translations for fr, de, zh-TW, hi, tr,
+it, pl, ar, and ca).
 Source-of-truth README: `README.md` (English, post-#3087).
 
 ## Status legend
@@ -130,6 +130,15 @@ what the `(partial)` badge is honest about.
 | Russian | `README.ru.md` | **shipped** | Same (#3092). Awaiting native-speaker review. |
 | Ukrainian | `README.uk.md` | **shipped** | Same (#4791). Awaiting native-speaker review. |
 | Indonesian | `README.id.md` | **shipped** | Same (#4789). Awaiting native-speaker review. |
+| French | `README.fr.md` | **shipped** | Same. Awaiting native-speaker review. |
+| German | `README.de.md` | **shipped** | Same. Awaiting native-speaker review. |
+| Traditional Chinese | `README.zh-TW.md` | **shipped** | Same. Awaiting native-speaker review. |
+| Hindi | `README.hi.md` | **shipped** | Same. Awaiting native-speaker review. |
+| Turkish | `README.tr.md` | **shipped** | Same. Awaiting native-speaker review. |
+| Italian | `README.it.md` | **shipped** | Same. Awaiting native-speaker review. |
+| Polish | `README.pl.md` | **shipped** | Same. Awaiting native-speaker review. |
+| Arabic | `README.ar.md` | **shipped** | Same. Awaiting native-speaker review. Markdown only; no HTML `dir` attributes. |
+| Catalan | `README.ca.md` | **shipped** | Same. Awaiting native-speaker review. |
 
 ## Drift checks
 

--- a/scripts/check-readme-translations.py
+++ b/scripts/check-readme-translations.py
@@ -32,6 +32,15 @@ TRANSLATIONS = [
     "README.pt-BR.md",
     "README.ru.md",
     "README.uk.md",
+    "README.fr.md",
+    "README.de.md",
+    "README.zh-TW.md",
+    "README.hi.md",
+    "README.tr.md",
+    "README.it.md",
+    "README.pl.md",
+    "README.ar.md",
+    "README.ca.md",
 ]
 STAMP_RE = re.compile(r"<!--\s*source:\s*README\.md\s+sha256:([0-9a-f]{12})\s*-->")
 FENCE_RE = re.compile(r"```[a-z]*\n(.*?)```", re.DOTALL)
@@ -49,6 +58,15 @@ LANGUAGE_LINKS = {
     "README.pt-BR.md",
     "README.ru.md",
     "README.uk.md",
+    "README.fr.md",
+    "README.de.md",
+    "README.zh-TW.md",
+    "README.hi.md",
+    "README.tr.md",
+    "README.it.md",
+    "README.pl.md",
+    "README.ar.md",
+    "README.ca.md",
 }
 
 

--- a/web/lib/public-surface-contract.test.ts
+++ b/web/lib/public-surface-contract.test.ts
@@ -405,12 +405,21 @@ done
     expect(matrixText).not.toContain('"approvalPostures"');
 
     for (const path of [
+      "README.ar.md",
+      "README.ca.md",
+      "README.de.md",
       "README.es-419.md",
+      "README.fr.md",
+      "README.hi.md",
+      "README.it.md",
       "README.ja-JP.md",
       "README.ko-KR.md",
+      "README.pl.md",
       "README.pt-BR.md",
+      "README.tr.md",
       "README.vi.md",
       "README.zh-CN.md",
+      "README.zh-TW.md",
     ]) {
       expect(text(path), path).toContain("Shift+Tab");
     }


### PR DESCRIPTION
## Summary

Add README translations for the languages the TUI already ships (and a few we were missing):

- `README.fr.md` (Français)
- `README.de.md` (Deutsch)
- `README.zh-TW.md` (繁體中文)
- `README.hi.md` (हिन्दी)
- `README.tr.md` (Türkçe)
- `README.it.md` (Italiano)
- `README.pl.md` (Polski)
- `README.ar.md` (العربية; Markdown only, no HTML `dir` attributes)
- `README.ca.md` (Català; remaining shipped TUI pack)

The English README language line and every existing translation now link the old set first, then the new ones. Source stamps are regenerated to `sha256:4fc19c5f9596`. Both lists in `scripts/check-readme-translations.py` include the new files, and `docs/LOCALIZATION.md` / `docs/LOCALIZATION.id.md` / the public-surface Shift+Tab contract list were updated to match.

Closes #5451

## Verification

```
python3 scripts/check-readme-translations.py
README translation check OK — 18 translations in sync with README.md (sha256:4fc19c5f9596)
```

Also ran `bash scripts/check-readme-locales.sh` — PASS (18 linked locale READMEs, no orphans).

Did not run cargo (docs-only change; lane instruction).

## Not verified

Native-speaker review of each new language. The new rows in `docs/LOCALIZATION.md` are marked awaiting that review.