### PR TITLE
fix(client): fail closed on SSE UTF-8 split across HTTP/2 DATA — shared decoder + tail flush (#5374)

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -3660,42 +3660,36 @@ fn extract_sse_data_value(line: &str) -> Option<&str> {
         .map(|value| value.strip_prefix(' ').unwrap_or(value))
 }
 
-/// A complete SSE line that was not valid UTF-8. Callers must fail closed:
-/// substituting U+FFFD would hide the error and can rewrite provider/model
-/// text into a different string (#5374).
+/// Genuine invalid UTF-8 in an SSE line (or an unterminated flush).
+///
+/// HTTP/2 DATA and other transports may split a multi-byte character across
+/// chunks. That is not this error: callers must buffer raw bytes until a
+/// complete line (or stream end) before decoding. This type is only returned
+/// when `str::from_utf8` rejects the assembled bytes. We never substitute
+/// U+FFFD — fail closed so garbled CJK cannot enter the transcript.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct InvalidSseUtf8 {
     valid_up_to: usize,
-    error_len: Option<usize>,
 }
 
 impl std::fmt::Display for InvalidSseUtf8 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.error_len {
-            None => write!(
-                f,
-                "SSE line is not valid UTF-8: incomplete sequence at byte {}",
-                self.valid_up_to
-            ),
-            Some(len) => write!(
-                f,
-                "SSE line is not valid UTF-8: invalid sequence of {len} byte(s) at byte {}",
-                self.valid_up_to
-            ),
-        }
+        write!(
+            f,
+            "invalid UTF-8 in SSE stream at byte {}",
+            self.valid_up_to
+        )
     }
 }
 
 impl std::error::Error for InvalidSseUtf8 {}
 
-fn decode_sse_line_bytes(bytes: &[u8]) -> Result<String, InvalidSseUtf8> {
-    match std::str::from_utf8(bytes) {
-        Ok(line) => Ok(line.trim().to_string()),
-        Err(err) => Err(InvalidSseUtf8 {
-            valid_up_to: err.valid_up_to(),
-            error_len: err.error_len(),
-        }),
-    }
+/// Decode one assembled SSE line (or stream-end tail) with `str::from_utf8`.
+/// Does not substitute U+FFFD.
+fn decode_sse_line_bytes(bytes: &[u8]) -> Result<&str, InvalidSseUtf8> {
+    std::str::from_utf8(bytes).map_err(|err| InvalidSseUtf8 {
+        valid_up_to: err.valid_up_to(),
+    })
 }
 
 /// Take the next COMPLETE line (up to the first `\n`) off a raw byte buffer,
@@ -3705,23 +3699,26 @@ fn decode_sse_line_bytes(bytes: &[u8]) -> Result<String, InvalidSseUtf8> {
 /// split across two reads is never corrupted to U+FFFD, since the `\n`
 /// delimiter is ASCII and can never fall inside a multi-byte sequence.
 ///
-/// Complete lines are decoded strictly. Invalid bytes are an error, not a
-/// silent U+FFFD substitution (#5374).
+/// Genuine invalid bytes fail closed (`Err(InvalidSseUtf8)`); we do not
+/// substitute U+FFFD.
 fn take_sse_line(buffer: &mut Vec<u8>) -> Result<Option<String>, InvalidSseUtf8> {
     let Some(line_end) = buffer.iter().position(|&b| b == b'\n') else {
         return Ok(None);
     };
+    // Strip a preceding `\r` so CRLF-delimited SSE frames do not leave CR.
     let mut end = line_end;
     if end > 0 && buffer[end - 1] == b'\r' {
         end -= 1;
     }
-    let decoded = decode_sse_line_bytes(&buffer[..end]);
+    let decoded = decode_sse_line_bytes(&buffer[..end]).map(|text| text.trim().to_string());
     buffer.drain(..=line_end);
     decoded.map(Some)
 }
 
-/// Decode leftover bytes after the HTTP body ends (final `data:` line with no
-/// trailing newline). Same strict UTF-8 contract as [`take_sse_line`].
+/// Decode the unterminated tail left in `buffer` at stream end.
+///
+/// Same fail-closed UTF-8 contract as [`take_sse_line`]. Empty / whitespace-only
+/// tails yield `Ok(None)`.
 fn flush_sse_line(buffer: &mut Vec<u8>) -> Result<Option<String>, InvalidSseUtf8> {
     if buffer.is_empty() {
         return Ok(None);
@@ -3730,9 +3727,47 @@ fn flush_sse_line(buffer: &mut Vec<u8>) -> Result<Option<String>, InvalidSseUtf8
     if buffer[end - 1] == b'\r' {
         end -= 1;
     }
-    let decoded = decode_sse_line_bytes(&buffer[..end]);
+    let decoded = decode_sse_line_bytes(&buffer[..end]).map(|text| text.trim().to_string());
     buffer.clear();
     decoded.map(|line| (!line.is_empty()).then_some(line))
+}
+
+/// Next decoded SSE line. When `at_end` is false, wait for `\n`. When `at_end`
+/// is true, also flush an unterminated tail (stream closed).
+fn next_sse_line(buffer: &mut Vec<u8>, at_end: bool) -> Result<Option<String>, InvalidSseUtf8> {
+    match take_sse_line(buffer)? {
+        Some(line) => Ok(Some(line)),
+        None if at_end => flush_sse_line(buffer),
+        None => Ok(None),
+    }
+}
+
+/// Incremental raw-byte SSE line assembler for tests and the Chat Completions
+/// decoder. HTTP/2 DATA may split a multi-byte UTF-8 character across chunks;
+/// we never decode until a complete line or [`SseLineDecoder::finish`].
+#[cfg(test)]
+struct SseLineDecoder {
+    buffer: Vec<u8>,
+}
+
+#[cfg(test)]
+impl SseLineDecoder {
+    fn new() -> Self {
+        Self { buffer: Vec::new() }
+    }
+
+    fn push(&mut self, chunk: &[u8]) -> Result<Vec<String>, InvalidSseUtf8> {
+        self.buffer.extend_from_slice(chunk);
+        let mut lines = Vec::new();
+        while let Some(line) = take_sse_line(&mut self.buffer)? {
+            lines.push(line);
+        }
+        Ok(lines)
+    }
+
+    fn finish(mut self) -> Result<Option<String>, InvalidSseUtf8> {
+        flush_sse_line(&mut self.buffer)
+    }
 }
 
 pub(crate) use chat::{CacheWarmupKey, PromptInspection};
@@ -10101,20 +10136,30 @@ mod tests {
         );
     }
 
+    fn mid_char_split(text: &str, ch: char) -> usize {
+        let needle = ch.to_string();
+        let start = text
+            .as_bytes()
+            .windows(needle.len())
+            .position(|window| window == needle.as_bytes())
+            .unwrap_or_else(|| panic!("{ch:?} present in {text:?}"));
+        start + 1
+    }
+
     #[test]
     fn take_sse_line_preserves_multibyte_split_across_reads() {
         // "你好" streamed so the 3-byte '好' straddles a read boundary.
         let full = "data: 你好\n";
         let bytes = full.as_bytes();
-        let split = bytes.len() - 2; // mid '好'
+        let split = mid_char_split(full, '好');
         let mut buffer: Vec<u8> = Vec::new();
         // First read: no complete line yet.
         buffer.extend_from_slice(&bytes[..split]);
-        assert_eq!(take_sse_line(&mut buffer).expect("utf-8"), None);
+        assert_eq!(take_sse_line(&mut buffer).expect("valid prefix"), None);
         // Second read completes the line; '好' must be intact, not U+FFFD.
         buffer.extend_from_slice(&bytes[split..]);
         let line = take_sse_line(&mut buffer)
-            .expect("utf-8")
+            .expect("valid utf-8")
             .expect("a complete line");
         assert_eq!(line, "data: 你好");
         assert!(!line.contains('\u{FFFD}'), "multibyte char was corrupted");
@@ -10126,8 +10171,33 @@ mod tests {
     #[test]
     fn take_sse_line_returns_none_without_newline() {
         let mut buffer = b"data: partial".to_vec();
-        assert_eq!(take_sse_line(&mut buffer).expect("utf-8"), None);
+        assert_eq!(take_sse_line(&mut buffer).expect("valid utf-8"), None);
         assert_eq!(buffer, b"data: partial");
+    }
+
+    #[test]
+    fn take_sse_line_reassembles_cjk_and_rejects_invalid_bytes() {
+        let full = "data: 测试中文\n";
+        let split = mid_char_split(full, '试');
+        let mut buffer = full.as_bytes()[..split].to_vec();
+        assert_eq!(take_sse_line(&mut buffer).expect("valid prefix"), None);
+        buffer.extend_from_slice(&full.as_bytes()[split..]);
+        let line = take_sse_line(&mut buffer)
+            .expect("valid utf-8")
+            .expect("complete line");
+        assert_eq!(line, "data: 测试中文");
+        assert!(!line.contains('\u{FFFD}'));
+
+        let mut invalid = b"data: ok".to_vec();
+        invalid.push(0xFF);
+        invalid.push(b'\n');
+        let err = take_sse_line(&mut invalid).expect_err("invalid bytes must fail closed");
+        assert!(!err.to_string().contains('\u{FFFD}'));
+        assert_eq!(err.valid_up_to, 8);
+        assert!(
+            invalid.is_empty(),
+            "invalid line is consumed so retries cannot loop"
+        );
     }
 
     #[test]
@@ -10136,15 +10206,38 @@ mod tests {
         buffer.push(0xFF);
         buffer.extend_from_slice(b"\n");
         let err = take_sse_line(&mut buffer).expect_err("0xFF is not UTF-8");
-        assert_eq!(err.error_len, Some(1));
+        assert_eq!(err.valid_up_to, 8);
+        assert!(!err.to_string().contains('\u{FFFD}'));
         assert!(buffer.is_empty(), "invalid line must be drained");
+    }
+
+    #[test]
+    fn flush_sse_line_reassembles_cjk_and_rejects_invalid_bytes() {
+        let text = "data: 你好世界";
+        let split = mid_char_split(text, '好');
+        let mut buffer = text.as_bytes()[..split].to_vec();
+        assert_eq!(take_sse_line(&mut buffer).expect("no newline yet"), None);
+        buffer.extend_from_slice(&text.as_bytes()[split..]);
+        let line = flush_sse_line(&mut buffer)
+            .expect("valid utf-8")
+            .expect("unterminated tail");
+        assert_eq!(line, "data: 你好世界");
+        assert!(!line.contains('\u{FFFD}'));
+        assert!(buffer.is_empty());
+        assert_eq!(flush_sse_line(&mut buffer).expect("empty"), None);
+
+        let mut invalid = vec![0x80, 0xBF];
+        let err = flush_sse_line(&mut invalid).expect_err("invalid flush must fail closed");
+        assert!(!err.to_string().contains('\u{FFFD}'));
+        assert_eq!(err.valid_up_to, 0);
+        assert!(invalid.is_empty());
     }
 
     #[test]
     fn flush_sse_line_preserves_unterminated_cjk() {
         let mut buffer = "data: 你好".as_bytes().to_vec();
         let line = flush_sse_line(&mut buffer)
-            .expect("utf-8")
+            .expect("valid utf-8")
             .expect("residual line");
         assert_eq!(line, "data: 你好");
         assert!(!line.contains('\u{FFFD}'));
@@ -10156,8 +10249,20 @@ mod tests {
         let mut buffer = "data: ".as_bytes().to_vec();
         buffer.extend_from_slice(&"好".as_bytes()[..2]);
         let err = flush_sse_line(&mut buffer).expect_err("truncated UTF-8");
-        assert!(err.error_len.is_none());
+        assert_eq!(err.valid_up_to, 6);
+        assert!(!err.to_string().contains('\u{FFFD}'));
         assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn decode_sse_line_bytes_rejects_invalid_without_replacement() {
+        let ok = decode_sse_line_bytes("data: 你好".as_bytes()).expect("valid");
+        assert_eq!(ok, "data: 你好");
+        assert!(!ok.contains('\u{FFFD}'));
+
+        let err = decode_sse_line_bytes(&[0xFF]).expect_err("bare 0xFF is invalid");
+        assert!(!err.to_string().contains('\u{FFFD}'));
+        assert_eq!(err.valid_up_to, 0);
     }
 
     #[test]

--- a/crates/tui/src/client/anthropic.rs
+++ b/crates/tui/src/client/anthropic.rs
@@ -303,41 +303,44 @@ impl DeepSeekClient {
         let stream = async_stream::stream! {
             use futures_util::StreamExt;
 
-            // Raw byte buffer: decode only COMPLETE lines so a multi-byte
-            // UTF-8 char (CJK/emoji) split across two network reads is never
-            // corrupted to U+FFFD. Line boundaries ('\n') are ASCII and can
-            // never fall inside a multi-byte sequence. (Mirrors chat.rs.)
+            // Raw byte buffer: decode only COMPLETE lines (or the stream-end
+            // tail) via the shared take_sse_line / flush_sse_line helpers so a
+            // multi-byte UTF-8 char (CJK/emoji) split across HTTP/2 DATA is
+            // never corrupted to U+FFFD. Genuine invalid bytes fail closed.
             let mut buffer: Vec<u8> = Vec::new();
             let stream_start = std::time::Instant::now();
             let mut last_chunk_at = std::time::Instant::now();
             let mut bytes_received: usize = 0;
+            let mut ended = false;
             tokio::pin!(byte_stream);
 
             loop {
-                let chunk = match tokio::time::timeout(stream_idle_timeout, byte_stream.next()).await {
-                    Ok(Some(Ok(chunk))) => chunk,
-                    Ok(Some(Err(e))) => {
-                        yield Err(anyhow::anyhow!("Stream read error: {e}"));
-                        return;
+                if !ended {
+                    match tokio::time::timeout(stream_idle_timeout, byte_stream.next()).await {
+                        Ok(Some(Ok(chunk))) => {
+                            bytes_received += chunk.len();
+                            last_chunk_at = std::time::Instant::now();
+                            buffer.extend_from_slice(&chunk);
+                        }
+                        Ok(Some(Err(e))) => {
+                            yield Err(anyhow::anyhow!("Stream read error: {e}"));
+                            return;
+                        }
+                        Ok(None) => ended = true,
+                        Err(_) => {
+                            yield Err(anyhow::anyhow!(super::stream_entry::idle_timeout_message(
+                                stream_idle_timeout,
+                                bytes_received,
+                                stream_start.elapsed(),
+                                last_chunk_at.elapsed(),
+                            )));
+                            return;
+                        }
                     }
-                    Ok(None) => break,
-                    Err(_) => {
-                        yield Err(anyhow::anyhow!(super::stream_entry::idle_timeout_message(
-                            stream_idle_timeout,
-                            bytes_received,
-                            stream_start.elapsed(),
-                            last_chunk_at.elapsed(),
-                        )));
-                        return;
-                    }
-                };
-
-                bytes_received += chunk.len();
-                last_chunk_at = std::time::Instant::now();
-                buffer.extend_from_slice(&chunk);
+                }
 
                 loop {
-                    let line = match super::take_sse_line(&mut buffer) {
+                    let line = match super::next_sse_line(&mut buffer, ended) {
                         Ok(Some(line)) => line,
                         Ok(None) => break,
                         Err(err) => {
@@ -372,6 +375,10 @@ impl DeepSeekClient {
                         }
                         None => {}
                     }
+                }
+
+                if ended {
+                    break;
                 }
             }
         };

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -1292,6 +1292,9 @@ impl DeepSeekClient {
             // Set when a `[DONE]` sentinel was seen, so the post-loop flush does
             // not re-process trailing post-DONE bytes.
             let mut saw_done = false;
+            // Set when a complete line or unterminated flush failed UTF-8.
+            // Skip further data-frame parsing so U+FFFD cannot enter the transcript.
+            let mut decode_failed = false;
 
             'stream: loop {
                 let chunk_result = match tokio_timeout(idle, byte_stream.next()).await {
@@ -1349,16 +1352,16 @@ impl DeepSeekClient {
                     tokio::time::sleep(Duration::from_millis(SSE_BACKPRESSURE_SLEEP_MS)).await;
                 }
 
-                // Process complete SSE lines from the buffer. Strict UTF-8:
-                // never `from_utf8_lossy` here — a mid-character TCP split
-                // stays in `byte_buf` until `\n`, and a genuinely invalid
-                // line fails closed instead of injecting U+FFFD (#5374).
+                // Process complete SSE lines from the buffer. Decode only after
+                // a `\n` so an HTTP/2 DATA split mid-character cannot become
+                // U+FFFD; genuine invalid bytes fail closed.
                 let mut lines_processed = 0usize;
                 loop {
                     let line = match super::take_sse_line(&mut byte_buf) {
                         Ok(Some(line)) => line,
                         Ok(None) => break,
                         Err(err) => {
+                            decode_failed = true;
                             yield Err(anyhow::anyhow!("{err}"));
                             break 'stream;
                         }
@@ -1429,24 +1432,25 @@ impl DeepSeekClient {
             // line (the stream closed straight after the last `data:` line, or
             // that line lacked a trailing newline). Without this the final delta
             // — last tokens, finish_reason, and usage — is silently dropped.
-            // Skipped after `[DONE]`, whose frame was already processed.
-            if !saw_done {
-                let residual = match super::flush_sse_line(&mut byte_buf) {
-                    Ok(line) => line,
+            // Skipped after `[DONE]`, whose frame was already processed, and
+            // after a fail-closed UTF-8 error.
+            if !saw_done && !decode_failed {
+                match super::flush_sse_line(&mut byte_buf) {
+                    Ok(Some(line)) => {
+                        if let Some(data) = super::extract_sse_data_value(&line) {
+                            if !line_buf.is_empty() {
+                                line_buf.push('\n');
+                            }
+                            line_buf.push_str(data);
+                        }
+                    }
+                    Ok(None) => {}
                     Err(err) => {
+                        decode_failed = true;
                         yield Err(anyhow::anyhow!("{err}"));
-                        None
                     }
-                };
-                if let Some(line) = residual
-                    && let Some(data) = super::extract_sse_data_value(&line)
-                {
-                    if !line_buf.is_empty() {
-                        line_buf.push('\n');
-                    }
-                    line_buf.push_str(data);
                 }
-                if !line_buf.is_empty() {
+                if !decode_failed && !line_buf.is_empty() {
                     let data = std::mem::take(&mut line_buf);
                     if let SseDataFrame::Events(events) = parse_sse_data_frame(
                         &data,

--- a/crates/tui/src/client/chat/tests/stream_decoder.rs
+++ b/crates/tui/src/client/chat/tests/stream_decoder.rs
@@ -58,6 +58,107 @@ fn decode_chunks_with_style(
     events
 }
 
+/// Drive the Chat Completions SSE path with raw byte chunks so tests can
+/// split a multi-byte UTF-8 character across HTTP/2-style DATA boundaries.
+fn decode_sse_byte_chunks(
+    chunks: &[&[u8]],
+) -> Result<Vec<StreamEvent>, super::super::InvalidSseUtf8> {
+    struct FrameState {
+        line_buf: String,
+        content_index: u32,
+        text_started: bool,
+        thinking_started: bool,
+        tool_indices: std::collections::HashMap<u32, u32>,
+        reasoning_detail_buffers: std::collections::HashMap<u32, String>,
+        inline_reasoning_tags: InlineReasoningTagState,
+        events: Vec<StreamEvent>,
+    }
+
+    impl FrameState {
+        fn new() -> Self {
+            Self {
+                line_buf: String::new(),
+                content_index: 0,
+                text_started: false,
+                thinking_started: false,
+                tool_indices: std::collections::HashMap::new(),
+                reasoning_detail_buffers: std::collections::HashMap::new(),
+                inline_reasoning_tags: InlineReasoningTagState::default(),
+                events: Vec::new(),
+            }
+        }
+
+        fn handle_line(&mut self, line: &str) -> bool {
+            if line.is_empty() {
+                return matches!(self.flush_frame(), SseDataFrame::Done);
+            }
+            if let Some(data) = super::super::extract_sse_data_value(line) {
+                if !self.line_buf.is_empty() {
+                    self.line_buf.push('\n');
+                }
+                self.line_buf.push_str(data);
+            }
+            false
+        }
+
+        fn flush_frame(&mut self) -> SseDataFrame {
+            if self.line_buf.is_empty() {
+                return SseDataFrame::Events(Vec::new());
+            }
+            let data = std::mem::take(&mut self.line_buf);
+            match parse_sse_data_frame(
+                &data,
+                &mut self.content_index,
+                &mut self.text_started,
+                &mut self.thinking_started,
+                &mut self.tool_indices,
+                &mut self.reasoning_detail_buffers,
+                &mut self.inline_reasoning_tags,
+                ReasoningStreamStyle::SeparateField,
+            ) {
+                SseDataFrame::Done => SseDataFrame::Done,
+                SseDataFrame::Events(frame_events) => {
+                    self.events.extend(frame_events);
+                    SseDataFrame::Events(Vec::new())
+                }
+            }
+        }
+    }
+
+    let mut decoder = super::super::SseLineDecoder::new();
+    let mut state = FrameState::new();
+    for chunk in chunks {
+        for line in decoder.push(chunk)? {
+            if state.handle_line(&line) {
+                return Ok(state.events);
+            }
+        }
+    }
+    if let Some(line) = decoder.finish()?
+        && state.handle_line(&line)
+    {
+        return Ok(state.events);
+    }
+    state.flush_frame();
+    Ok(state.events)
+}
+
+fn cjk_content_sse(text: &str) -> Vec<u8> {
+    let payload = serde_json::json!({
+        "choices": [{ "delta": { "content": text } }]
+    });
+    format!("data: {payload}\n\n").into_bytes()
+}
+
+fn mid_char_split(bytes: &[u8], ch: char) -> usize {
+    let needle = ch.to_string();
+    let start = bytes
+        .windows(needle.len())
+        .position(|window| window == needle.as_bytes())
+        .unwrap_or_else(|| panic!("{ch:?} present in SSE frame"));
+    start + 1
+}
+
 fn text_delta_text(events: &[StreamEvent]) -> String {
     events
         .iter()
@@ -82,6 +183,51 @@ fn thinking_delta_text(events: &[StreamEvent]) -> String {
             _ => None,
         })
         .collect()
+}
+
+#[test]
+fn decoder_reassembles_cjk_split_across_byte_chunks() {
+    let frame = cjk_content_sse("你好世界");
+    let split = mid_char_split(&frame, '好');
+    let events = decode_sse_byte_chunks(&[&frame[..split], &frame[split..]]).expect("valid utf-8");
+    let text = text_delta_text(&events);
+    assert_eq!(text, "你好世界");
+    assert!(
+        !text.contains('\u{FFFD}'),
+        "HTTP/2 mid-character split must not substitute U+FFFD; got {text:?}"
+    );
+}
+
+#[test]
+fn decoder_reassembles_emoji_and_cjk_fed_one_byte_at_a_time() {
+    let frame = cjk_content_sse("你好🌊世界");
+    let chunks: Vec<&[u8]> = frame.chunks(1).collect();
+    let events = decode_sse_byte_chunks(&chunks).expect("valid utf-8");
+    let text = text_delta_text(&events);
+    assert_eq!(text, "你好🌊世界");
+    assert!(
+        !text.contains('\u{FFFD}'),
+        "byte-at-a-time feed garbled: {text:?}"
+    );
+}
+
+#[test]
+fn decoder_rejects_invalid_sse_bytes_without_replacement() {
+    let mut frame = cjk_content_sse("ok");
+    // Bare 0xFF is never valid UTF-8. Insert it inside the first SSE line.
+    let newline = frame.iter().position(|&b| b == b'\n').expect("SSE line");
+    frame.insert(newline, 0xFF);
+    let result = decode_sse_byte_chunks(&[&frame]);
+    let err = result.expect_err("invalid SSE bytes must fail closed");
+    assert!(
+        !err.to_string().contains('\u{FFFD}'),
+        "error path must not substitute U+FFFD: {err}"
+    );
+
+    // Unterminated tail of continuation bytes: fail on flush, no replacement.
+    let result = decode_sse_byte_chunks(&[&[0x80, 0xBF]]);
+    let err = result.expect_err("invalid unterminated flush must fail closed");
+    assert!(!err.to_string().contains('\u{FFFD}'));
 }
 
 #[test]

--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -220,11 +220,13 @@ impl DeepSeekClient {
             let mut reasoning_text_emitted = false;
             let mut saw_tool_call = false;
             let mut usage_data: Option<Usage> = None;
-            // Raw byte buffer: decode only COMPLETE lines so a multi-byte
-            // UTF-8 char split across two network reads is never corrupted
-            // to U+FFFD (line boundaries are ASCII). Mirrors chat.rs.
+            // Raw byte buffer: decode only COMPLETE lines (or the stream-end
+            // tail) via the shared take_sse_line / flush_sse_line helpers so a
+            // multi-byte UTF-8 char split across HTTP/2 DATA is never
+            // corrupted to U+FFFD. Genuine invalid bytes fail closed.
             let mut buffer: Vec<u8> = Vec::new();
             let mut done = false;
+            let mut ended = false;
             let mut content_block_counter: u32 = 0;
             let stream_start = std::time::Instant::now();
             let mut last_chunk_at = std::time::Instant::now();
@@ -233,31 +235,33 @@ impl DeepSeekClient {
             tokio::pin!(byte_stream);
 
             while !done {
-                let chunk = match tokio::time::timeout(stream_idle_timeout, byte_stream.next()).await {
-                    Ok(Some(Ok(chunk))) => chunk,
-                    Ok(Some(Err(e))) => {
-                        yield Err(anyhow::anyhow!("Stream read error: {e}"));
-                        return;
+                if !ended {
+                    match tokio::time::timeout(stream_idle_timeout, byte_stream.next()).await {
+                        Ok(Some(Ok(chunk))) => {
+                            bytes_received += chunk.len();
+                            last_chunk_at = std::time::Instant::now();
+                            buffer.extend_from_slice(&chunk);
+                        }
+                        Ok(Some(Err(e))) => {
+                            yield Err(anyhow::anyhow!("Stream read error: {e}"));
+                            return;
+                        }
+                        Ok(None) => ended = true,
+                        Err(_) => {
+                            yield Err(anyhow::anyhow!(super::stream_entry::idle_timeout_message(
+                                stream_idle_timeout,
+                                bytes_received,
+                                stream_start.elapsed(),
+                                last_chunk_at.elapsed(),
+                            )));
+                            return;
+                        }
                     }
-                    Ok(None) => break,
-                    Err(_) => {
-                        yield Err(anyhow::anyhow!(super::stream_entry::idle_timeout_message(
-                            stream_idle_timeout,
-                            bytes_received,
-                            stream_start.elapsed(),
-                            last_chunk_at.elapsed(),
-                        )));
-                        return;
-                    }
-                };
+                }
 
-                bytes_received += chunk.len();
-                last_chunk_at = std::time::Instant::now();
-                buffer.extend_from_slice(&chunk);
-
-                // Process complete SSE lines.
+                // Process complete SSE lines, and the unterminated tail at stream end.
                 loop {
-                    let line = match super::take_sse_line(&mut buffer) {
+                    let line = match super::next_sse_line(&mut buffer, ended) {
                         Ok(Some(line)) => line,
                         Ok(None) => break,
                         Err(err) => {
@@ -509,6 +513,10 @@ impl DeepSeekClient {
                             }
                         }
                     }
+                }
+
+                if ended {
+                    break;
                 }
             }
 


### PR DESCRIPTION
## Summary

Closes #5374 — DeepSeek Flash on macOS showed garbled streaming agent text (U+FFFD / broken CJK) because HTTP/2 DATA frames can split a multi-byte UTF-8 character across chunks and the SSE readers decoded per chunk.

**What main already had (19c4d1ddb):** `take_sse_line` / `flush_sse_line` buffer raw bytes and decode only complete `\n`-terminated lines with strict `str::from_utf8`; a genuinely invalid line returns `InvalidSseUtf8` instead of substituting U+FFFD.

**What this PR adds on top of that baseline:**

- `decode_sse_line_bytes` — the one shared strict decoder used by both `take_sse_line` and `flush_sse_line`; `InvalidSseUtf8` slimmed to `valid_up_to` with a single Display form.
- `next_sse_line(buffer, at_end)` — complete-line-or-tail helper so every dialect flushes the unterminated stream-end tail through the same fail-closed path.
- Per-dialect propagation of the decode failure:
  - **Chat Completions** (`chat.rs`): new `decode_failed` flag; a UTF-8 error on a complete line or on the tail flush yields `Err(InvalidSseUtf8)` and skips the post-loop frame parse so nothing after the error reaches the transcript.
  - **Anthropic** (`anthropic.rs`) and **Responses** (`responses.rs`): read loop switched to an `ended` state so the stream-end tail is flushed via `next_sse_line`; decode errors yield `Err` and return.
- `SseLineDecoder` (`#[cfg(test)]`) — incremental raw-byte line assembler used by the new decoder tests.

## Tests

- `crates/tui/src/client.rs`: `take_sse_line_reassembles_cjk_and_rejects_invalid_bytes`, `flush_sse_line_reassembles_cjk_and_rejects_invalid_bytes`, `decode_sse_line_bytes_rejects_invalid_without_replacement`; existing take/flush tests updated for the slimmed error type (byte-split positions computed via `mid_char_split`).
- `crates/tui/src/client/chat/tests/stream_decoder.rs`: `decoder_reassembles_cjk_split_across_byte_chunks`, `decoder_reassembles_emoji_and_cjk_fed_one_byte_at_a_time`, `decoder_rejects_invalid_sse_bytes_without_replacement` — drive the Chat Completions frame parser over raw byte chunks split mid-character.

## Relation to #5404

Supersedes draft #5404 (cursor branch, based on `5ac75add4`, before main's fail-closed baseline landed). This branch is rebased onto current main containing 19c4d1ddb, so it only carries the delta (shared decoder, tail flush, per-dialect propagation, tests). #5404 is left open for the owner to close.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (CI)
- [ ] `cargo test --workspace --all-features --locked` (CI)

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (no co-author trailers)
