### PR TITLE
fix(config): resolve owned direct model casing safely

### DIFF
--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -335,6 +335,14 @@ impl RouteResolver {
         // Try to match a catalog offering owned by THIS provider, either by
         // canonical model id or by exact wire id. This keeps interpretation
         // inside provider scope; offerings from other providers are ignored.
+        // DeepSeek and Z.ai also publish marketing-cased wire ids while saved
+        // selectors can be lowercase. Defer that fallback until exact matching
+        // is exhausted, and only accept a unique provider-owned match so
+        // catalog order can never choose between case-distinct model ids.
+        let allow_casefold_wire_match = class == ProviderClass::StrictDirect
+            && matches!(provider_kind, ProviderKind::Deepseek | ProviderKind::Zai);
+        let mut casefold_match = None;
+        let mut casefold_ambiguous = false;
         for offering in &self.offerings {
             if offering.provider != *provider_id {
                 continue;
@@ -347,6 +355,18 @@ impl RouteResolver {
             if matches_canonical || matches_wire {
                 return Ok(ResolvedOffering::from_offering(offering));
             }
+            if allow_casefold_wire_match
+                && offering.wire_model_id.as_str().eq_ignore_ascii_case(raw)
+            {
+                if casefold_match.is_some() {
+                    casefold_ambiguous = true;
+                } else {
+                    casefold_match = Some(offering);
+                }
+            }
+        }
+        if !casefold_ambiguous && let Some(offering) = casefold_match {
+            return Ok(ResolvedOffering::from_offering(offering));
         }
 
         // No catalog match. Apply class-specific pass-through rules.

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -626,6 +626,81 @@ fn resolver_strict_direct_rejects_clearly_foreign_selector() {
 }
 
 #[test]
+fn resolver_direct_owned_row_match_survives_casing_mismatch() {
+    let r = RouteResolver::new();
+    let out = r
+        .resolve(&req(Some(ProviderKind::Zai), Some("glm-5.2")))
+        .expect("lowercase selector on the owning Z.ai row must resolve");
+    assert_eq!(out.provider_kind(), ProviderKind::Zai);
+    assert_eq!(out.wire_model_id().as_str(), "GLM-5.2");
+    assert!(out.limits().has_known_limit());
+
+    let saved = RouteRequest {
+        saved_provider_model: Some(WireModelId::from("glm-5.2")),
+        ..req(Some(ProviderKind::Zai), None)
+    };
+    let out = r
+        .resolve(&saved)
+        .expect("saved lowercase Z.ai model must resolve");
+    assert_eq!(out.wire_model_id().as_str(), "GLM-5.2");
+
+    let out = r
+        .resolve(&req(Some(ProviderKind::Deepseek), Some("Deepseek-V4-Pro")))
+        .expect("DeepSeek's own casing variant must resolve");
+    assert_eq!(out.provider_kind(), ProviderKind::Deepseek);
+    assert_eq!(out.wire_model_id().as_str(), "deepseek-v4-pro");
+
+    let custom = RouteRequest {
+        explicit_provider: Some(ProviderKind::Zai),
+        model_selector: Some(LogicalModelRef::from("glm-5.2")),
+        saved_provider_model: None,
+        base_url_override: Some("https://compatible.example.test/v1".to_string()),
+        limit_overrides: Vec::new(),
+    };
+    let out = r
+        .resolve(&custom)
+        .expect("custom endpoint keeps model pass-through semantics");
+    assert_eq!(out.wire_model_id().as_str(), "glm-5.2");
+    assert!(!out.limits().has_known_limit());
+}
+
+#[test]
+fn resolver_direct_casefold_match_requires_one_owned_row() {
+    let raw = r#"{
+      "providers": {
+        "zai": {
+          "models": {
+            "CaseModel": {
+              "id": "CaseModel",
+              "modalities": { "input": ["text"], "output": ["text"] },
+              "limit": { "context": 1000 }
+            },
+            "casemodel": {
+              "id": "casemodel",
+              "modalities": { "input": ["text"], "output": ["text"] },
+              "limit": { "context": 2000 }
+            }
+          }
+        }
+      }
+    }"#;
+    let catalog = ModelsDevCatalog::parse_json(raw).expect("Models.dev fixture parses");
+    let offerings = catalog
+        .provider_offerings("zai")
+        .expect("Z.ai provider offerings");
+    let r = RouteResolver::from_offerings(offerings);
+
+    let out = r
+        .resolve(&req(Some(ProviderKind::Zai), Some("CASEMODEL")))
+        .expect("ambiguous casefold stays an unknown direct model");
+    assert_eq!(out.wire_model_id().as_str(), "CASEMODEL");
+    assert!(
+        !out.limits().has_known_limit(),
+        "ambiguous rows must not lend arbitrary catalog metadata"
+    );
+}
+
+#[test]
 fn resolver_strict_direct_rejects_other_provider_known_bare_offering() {
     let r = RouteResolver::new();
     let out = r.resolve(&req(Some(ProviderKind::Zai), Some("deepseek-v4-pro")));


### PR DESCRIPTION
## Summary

- resolve lowercase saved selectors such as `glm-5.2` against the owning Z.ai catalog row before another provider's identical bare wire id can classify them as foreign
- keep exact matches authoritative and allow the DeepSeek/Z.ai case-fold fallback only when exactly one provider-owned wire row matches
- preserve unknown-model pass-through for ambiguous rows and custom endpoints, without borrowing arbitrary catalog limits or capabilities

This was reproduced in downstream [Pinvou/CodeWhale#14](https://github.com/Pinvou/CodeWhale/pull/14): Z.ai advertises `GLM-5.2`, while a saved lowercase selector collided with Model Studio's bare `glm-5.2` offering.

Diagnosis and the initial provider-scoped fix were contributed by @asto18089 in that downstream PR.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [ ] `cargo test --workspace --all-features --locked`
- [x] `cargo test -p codewhale-config --all-targets --all-features --locked` (563 passed)
- [x] `cargo clippy -p codewhale-config --all-targets --all-features --locked -- -D warnings`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

No-Issue: reproduced from downstream Pinvou/CodeWhale#14; no matching upstream issue or pull request exists.
