### PR TITLE
perf(skills): keep configured skill prompts stable

### DIFF
--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -1279,14 +1279,31 @@ pub fn render_available_skills_context_for_workspace_and_dir_with_mode_and_plugi
     let registry =
         discover_for_workspace_and_dir_with_mode_and_plugins(workspace, skills_dir, mode, plugins)
             .into_enabled();
-    render_skills_block(&registry, locale, workspace)
+    render_skills_block_with_configured_root(&registry, locale, workspace, Some(skills_dir))
 }
 
 /// Replace absolute path prefixes in free-form text (skill load warnings)
 /// with privacy-safe stand-ins before the text enters the system-prompt
-/// prefix (#4632). Workspace paths become `.`, home-dir paths become `~`.
-fn sanitize_prompt_path_text(text: &str, workspace: &Path) -> String {
+/// prefix (#4632). Workspace paths become `.`, home-dir paths become `~`,
+/// and a caller-provided skills root gets a stable logical name.
+fn sanitize_prompt_path_text(
+    text: &str,
+    workspace: &Path,
+    configured_skills_root: Option<&Path>,
+) -> String {
     let mut out = text.to_string();
+    if let Some(root) = configured_skills_root {
+        for root in [Some(root.to_path_buf()), fs::canonicalize(root).ok()]
+            .into_iter()
+            .flatten()
+        {
+            if let Some(root) = root.to_str()
+                && !root.is_empty()
+            {
+                out = out.replace(root, "<configured-skills>");
+            }
+        }
+    }
     if let Some(ws) = workspace.to_str()
         && !ws.is_empty()
     {
@@ -1337,7 +1354,42 @@ fn privacy_safe_skill_path(path: &Path, workspace: &Path) -> String {
     }
 }
 
+fn path_is_within_root(path: &Path, root: &Path) -> bool {
+    if path.starts_with(root) {
+        return true;
+    }
+    let Some(canonical_path) = fs::canonicalize(path).ok() else {
+        return false;
+    };
+    let Some(canonical_root) = fs::canonicalize(root).ok() else {
+        return false;
+    };
+    canonical_path.starts_with(canonical_root)
+}
+
+fn prompt_skill_path(
+    path: &Path,
+    workspace: &Path,
+    configured_skills_root: Option<&Path>,
+) -> Option<String> {
+    if let Some(root) = configured_skills_root {
+        if path_is_within_root(path, root) {
+            return None;
+        }
+    }
+    Some(privacy_safe_skill_path(path, workspace))
+}
+
 fn render_skills_block(registry: &SkillRegistry, locale: &str, workspace: &Path) -> Option<String> {
+    render_skills_block_with_configured_root(registry, locale, workspace, None)
+}
+
+fn render_skills_block_with_configured_root(
+    registry: &SkillRegistry,
+    locale: &str,
+    workspace: &Path,
+    configured_skills_root: Option<&Path>,
+) -> Option<String> {
     if registry.is_empty() && registry.warnings().is_empty() {
         return None;
     }
@@ -1395,24 +1447,29 @@ Skills are optional local instruction packs. This budgeted index exposes routing
         // installs, in which case `<dir>/<name>/SKILL.md` would not exist
         // and the model would fail to open it. Rendered privacy-safe
         // (workspace-relative or ~/…) so the prompt prefix never embeds
-        // absolute user paths (#4632).
-        let display_path = privacy_safe_skill_path(&skill.path, workspace);
+        // absolute user paths (#4632). A caller-provided skills root omits its
+        // physical path because that root may change per session; load_skill
+        // still resolves the stable skill name through the internal registry.
+        let display_path = prompt_skill_path(&skill.path, workspace, configured_skills_root);
         let description = truncate_for_prompt(
             skill.description_for_locale(locale),
             MAX_SKILL_DESCRIPTION_CHARS,
         );
         let source = match &skill.source {
-            SkillSource::Native => format!("file: {display_path}"),
+            SkillSource::Native => display_path.map(|path| format!("file: {path}")),
             SkillSource::Plugin {
                 plugin_id,
                 plugin_name,
                 ..
-            } => format!("reviewed plugin snapshot: {plugin_name} ({plugin_id}); use load_skill"),
+            } => Some(format!(
+                "reviewed plugin snapshot: {plugin_name} ({plugin_id}); use load_skill"
+            )),
         };
-        let line = if description.is_empty() {
-            format!("- {}: ({source})\n", skill.name)
-        } else {
-            format!("- {}: {} ({source})\n", skill.name, description)
+        let line = match (description.is_empty(), source) {
+            (true, Some(source)) => format!("- {}: ({source})\n", skill.name),
+            (true, None) => format!("- {}\n", skill.name),
+            (false, Some(source)) => format!("- {}: {} ({source})\n", skill.name, description),
+            (false, None) => format!("- {}: {}\n", skill.name, description),
         };
 
         if out.chars().count() + line.chars().count() + fixed_reserve > MAX_AVAILABLE_SKILLS_CHARS {
@@ -1435,7 +1492,7 @@ Skills are optional local instruction packs. This budgeted index exposes routing
             let line = format!(
                 "- {}\n",
                 truncate_for_prompt(
-                    &sanitize_prompt_path_text(warning, workspace),
+                    &sanitize_prompt_path_text(warning, workspace, configured_skills_root,),
                     MAX_SKILL_DESCRIPTION_CHARS,
                 )
             );

--- a/crates/tui/src/skills/tests.rs
+++ b/crates/tui/src/skills/tests.rs
@@ -53,7 +53,7 @@ fn discovery_metrics_reset_and_snapshot_are_exact() {
 fn prompt_warning_sanitizer_scrubs_stale_conventional_home_roots() {
     let workspace = std::path::Path::new("/tmp/workspace");
     let warning = "Skill at /Users/private-name/.agents/skills/a/SKILL.md is shadowed by /home/other/.skills/a/SKILL.md";
-    let sanitized = super::sanitize_prompt_path_text(warning, workspace);
+    let sanitized = super::sanitize_prompt_path_text(warning, workspace, None);
     assert_eq!(
         sanitized,
         "Skill at ~/.agents/skills/a/SKILL.md is shadowed by ~/.skills/a/SKILL.md"
@@ -1724,6 +1724,59 @@ fn workspace_and_dir_entry_point_shares_the_same_cache() {
     assert_eq!(rewalked, super::SkillDiscoveryMetrics::default());
     assert_eq!(first.len(), second.len());
     assert!(second.get("configured").is_some());
+}
+
+#[test]
+fn configured_skill_prompt_uses_a_stable_root_in_entries_and_warnings() {
+    let _env_lock = crate::test_support::lock_test_env();
+    super::clear_skill_discovery_cache();
+    let tmpdir = TempDir::new().unwrap();
+    let home = tmpdir.path().join("home");
+    let workspace = home.join("workspace");
+    let skills_dir = home
+        .join("runtime")
+        .join("sessions")
+        .join("session-123")
+        .join("skills");
+    std::fs::create_dir_all(&workspace).unwrap();
+    write_skill(
+        &workspace.join(".claude").join("skills"),
+        "workspace-skill",
+        "Workspace skill",
+        "Instructions",
+    );
+    let configured_skill = skills_dir.join("visual-design");
+    std::fs::create_dir_all(&configured_skill).unwrap();
+    std::fs::write(
+        configured_skill.join("SKILL.md"),
+        "---\nname: Visual Design\ndescription: Design assets\n---\nInstructions",
+    )
+    .unwrap();
+    let _home = crate::test_support::EnvVarGuard::set("HOME", &home);
+    let _userprofile = crate::test_support::EnvVarGuard::set("USERPROFILE", &home);
+    let _codewhale_home =
+        crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", home.join(".codewhale"));
+
+    let rendered =
+        super::render_available_skills_context_for_workspace_and_dir_with_mode_and_plugins(
+            &workspace,
+            &skills_dir,
+            super::SkillDiscoveryMode::Compatible,
+            "en",
+            None,
+        )
+        .expect("configured skill context");
+
+    assert!(rendered.contains("- visual-design: Design assets\n"));
+    assert!(rendered.contains(
+        "- workspace-skill: Workspace skill (file: .claude/skills/workspace-skill/SKILL.md)"
+    ));
+    assert!(
+        rendered
+            .contains("in <configured-skills>/visual-design/SKILL.md is not a safe command name")
+    );
+    assert!(!rendered.contains("session-123"), "{rendered}");
+    assert!(!rendered.contains(home.to_str().unwrap()), "{rendered}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- keep native skills below an explicitly configured skills root stable in the model-facing catalog by listing only their name and description
- replace that physical root with `<configured-skills>` in model-facing discovery warnings
- preserve workspace/global skill paths, plugin provenance, and internal `load_skill` registry resolution

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [ ] `cargo test --workspace --all-features --locked`
- [x] `cargo test -p codewhale-tui --lib --locked configured_skill_prompt_uses_a_stable_root_in_entries_and_warnings`
- [x] `cargo test -p codewhale-tui --lib --locked` (10,665 passed, 12 ignored before the final unrelated `main` rebase)
- [x] `cargo clippy -p codewhale-tui --all-targets --all-features --locked -- -D warnings ...` with the documented allow list plus the current baseline-only `nonminimal_bool`, `collapsible_match`, and `overly_complex_bool_expr` allowances

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (not applicable; no harvested/co-authored credit)

No-Issue: reproduced from a downstream fork report; no matching upstream issue exists.
