### PR TITLE
fix(tui): exec stream creation must fail soft and never wedge the shell tool

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -1519,6 +1519,10 @@ pub struct ShellManager {
     sandbox_manager: SandboxManager,
     sandbox_policy: ExecutionSandboxPolicy,
     foreground_background_requested: bool,
+    /// Directory for lowercase-`bash` complete-output spill files
+    /// (`None` = process temp dir). Overridable so tests can fault-inject a
+    /// missing/unwritable spill location.
+    output_spill_dir: Option<PathBuf>,
 }
 
 impl std::fmt::Debug for ShellManager {
@@ -1546,7 +1550,16 @@ impl ShellManager {
             sandbox_manager: SandboxManager::new(),
             sandbox_policy: ExecutionSandboxPolicy::default(),
             foreground_background_requested: false,
+            output_spill_dir: None,
         }
+    }
+
+    /// Point lowercase-`bash` complete-output spill files at `dir` instead of
+    /// the process temp dir. Tests use a nonexistent dir to simulate a full or
+    /// broken temp volume.
+    #[cfg(test)]
+    pub(crate) fn set_output_spill_dir_for_test(&mut self, dir: Option<PathBuf>) {
+        self.output_spill_dir = dir;
     }
 
     /// Test-only observation of the workspace selected by runtime rebuilds.
@@ -2088,11 +2101,14 @@ impl ShellManager {
         } else {
             Some(Arc::new(Mutex::new(Vec::new())))
         };
-        let bounded_output = small_contract_mode
-            .then(BoundedOutputAccumulator::new)
-            .transpose()
-            .context("Failed to create streaming shell output")?
-            .map(|output| Arc::new(Mutex::new(output)));
+        // The spill file is best-effort: a full disk or exhausted descriptor
+        // table must not make `echo ok` unrunnable (that is exactly how the
+        // owner's session got wedged under swap exhaustion).
+        let bounded_output = small_contract_mode.then(|| {
+            Arc::new(Mutex::new(BoundedOutputAccumulator::new_in(
+                self.output_spill_dir.as_deref(),
+            )))
+        });
 
         #[cfg(windows)]
         let mut windows_job = None;
@@ -4646,8 +4662,26 @@ impl ToolSpec for BashTool {
                     metadata: Some(metadata),
                 })
             }
-            Err(e) => Ok(ToolResult::error(format!("Shell execution failed: {e}"))),
+            Err(e) => Ok(ToolResult::error(shell_execution_failed_message(&e))),
         }
+    }
+}
+
+/// Render a spawn/stream failure for the model and the user: the full cause
+/// chain (an anyhow context alone hides the `ENOSPC`/`EMFILE` underneath) plus,
+/// when the innermost error looks like host resource exhaustion, what to do
+/// about it. The shell tool keeps no state from a failed spawn, so retrying is
+/// always safe.
+fn shell_execution_failed_message(error: &anyhow::Error) -> String {
+    let hint = error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<io::Error>())
+        .find_map(output::resource_exhaustion_hint);
+    match hint {
+        Some(hint) => format!(
+            "Shell execution failed: {error:#}. Likely host resource exhaustion — {hint}. The shell tool itself is still usable; the next call starts fresh."
+        ),
+        None => format!("Shell execution failed: {error:#}"),
     }
 }
 

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -1556,8 +1556,9 @@ impl ShellManager {
 
     /// Point lowercase-`bash` complete-output spill files at `dir` instead of
     /// the process temp dir. Tests use a nonexistent dir to simulate a full or
-    /// broken temp volume.
-    #[cfg(test)]
+    /// broken temp volume. (unix-only: the regression test that uses it drives
+    /// a POSIX shell loop.)
+    #[cfg(all(test, unix))]
     pub(crate) fn set_output_spill_dir_for_test(&mut self, dir: Option<PathBuf>) {
         self.output_spill_dir = dir;
     }

--- a/crates/tui/src/tools/shell/output.rs
+++ b/crates/tui/src/tools/shell/output.rs
@@ -33,11 +33,42 @@ pub(super) struct BoundedOutputAccumulator {
     stream_error: Option<String>,
     temp: Option<tempfile::NamedTempFile>,
     full_output_path: Option<PathBuf>,
+    /// Why the on-disk spill file could not be created (disk full, descriptor
+    /// exhaustion, unwritable temp dir). The stream still runs and the bounded
+    /// tail is still delivered; only "Full output: <path>" is unavailable.
+    spill_unavailable: Option<String>,
 }
 
 impl BoundedOutputAccumulator {
-    pub(super) fn new() -> io::Result<Self> {
-        Ok(Self {
+    /// Build an accumulator whose complete-output spill file lives in the
+    /// process temp dir. Never fails: when the spill file cannot be created
+    /// (disk full, `EMFILE`, missing temp dir) the command still runs and the
+    /// bounded tail is still returned — the spill is a convenience, not a
+    /// precondition for executing `echo ok`.
+    pub(super) fn new() -> Self {
+        Self::new_in(None)
+    }
+
+    /// Like [`Self::new`], with an explicit spill directory (`None` = process
+    /// temp dir). Used to fault-inject spill failure in tests.
+    pub(super) fn new_in(spill_dir: Option<&std::path::Path>) -> Self {
+        let mut builder = tempfile::Builder::new();
+        builder.prefix("codewhale-bash-");
+        let temp = match spill_dir {
+            Some(dir) => builder.tempfile_in(dir),
+            None => builder.tempfile(),
+        };
+        let (temp, spill_unavailable) = match temp {
+            Ok(temp) => (Some(temp), None),
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "shell output spill file unavailable; continuing with the in-memory tail only"
+                );
+                (None, Some(spill_unavailable_reason(&error)))
+            }
+        };
+        Self {
             tail: VecDeque::with_capacity(BOUNDED_OUTPUT_RETAIN_BYTES),
             tail_newlines: 0,
             total_bytes: 0,
@@ -49,13 +80,15 @@ impl BoundedOutputAccumulator {
             decoder: UTF_8.new_decoder_without_bom_handling(),
             stream_finished: false,
             stream_error: None,
-            temp: Some(
-                tempfile::Builder::new()
-                    .prefix("codewhale-bash-")
-                    .tempfile()?,
-            ),
+            temp,
             full_output_path: None,
-        })
+            spill_unavailable,
+        }
+    }
+
+    /// Why the complete output is not being persisted, if it is not.
+    pub(super) fn spill_unavailable(&self) -> Option<&str> {
+        self.spill_unavailable.as_deref()
     }
 
     fn decode(&mut self, bytes: &[u8], last: bool) -> String {
@@ -212,7 +245,17 @@ impl BoundedOutputAccumulator {
                 self.temp.take();
             }
         }
-        if truncated
+        if truncated && finalize && self.full_output_path.is_none() {
+            let reason = self.spill_unavailable.as_deref().unwrap_or(
+                "the output stream did not close cleanly, so the spill file was not kept",
+            );
+            content.push_str(&format!(
+                "\n\n[Showing the last {} of {} lines ({} limit). Full output was not persisted: {reason}]",
+                Self::format_size(retained_bytes),
+                total_lines,
+                Self::format_size(BOUNDED_OUTPUT_MAX_BYTES),
+            ));
+        } else if truncated
             && finalize
             && let Some(path) = self.full_output_path.as_ref()
         {
@@ -254,6 +297,68 @@ impl BoundedOutputAccumulator {
     pub(super) fn full_output_path(&self) -> Option<&std::path::Path> {
         self.full_output_path.as_deref()
     }
+}
+
+/// Human-readable, actionable reason for a failed spill-file creation.
+pub(super) fn spill_unavailable_reason(error: &io::Error) -> String {
+    match resource_exhaustion_hint(error) {
+        Some(hint) => format!("{error} ({hint})"),
+        None => error.to_string(),
+    }
+}
+
+/// When an I/O error looks like host resource exhaustion, name the likely
+/// cause and the remedy. Returns `None` for ordinary errors.
+pub(super) fn resource_exhaustion_hint(error: &io::Error) -> Option<&'static str> {
+    use io::ErrorKind;
+    match error.kind() {
+        ErrorKind::StorageFull | ErrorKind::QuotaExceeded => {
+            return Some("the disk holding the temp dir is full; free space and retry");
+        }
+        ErrorKind::OutOfMemory => {
+            return Some("the host is out of memory; close heavy processes and retry");
+        }
+        _ => {}
+    }
+    let code = error.raw_os_error()?;
+    // ENOSPC / EDQUOT / EMFILE / ENFILE / ENOMEM / EAGAIN — the codes fork(2),
+    // pipe(2), and open(2) return when the machine is thrashing.
+    #[cfg(unix)]
+    {
+        if code == libc::ENOSPC || code == libc::EDQUOT {
+            return Some("the disk holding the temp dir is full; free space and retry");
+        }
+        if code == libc::EMFILE || code == libc::ENFILE {
+            return Some(
+                "the process or host has run out of file descriptors; close background jobs or raise `ulimit -n` and retry",
+            );
+        }
+        if code == libc::ENOMEM {
+            return Some("the host is out of memory; close heavy processes and retry");
+        }
+        if code == libc::EAGAIN {
+            return Some(
+                "the host refused to create a process, thread, or pipe (resource limit reached); close heavy processes and retry",
+            );
+        }
+    }
+    #[cfg(windows)]
+    {
+        // ERROR_DISK_FULL, ERROR_HANDLE_DISK_FULL, ERROR_NOT_ENOUGH_MEMORY, ERROR_TOO_MANY_OPEN_FILES
+        if code == 112 || code == 39 {
+            return Some("the disk holding the temp dir is full; free space and retry");
+        }
+        if code == 8 {
+            return Some("the host is out of memory; close heavy processes and retry");
+        }
+        if code == 4 {
+            return Some(
+                "the process has run out of file handles; close background jobs and retry",
+            );
+        }
+    }
+    let _ = code;
+    None
 }
 
 pub(super) fn take_delta_from_buffer(
@@ -372,7 +477,7 @@ mod tests {
             .map(|index| format!("line-{index}"))
             .collect::<Vec<_>>()
             .join("\n");
-        let mut output = BoundedOutputAccumulator::new().expect("accumulator");
+        let mut output = BoundedOutputAccumulator::new();
         output.append(source.as_bytes()).expect("append");
         output.finish().expect("finish");
         let snapshot = output.snapshot(true).expect("snapshot");
@@ -384,7 +489,7 @@ mod tests {
     #[test]
     fn bounded_output_streams_raw_full_output_and_bounds_decoded_tail() {
         let raw = vec![0xFF; 2 * 1024 * 1024];
-        let mut output = BoundedOutputAccumulator::new().expect("accumulator");
+        let mut output = BoundedOutputAccumulator::new();
         for chunk in raw.chunks(4_096) {
             output.append(chunk).expect("append");
             assert!(output.retained_memory_bytes() <= BOUNDED_OUTPUT_MAX_BYTES + 4);
@@ -407,7 +512,7 @@ mod tests {
     fn bounded_output_huge_terminal_line_matches_upstream_notice() {
         let mut source = vec![b'x'; BOUNDED_OUTPUT_MAX_BYTES + 1_024];
         source.push(b'\n');
-        let mut output = BoundedOutputAccumulator::new().expect("accumulator");
+        let mut output = BoundedOutputAccumulator::new();
         output.append(&source).expect("append");
         output.finish().expect("finish");
         let snapshot = output.snapshot(true).expect("snapshot");
@@ -419,5 +524,79 @@ mod tests {
             .to_path_buf();
         drop(output);
         std::fs::remove_file(path).expect("remove full output");
+    }
+
+    #[test]
+    fn spill_failure_is_soft_and_names_the_reason() {
+        // A missing spill dir simulates a full or broken temp volume: the
+        // stream still runs, the tail is still delivered, and the notice says
+        // why "Full output: <path>" is absent instead of failing the command.
+        let missing =
+            std::env::temp_dir().join(format!("codewhale-missing-spill-{}", std::process::id()));
+        let mut output = BoundedOutputAccumulator::new_in(Some(&missing));
+        let reason = output.spill_unavailable().expect("spill unavailable");
+        assert!(!reason.is_empty(), "reason must name the io error");
+
+        output.append(b"ok\n").expect("append works without spill");
+        output.finish().expect("finish works without spill");
+        let short = output.snapshot(true).expect("snapshot");
+        assert_eq!(short.content, "ok\n");
+        assert!(!short.truncated);
+        assert!(output.full_output_path().is_none());
+
+        let source = (0..=BOUNDED_OUTPUT_MAX_LINES)
+            .map(|index| format!("line-{index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut output = BoundedOutputAccumulator::new_in(Some(&missing));
+        output.append(source.as_bytes()).expect("append");
+        output.finish().expect("finish");
+        let snapshot = output.snapshot(true).expect("snapshot");
+        assert!(snapshot.truncated);
+        assert!(snapshot.content.starts_with("line-1\n"));
+        assert!(
+            snapshot.content.contains("Full output was not persisted:"),
+            "{}",
+            snapshot.content
+        );
+        assert!(!snapshot.content.contains("Full output: "));
+        assert!(output.full_output_path().is_none());
+    }
+
+    #[test]
+    fn resource_exhaustion_hint_names_disk_descriptors_and_memory() {
+        use std::io::{Error, ErrorKind};
+        assert!(
+            super::resource_exhaustion_hint(&Error::from(ErrorKind::StorageFull))
+                .expect("storage full")
+                .contains("disk")
+        );
+        assert!(
+            super::resource_exhaustion_hint(&Error::from(ErrorKind::OutOfMemory))
+                .expect("oom")
+                .contains("memory")
+        );
+        #[cfg(unix)]
+        {
+            assert!(
+                super::resource_exhaustion_hint(&Error::from_raw_os_error(libc::ENOSPC))
+                    .expect("enospc")
+                    .contains("disk")
+            );
+            assert!(
+                super::resource_exhaustion_hint(&Error::from_raw_os_error(libc::EMFILE))
+                    .expect("emfile")
+                    .contains("file descriptors")
+            );
+            assert!(
+                super::resource_exhaustion_hint(&Error::from_raw_os_error(libc::EAGAIN))
+                    .expect("eagain")
+                    .contains("retry")
+            );
+        }
+        assert!(super::resource_exhaustion_hint(&Error::from(ErrorKind::NotFound)).is_none());
+        assert!(
+            super::resource_exhaustion_hint(&Error::from(ErrorKind::PermissionDenied)).is_none()
+        );
     }
 }

--- a/crates/tui/src/tools/shell/output.rs
+++ b/crates/tui/src/tools/shell/output.rs
@@ -40,17 +40,12 @@ pub(super) struct BoundedOutputAccumulator {
 }
 
 impl BoundedOutputAccumulator {
-    /// Build an accumulator whose complete-output spill file lives in the
-    /// process temp dir. Never fails: when the spill file cannot be created
-    /// (disk full, `EMFILE`, missing temp dir) the command still runs and the
-    /// bounded tail is still returned — the spill is a convenience, not a
-    /// precondition for executing `echo ok`.
-    pub(super) fn new() -> Self {
-        Self::new_in(None)
-    }
-
-    /// Like [`Self::new`], with an explicit spill directory (`None` = process
-    /// temp dir). Used to fault-inject spill failure in tests.
+    /// Build an accumulator whose complete-output spill file lives in
+    /// `spill_dir` (`None` = process temp dir). Never fails: when the spill
+    /// file cannot be created (disk full, `EMFILE`, missing temp dir) the
+    /// command still runs and the bounded tail is still returned — the spill
+    /// is a convenience, not a precondition for executing `echo ok`. Tests
+    /// pass a nonexistent dir to fault-inject the failure.
     pub(super) fn new_in(spill_dir: Option<&std::path::Path>) -> Self {
         let mut builder = tempfile::Builder::new();
         builder.prefix("codewhale-bash-");
@@ -87,6 +82,7 @@ impl BoundedOutputAccumulator {
     }
 
     /// Why the complete output is not being persisted, if it is not.
+    #[cfg(test)]
     pub(super) fn spill_unavailable(&self) -> Option<&str> {
         self.spill_unavailable.as_deref()
     }
@@ -477,7 +473,7 @@ mod tests {
             .map(|index| format!("line-{index}"))
             .collect::<Vec<_>>()
             .join("\n");
-        let mut output = BoundedOutputAccumulator::new();
+        let mut output = BoundedOutputAccumulator::new_in(None);
         output.append(source.as_bytes()).expect("append");
         output.finish().expect("finish");
         let snapshot = output.snapshot(true).expect("snapshot");
@@ -489,7 +485,7 @@ mod tests {
     #[test]
     fn bounded_output_streams_raw_full_output_and_bounds_decoded_tail() {
         let raw = vec![0xFF; 2 * 1024 * 1024];
-        let mut output = BoundedOutputAccumulator::new();
+        let mut output = BoundedOutputAccumulator::new_in(None);
         for chunk in raw.chunks(4_096) {
             output.append(chunk).expect("append");
             assert!(output.retained_memory_bytes() <= BOUNDED_OUTPUT_MAX_BYTES + 4);
@@ -512,7 +508,7 @@ mod tests {
     fn bounded_output_huge_terminal_line_matches_upstream_notice() {
         let mut source = vec![b'x'; BOUNDED_OUTPUT_MAX_BYTES + 1_024];
         source.push(b'\n');
-        let mut output = BoundedOutputAccumulator::new();
+        let mut output = BoundedOutputAccumulator::new_in(None);
         output.append(&source).expect("append");
         output.finish().expect("finish");
         let snapshot = output.snapshot(true).expect("snapshot");

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -124,6 +124,116 @@ async fn lowercase_bash_readonly_refusal_names_work_mode() {
     assert!(!workspace.path().join("blocked-by-plan").exists());
 }
 
+/// Regression for the wedge that took out the owner's own session under swap
+/// exhaustion: the lowercase `bash` spill file could not be created (full temp
+/// volume), every call — including `echo ok` — failed with the harness-internal
+/// "Failed to create streaming shell output", and nothing recovered. Spill
+/// failure must be soft: the command still runs, the tail is still returned,
+/// the next call still works, and no job state leaks.
+#[cfg(unix)]
+#[tokio::test]
+async fn lowercase_bash_survives_spill_file_failure_and_stays_usable() {
+    let workspace = tempdir().expect("workspace");
+    let context = ToolContext::new(workspace.path());
+    let missing_spill_dir = workspace.path().join("no-such-temp-volume");
+    assert!(!missing_spill_dir.exists());
+    context
+        .shell_manager
+        .lock()
+        .expect("shell manager")
+        .set_output_spill_dir_for_test(Some(missing_spill_dir.clone()));
+
+    // (ii) the command runs and (i) no harness-internal error leaks.
+    let first = LowercaseBashTool
+        .execute(json!({"command": echo_command("ok")}), &context)
+        .await
+        .expect("bash runs even when the spill file cannot be created");
+    assert!(first.success, "{}", first.content);
+    assert_eq!(first.content.trim(), "ok");
+    assert!(
+        !first
+            .content
+            .contains("Failed to create streaming shell output")
+    );
+
+    // The next call must work too — the whole point of the fix.
+    let second = LowercaseBashTool
+        .execute(json!({"command": echo_command("still-ok")}), &context)
+        .await
+        .expect("second bash call after a spill failure");
+    assert!(second.success, "{}", second.content);
+    assert_eq!(second.content.trim(), "still-ok");
+
+    // Output past the bound is still delivered, and the notice explains why the
+    // full-output path is missing instead of pointing at a file that was never
+    // written.
+    let long = LowercaseBashTool
+        .execute(
+            json!({"command": "i=0; while [ $i -lt 2100 ]; do echo line-$i; i=$((i+1)); done"}),
+            &context,
+        )
+        .await
+        .expect("long bash output without a spill file");
+    assert!(long.success, "{}", long.content);
+    assert!(long.content.contains("line-2099"));
+    assert!(
+        long.content.contains("Full output was not persisted:"),
+        "{}",
+        long.content
+    );
+    assert!(!long.content.contains("Full output: "));
+
+    // (iii) no leaked session state: nothing is still running or unowned-pending.
+    let mut manager = context.shell_manager.lock().expect("shell manager");
+    let running = manager
+        .list_jobs()
+        .into_iter()
+        .filter(|job| job.status == ShellStatus::Running)
+        .count();
+    assert_eq!(running, 0, "no shell job may be left running");
+    assert!(
+        !missing_spill_dir.exists(),
+        "fail-soft must not create the dir"
+    );
+}
+
+/// A spawn/stream failure caused by host exhaustion must reach the model as
+/// an actionable message (cause chain + likely reason + retry), never as a
+/// bare harness-internal context string.
+#[test]
+fn shell_execution_failure_names_resource_exhaustion_and_says_retry() {
+    let error = anyhow::Error::from(std::io::Error::from(std::io::ErrorKind::StorageFull))
+        .context("Failed to open PTY");
+    let message = shell_execution_failed_message(&error);
+    assert!(
+        message.starts_with("Shell execution failed: Failed to open PTY"),
+        "{message}"
+    );
+    assert!(
+        message.contains("Likely host resource exhaustion"),
+        "{message}"
+    );
+    assert!(message.contains("disk"), "{message}");
+    assert!(message.contains("retry"), "{message}");
+    assert!(message.contains("still usable"), "{message}");
+
+    #[cfg(unix)]
+    {
+        let error = anyhow::Error::from(std::io::Error::from_raw_os_error(libc::EMFILE))
+            .context("Failed to spawn PTY command: echo ok");
+        let message = shell_execution_failed_message(&error);
+        assert!(message.contains("file descriptors"), "{message}");
+        assert!(message.contains("echo ok"), "{message}");
+    }
+
+    let plain = anyhow::anyhow!("working directory does not exist");
+    let message = shell_execution_failed_message(&plain);
+    assert_eq!(
+        message,
+        "Shell execution failed: working directory does not exist"
+    );
+}
+
 #[tokio::test]
 async fn lowercase_bash_timeout_uses_seconds_and_fails() {
     let workspace = tempdir().expect("workspace");


### PR DESCRIPTION
## What broke

During the 2026-08-16 v0.9.9 session the owner's macOS host memory-thrashed (11 GB swap on a root volume that has ~11 GB free). From that point **every** Codewhale `bash` call — `echo ok` included — returned

```
Shell execution failed: Failed to create streaming shell output
```

and kept failing after the heavy processes were killed and RAM was back.

## Root cause (with the evidence)

- The string is the anyhow context on `BoundedOutputAccumulator::new()` (`crates/tui/src/tools/shell/output.rs`), which does `tempfile::Builder::new().prefix("codewhale-bash-").tempfile()?` **before anything is spawned**, for every lowercase-`bash` call. Only `open(2)`-class errors can fail there: ENOSPC / EDQUOT / EMFILE / ENFILE / ENOMEM / bad temp dir.
- `format!("Shell execution failed: {e}")` printed only the outer context, so the ENOSPC underneath was invisible to the model and the user.
- Host evidence after reboot: `df -h` → `/System/Volumes/Data 460Gi 425Gi 11Gi 98%`; `vm.swapusage` at the wedge was `11264M used`; swap files live on that same volume, and macOS keeps them allocated after pressure eases. That is why killing cargo/grok did not un-wedge anything: the disk, not the process, stayed exhausted until reboot (`uptime` = 6 min when this session started, `/private/var/vm` now empty).
- In-process wedge check: the failure path returns before spawn; `ShellSpawnIntentGuard` drops (records Failed), the manager mutex guard is scoped to the block, no registry entry is inserted, `heavy_permit` drops. I found no leaked in-process state — the persistence was environmental. Honest caveat: I could not reproduce the exact host state (machine was rebooted before this session), so the ENOSPC identification is inferred from the code path + disk evidence, not from a captured errno.

## Fix

1. **Fail soft.** Spill-file creation is best-effort: on failure the command still runs, the bounded 2,000-line / 50 KiB tail is still delivered, and the truncation notice reads `Full output was not persisted: <io error> (<likely cause; remedy>)` instead of `Full output: <path>`.
2. **Actionable error.** Any remaining spawn/stream failure renders the full cause chain (`{:#}`) and, when the innermost `io::Error` is ENOSPC/EDQUOT/EMFILE/ENFILE/ENOMEM/EAGAIN (or `StorageFull`/`QuotaExceeded`/`OutOfMemory`), appends: *Likely host resource exhaustion — <what to free>. The shell tool itself is still usable; the next call starts fresh.*
3. **Fault injection.** `ShellManager::set_output_spill_dir_for_test` points the spill at a nonexistent dir.

## Tests (new)

- `lowercase_bash_survives_spill_file_failure_and_stays_usable` — (i) no harness-internal string, `echo ok` succeeds; (ii) the next call succeeds; long output streams with the honest notice; (iii) no job left running, no dir created.
- `shell_execution_failure_names_resource_exhaustion_and_says_retry` — StorageFull / EMFILE chains render cause + hint + retry; plain errors unchanged.
- `spill_failure_is_soft_and_names_the_reason`, `resource_exhaustion_hint_names_disk_descriptors_and_memory` (accumulator/classifier units).

Local: `cargo fmt --all -- --check` only — per the owner's rule (no local cargo builds on the thrashed host) CI is the verifier for compile/tests.

No-Issue: incident fix from the v0.9.9 release session (owner's own session wedged); shell tool must never become unusable because a convenience file could not be created.
