### PR TITLE
perf(context): compact all noisy web tool results

### DIFF
--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -92,7 +92,10 @@ fn tool_result_is_noisy(tool_name: &str) -> bool {
             | "run_verifiers"
             | "task_gate_run"
             | "multi_tool_use.parallel"
+            | "Web"
             | "web_search"
+            | "web.run"
+            | "fetch_url"
     )
 }
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -13440,6 +13440,26 @@ fn v4_keeps_large_file_reads_but_compacts_noisy_shell_output() {
 }
 
 #[test]
+fn web_tool_surfaces_use_the_noisy_soft_limit() {
+    // This stays below the ordinary 12K hard limit but exceeds the 2K noisy
+    // soft limit, so the assertion proves the tool name triggered compaction.
+    let content = "w".repeat(4_000);
+    let output = ToolResult::success(content.clone());
+
+    let file_context = compact_tool_result_for_context("deepseek-v3.2-128k", "read_file", &output);
+    assert_eq!(file_context, content);
+
+    for tool_name in ["Web", "web_search", "web.run", "fetch_url"] {
+        let web_context = compact_tool_result_for_context("deepseek-v3.2-128k", tool_name, &output);
+        assert!(
+            web_context.contains(&format!("{tool_name} output compacted to protect context")),
+            "{tool_name} did not use the noisy soft limit: {web_context}"
+        );
+        assert!(web_context.len() < file_context.len());
+    }
+}
+
+#[test]
 fn evidence_bounded_preview_is_not_recompacted() {
     // The adaptive evidence envelope already produced an honest bounded
     // preview (head + footer with the recovery path + tail). The context


### PR DESCRIPTION
## Summary

- apply the existing noisy-result soft limit to all known web tool surfaces: `Web`, `web_search`, `web.run`, and `fetch_url`
- retain the ordinary hard limit for non-noisy tools such as `read_file`
- cover both alias routing and the existing bounded-evidence exemption with regression tests

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [ ] `cargo test --workspace --all-features --locked`
- [x] `cargo test -p codewhale-tui --lib --locked web_tool_surfaces_use_the_noisy_soft_limit`
- [x] `cargo test -p codewhale-tui --lib --locked v4_keeps_large_file_reads_but_compacts_noisy_shell_output`
- [x] `cargo test -p codewhale-tui --lib --locked evidence_bounded_preview_is_not_recompacted`
- [x] `cargo test -p codewhale-tui --lib --locked -- --test-threads=1` (10,665 passed, 12 ignored before the final unrelated `main` rebase)
- [x] `cargo clippy -p codewhale-tui --all-targets --all-features --locked -- -D warnings ...` with the documented allow list plus the current baseline-only `nonminimal_bool`, `collapsible_match`, and `overly_complex_bool_expr` allowances

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (not applicable; no harvested/co-authored credit)

No-Issue: reproduced from a downstream fork report; no matching upstream issue exists.
