### PR TITLE
test(pty): deflake release_four_read_only_fleet_roles_launch_with_canonical_prompts (children need JSON, not SSE)

### DIFF
--- a/crates/tui/tests/pty/release_runtime_qa.rs
+++ b/crates/tui/tests/pty/release_runtime_qa.rs
@@ -1349,7 +1349,26 @@ impl Respond for FleetRoleResponder {
             if raw.contains(expected_prompt) {
                 self.canonical_prompts.fetch_add(1, Ordering::SeqCst);
             }
-            return sse_response(text_sse(DEEPSEEK_TEST_MODEL, "role-launch-complete"));
+            // Children call the blocking `create_message` (`stream: false`) and
+            // parse a JSON body. An SSE body fails "Failed to parse Chat API
+            // JSON", which the sub-agent runtime classifies as transient and
+            // re-sends verbatim 250 ms later — so the worker (tool_call index
+            // 0, first launched) counted twice on a slow macOS runner before
+            // the fourth child had even sent its first request. Answer with a
+            // real non-stream chat.completion so each role launches exactly
+            // once and the counters mean what the assertions say.
+            return json_response(json!({
+                "id": "chatcmpl-role-launch",
+                "object": "chat.completion",
+                "created": 0,
+                "model": DEEPSEEK_TEST_MODEL,
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "role-launch-complete"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 20, "completion_tokens": 4, "total_tokens": 24}
+            }));
         }
 
         if raw.contains("launch four canonical read-only Fleet roles") {


### PR DESCRIPTION
## Why

`release_runtime_qa::release_four_read_only_fleet_roles_launch_with_canonical_prompts` failed three times on `macos-latest` today on docs-only PRs (#5459 once, #5464 twice incl. the in-job retry) with

```
assertion `left == right` failed: worker did not launch once
  left: 2
 right: 1
```

## Root cause (read-only trace, no local build)

- Fleet children send `stream: Some(false)` and call the blocking `create_message` (`crates/tui/src/tools/subagent/mod.rs` ~10606 / ~10149), which parses a JSON body (`crates/tui/src/client/chat.rs` ~1143).
- `FleetRoleResponder` answered the child match with `sse_response(text_sse(..))` → `Failed to parse Chat API JSON`.
- That message is in the sub-agent runtime's transient needle list (`is_transient_subagent_provider_error`, ~10084) and the runtime re-sends the identical request after `SUBAGENT_TRANSIENT_PROVIDER_INITIAL_BACKOFF` = 250 ms (max 2 retries).
- The worker is tool_call index 0 → launched first → its retry lands before the 4th child's first request on a slow runner → `wait_for_counter(launched, 4)` returns with `worker == 2`. Pure timing; passes on fast runners.
- Not caused by #5461/#5458 (neither touches this path). Parent duplicate-dispatch ruled out: parent follow-ups carry all four markers → `matched.len() == 4` → not counted.

## Fix

Answer the child match with a real non-stream `chat.completion` (same shape `CompactionLifecycleResponder` already returns). One request per role; the assertions keep their meaning ("exactly once, canonical prompt").

`cargo fmt --all -- --check` clean locally; CI is the verifier (owner's no-local-builds rule for this host).

Refs #5056 (test reliability).

No-Issue: CI deflake for the v0.9.9 cut (macOS-only timing failure on docs-only PRs).

