### PR TITLE
test(pty): deflake agent_focus auto-review receipt test

### DIFF
--- a/crates/tui/tests/pty/agent_focus_pty.rs
+++ b/crates/tui/tests/pty/agent_focus_pty.rs
@@ -276,6 +276,37 @@ fn type_and_submit(harness: &mut Harness, text: &str) -> Result<()> {
     Ok(())
 }
 
+/// `←` then Enter after the parent turn has settled on a still-running row.
+///
+/// A 200ms sleep between those keys is a race: completion redraws drop rail
+/// focus and Enter becomes a composer no-op. Wait for the live row, then
+/// send the keys back-to-back.
+fn focus_listed_worker(harness: &mut Harness, worker: &str) -> Result<()> {
+    harness.wait_for_text("for agents", INTERACTION_TIMEOUT)?;
+    harness.wait_for_text("to manage", INTERACTION_TIMEOUT)?;
+    harness.wait_for_text(COMPOSER_READY_TEXT, INTERACTION_TIMEOUT)?;
+    harness.wait_for_text("✓ done", INTERACTION_TIMEOUT)?;
+    harness.wait_for(
+        |frame| {
+            let text = frame.text();
+            text.contains(worker) && !text.contains("completed")
+        },
+        INTERACTION_TIMEOUT,
+    )?;
+    let mut chord = keys::key::left();
+    chord.extend(keys::key::enter());
+    harness.send(chord)?;
+    harness
+        .wait_for_text(FOCUS_MARKER, INTERACTION_TIMEOUT)
+        .map_err(|_| {
+            anyhow!(
+                "← then Enter did not focus the worker\n{}",
+                harness.debug_dump()
+            )
+        })?;
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn focus_a_worker_send_a_follow_up_and_return_to_main() -> Result<()> {
     let _guard = AGENT_FOCUS_PTY_LOCK.lock().await;
@@ -392,13 +423,15 @@ const GATE_PARENT_PROMPT: &str = "spawn the gate probe worker now";
 const GATE_CHILD_MARKER: &str = "gateprobe";
 const GATE_ECHO: &str = "gate-probe-output";
 
-/// Serves the parent (streaming), the child (non-streaming: one held `bash`
-/// call, then a wrap-up), and the Auto-Review guardian (non-streaming
-/// verdict) from one loopback endpoint, telling them apart by body shape.
+/// Serves the parent (streaming), the child (non-streaming: one `bash` call,
+/// then a held wrap-up so the worker stays `running` while we focus), and the
+/// Auto-Review guardian (non-streaming verdict) from one loopback endpoint,
+/// telling them apart by body shape.
 struct GateResponder {
     child_rounds: Arc<AtomicUsize>,
     guardian_requests: Arc<AtomicUsize>,
     parent_turns: Arc<AtomicUsize>,
+    child_hold: Duration,
 }
 
 impl Respond for GateResponder {
@@ -441,7 +474,7 @@ impl Respond for GateResponder {
                     "usage": {"prompt_tokens": 12, "completion_tokens": 6, "total_tokens": 18}
                 }));
             }
-            return chat_message_response("gate child wrapped up");
+            return chat_message_response("gate child wrapped up").set_delay(self.child_hold);
         }
         if raw.contains(GATE_PARENT_PROMPT) {
             if self.parent_turns.fetch_add(1, Ordering::SeqCst) == 0 {
@@ -505,6 +538,10 @@ async fn auto_review_gates_a_workers_call_and_the_receipt_shows_in_focus() -> Re
             child_rounds: Arc::clone(&child_rounds),
             guardian_requests: Arc::clone(&guardian_requests),
             parent_turns: Arc::new(AtomicUsize::new(0)),
+            // Hold the wrap-up, not the bash call: the guardian receipt is
+            // written when bash is allowed, and ← focuses a *running* row
+            // the same way the sibling journey does.
+            child_hold: Duration::from_secs(40),
         })
         .mount(&server)
         .await;
@@ -521,7 +558,7 @@ async fn auto_review_gates_a_workers_call_and_the_receipt_shows_in_focus() -> Re
     let mut tui = tui_builder_with_posture(&ws, &server.uri(), false).spawn()?;
     tui.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
     type_and_submit(&mut tui, GATE_PARENT_PROMPT)?;
-    // Child round 1 (held bash) → guardian → the call runs → child round 2.
+    // Child bash → guardian → the call runs → child wrap-up request (held).
     wait_for_counter(&mut tui, &guardian_requests, 1, INTERACTION_TIMEOUT)?;
     wait_for_counter(&mut tui, &child_rounds, 2, INTERACTION_TIMEOUT)?;
     tui.wait_for_text("gate parent wrapped up", INTERACTION_TIMEOUT)?;
@@ -533,31 +570,21 @@ async fn auto_review_gates_a_workers_call_and_the_receipt_shows_in_focus() -> Re
     );
     capture(&mut tui, "10-gate-main");
 
-    // Focus the worker: its transcript carries the guardian receipt.
-    tui.wait_for_text("for agents", INTERACTION_TIMEOUT)?;
-    tui.send(b"\x1b[D")?; // Left
-    std::thread::sleep(Duration::from_millis(200));
-    tui.pump();
-    tui.send(keys::key::enter())?;
-    tui.wait_for_text(FOCUS_MARKER, Duration::from_secs(5))
-        .map_err(|_| {
-            anyhow!(
-                "← then Enter did not focus the worker\n{}",
-                tui.debug_dump()
-            )
-        })?;
-    tui.wait_for_text("Auto-Review allowed 'bash'", Duration::from_secs(10))
-        .map_err(|_| {
-            anyhow!(
-                "focused worker transcript lacks the guardian receipt\n{}",
-                tui.debug_dump()
-            )
-        })?;
-    let focused = tui.debug_dump();
-    assert!(
-        focused.contains("model guardian"),
-        "receipt must name the guardian:\n{focused}"
-    );
+    // Focus the still-running worker: its transcript carries the receipt.
+    focus_listed_worker(&mut tui, "gate-worker")?;
+    tui.wait_for(
+        |frame| {
+            let text = frame.text();
+            text.contains("Auto-Review allowed 'bash'") && text.contains("model guardian")
+        },
+        INTERACTION_TIMEOUT,
+    )
+    .map_err(|_| {
+        anyhow!(
+            "focused worker transcript lacks the guardian receipt\n{}",
+            tui.debug_dump()
+        )
+    })?;
     capture(&mut tui, "11-gate-focused-receipt");
     tui.send(keys::key::esc())?;
     let _ = tui.shutdown();


### PR DESCRIPTION
## Summary

macOS CI flake in `agent_focus_pty::auto_review_gates_a_workers_call_and_the_receipt_shows_in_focus`. The nextest FAIL block is:

```
Error: ← then Enter did not focus the worker
== frame 42x150 cursor=(40, 2) ==
  ▾ Subagents 1
  ✓ gate-worker  completed  ...
  ...
  ▌✓ done │ 2 turns · 5 steps │ ...  ← for agents · ↓ to manage
  ❯ Write a task or use /.
```

Seen on jobs 95242220506 (PR #5448), 95242912374 (PR #5438 run 31979001550), and reported on 95245484898 (PR #5445). Same dump on independent PRs (including docs-only); reruns pass.

### Root cause

The sibling `focus_a_worker_send_a_follow_up_and_return_to_main` keeps workers `running` (40s mock hold) and does not flake. This test let the child's wrap-up return immediately, then slept 200ms between `←` and Enter.

By the time those keys were sent the worker was already `completed`. Top placement collapses settled workers off the live strip (`project_visible` / `agent_row_is_strip_settled`). `←` can still switch the rail to the Agents panel, but the 200ms gap is a window for completion redraws / `clamp_viewport` / `collapse_strip` to drop rail keyboard focus. Enter then hits the empty composer (no-op). After the CI-scaled 5s wait the dump is still the main conversation with `← for agents` advertised.

`wait_for_text("for agents")` is also true from the moment the worker exists, so it does not mean the parent turn or the rail have settled.

This is a test race, not a product bug in Auto-Review. Focusing a completed worker via the Agents register remains a supported path (`finished_agent_row_opens_its_transcript_and_alt_v_reaches_details`); this journey just needs a live row, the same way the sibling does.

### Fix

- Hold the child's wrap-up (not the bash call) for 40s so the guardian receipt exists and the worker stays `running` while we focus.
- Wait for a settled live row (`✓ done`, empty composer, `gate-worker` without `completed`) instead of a fixed sleep.
- Send `←`+Enter back-to-back so Enter lands on the Agents panel.
- Assert the receipt as a condition (`Auto-Review allowed 'bash'` and `model guardian`) on the focused frame.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-tui --test pty -- -D warnings`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked`
- [ ] `cargo test --workspace --all-features --locked`

### Verification

```sh
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --test pty -- auto_review_gates_a_workers_call_and_the_receipt_shows_in_focus
# 15-iteration bash for-loop: pass=15 fail=0
# individual runtimes ~1.2–3.5s after compile (loop 1 was 9.34s under a cargo lock)

RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --test pty -- agent_focus_pty
# 2 passed (focus_a_worker_send_a_follow_up_and_return_to_main + auto_review_...)
```

Not verified: macOS GitHub Actions under full-workspace nextest load; workspace clippy/test gate.

Refs #5056 #5403
No-Issue: CI flake fix tracked under #5056