### PR TITLE
web: advance the published release record to v0.9.8

### DIFF
--- a/docs/public-surface-facts.json
+++ b/docs/public-surface-facts.json
@@ -35,10 +35,10 @@
     ]
   },
   "latestPublishedRelease": {
-    "tag": "v0.9.7",
-    "version": "0.9.7",
-    "publishedAt": "2026-08-13T08:36:49Z",
-    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.7",
+    "tag": "v0.9.8",
+    "version": "0.9.8",
+    "publishedAt": "2026-08-16T19:25:25Z",
+    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.8",
     "sources": [
       "web/data/latest-published-release.json"
     ]

--- a/web/data/latest-published-release.json
+++ b/web/data/latest-published-release.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v0.9.7",
-  "version": "0.9.7",
-  "publishedAt": "2026-08-13T08:36:49Z",
-  "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.7"
+  "tag": "v0.9.8",
+  "version": "0.9.8",
+  "publishedAt": "2026-08-16T19:25:25Z",
+  "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.8"
 }

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -27,7 +27,7 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-08-16T06:49:12.949Z",
+  "generatedAt": "2026-08-17T06:09:37.228Z",
   "sourceRevision": null,
   "sourceCommittedAt": null,
   "version": "0.9.8",
@@ -290,9 +290,9 @@ export const FACTS: RepoFacts = {
   "toolCount": 74,
   "license": "MIT",
   "latestPublishedRelease": {
-    "tag": "v0.9.7",
-    "version": "0.9.7",
-    "publishedAt": "2026-08-13T08:36:49Z",
-    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.7"
+    "tag": "v0.9.8",
+    "version": "0.9.8",
+    "publishedAt": "2026-08-16T19:25:25Z",
+    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.8"
   }
 };


### PR DESCRIPTION
codewhale.net still says **Latest release v0.9.7**. `web/data/latest-published-release.json` is advanced by hand after publication (see `web/README.md` § Facts pipeline) and v0.9.8 — published 2026-08-16T19:25:25Z on GitHub Releases, npm `latest` — had not been recorded.

- `web/data/latest-published-release.json` → v0.9.8
- `docs/public-surface-facts.json` latestPublishedRelease → v0.9.8
- `web/lib/facts.generated.ts` regenerated via `npm run prebuild`

Checks: `prebuild`, `check:facts`, `check:docs`, vitest (265 passed), eslint — all green.

After merge the site needs `npm run deploy` from `web/` (opennextjs-cloudflare) to go live; the cron facts-drift only refreshes source facts, not the published-release record.
No-Issue: published-release record refresh (data-only follow-up to the v0.9.8 release; no user-facing issue tracks this)