### PR TITLE
feat(subagent): slim the agent tool schema to 12 advertised fields (#5324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The model-facing `agent` tool advertises exactly 12 fields — `action`,
+  `prompt`, `type`, `profile`, `name`, `agent_id`, `message`, `until`,
+  `detached`, `worktree`, `write_roots`, `resume_from` — down from 33
+  (#5324, refs #5123). Budgets (`max_steps`, `wall_time_secs`, `max_depth`),
+  routing overrides (`model`, `model_strength`, `thinking`), worktree-path
+  knobs, the deliberate/spawn-contract fields and the wait/status/interrupt
+  extras moved off the advertised schema. Every removed field stays
+  parse-accepted and honored unchanged (same contract as `token_budget`), so
+  saved transcripts, ACP/MCP clients and Fleet configs replay as-is; the
+  #5426/#5435 containment clamps are untouched. Child budgets now resolve
+  from role defaults (60/120 turns, 1800 s wall time, unchanged clamps) and
+  new `[subagents]` keys `default_max_steps` / `default_wall_time_secs`.
+  Because the tool catalog is part of the session-pinned prompt prefix
+  (docs/CACHE.md), upgrading re-fills the KV prefix once per session.
 - TUI prose — user messages, assistant answers, and reasoning/thinking —
   now wraps at the full content width on wide terminals, matching
   tool/status cells, instead of stopping at a 105-column rail that left a

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The model-facing `agent` tool advertises exactly 12 fields — `action`,
+  `prompt`, `type`, `profile`, `name`, `agent_id`, `message`, `until`,
+  `detached`, `worktree`, `write_roots`, `resume_from` — down from 33
+  (#5324, refs #5123). Budgets (`max_steps`, `wall_time_secs`, `max_depth`),
+  routing overrides (`model`, `model_strength`, `thinking`), worktree-path
+  knobs, the deliberate/spawn-contract fields and the wait/status/interrupt
+  extras moved off the advertised schema. Every removed field stays
+  parse-accepted and honored unchanged (same contract as `token_budget`), so
+  saved transcripts, ACP/MCP clients and Fleet configs replay as-is; the
+  #5426/#5435 containment clamps are untouched. Child budgets now resolve
+  from role defaults (60/120 turns, 1800 s wall time, unchanged clamps) and
+  new `[subagents]` keys `default_max_steps` / `default_wall_time_secs`.
+  Because the tool catalog is part of the session-pinned prompt prefix
+  (docs/CACHE.md), upgrading re-fills the KV prefix once per session.
 - TUI prose — user messages, assistant answers, and reasoning/thinking —
   now wraps at the full content width on wide terminals, matching
   tool/status cells, instead of stopping at a 105-column rail that left a

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2406,6 +2406,19 @@ pub struct SubagentsConfig {
     /// cancelled before their request timeout can fire (#2614).
     #[serde(default)]
     pub heartbeat_timeout_secs: Option<u64>,
+    /// Default per-child model-turn budget applied when an `agent` start
+    /// carries no explicit `max_steps` (#5324). When unset, the Fleet role
+    /// default applies (60 turns for read-only roles, 120 for
+    /// builder/worker/custom); values are clamped to the runtime ceiling
+    /// (2000) at resolution.
+    #[serde(default)]
+    pub default_max_steps: Option<u32>,
+    /// Default per-child wall-clock budget in seconds applied when an
+    /// `agent` start carries no explicit `wall_time_secs` (#5324). When
+    /// unset, children get 1800s; values are clamped to 1..=86400 at
+    /// resolution.
+    #[serde(default)]
+    pub default_wall_time_secs: Option<u64>,
     /// Per-provider overrides for sub-agent fanout and budget knobs. Keys are
     /// provider names such as `deepseek`, `zai`, `openrouter`, or `anthropic`.
     #[serde(default)]
@@ -6919,6 +6932,31 @@ impl Config {
             .and_then(|cfg| cfg.token_budget)
             .or_else(|| self.subagents.as_ref().and_then(|cfg| cfg.token_budget))
             .filter(|budget| *budget > 0)
+    }
+
+    /// Default per-child model-turn budget from `[subagents]
+    /// default_max_steps`, applied when an `agent` start carries no explicit
+    /// `max_steps` (#5324). `None` or `0` keep the Fleet role defaults
+    /// (60 read-only roles / 120 builder/worker/custom); the resolved value
+    /// is clamped to the runtime ceiling when applied.
+    #[must_use]
+    pub fn subagent_default_max_steps(&self) -> Option<u32> {
+        self.subagents
+            .as_ref()
+            .and_then(|cfg| cfg.default_max_steps)
+            .filter(|steps| *steps > 0)
+    }
+
+    /// Default per-child wall-clock budget in seconds from `[subagents]
+    /// default_wall_time_secs`, applied when an `agent` start carries no
+    /// explicit `wall_time_secs` (#5324). `None` or `0` keep the 1800s
+    /// default; the resolved value is clamped to 1..=86400 when applied.
+    #[must_use]
+    pub fn subagent_default_wall_time_secs(&self) -> Option<u64> {
+        self.subagents
+            .as_ref()
+            .and_then(|cfg| cfg.default_wall_time_secs)
+            .filter(|secs| *secs > 0)
     }
 
     /// Resolved per-step DeepSeek API timeout for sub-agents, in seconds.

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -1973,6 +1973,40 @@ fn launch_concurrency_defaults_and_clamps_to_max_subagents() {
 }
 
 #[test]
+fn subagent_budget_defaults_read_the_subagents_table() {
+    // #5324: per-child step/wall-time defaults are operator config
+    // (`[subagents]`), not per-call schema fields. `0` means unset (keep the
+    // role / 1800s defaults).
+    let cfg: SubagentsConfig =
+        toml::from_str("default_max_steps = 90\ndefault_wall_time_secs = 600")
+            .expect("parse [subagents] budget keys");
+    assert_eq!(cfg.default_max_steps, Some(90));
+    assert_eq!(cfg.default_wall_time_secs, Some(600));
+
+    let mut config = Config {
+        subagents: Some(SubagentsConfig {
+            default_max_steps: Some(240),
+            default_wall_time_secs: Some(2700),
+            ..SubagentsConfig::default()
+        }),
+        ..Config::default()
+    };
+    assert_eq!(config.subagent_default_max_steps(), Some(240));
+    assert_eq!(config.subagent_default_wall_time_secs(), Some(2700));
+
+    config.subagents = Some(SubagentsConfig {
+        default_max_steps: Some(0),
+        default_wall_time_secs: Some(0),
+        ..SubagentsConfig::default()
+    });
+    assert_eq!(config.subagent_default_max_steps(), None);
+    assert_eq!(config.subagent_default_wall_time_secs(), None);
+
+    assert_eq!(Config::default().subagent_default_max_steps(), None);
+    assert_eq!(Config::default().subagent_default_wall_time_secs(), None);
+}
+
+#[test]
 fn launch_concurrency_honors_deprecated_interactive_max_launch_alias() {
     // The old TOML key `interactive_max_launch` still deserializes, via
     // #[serde(rename)], into the hidden legacy field, and the resolver

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1262,6 +1262,12 @@ impl Engine {
             config.subagent_heartbeat_timeout,
             config.launch_concurrency,
             config.subagent_token_budget,
+            // #5324: per-child budget defaults are operator config, not
+            // per-call schema fields.
+            api_config.subagent_default_max_steps(),
+            api_config
+                .subagent_default_wall_time_secs()
+                .map(std::time::Duration::from_secs),
         );
         let shell_manager = config
             .runtime_services

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -3188,7 +3188,16 @@ pub struct SubAgentManager {
     state_path: Option<PathBuf>,
     coordination_process_lock: std::sync::Mutex<Option<CoordinationProcessLock>>,
     coordination_process_lock_required: bool,
+    /// Configured default per-child model-turn budget (`[subagents]
+    /// default_max_steps`, #5324). `None` keeps the Fleet role defaults
+    /// (`WorkerRuntimeProfile::default_max_steps`); an explicit spawn
+    /// `max_steps` still wins.
     max_steps: Option<u32>,
+    /// Configured default per-child wall-clock budget (`[subagents]
+    /// default_wall_time_secs`, #5324). `None` keeps
+    /// `DEFAULT_CHILD_WALL_TIME`; an explicit spawn `wall_time_secs` still
+    /// wins.
+    wall_time: Option<Duration>,
     max_agents: usize,
     max_admitted_agents: usize,
     default_token_budget: Option<u64>,
@@ -3317,6 +3326,7 @@ impl SubAgentManager {
             coordination_process_lock: std::sync::Mutex::new(None),
             coordination_process_lock_required: false,
             max_steps: None,
+            wall_time: None,
             max_agents,
             max_admitted_agents: max_agents,
             default_token_budget: None,
@@ -3364,6 +3374,24 @@ impl SubAgentManager {
     #[must_use]
     pub fn with_default_token_budget(mut self, budget: Option<u64>) -> Self {
         self.default_token_budget = positive_token_budget(budget);
+        self
+    }
+
+    /// Set the configured default per-child model-turn budget applied when a
+    /// spawn carries no explicit `max_steps` (#5324). `None` keeps the Fleet
+    /// role defaults.
+    #[must_use]
+    pub fn with_default_max_steps(mut self, max_steps: Option<u32>) -> Self {
+        self.max_steps = max_steps;
+        self
+    }
+
+    /// Set the configured default per-child wall-clock budget applied when a
+    /// spawn carries no explicit `wall_time_secs` (#5324). `None` keeps
+    /// `DEFAULT_CHILD_WALL_TIME`.
+    #[must_use]
+    pub fn with_default_wall_time(mut self, wall_time: Option<Duration>) -> Self {
+        self.wall_time = wall_time;
         self
     }
 
@@ -6034,6 +6062,7 @@ impl SubAgentManager {
         runtime.worker_profile.max_steps = max_steps;
         let wall_time = options
             .wall_time
+            .or(self.wall_time)
             .unwrap_or(DEFAULT_CHILD_WALL_TIME)
             .min(MAX_CHILD_WALL_TIME);
         let worker_spec = AgentWorkerSpec {
@@ -7377,6 +7406,10 @@ pub fn new_shared_subagent_manager_with_timeout(
         running_heartbeat_timeout,
         launch_concurrency,
         default_token_budget,
+        // `[subagents]` budget defaults are an interactive `agent`-tool
+        // concern; this control-plane path keeps role/spec defaults.
+        None,
+        None,
     )
 }
 
@@ -7387,6 +7420,7 @@ pub fn new_shared_subagent_manager_with_timeout(
 /// `state_root/.codewhale/state`. Distinct state roots intentionally do not
 /// share write claims; an embedding host that runs them against the same
 /// workspace must provide any required cross-session write coordination.
+#[allow(clippy::too_many_arguments)] // legacy open constructor; budget pair rides along
 #[must_use]
 pub fn new_shared_subagent_manager_with_state_root_and_timeout(
     workspace: PathBuf,
@@ -7396,6 +7430,8 @@ pub fn new_shared_subagent_manager_with_state_root_and_timeout(
     running_heartbeat_timeout: Duration,
     launch_concurrency: usize,
     default_token_budget: Option<u64>,
+    default_max_steps: Option<u32>,
+    default_wall_time: Option<Duration>,
 ) -> SharedSubAgentManager {
     let max_agents = max_agents.clamp(1, MAX_SUBAGENTS);
     let state_path = match default_state_path(&state_root) {
@@ -7414,7 +7450,9 @@ pub fn new_shared_subagent_manager_with_state_root_and_timeout(
         .with_admission_limit(max_admitted_agents)
         .with_running_heartbeat_timeout(running_heartbeat_timeout)
         .with_launch_concurrency(launch_concurrency)
-        .with_default_token_budget(default_token_budget);
+        .with_default_token_budget(default_token_budget)
+        .with_default_max_steps(default_max_steps)
+        .with_default_wall_time(default_wall_time);
     if let Some(state_path) = state_path {
         manager = manager.with_state_path(state_path);
     }
@@ -7574,18 +7612,27 @@ impl ToolSpec for AgentTool {
             "Start with action=start and prompt; returns a turn-owned agent_id immediately. Read-only roles need no extra fields. Set detached=true only for work that must remain independently observable after the turn. ",
             "Use multiple starts for independent parallel tasks. ",
             "type selects the Fleet role: worker (full tool access), scout (fast read-only exploration), planner (grounded strategy, read-only probes), reviewer (reads and grades code), builder (lands focused code changes), verifier (runs tests and reports evidence), consultant (read-only design counsel), or custom (allowed_tools on the parent's posture). ",
-            "profile runs the child as a named Fleet profile (roster member) — its role posture, model route, and instruction overlay — so pass a profile only when the task needs that member and never pass model alongside it. ",
-            "max_depth caps how deep the child may spawn its own descendants (it can only narrow the inherited budget). workspace_policy=shared (default) runs in the parent checkout; worktree=true (or workspace_policy=worktree) gives the child an isolated git worktree — use it whenever parallel writers must not collide with the parent checkout. ",
-            "A write-capable child defaults write scope to the parent workspace; narrow it with write_roots (repo-relative directory trees) and exact_files (individual files) so parallel children claim disjoint scope. ",
+            "profile runs the child as a named Fleet profile (roster member) — its role posture, model route, and thinking tier — so pass a profile only when the task needs that member. Without a profile the child inherits the parent's model; per-call model or thinking overrides are not part of this surface. ",
+            "Child run budgets (model turns, wall time) come from Fleet role defaults and operator [subagents] config, not per-call fields. ",
+            "worktree=true gives the child an isolated git worktree — use it whenever parallel writers must not collide with the parent checkout. ",
+            "A write-capable child defaults write scope to the parent workspace; narrow it with write_roots (repo-relative directory trees) so parallel children claim disjoint scope. ",
             "Prefer type=builder for write work and type=verifier (or the Run tool with action=\"verifiers\") after writes settle — dispatch is not completion. ",
             "Coordinate through this same tool: action=message queues a note without waking the child; action=followup delivers queued notes and wakes a running child for its next user-provenance turn; action=interrupt stops the current child turn while preserving its checkpoint; action=wait blocks without changing child state, and until=\"all\" joins a whole fan-out in one call. ",
             "Action contract: start requires prompt; message/followup require a target and message; peek/interrupt/cancel require a target; status and wait may be unscoped. ",
             "The narrow agents/list, agents/message, agents/followup, agents/interrupt, and agents/wait tools expose the same semantics directly; there is no second transport. ",
-            "In Operate, use detached=true only for independent or long work that must outlive the active turn; a write-capable root start defaults write scope to the parent workspace unless narrowed with write_roots, exact_files, or coordination_contracts; arbitrary shell remains gated. ",
+            "In Operate, use detached=true only for independent or long work that must outlive the active turn; a write-capable root start defaults write scope to the parent workspace unless narrowed with write_roots; arbitrary shell remains gated. ",
             "Legacy action=status|peek|cancel remain for compatibility."
         )
     }
 
+    /// Advertised `agent` schema: exactly 12 fields (#5324, #5123) —
+    /// action, prompt, type, profile, name, agent_id, message, until,
+    /// detached, worktree, write_roots, resume_from — plus the
+    /// action-discriminated `dependentSchemas` tree. Every field removed
+    /// from this schema (budgets, model/thinking overrides, worktree-path
+    /// knobs, deliberate/spawn-contract knobs, wait/status extras) stays
+    /// parse-accepted unchanged for saved transcripts, ACP/MCP clients and
+    /// Fleet configs, exactly like `token_budget`; see docs/SUBAGENTS.md.
     fn input_schema(&self) -> Value {
         let target_required = json!([
             {
@@ -7614,23 +7661,9 @@ impl ToolSpec for AgentTool {
                     "type": "string",
                     "description": "Agent id or session name for any action except start and unscoped status/wait."
                 },
-                "timeout_secs": {
-                    "type": "integer",
-                    "minimum": 5,
-                    "maximum": 120,
-                    "description": "For action=wait: maximum seconds to block (default 30). Prefer ending the turn and staying reachable — results arrive automatically as <codewhale:subagent.done> sentinels — only wait when you must join before continuing."
-                },
                 "message": {
                     "type": "string",
                     "description": "Parent note for action=message or action=followup. message queues only; followup also wakes a running child."
-                },
-                "reason": {
-                    "type": "string",
-                    "description": "Optional bounded reason for action=interrupt."
-                },
-                "include_archived": {
-                    "type": "boolean",
-                    "description": "For action=status without agent_id, include prior-session completed agents."
                 },
                 "name": {
                     "type": "string",
@@ -7638,21 +7671,11 @@ impl ToolSpec for AgentTool {
                 },
                 "prompt": {
                     "type": "string",
-                    "description": "The focused task to give the worker. A read-only role needs no write scope; a write-capable role defaults to the parent workspace unless narrowed with write_roots, exact_files, or coordination_contracts."
+                    "description": "The focused task to give the worker. A read-only role needs no write scope; a write-capable role defaults to the parent workspace unless narrowed with write_roots."
                 },
                 "detached": {
                     "type": "boolean",
                     "description": "False (default): the active turn owns this direct child and cancels it before ending. true: explicitly detached work remains running and inspectable after the parent turn ends; cancel it with agent(action=cancel)."
-                },
-                "dependencies": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Bounded prerequisite facts or task ids relevant to this child. Raw parent reasoning and transcript text do not belong here."
-                },
-                "acceptance": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Bounded observable checks this child must satisfy before completion."
                 },
                 "type": {
                     "type": "string",
@@ -7661,91 +7684,16 @@ impl ToolSpec for AgentTool {
                 },
                 "profile": {
                     "type": "string",
-                    "description": "Optional Fleet roster member to run this child as (e.g. reviewer, scout, builder, verifier, synthesizer, manager, or a custom member from project .codewhale/agents/, personal $CODEWHALE_HOME/agents/, or [fleet.profiles] config). The member supplies role posture, model routing, instruction overlay, and delegation bounds. Named profiles bind 1:1 to their configured route — 'model' is not accepted when a named profile is set. Only 'general' (no profile) permits the model option. See /fleet. For fast exploration use the scout role."
-                },
-                "model": {
-                    "type": "string",
-                    "description": "Optional exact provider model id for the child — general dispatch only (no named profile). Not accepted when a named fleet profile is set; named agents use their configured route. For quick research and triage use the scout role, which resolves its own route."
-                },
-                "thinking": {
-                    "type": "string",
-                    "enum": ["inherit", "auto", "off", "low", "medium", "high", "max"],
-                    "description": "Optional child thinking budget. inherit (default) follows the parent thinking mode. auto chooses from the child prompt. off is best for scout/lookups. high is for normal reasoning. max is for hard design/debug/release/security work."
-                },
-                "cwd": {
-                    "type": "string",
-                    "description": "Optional pre-existing working directory for the child; must be inside the parent workspace. Prefer worktree=true for isolated parallel edit tasks."
+                    "description": "Optional Fleet roster member to run this child as (e.g. reviewer, scout, builder, verifier, synthesizer, manager, or a custom member from project .codewhale/agents/, personal $CODEWHALE_HOME/agents/, or [fleet.profiles] config). The member supplies role posture, model routing, thinking tier, instruction overlay, and delegation bounds. Named profiles bind 1:1 to their configured route — the child's model and thinking come from the profile or inherit the parent; there is no per-call model override on this surface. See /fleet. For fast exploration use the scout role."
                 },
                 "worktree": {
                     "type": "boolean",
                     "description": "When true, create a fresh git worktree and branch for this child before it starts. Use for parallel edit tasks that must not collide with the parent checkout."
                 },
-                "worktree_branch": {
-                    "type": "string",
-                    "description": "Optional branch name for worktree=true. Defaults to codex/agent-<name>-<id>."
-                },
-                "worktree_base": {
-                    "type": "string",
-                    "description": "Optional git ref to branch the worktree from. Defaults to HEAD in the parent checkout."
-                },
-                "worktree_path": {
-                    "type": "string",
-                    "description": "Optional worktree checkout path. Relative paths are created under the default sibling .codewhale-worktrees directory, not inside the parent checkout."
-                },
-                "fork_context": {
-                    "type": "boolean",
-                    "description": "Unset (default): auto — a read-only Fleet worker (scout/planner/reviewer/verifier or read_only write authority) running the parent's exact model route in the parent workspace forks the parent's cached context prefix; anything else starts fresh. true: force the parent prefix (cheap only on the parent's model route). false: force a fresh isolated context."
-                },
-                "max_depth": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 3,
-                    "description": "Optional absolute nested-agent depth cap for this child. It may only narrow the inherited runtime budget, never widen it. Defaults to the inherited budget."
-                },
-                "max_steps": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 2000,
-                    "description": "Optional child model-turn budget. Defaults by Fleet role (60 for scout/reviewer/planner/verifier, 120 for builder/worker/custom) and is clamped to 2000."
-                },
-                "wall_time_secs": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 86400,
-                    "description": "Optional child wall-clock budget in seconds. Default 1800; clamped to 86400."
-                },
-                "workspace_policy": {
-                    "type": "string",
-                    "enum": ["shared", "worktree"],
-                    "description": "Workspace isolation policy — enforced. worktree creates a fresh git worktree for the child; shared runs in the parent checkout and conflicts with worktree options."
-                },
-                "expected_artifact": {
-                    "type": "string",
-                    "description": "What the child should return (summary, patch path, test report, review findings, …). Appended to the child's prompt so the contract is visible to it."
-                },
-                "write_authority": {
-                    "type": "string",
-                    "enum": ["read_only", "workspace_write", "worktree_write"],
-                    "description": "Write authority for the child — enforced. read_only removes write permission from the child's runtime profile (and its descendants); worktree_write requires worktree isolation."
-                },
                 "write_roots": {
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "Expected repo-relative directory trees this child may mutate. Defaults to the parent workspace ('.') when omitted on a write-capable start. Shared write-capable children claim these before launch; scope expansion must use agents/coordinate before mutation. Paths outside the parent workspace are refused."
-                },
-                "exact_files": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Expected repo-relative individual files this child may mutate."
-                },
-                "coordination_contracts": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Named shared contracts or schemas this child owns while active; equal names contend even when file paths differ."
-                },
-                "deliberate": {
-                    "type": "boolean",
-                    "description": "When true, require type (or profile), workspace_policy, expected_artifact, and write_authority."
                 },
                 "resume_from": {
                     "type": "string",

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -4789,31 +4789,169 @@ fn subagent_tool_schemas_advertise_real_type_and_role_vocabulary() {
         );
     }
     assert!(agent_schema["properties"].get("role").is_none());
-    assert!(agent_schema["properties"].get("max_depth").is_some());
-    // Scout replaced the user-facing `model_strength` control: the schema no
-    // longer advertises it (legacy parsing survives for compatibility only).
-    assert!(
-        agent_schema["properties"].get("model_strength").is_none(),
-        "model_strength must not be advertised: {}",
+    // #5324/#5123: the advertised surface is exactly 12 fields. Budgets,
+    // model/thinking overrides, worktree-path knobs and spawn-contract
+    // ceremony moved off the schema; the parser still accepts them for
+    // replay compat (pinned by
+    // `agent_tool_unadvertised_fields_remain_parse_accepted` below).
+    let mut advertised: Vec<&str> = agent_schema["properties"]
+        .as_object()
+        .expect("agent schema properties must be an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    advertised.sort_unstable();
+    let mut expected = [
+        "action",
+        "agent_id",
+        "detached",
+        "message",
+        "name",
+        "profile",
+        "prompt",
+        "resume_from",
+        "type",
+        "until",
+        "worktree",
+        "write_roots",
+    ];
+    expected.sort_unstable();
+    assert_eq!(
+        advertised, expected,
+        "the agent tool must advertise exactly the 12-field surface: {}",
         agent_schema["properties"]
     );
-    let thinking = schema_property_description(&agent_schema, "thinking");
-    assert!(
-        thinking.contains("inherit") && thinking.contains("scout/lookups"),
-        "thinking description should teach child thinking control: {thinking}"
-    );
-    assert!(agent_schema["properties"].get("model").is_some());
-    assert!(
-        agent_schema["properties"].get("token_budget").is_none(),
-        "ad-hoc children should inherit the generous runtime budget; exposing an optional cap invites accidental micromanagement"
-    );
+    for unadvertised in [
+        "max_depth",
+        "max_steps",
+        "wall_time_secs",
+        "model",
+        "model_strength",
+        "thinking",
+        "fork_context",
+        "workspace_policy",
+        "write_authority",
+        "worktree_base",
+        "worktree_branch",
+        "worktree_path",
+        "cwd",
+        "deliberate",
+        "dependencies",
+        "acceptance",
+        "expected_artifact",
+        "exact_files",
+        "coordination_contracts",
+        "timeout_secs",
+        "reason",
+        "include_archived",
+        // Pre-#5324 precedent: parse-accepted but never advertised.
+        "token_budget",
+    ] {
+        assert!(
+            agent_schema["properties"].get(unadvertised).is_none(),
+            "agent schema must not advertise {unadvertised:?}: {}",
+            agent_schema["properties"]
+        );
+    }
     let worktree = schema_property_description(&agent_schema, "worktree");
     assert!(
         worktree.contains("git worktree") && worktree.contains("parallel edit"),
         "worktree description should teach isolated parallel edits: {worktree}"
     );
-    assert!(agent_schema["properties"].get("worktree_branch").is_some());
-    assert!(agent_schema["properties"].get("worktree_path").is_some());
+}
+
+#[test]
+fn agent_tool_unadvertised_fields_remain_parse_accepted() {
+    // #5324 compat: the fields removed from the advertised schema must stay
+    // parse-accepted and honored unchanged — saved transcripts, ACP/MCP
+    // clients and Fleet configs still replay them. Same contract as the
+    // `token_budget` precedent (docs/SUBAGENTS.md).
+    let request = parse_spawn_request(&json!({
+        "prompt": "summarize the diff",
+        "model": "deepseek-v4-flash",
+        "model_strength": "faster",
+        "thinking": "max",
+        "max_steps": 300,
+        "wall_time_secs": 900,
+        "max_depth": 2,
+        "fork_context": false,
+        "workspace_policy": "shared",
+        "expected_artifact": "review findings",
+        "dependencies": ["#5324"],
+        "acceptance": ["tests pass"],
+        "exact_files": ["Cargo.toml"],
+        "coordination_contracts": ["public-api"],
+        "deliberate": false,
+    }))
+    .expect("every removed field must stay parse-accepted");
+    assert_eq!(request.model.as_deref(), Some("deepseek-v4-flash"));
+    assert_eq!(request.model_strength, SubAgentModelStrength::Faster);
+    assert!(request.model_strength_explicit);
+    assert_eq!(subagent_thinking_label(request.thinking), "max");
+    assert!(request.thinking_explicit);
+    assert_eq!(request.max_steps, Some(300));
+    assert_eq!(request.wall_time, Some(Duration::from_secs(900)));
+    assert_eq!(request.max_depth, Some(2));
+    assert_eq!(request.fork_context, Some(false));
+    assert!(
+        request.worktree.is_none(),
+        "workspace_policy=shared must not fabricate a worktree"
+    );
+    assert_eq!(
+        request.expected_artifact.as_deref(),
+        Some("review findings")
+    );
+    assert_eq!(request.dependencies, vec!["#5324".to_string()]);
+    assert_eq!(request.acceptance, vec!["tests pass".to_string()]);
+    assert_eq!(request.exact_files, vec!["Cargo.toml".to_string()]);
+    assert_eq!(
+        request.coordination_contracts,
+        vec!["public-api".to_string()]
+    );
+
+    // Declared authority still parses on its own (the containment rule that
+    // read_only cannot also declare write scope is unchanged #5426/#5435
+    // behavior, not schema rejection).
+    let request = parse_spawn_request(&json!({
+        "prompt": "p",
+        "write_authority": "read_only",
+    }))
+    .expect("write_authority must stay parse-accepted");
+    assert_eq!(request.write_authority, Some(SpawnWriteAuthority::ReadOnly));
+    let err = parse_spawn_request(&json!({
+        "prompt": "p",
+        "write_authority": "read_only",
+        "exact_files": ["Cargo.toml"],
+    }))
+    .expect_err("read_only plus a declared write scope stays refused");
+    assert!(err.to_string().contains("read_only"), "{err}");
+
+    // token_budget keeps its own long-standing unadvertised-but-accepted
+    // contract.
+    let request = parse_spawn_request(&json!({
+        "prompt": "p",
+        "token_budget": 5000,
+    }))
+    .expect("token_budget must stay parse-accepted");
+    assert_eq!(request.token_budget, Some(5000));
+
+    // The removed lifecycle extras are still read on their actions:
+    // action aliases keep parsing, wait still reads timeout_secs, status
+    // still reads include_archived, and interrupt still reaches its target
+    // resolution carrying reason (an unknown id proves parsing succeeded —
+    // a schema-style rejection would name the field instead).
+    assert_eq!(
+        parse_agent_tool_action(&json!({"action": "wait", "timeout_secs": 5})).unwrap(),
+        AgentToolAction::Wait
+    );
+    assert_eq!(
+        parse_agent_tool_action(&json!({"op": "status", "include_archived": true})).unwrap(),
+        AgentToolAction::Status
+    );
+    assert_eq!(
+        parse_agent_tool_action(&json!({"action": "interrupt", "reason": "stale"})).unwrap(),
+        AgentToolAction::Interrupt
+    );
 }
 
 #[test]
@@ -4977,7 +5115,10 @@ fn agent_tool_schema_advertises_lifecycle_and_coordination_actions() {
     assert!(action.contains("cancel"));
     assert!(agent_schema["properties"].get("agent_id").is_some());
     assert!(agent_schema["properties"].get("message").is_some());
-    assert!(agent_schema["properties"].get("reason").is_some());
+    // `reason` (interrupt), `timeout_secs` (wait) and `include_archived`
+    // (status) moved off the advertised schema with #5324; the pinning test
+    // above asserts their absence and the compat test below their continued
+    // parse-acceptance.
 }
 
 #[test]
@@ -9091,6 +9232,8 @@ fn explicit_state_roots_isolate_managers_for_the_same_execution_workspace() {
         Duration::from_secs(60),
         2,
         None,
+        None,
+        None,
     );
     let manager_b = new_shared_subagent_manager_with_state_root_and_timeout(
         workspace.clone(),
@@ -9099,6 +9242,8 @@ fn explicit_state_roots_isolate_managers_for_the_same_execution_workspace() {
         2,
         Duration::from_secs(60),
         2,
+        None,
+        None,
         None,
     );
 
@@ -14176,6 +14321,15 @@ fn child_step_override_wins_and_clamps_to_hard_ceiling() {
     assert_eq!(resolve_max_steps(FleetRole::Builder, Some(7), None), 7);
     assert_eq!(
         resolve_max_steps(FleetRole::Worker, Some(u32::MAX), None),
+        MAX_SUBAGENT_STEPS
+    );
+    // #5324: `[subagents] default_max_steps` is the configured fallback when
+    // the call carries no explicit budget; an explicit value still wins and
+    // the hard ceiling still clamps the configured default.
+    assert_eq!(resolve_max_steps(FleetRole::Scout, None, Some(90)), 90);
+    assert_eq!(resolve_max_steps(FleetRole::Builder, Some(7), Some(90)), 7);
+    assert_eq!(
+        resolve_max_steps(FleetRole::Worker, None, Some(u32::MAX)),
         MAX_SUBAGENT_STEPS
     );
 }

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -129,6 +129,14 @@ user-named OpenAI-compatible provider configured under `[providers.<name>]`
 such as `lm-studio`; the launch path preserves that id and fails closed if the
 provider is not configured.
 
+Profiles are also how the model-facing `agent` tool selects a route since the
+v0.9.9 schema slim (#5324, #5123): the advertised surface no longer carries
+`model` or `thinking` — a child either runs as a `profile` (whose saved route
+and thinking tier it uses exactly) or inherits the operator's model. Removed
+fields stay parse-accepted for saved transcripts, ACP/MCP clients and Fleet
+configs; see docs/SUBAGENTS.md for the advertised 12-field list and the
+compat list.
+
 When a provider is configured, the review step also offers model-assisted
 drafting behind an explicit preview-before-save gate:
 

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -121,7 +121,9 @@ turn's user message.
 
 `agent` starts fresh by default: the child gets its role prompt plus the
 task you pass. Use `fork_context: true` when the child should continue from
-the parent's current request prefix instead. In fork mode the runtime keeps the
+the parent's current request prefix instead. (`fork_context` is not in the
+advertised v0.9.9 schema — it stays parse-accepted for compat callers, and
+auto-forking for read-only roles continues unchanged.) In fork mode the runtime keeps the
 parent prefill/prompt prefix byte-identical where available, appends a
 structured state snapshot, then adds the sub-agent role instructions and task
 at the tail. That preserves DeepSeek prefix-cache reuse while giving the child
@@ -338,6 +340,9 @@ max_concurrent = 20
 launch_concurrency = 20
 max_admitted = 200
 max_depth = 6
+# Per-child run budgets when a call carries none (role defaults: 60/120 turns).
+default_max_steps = 120
+default_wall_time_secs = 1800
 token_budget = 100000
 
 [subagents.providers.deepseek]
@@ -369,6 +374,58 @@ max_admitted = 12
 Use `/config subagents status` to see both the global values and the active
 provider's resolved fanout, depth, and timeout profile.
 
+## Advertised agent-tool fields (v0.9.9)
+
+The model-facing `agent` tool schema advertises exactly **12 fields**
+(#5324, #5123):
+
+`action`, `prompt`, `type`, `profile`, `name`, `agent_id`, `message`,
+`until`, `detached`, `worktree`, `write_roots`, `resume_from`
+
+plus the action-discriminated `dependentSchemas` tree (`start` requires
+`prompt`; `message`/`followup` require a target and `message`; `peek`/
+`interrupt`/`cancel` require a target). The schema change is part of the
+pinned prompt prefix, so upgrading re-fills the provider KV prefix once per
+session (docs/CACHE.md; accepted at the v0.9.9 boundary).
+
+**Parse-accepted but unadvertised (compat).** The following inputs were
+removed from the advertised schema but remain parse-accepted and honored
+unchanged, so saved transcripts, ACP/MCP clients and Fleet configs replay
+as-is — the same contract `token_budget` already follows:
+
+- budgets: `max_steps`, `wall_time_secs`, `max_depth` (see
+  [Child budgets](#child-budgets-steps-wall-time) for where defaults now
+  come from)
+- routing: `model`, `model_strength`, `thinking` (a `profile` pins route and
+  thinking tier; without one the child inherits the operator model)
+- workspace/isolation: `workspace_policy`, `write_authority`, `fork_context`,
+  `cwd`, `worktree_path`, `worktree_branch`, `worktree_base`
+- spawn contract: `deliberate`, `dependencies`, `acceptance`,
+  `expected_artifact`, `exact_files`, `coordination_contracts`
+- lifecycle extras: `timeout_secs` (wait), `reason` (interrupt),
+  `include_archived` (status), and `token_budget`
+
+Authority never widens: the #5426/#5435 containment clamps are unchanged —
+`write_authority` moves to roles/profiles, and delegation can only narrow
+inherited authority.
+
+## Child budgets (steps, wall time)
+
+Per-child run budgets are no longer per-call schema fields (#5324). They come
+from, in order:
+
+1. an explicit parse-accepted `max_steps` / `wall_time_secs` on the call
+   (replay compat),
+2. the operator defaults `[subagents] default_max_steps` and
+   `[subagents] default_wall_time_secs`,
+3. Fleet role defaults: **60** model turns for read-mostly roles
+   (scout/planner/reviewer/verifier/consultant), **120** for
+   builder/worker/custom (`WorkerRuntimeProfile::default_max_steps`), and a
+   **1800 s** wall-clock default.
+
+Step values clamp to the 2000-turn hard ceiling; wall-time values clamp to
+1..=86400 s.
+
 ## Token budget governor
 
 Set `[subagents].token_budget` to give each root `agent` run an aggregate
@@ -382,7 +439,8 @@ runtime budget; exposing an optional cap invites accidental micromanagement."
 The parser still accepts the key (plus the `tokenBudget`/`max_tokens` aliases,
 `mod.rs:10620`) so Workflow-shaped callers that construct the call themselves
 can scope a budget, but the model is never told the field exists. Configure it
-through `[subagents].token_budget` instead.
+through `[subagents].token_budget` instead. Since v0.9.9 it is one entry in
+the wider parse-accepted-but-unadvertised compat list above.
 
 Provider-reported input and output tokens are folded into the worker record as
 each child model call completes. The persisted `usage` object shows the


### PR DESCRIPTION
## Summary
The model-facing `agent` tool now advertises 12 fields — `action, prompt, type, profile, name, agent_id, message, detached, worktree, write_roots, resume_from, until` — instead of 33 (+~20 unadvertised aliases). Removed from the advertised schema (all remain **parse-accepted** for transcript replay / ACP / MCP / Fleet configs, following the existing `token_budget` pattern): `max_steps`, `wall_time_secs`, `max_depth`, `thinking`, `model`, `model_strength`, `fork_context`, `workspace_policy`, `write_authority`, `cwd`/`worktree_branch`/`worktree_base`/`worktree_path`, `deliberate`, `dependencies`, `acceptance`, `expected_artifact`, `exact_files`, `coordination_contracts`, `timeout_secs`, `reason`, `include_archived`.

Budgets move to policy: role defaults (60/120 steps, clamp 2000; 1800s wall time) with new optional `[subagents] default_max_steps` / `default_wall_time_secs` config keys; model selection collapses to operator-model inheritance + profile-pinned routes. #5426/#5435 containment clamps untouched — authority still comes from roles/profiles, and delegation never widens it.

Maintainer decisions applied: steps are no longer something a model or user picks per spawn; per-call `model`/`thinking` gone (Grok/Kimi/Codex parity); `write_roots` kept for containment. KV-cache: the tool catalog is part of the pinned prefix, so this re-fills the prefix once per session at the 0.9.9 boundary (noted in CHANGELOG).

Closes #5324
Refs #5123

## Verification
- `cargo test -p codewhale-tui --lib -- tools::subagent` → 524 passed (absence assertions for every removed field + parse-acceptance tests)
- `cargo clippy -p codewhale-tui --lib --tests --all-features -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- Builder (GLM-5.3 delegate) also ran the full `cargo test -p codewhale-tui --lib` (10,646 passed; the only failures were the known load-flaky `runtime_threads` cancellation tests, which passed on individual rerun).

## Not verified
- PTY suites; live multi-agent dogfood on the rebuilt binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZU7GQ3ygtcTugBtzqRDMj