### PR TITLE
test(tui): assembled journey acceptance for the Auto-Review guardian (#5361)

### DIFF
--- a/crates/tui/tests/README.md
+++ b/crates/tui/tests/README.md
@@ -59,7 +59,21 @@ over large full-screen goldens; pin only the durable events, protocol text,
 side effects, accounting, and next request whose exact shape is the feature.
 Do not add a new snapshot framework, network call, provider key, timing sleep,
 or platform shell merely to cover the journey. The Auto-Review guardian
-journeys in `src/core/engine/tests.rs` are the first fixture.
+journeys in `src/core/engine/tests.rs` are the first fixture (#5361); each
+drives one mock-model tool turn through `Engine::run` and pins:
+
+- `auto_review_guardian_allow_executes_once_and_accounts_usage_without_prompt_leak`
+  — allow executes the tool exactly once, reviewer usage reaches `TurnUsage`
+  and `TurnComplete`, and the reviewer rationale/audit fields never appear in
+  the follow-up model request
+- `auto_review_guardian_deny_returns_one_paired_failed_result` — deny yields
+  one paired `is_error` tool result carrying the rationale, no orphaned call,
+  no side effect
+- `auto_review_guardian_parse_and_transport_failures_deny_closed` — reviewer
+  parse or transport failure denies fail-closed with an `Unavailable` receipt
+- `auto_review_cancellation_promptly_drops_the_guardian_request` — cancel
+  drops the in-flight guardian future and interrupts the turn without a
+  follow-up model request
 
 ## `--record` mode for `deepseek eval`
 

--- a/crates/tui/tests/README.md
+++ b/crates/tui/tests/README.md
@@ -53,12 +53,13 @@ Coverage today exercises the trait surface end-to-end:
 - capacity-gate observation of a captured request before stream drain
 
 Full-engine journeys use `Engine::new_with_model_client` and the same mock.
-When a model-visible behavior crosses prompt assembly, a provider call, a tool
-gate or execution, and the follow-up prompt, add a keyless assembled journey to
-the existing engine harness. Assert the externally meaningful events, exact
-side effects, accounting, and next request. Do not add a new snapshot framework,
-network call, provider key, timing sleep, or platform shell merely to cover the
-journey.
+A non-trivial model/protocol/user-visible behavior change needs one keyless
+assembled journey at the nearest real entry path. Prefer semantic assertions
+over large full-screen goldens; pin only the durable events, protocol text,
+side effects, accounting, and next request whose exact shape is the feature.
+Do not add a new snapshot framework, network call, provider key, timing sleep,
+or platform shell merely to cover the journey. The Auto-Review guardian
+journeys in `src/core/engine/tests.rs` are the first fixture.
 
 ## `--record` mode for `deepseek eval`
 


### PR DESCRIPTION
## Summary

Documents the contributor rule from #5361 in `crates/tui/tests/README.md`: a non-trivial model/protocol/user-visible behavior change needs one keyless assembled journey at the nearest real entry path (semantic assertions, no new snapshot framework, no network/key/sleep/platform shell). The first acceptance fixture — the Auto-Review guardian — already exists as four engine-level journeys in `crates/tui/src/core/engine/tests.rs` (each drives one mock-model tool turn through `Engine::new_with_model_client` + `Engine::run`); the README now cites them by name.

## Acceptance mapping

| # | Issue acceptance item | Test (all existing, `crates/tui/src/core/engine/tests.rs`) |
|---|---|---|
| 1 | guardian allow executes once | `auto_review_guardian_allow_executes_once_and_accounts_usage_without_prompt_leak` — one paired non-error tool result, `.env` written once, 3 captured requests (main, guardian, follow-up) |
| 2 | deny emits paired failed tool result with rationale, no orphaned call | `auto_review_guardian_deny_returns_one_paired_failed_result` — one `is_error` result containing the denial reason, `Denied` receipt, no side effect |
| 3 | reviewer transport/parse failure denies fail-closed | `auto_review_guardian_parse_and_transport_failures_deny_closed` — both `parse` and `transport` variants, `Unavailable` receipt, "fail closed" error |
| 4 | cancellation interrupts the guardian request promptly | `auto_review_cancellation_promptly_drops_the_guardian_request` — `Notify`/drop-signal, no sleeps, `Interrupted` turn, no follow-up model request |
| 5 | reviewer usage in turn/cost accounting | `auto_review_guardian_allow_executes_once_and_accounts_usage_without_prompt_leak` — guardian usage (17/3) present in `TurnUsage` events and `TurnComplete.usage` |
| 6 | reviewer audit details do not leak into next prompt except via tool result | `auto_review_guardian_allow_executes_once_and_accounts_usage_without_prompt_leak` and `auto_review_guardian_deny_returns_one_paired_failed_result` — follow-up request JSON asserted free of the reviewer reason (allow), `deterministic_observations`, `hold_reason` |

No new tests added: every item was already covered through the real engine turn path. Keyless, no sleeps (`tokio::time::timeout` + `Notify` only).

## README rule

> A non-trivial model/protocol/user-visible behavior change needs one keyless assembled journey at the nearest real entry path. Prefer semantic assertions over large full-screen goldens; pin only the durable events, protocol text, side effects, accounting, and next request whose exact shape is the feature. Do not add a new snapshot framework, network call, provider key, timing sleep, or platform shell merely to cover the journey.

`cargo fmt --all -- --check` passes.

Closes #5361
