### PR TITLE
release: 0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS CI: the `agent_focus_pty` auto-review receipt test waited on a
   worker that had already completed and raced the rail's focus; it now holds
   the child's wrap-up and waits for a settled live row (refs #5056, #5403).
+- SSE UTF-8 split across HTTP/2 DATA frames now fails closed in every
+  streaming dialect: a shared strict decoder, tail flush, and
+  `decode_failed` propagation (`InvalidSseUtf8`) replace the per-dialect
+  approximations, with byte-chunk decoder tests (#5374; supersedes draft
+  #5404).
 - CI: the release workflows no longer restore npm/cargo caches after
   checking out a caller-supplied SHA — the CodeQL cache-poisoning Highs
   #88–#107 are closed with a contract test over the workflow files (#5463).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference for agents/workflows/plugins/skills
   (docs/design/CLAUDE_CODE_PARITY.md); config.example.toml / SUBAGENTS.md /
   TOOL_LIFECYCLE.md brought back in line with the code (#5447).
+- `dsh` integration: the Codewhale palette is applied through the bundle
+  profile via dsh's documented `overrideTokens` (on by default;
+  `codewhale integrations dsh update --skin false` turns it off), replacing
+  the 0.9.8 exported-CSS skin that dsh's inline body variables overrode
+  (docs/design/DSH_BUNDLE_SKIN.md, docs/INTEGRATIONS_DSH.md) (#5469).
 - Fleet: agent shadowing is visible — a roster-row badge, a Layers block in
   agent detail, and a `doctor` "Fleet roster layers" section (JSON
   `operate_fleet.roster.multi_layer`), in all 15 TUI locales. Layer collapse
@@ -149,6 +154,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rule and maps the Auto-Review guardian acceptance items to the engine
   journeys that exercise them (#5361).
 - Dependencies: ratatui 0.30.2, thiserror 2.0.20.
+
+### Removed
+
+- `dsh` integration: the exported-CSS skin file and its "skin export" status
+  line (superseded by the bundle-applied `overrideTokens` skin, #5469).
 
 ## [0.9.8] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference for agents/workflows/plugins/skills
   (docs/design/CLAUDE_CODE_PARITY.md); config.example.toml / SUBAGENTS.md /
   TOOL_LIFECYCLE.md brought back in line with the code (#5447).
+- Fleet: agent shadowing is visible — a roster-row badge, a Layers block in
+  agent detail, and a `doctor` "Fleet roster layers" section (JSON
+  `operate_fleet.roster.multi_layer`), in all 15 TUI locales. Layer collapse
+  and `[fleet.profiles]` migration stay for 0.9.10 (#5098).
 - Sandbox: bwrap containers get the `--dev/--proc/--tmpfs` essentials plus
   configurable extra roots (`bwrap_ro_roots` / `bwrap_dev_roots`) so
   toolchains that live outside the workspace stay reachable read-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.9] - 2026-08-17
+
 ### Fixed
 
 - A concrete route/offering output limit now outranks the conservative
@@ -37,8 +39,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `codewhale config get telemetry` reports the resolved consent with its
   source instead of `key not found` on a machine whose batches ship. Truth
   change only; resolution and behavior are untouched.
+- Fleet: a scout's read-only shell carve-out (#5428) is now honored by both
+  the posture gate and the execution envelope, so `git log`, `find | head`,
+  `npm view` and the other bounded read-only commands run in-place instead
+  of being refused as "Executes" (#5426). Delegation still never widens
+  authority: the role-isolation test and docs/SUBAGENTS.md pin that a child
+  cannot exceed its parent's posture (#5426, #5435).
+- `/rename` and `/title` now apply mid-first-turn: the session file does
+  not exist until the first autosave, so the rename fell through with
+  NotFound; the shared path now prefers the per-session checkpoint and
+  rebuilds from App state, with a PTY regression test through the live
+  event loop (#5430).
+- `integrations dsh plan` no longer refuses DeepSeek's default
+  Responses-dialect route (`deepseek-v4-flash`); Responses and
+  Anthropic-Messages routes are carried through pi-ai
+  `openai-responses` / `anthropic-messages` instead of being approximated
+  or refused; only credentialed base URLs are still refused, with an error
+  that names provider and model (#5434).
+- Session cost no longer sits at `unverified_live_pricing` when live pricing
+  cannot be verified (control-plane 503, Models.dev capabilities-only
+  overlays): provider-docs bundled fallback rates for the DeepSeek V4
+  family on Fireworks / OpenCode Zen restore a usable figure, live
+  per-provider rows still win, and `kimi-k3` stays unpriced until a
+  published rate exists (#5241; harvested from #5402).
+- Release assets: `release.yml` asset-freshness checks compare against the
+  release job's own `started_at`, so job-level reruns of the npm step are no
+  longer poisoned by earlier uploads (#5429).
+- macOS CI: the `agent_focus_pty` auto-review receipt test waited on a
+  worker that had already completed and raced the rail's focus; it now holds
+  the child's wrap-up and waits for a settled live row (refs #5056, #5403).
 
 ### Changed
+
 
 - The model-facing `agent` tool advertises exactly 12 fields — `action`,
   `prompt`, `type`, `profile`, `name`, `agent_id`, `message`, `until`,
@@ -66,6 +98,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ultrawide terminals. `0` or absent keeps the full width; negative or
   non-integer values are rejected with a clear config error. Tool, diff,
   and status cells never inherit the cap (#5436).
+- Localization: README translations for Français, Deutsch, 繁體中文, हिन्दी,
+  Türkçe, Italiano, Polski, العربية and Català join the existing nine
+  (#5451); codewhale.net routes fr, de, ca, hi, tr, it, pl and ar (with
+  `dir="rtl"` plumbing) as partial locales (#5453).
+- Docs: README Integrations section (incl. the DeepSeek Harness `dsh` plugin
+  path, docs/INTEGRATIONS_DSH.md) localized across all READMEs; RFC keeping
+  the deterministic-first auto-review hybrid (#5427); Claude Code parity
+  reference for agents/workflows/plugins/skills
+  (docs/design/CLAUDE_CODE_PARITY.md); config.example.toml / SUBAGENTS.md /
+  TOOL_LIFECYCLE.md brought back in line with the code (#5447).
+- Dependencies: ratatui 0.30.2, thiserror 2.0.20.
 
 ## [0.9.8] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS CI: the `agent_focus_pty` auto-review receipt test waited on a
   worker that had already completed and raced the rail's focus; it now holds
   the child's wrap-up and waits for a settled live row (refs #5056, #5403).
+- DeepSeek V4 pricing follows the published peak/off-peak tiers (peak
+  01:00–04:00 and 06:00–10:00 UTC; off-peak is half of peak) for
+  `deepseek-v4-flash` and `deepseek-v4-pro` in USD and CNY, resolved from
+  each turn's recorded time; the stale single-tier rows understated cost up
+  to ~4×. Because every direct DeepSeek first-party rate is now
+  time-windowed, the scorecard fails closed (`missing_recorded_time`) on an
+  undated DeepSeek turn instead of guessing a tier (#5470; #5241 follow-up,
+  verified against api-docs.deepseek.com on 2026-08-17).
 - SSE UTF-8 split across HTTP/2 DATA frames now fails closed in every
   streaming dialect: a shared strict decoder, tail flush, and
   `decode_failed` propagation (`InvalidSseUtf8`) replace the per-dialect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The lowercase `bash` tool no longer wedges when its complete-output spill
+  file cannot be created: a full temp volume or exhausted descriptor table
+  used to fail *every* call — `echo ok` included — with the harness-internal
+  "Failed to create streaming shell output" and never recover until the
+  host was cleaned up. The spill is now best-effort (the bounded tail is
+  still returned and the truncation notice says why the full-output path is
+  missing), and any remaining spawn/stream failure names the exhausted
+  resource — disk, file descriptors, memory — and says the next call is safe
+  to retry (#5465; the wedge that took out the owner's own 0.9.9 session).
 - A concrete route/offering output limit now outranks the conservative
   8,192-token compatibility guess for an uncatalogued model. Routes that
   publish no output limit remain fail-closed, documented model ceilings stay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6046,7 +6046,8 @@ overflow report and `/theme` picker edge-wrapping patch in #1814.
 
 Older releases (v0.8.39 and earlier) are archived in [docs/CHANGELOG_ARCHIVE.md](docs/CHANGELOG_ARCHIVE.md).
 
-[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.9.7...HEAD
+[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.9.9...HEAD
+[0.9.9]: https://github.com/Hmbown/CodeWhale/compare/v0.9.8...v0.9.9
 [0.9.8]: https://github.com/Hmbown/CodeWhale/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/Hmbown/CodeWhale/compare/v0.9.6...v0.9.7
 [0.9.6]: https://github.com/Hmbown/CodeWhale/compare/v0.9.5...v0.9.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.9] - 2026-08-17
 
+Codewhale v0.9.9 is a truth-and-resilience release: the shell tool can no
+longer wedge a session when the host runs out of disk or descriptors,
+unverified context windows and output ceilings are labeled honestly at every
+surface, DeepSeek V4 is priced on the published peak/off-peak tiers, SSE
+UTF-8 fails closed in every dialect, Fleet shadowing is visible, bwrap gets
+container essentials and extra roots, the `dsh` skin rides the bundle
+profile, the `agent` tool schema is down to 12 fields, and README/website
+locales grow to 18 and 8.
+
 ### Fixed
 
 - The lowercase `bash` tool no longer wedges when its complete-output spill
@@ -159,6 +168,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `dsh` integration: the exported-CSS skin file and its "skin export" status
   line (superseded by the bundle-applied `overrideTokens` skin, #5469).
+
+### Contributors
+
+- hexin (@h3c-hexin) — a concrete route/offering output limit outranks the
+  8,192-token compatibility guess for an uncatalogued model (#5461, closes
+  #5460).
+- Reports and reproductions that shaped this release: @hardy922 (context-
+  window honesty, #5239), @redstar (bwrap extra roots, #5410), @all-lopezg
+  (SSE UTF-8 garbling on DeepSeek Flash, #5374), @alitvak69 (unverified live
+  pricing, #5241), and @wuisabel-gif (the macOS filtered-suite hang
+  investigation on #5056).
 
 ## [0.9.8] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS CI: the `agent_focus_pty` auto-review receipt test waited on a
   worker that had already completed and raced the rail's focus; it now holds
   the child's wrap-up and waits for a settled live row (refs #5056, #5403).
+- CI: the release workflows no longer restore npm/cargo caches after
+  checking out a caller-supplied SHA — the CodeQL cache-poisoning Highs
+  #88–#107 are closed with a contract test over the workflow files (#5463).
 
 ### Changed
 
@@ -108,6 +111,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference for agents/workflows/plugins/skills
   (docs/design/CLAUDE_CODE_PARITY.md); config.example.toml / SUBAGENTS.md /
   TOOL_LIFECYCLE.md brought back in line with the code (#5447).
+- Sandbox: bwrap containers get the `--dev/--proc/--tmpfs` essentials plus
+  configurable extra roots (`bwrap_ro_roots` / `bwrap_dev_roots`) so
+  toolchains that live outside the workspace stay reachable read-only
+  (#5410).
+- Tests: `crates/tui/tests/README.md` states the keyless assembled-journey
+  rule and maps the Auto-Review guardian acceptance items to the engine
+  journeys that exercise them (#5361).
 - Dependencies: ratatui 0.30.2, thiserror 2.0.20.
 
 ## [0.9.8] - 2026-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `decode_failed` propagation (`InvalidSseUtf8`) replace the per-dialect
   approximations, with byte-chunk decoder tests (#5374; supersedes draft
   #5404).
+- CI: `release_four_read_only_fleet_roles_launch_with_canonical_prompts`
+  answered Fleet children with SSE while they call the blocking JSON path;
+  the parse failure was retried and double-counted the worker on slow macOS
+  runners (#5471; refs #5056).
 - CI: the release workflows no longer restore npm/cargo caches after
   checking out a caller-supplied SHA — the CodeQL cache-poisoning Highs
   #88–#107 are closed with a contract test over the workflow files (#5463).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-agent"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "codewhale-config",
  "serde",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-app-server"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -793,11 +793,11 @@ dependencies = [
 
 [[package]]
 name = "codewhale-build-support"
-version = "0.9.8"
+version = "0.9.9"
 
 [[package]]
 name = "codewhale-cli"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,14 +837,14 @@ dependencies = [
 
 [[package]]
 name = "codewhale-command-contract"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "codewhale-core",
 ]
 
 [[package]]
 name = "codewhale-config"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "codewhale-execpolicy",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-core"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-execpolicy"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "codewhale-protocol",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-hooks"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-lane"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-mcp"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "serde",
@@ -939,14 +939,14 @@ dependencies = [
 
 [[package]]
 name = "codewhale-paths"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "codewhale-protocol"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "chrono",
  "serde",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-release"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-secrets"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "chrono",
  "codewhale-paths",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-state"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-telemetry"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tools"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tui"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-workflow"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-workflow-js"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.8"
+version = "0.9.9"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -8,5 +8,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for Codewhale"
 
 [dependencies]
-codewhale-config = { path = "../config", version = "0.9.8" }
+codewhale-config = { path = "../config", version = "0.9.9" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -12,16 +12,16 @@ autobins = false
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true
-codewhale-agent = { path = "../agent", version = "0.9.8" }
-codewhale-config = { path = "../config", version = "0.9.8" }
-codewhale-core = { path = "../core", version = "0.9.8" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.9.8" }
-codewhale-hooks = { path = "../hooks", version = "0.9.8" }
-codewhale-mcp = { path = "../mcp", version = "0.9.8" }
-codewhale-protocol = { path = "../protocol", version = "0.9.8" }
-codewhale-release = { path = "../release", version = "0.9.8" }
-codewhale-state = { path = "../state", version = "0.9.8" }
-codewhale-tools = { path = "../tools", version = "0.9.8" }
+codewhale-agent = { path = "../agent", version = "0.9.9" }
+codewhale-config = { path = "../config", version = "0.9.9" }
+codewhale-core = { path = "../core", version = "0.9.9" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.9.9" }
+codewhale-hooks = { path = "../hooks", version = "0.9.9" }
+codewhale-mcp = { path = "../mcp", version = "0.9.9" }
+codewhale-protocol = { path = "../protocol", version = "0.9.9" }
+codewhale-release = { path = "../release", version = "0.9.9" }
+codewhale-state = { path = "../state", version = "0.9.9" }
+codewhale-tools = { path = "../tools", version = "0.9.9" }
 serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,19 +15,19 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-codewhale-tui = { path = "../tui", version = "0.9.8" }
-codewhale-agent = { path = "../agent", version = "0.9.8" }
-codewhale-app-server = { path = "../app-server", version = "0.9.8" }
-codewhale-config = { path = "../config", version = "0.9.8" }
-codewhale-lane = { path = "../lane", version = "0.9.8" }
-codewhale-workflow = { path = "../workflow", version = "0.9.8" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.9.8" }
-codewhale-mcp = { path = "../mcp", version = "0.9.8" }
-codewhale-paths = { path = "../paths", version = "0.9.8" }
-codewhale-release = { path = "../release", version = "0.9.8" }
-codewhale-secrets = { path = "../secrets", version = "0.9.8" }
-codewhale-state = { path = "../state", version = "0.9.8" }
-codewhale-telemetry = { path = "../telemetry", version = "0.9.8" }
+codewhale-tui = { path = "../tui", version = "0.9.9" }
+codewhale-agent = { path = "../agent", version = "0.9.9" }
+codewhale-app-server = { path = "../app-server", version = "0.9.9" }
+codewhale-config = { path = "../config", version = "0.9.9" }
+codewhale-lane = { path = "../lane", version = "0.9.9" }
+codewhale-workflow = { path = "../workflow", version = "0.9.9" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.9.9" }
+codewhale-mcp = { path = "../mcp", version = "0.9.9" }
+codewhale-paths = { path = "../paths", version = "0.9.9" }
+codewhale-release = { path = "../release", version = "0.9.9" }
+codewhale-secrets = { path = "../secrets", version = "0.9.9" }
+codewhale-state = { path = "../state", version = "0.9.9" }
+codewhale-telemetry = { path = "../telemetry", version = "0.9.9" }
 chrono.workspace = true
 console = "0.16.3"
 dirs.workspace = true
@@ -45,7 +45,7 @@ webbrowser = "1.0"
 zeroize = "1.8.2"
 
 [build-dependencies]
-codewhale-build-support = { path = "../build-support", version = "0.9.8" }
+codewhale-build-support = { path = "../build-support", version = "0.9.9" }
 
 # Parent-death cleanup for delegated server children (#3259): on Linux the
 # dispatcher sets PR_SET_PDEATHSIG so the child is signalled if the dispatcher

--- a/crates/command-contract/Cargo.toml
+++ b/crates/command-contract/Cargo.toml
@@ -8,4 +8,4 @@ repository.workspace = true
 description = "Prototype command capability and dispatch shapes for the staged TUI command extraction"
 
 [dependencies]
-codewhale-core = { path = "../core", version = "0.9.8" }
+codewhale-core = { path = "../core", version = "0.9.9" }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -9,9 +9,9 @@ description = "Config schema and precedence model for Codewhale"
 
 [dependencies]
 anyhow.workspace = true
-codewhale-execpolicy = { path = "../execpolicy", version = "0.9.8" }
-codewhale-paths = { path = "../paths", version = "0.9.8" }
-codewhale-secrets = { path = "../secrets", version = "0.9.8" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.9.9" }
+codewhale-paths = { path = "../paths", version = "0.9.9" }
+codewhale-secrets = { path = "../secrets", version = "0.9.9" }
 fd-lock = "4.0.4"
 libc = "0.2"
 serde.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,14 +13,14 @@ chrono.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio-util.workspace = true
-codewhale-agent = { path = "../agent", version = "0.9.8" }
-codewhale-config = { path = "../config", version = "0.9.8" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.9.8" }
-codewhale-hooks = { path = "../hooks", version = "0.9.8" }
-codewhale-mcp = { path = "../mcp", version = "0.9.8" }
-codewhale-protocol = { path = "../protocol", version = "0.9.8" }
-codewhale-state = { path = "../state", version = "0.9.8" }
-codewhale-tools = { path = "../tools", version = "0.9.8" }
+codewhale-agent = { path = "../agent", version = "0.9.9" }
+codewhale-config = { path = "../config", version = "0.9.9" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.9.9" }
+codewhale-hooks = { path = "../hooks", version = "0.9.9" }
+codewhale-mcp = { path = "../mcp", version = "0.9.9" }
+codewhale-protocol = { path = "../protocol", version = "0.9.9" }
+codewhale-state = { path = "../state", version = "0.9.9" }
+codewhale-tools = { path = "../tools", version = "0.9.9" }
 regex = "1.11"
 serde_json = { workspace = true, features = ["preserve_order"] }
 tokio = { workspace = true, features = ["time"] }

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -9,5 +9,5 @@ description = "Execution policy and approval model for Codewhale"
 
 [dependencies]
 anyhow.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.9.8" }
+codewhale-protocol = { path = "../protocol", version = "0.9.9" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -11,8 +11,8 @@ description = "Hook dispatch and notifications support for Codewhale"
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.9.8" }
-codewhale-release = { path = "../release", version = "0.9.8" }
+codewhale-protocol = { path = "../protocol", version = "0.9.9" }
+codewhale-release = { path = "../release", version = "0.9.9" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/lane/Cargo.toml
+++ b/crates/lane/Cargo.toml
@@ -10,7 +10,7 @@ description = "Lane registry and Runtime backends for Codewhale workflow instanc
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-config = { path = "../config", version = "0.9.8" }
+codewhale-config = { path = "../config", version = "0.9.9" }
 fd-lock = "4.0.4"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "Secret storage backends for Codewhale, with OS keyring and file fallback"
 
 [dependencies]
-codewhale-paths = { path = "../paths", version = "0.9.8" }
+codewhale-paths = { path = "../paths", version = "0.9.9" }
 chrono.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -10,8 +10,8 @@ description = "Session/thread persistence and recovery model for Codewhale"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-paths = { path = "../paths", version = "0.9.8" }
-codewhale-protocol = { path = "../protocol", version = "0.9.8" }
+codewhale-paths = { path = "../paths", version = "0.9.9" }
+codewhale-protocol = { path = "../protocol", version = "0.9.9" }
 fd-lock = "4.0.4"
 rusqlite.workspace = true
 serde.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -10,9 +10,9 @@ description = "Anonymous, user-disableable product usage counting for Codewhale"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-config = { path = "../config", version = "0.9.8" }
-codewhale-paths = { path = "../paths", version = "0.9.8" }
-codewhale-release = { path = "../release", version = "0.9.8" }
+codewhale-config = { path = "../config", version = "0.9.9" }
+codewhale-paths = { path = "../paths", version = "0.9.9" }
+codewhale-release = { path = "../release", version = "0.9.9" }
 fd-lock = "4.0.4"
 reqwest = { workspace = true, features = ["blocking"] }
 serde.workspace = true
@@ -22,9 +22,9 @@ tracing.workspace = true
 uuid.workspace = true
 
 [build-dependencies]
-codewhale-build-support = { path = "../build-support", version = "0.9.8" }
+codewhale-build-support = { path = "../build-support", version = "0.9.9" }
 
 [dev-dependencies]
 # Used as an *assertion*, never as a filter: every string leaf of a serialized
 # batch is run through `redact_for_disclosure` and must come back unredacted.
-codewhale-workflow = { path = "../workflow", version = "0.9.8" }
+codewhale-workflow = { path = "../workflow", version = "0.9.9" }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -10,7 +10,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.9.8" }
+codewhale-protocol = { path = "../protocol", version = "0.9.9" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -68,6 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS CI: the `agent_focus_pty` auto-review receipt test waited on a
   worker that had already completed and raced the rail's focus; it now holds
   the child's wrap-up and waits for a settled live row (refs #5056, #5403).
+- SSE UTF-8 split across HTTP/2 DATA frames now fails closed in every
+  streaming dialect: a shared strict decoder, tail flush, and
+  `decode_failed` propagation (`InvalidSseUtf8`) replace the per-dialect
+  approximations, with byte-chunk decoder tests (#5374; supersedes draft
+  #5404).
 - CI: the release workflows no longer restore npm/cargo caches after
   checking out a caller-supplied SHA — the CodeQL cache-poisoning Highs
   #88–#107 are closed with a contract test over the workflow files (#5463).

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -137,6 +137,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference for agents/workflows/plugins/skills
   (docs/design/CLAUDE_CODE_PARITY.md); config.example.toml / SUBAGENTS.md /
   TOOL_LIFECYCLE.md brought back in line with the code (#5447).
+- `dsh` integration: the Codewhale palette is applied through the bundle
+  profile via dsh's documented `overrideTokens` (on by default;
+  `codewhale integrations dsh update --skin false` turns it off), replacing
+  the 0.9.8 exported-CSS skin that dsh's inline body variables overrode
+  (docs/design/DSH_BUNDLE_SKIN.md, docs/INTEGRATIONS_DSH.md) (#5469).
 - Fleet: agent shadowing is visible — a roster-row badge, a Layers block in
   agent detail, and a `doctor` "Fleet roster layers" section (JSON
   `operate_fleet.roster.multi_layer`), in all 15 TUI locales. Layer collapse
@@ -149,6 +154,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rule and maps the Auto-Review guardian acceptance items to the engine
   journeys that exercise them (#5361).
 - Dependencies: ratatui 0.30.2, thiserror 2.0.20.
+
+### Removed
+
+- `dsh` integration: the exported-CSS skin file and its "skin export" status
+  line (superseded by the bundle-applied `overrideTokens` skin, #5469).
 
 ## [0.9.8] - 2026-08-16
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -116,6 +116,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference for agents/workflows/plugins/skills
   (docs/design/CLAUDE_CODE_PARITY.md); config.example.toml / SUBAGENTS.md /
   TOOL_LIFECYCLE.md brought back in line with the code (#5447).
+- Fleet: agent shadowing is visible — a roster-row badge, a Layers block in
+  agent detail, and a `doctor` "Fleet roster layers" section (JSON
+  `operate_fleet.roster.multi_layer`), in all 15 TUI locales. Layer collapse
+  and `[fleet.profiles]` migration stay for 0.9.10 (#5098).
 - Sandbox: bwrap containers get the `--dev/--proc/--tmpfs` essentials plus
   configurable extra roots (`bwrap_ro_roots` / `bwrap_dev_roots`) so
   toolchains that live outside the workspace stay reachable read-only

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -77,6 +77,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS CI: the `agent_focus_pty` auto-review receipt test waited on a
   worker that had already completed and raced the rail's focus; it now holds
   the child's wrap-up and waits for a settled live row (refs #5056, #5403).
+- DeepSeek V4 pricing follows the published peak/off-peak tiers (peak
+  01:00–04:00 and 06:00–10:00 UTC; off-peak is half of peak) for
+  `deepseek-v4-flash` and `deepseek-v4-pro` in USD and CNY, resolved from
+  each turn's recorded time; the stale single-tier rows understated cost up
+  to ~4×. Because every direct DeepSeek first-party rate is now
+  time-windowed, the scorecard fails closed (`missing_recorded_time`) on an
+  undated DeepSeek turn instead of guessing a tier (#5470; #5241 follow-up,
+  verified against api-docs.deepseek.com on 2026-08-17).
 - SSE UTF-8 split across HTTP/2 DATA frames now fails closed in every
   streaming dialect: a shared strict decoder, tail flush, and
   `decode_failed` propagation (`InvalidSseUtf8`) replace the per-dialect

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The lowercase `bash` tool no longer wedges when its complete-output spill
+  file cannot be created: a full temp volume or exhausted descriptor table
+  used to fail *every* call — `echo ok` included — with the harness-internal
+  "Failed to create streaming shell output" and never recover until the
+  host was cleaned up. The spill is now best-effort (the bounded tail is
+  still returned and the truncation notice says why the full-output path is
+  missing), and any remaining spawn/stream failure names the exhausted
+  resource — disk, file descriptors, memory — and says the next call is safe
+  to retry (#5465; the wedge that took out the owner's own 0.9.9 session).
 - A concrete route/offering output limit now outranks the conservative
   8,192-token compatibility guess for an uncatalogued model. Routes that
   publish no output limit remain fail-closed, documented model ceilings stay

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.9] - 2026-08-17
+
 ### Fixed
 
 - A concrete route/offering output limit now outranks the conservative
@@ -37,8 +39,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `codewhale config get telemetry` reports the resolved consent with its
   source instead of `key not found` on a machine whose batches ship. Truth
   change only; resolution and behavior are untouched.
+- Fleet: a scout's read-only shell carve-out (#5428) is now honored by both
+  the posture gate and the execution envelope, so `git log`, `find | head`,
+  `npm view` and the other bounded read-only commands run in-place instead
+  of being refused as "Executes" (#5426). Delegation still never widens
+  authority: the role-isolation test and docs/SUBAGENTS.md pin that a child
+  cannot exceed its parent's posture (#5426, #5435).
+- `/rename` and `/title` now apply mid-first-turn: the session file does
+  not exist until the first autosave, so the rename fell through with
+  NotFound; the shared path now prefers the per-session checkpoint and
+  rebuilds from App state, with a PTY regression test through the live
+  event loop (#5430).
+- `integrations dsh plan` no longer refuses DeepSeek's default
+  Responses-dialect route (`deepseek-v4-flash`); Responses and
+  Anthropic-Messages routes are carried through pi-ai
+  `openai-responses` / `anthropic-messages` instead of being approximated
+  or refused; only credentialed base URLs are still refused, with an error
+  that names provider and model (#5434).
+- Session cost no longer sits at `unverified_live_pricing` when live pricing
+  cannot be verified (control-plane 503, Models.dev capabilities-only
+  overlays): provider-docs bundled fallback rates for the DeepSeek V4
+  family on Fireworks / OpenCode Zen restore a usable figure, live
+  per-provider rows still win, and `kimi-k3` stays unpriced until a
+  published rate exists (#5241; harvested from #5402).
+- Release assets: `release.yml` asset-freshness checks compare against the
+  release job's own `started_at`, so job-level reruns of the npm step are no
+  longer poisoned by earlier uploads (#5429).
+- macOS CI: the `agent_focus_pty` auto-review receipt test waited on a
+  worker that had already completed and raced the rail's focus; it now holds
+  the child's wrap-up and waits for a settled live row (refs #5056, #5403).
 
 ### Changed
+
 
 - The model-facing `agent` tool advertises exactly 12 fields — `action`,
   `prompt`, `type`, `profile`, `name`, `agent_id`, `message`, `until`,
@@ -66,6 +98,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ultrawide terminals. `0` or absent keeps the full width; negative or
   non-integer values are rejected with a clear config error. Tool, diff,
   and status cells never inherit the cap (#5436).
+- Localization: README translations for Français, Deutsch, 繁體中文, हिन्दी,
+  Türkçe, Italiano, Polski, العربية and Català join the existing nine
+  (#5451); codewhale.net routes fr, de, ca, hi, tr, it, pl and ar (with
+  `dir="rtl"` plumbing) as partial locales (#5453).
+- Docs: README Integrations section (incl. the DeepSeek Harness `dsh` plugin
+  path, docs/INTEGRATIONS_DSH.md) localized across all READMEs; RFC keeping
+  the deterministic-first auto-review hybrid (#5427); Claude Code parity
+  reference for agents/workflows/plugins/skills
+  (docs/design/CLAUDE_CODE_PARITY.md); config.example.toml / SUBAGENTS.md /
+  TOOL_LIFECYCLE.md brought back in line with the code (#5447).
+- Dependencies: ratatui 0.30.2, thiserror 2.0.20.
 
 ## [0.9.8] - 2026-08-16
 
@@ -3704,96 +3747,6 @@ reproductions shaped v0.9.0:
 - **Public release surface cleanup.** Benchmark-specific materials were kept
   out of the public release repo; benchmark source fragments belong in the
   separate `codewhale-bench` lane.
-
-## [0.8.63] - 2026-06-19
-
-### Added
-
-- **Sub-agent fanout safeguards (#3318, #3319).** High-fanout Workflow runs can
-  now queue and drain more agents than the instantaneous concurrency cap by
-  default, with `[subagents] max_admitted` available to tune that bounded
-  admission population. Distinct `agent` calls are no longer capped by the
-  per-turn loop guard before runtime launch concurrency and provider
-  rate-limit backoff can apply. `[subagents] token_budget` applies a shared
-  aggregate token ceiling to a root `agent` run and its descendants.
-- **Per-worker sub-agent token enforcement (#3321).** A `token_budget` /
-  `max_tokens` set on an individual `agent` call now bounds that single worker
-  mid-run: once its accumulated model tokens exceed the cap it stops cleanly
-  with a `budget_exhausted` status instead of running to `max_steps`. This
-  complements the scope-level admission gate (#3319) — the per-worker cap stops
-  one runaway worker, the scope cap bounds total fan-out — without
-  double-counting. Harvested from #3321 by @donglovejava.
-- **Provider-specific sub-agent fanout config.** `[subagents.providers.<provider>]`
-  profiles now override `enabled`, `max_concurrent`, `max_admitted`,
-  `launch_concurrency`, `max_depth`, token budget, API timeout, and heartbeat
-  timeout for the active provider. Use broad direct-API profiles such as
-  `[subagents.providers.deepseek]` and tighter subscription profiles such as
-  `[subagents.providers.glm]`; `/config subagents status` shows both global
-  and active-provider resolved values.
-- **Sub-agent control and isolation.** The single `agent` tool now exposes
-  status, peek, and cancel actions for running children, and accepts
-  `worktree: true` to create an isolated git worktree/branch for parallel edit
-  lanes instead of requiring callers to hand-roll a `cwd`.
-
-### Fixed
-
-- **Mode and tool catalog correctness.** Core action tools remain discoverable
-  in the model-facing catalog/tool search, and a consistency self-check flags
-  registered handlers that drift out of the advertised catalog. Review-looking
-  prompts in explicit Agent/YOLO mode now keep the requested mode and tools,
-  with only an advisory review hint.
-- **Sub-agent orchestration recovery.** Child agents now retry transient
-  provider header/SSE timeouts before failing, and parent runs synthesize missed
-  child completions from terminal child state so orchestration cannot hang on a
-  lost completion event.
-- **DeepSeek thinking tool calls.** DeepSeek chat-completions requests now omit
-  explicit `tool_choice` whenever reasoning/thinking is enabled, avoiding
-  provider rejections while leaving no-thinking routes unchanged.
-- **Task sidebar shortcuts and attribution.** Ctrl-K stays palette/emacs-kill,
-  while Ctrl-X is scoped to Tasks-sidebar background shell cancellation. Shell
-  jobs launched by sub-agents now render with their child-agent owner in the
-  Tasks sidebar and transcript.
-- **Long-turn recovery and context economy.** Repeated read-only search
-  loop blocks now return guidance instead of fatal tool failures, Python build
-  failures that are missing `setuptools` include an install/retry hint, long
-  foreground shell timeouts steer models toward background execution, and noisy
-  shell/test/web outputs are compacted earlier for large-context routes.
-- **Config display redaction.** `codew config get/list` now recursively masks
-  token-, secret-, password-, credential-, and authorization-like keys inside
-  unknown `extras` tables and redacts sensitive HTTP header values before
-  printing config output.
-- **Queued follow-up hints and force-steer keys.** The pending-input preview now
-  advertises `Ctrl+S send now` whenever queued follow-ups exist, and
-  Ctrl/Cmd+Enter force-steering also accepts the common Ctrl+J terminal
-  encoding while a turn is running.
-- **Sidebar default visibility restored (#3328).** New and upgraded sessions
-  now use a pinned composed sidebar by default when the terminal is wide
-  enough, so live Agents and Tasks surface without opting back into idle
-  auto-collapse. Older settings files that captured the v0.8.62 auto-collapse
-  default now migrate to `pinned` unless `/sidebar auto --save` records an
-  explicit opt-in. `/sidebar` now reports when width or auto-collapse
-  suppresses rendering instead of saying the sidebar is visible. Reported by
-  @dxfq.
-- **JavaScript execution proxy env handling (#3273, #3331).** `js_execution`
-  now enables Node's environment-proxy mode when proxy variables are present,
-  mirrors lowercase proxy variables for the child process, and backfills
-  `HTTP_PROXY` / `HTTPS_PROXY` from `ALL_PROXY`. Reported by @lordwedggie and
-  harvested from #3331 by @cyq1017.
-- **Legacy app-server non-loopback auth hardening (#3258).** Bare
-  `codewhale app-server --host 0.0.0.0` now fails fast unless an explicit
-  `--auth-token` or `CODEWHALE_APP_SERVER_TOKEN` is supplied, keeping generated
-  one-time `cwapp_*` tokens loopback-only.
-- **Legacy `.deepseek` state write-path migration (#3240).** State subdirectories
-  (`sessions`, `slop_ledger`, `trophies`, `catalog`) are now always written under
-  `~/.codewhale/`, and the first write of a subdir relocates any pre-existing
-  `~/.deepseek/<sub>` contents into the primary location so the legacy tree stops
-  growing while old data is preserved. The read resolver still finds legacy data
-  for backfill until each subdir migrates. Reported by @Final527; onboarding
-  marker slice from #3302 by @nightt5879.
-- **State subdir validation on Windows (#3240).** State path hardening now
-  rejects rooted/prefixed subdir strings such as `/etc` before resolving or
-  migrating state directories, keeping the `.codewhale` write resolver inside
-  its state root across platforms.
 
 ---
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.9] - 2026-08-17
 
+Codewhale v0.9.9 is a truth-and-resilience release: the shell tool can no
+longer wedge a session when the host runs out of disk or descriptors,
+unverified context windows and output ceilings are labeled honestly at every
+surface, DeepSeek V4 is priced on the published peak/off-peak tiers, SSE
+UTF-8 fails closed in every dialect, Fleet shadowing is visible, bwrap gets
+container essentials and extra roots, the `dsh` skin rides the bundle
+profile, the `agent` tool schema is down to 12 fields, and README/website
+locales grow to 18 and 8.
+
 ### Fixed
 
 - The lowercase `bash` tool no longer wedges when its complete-output spill
@@ -159,6 +168,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `dsh` integration: the exported-CSS skin file and its "skin export" status
   line (superseded by the bundle-applied `overrideTokens` skin, #5469).
+
+### Contributors
+
+- hexin (@h3c-hexin) — a concrete route/offering output limit outranks the
+  8,192-token compatibility guess for an uncatalogued model (#5461, closes
+  #5460).
+- Reports and reproductions that shaped this release: @hardy922 (context-
+  window honesty, #5239), @redstar (bwrap extra roots, #5410), @all-lopezg
+  (SSE UTF-8 garbling on DeepSeek Flash, #5374), @alitvak69 (unverified live
+  pricing, #5241), and @wuisabel-gif (the macOS filtered-suite hang
+  investigation on #5056).
 
 ## [0.9.8] - 2026-08-16
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS CI: the `agent_focus_pty` auto-review receipt test waited on a
   worker that had already completed and raced the rail's focus; it now holds
   the child's wrap-up and waits for a settled live row (refs #5056, #5403).
+- CI: the release workflows no longer restore npm/cargo caches after
+  checking out a caller-supplied SHA — the CodeQL cache-poisoning Highs
+  #88–#107 are closed with a contract test over the workflow files (#5463).
 
 ### Changed
 
@@ -108,6 +111,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference for agents/workflows/plugins/skills
   (docs/design/CLAUDE_CODE_PARITY.md); config.example.toml / SUBAGENTS.md /
   TOOL_LIFECYCLE.md brought back in line with the code (#5447).
+- Sandbox: bwrap containers get the `--dev/--proc/--tmpfs` essentials plus
+  configurable extra roots (`bwrap_ro_roots` / `bwrap_dev_roots`) so
+  toolchains that live outside the workspace stay reachable read-only
+  (#5410).
+- Tests: `crates/tui/tests/README.md` states the keyless assembled-journey
+  rule and maps the Auto-Review guardian acceptance items to the engine
+  journeys that exercise them (#5361).
 - Dependencies: ratatui 0.30.2, thiserror 2.0.20.
 
 ## [0.9.8] - 2026-08-16

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -73,6 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `decode_failed` propagation (`InvalidSseUtf8`) replace the per-dialect
   approximations, with byte-chunk decoder tests (#5374; supersedes draft
   #5404).
+- CI: `release_four_read_only_fleet_roles_launch_with_canonical_prompts`
+  answered Fleet children with SSE while they call the blocking JSON path;
+  the parse failure was retried and double-counted the worker on slow macOS
+  runners (#5471; refs #5056).
 - CI: the release workflows no longer restore npm/cargo caches after
   checking out a caller-supplied SHA — the CodeQL cache-poisoning Highs
   #88–#107 are closed with a contract test over the workflow files (#5463).

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -27,18 +27,18 @@ path = "src/main.rs"
 [dependencies]
 ahash = "0.8"
 anyhow.workspace = true
-codewhale-config = { path = "../config", version = "0.9.8" }
-codewhale-core = { path = "../core", version = "0.9.8" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.9.8" }
-codewhale-lane = { path = "../lane", version = "0.9.8" }
-codewhale-paths = { path = "../paths", version = "0.9.8" }
-codewhale-protocol = { path = "../protocol", version = "0.9.8" }
-codewhale-release = { path = "../release", version = "0.9.8" }
-codewhale-secrets = { path = "../secrets", version = "0.9.8" }
-codewhale-telemetry = { path = "../telemetry", version = "0.9.8" }
-codewhale-tools = { path = "../tools", version = "0.9.8" }
-codewhale-workflow = { path = "../workflow", version = "0.9.8" }
-codewhale-workflow-js = { path = "../workflow-js", version = "0.9.8" }
+codewhale-config = { path = "../config", version = "0.9.9" }
+codewhale-core = { path = "../core", version = "0.9.9" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.9.9" }
+codewhale-lane = { path = "../lane", version = "0.9.9" }
+codewhale-paths = { path = "../paths", version = "0.9.9" }
+codewhale-protocol = { path = "../protocol", version = "0.9.9" }
+codewhale-release = { path = "../release", version = "0.9.9" }
+codewhale-secrets = { path = "../secrets", version = "0.9.9" }
+codewhale-telemetry = { path = "../telemetry", version = "0.9.9" }
+codewhale-tools = { path = "../tools", version = "0.9.9" }
+codewhale-workflow = { path = "../workflow", version = "0.9.9" }
+codewhale-workflow-js = { path = "../workflow-js", version = "0.9.9" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait.workspace = true
@@ -107,7 +107,7 @@ shell-words = "1.1.1"
 mimalloc.workspace = true
 
 [build-dependencies]
-codewhale-build-support = { path = "../build-support", version = "0.9.8" }
+codewhale-build-support = { path = "../build-support", version = "0.9.9" }
 
 [dev-dependencies]
 cucumber = "0.23.0"

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -28,6 +28,31 @@ notes, and relevant issue/PR comments.
 ## Contributors by time
 
 <details open>
+<summary><strong>v0.9.9 — truth and resilience</strong></summary>
+
+**Merged or adapted contributions**
+
+- **[h3c-hexin](https://github.com/h3c-hexin)** — a concrete route/offering
+  output limit now outranks the conservative 8,192-token compatibility guess
+  for an uncatalogued model; routes that publish no limit stay fail-closed
+  (#5461, closes #5460)
+
+**Reports, reproductions, and verification**
+
+- **[hardy922](https://github.com/hardy922)** — the context-window honesty
+  report that became the every-surface labeling pass (#5239)
+- **[redstar](https://github.com/redstar)** — bwrap container essentials and
+  configurable extra roots (#5410)
+- **[all-lopezg](https://github.com/all-lopezg)** — SSE UTF-8 garbling on
+  DeepSeek Flash with screenshots, fixed fail-closed in every dialect (#5374)
+- **[alitvak69](https://github.com/alitvak69)** — the unverified-live-pricing
+  report behind the bundled fallback rates and DeepSeek V4 tiers (#5241)
+- **[wuisabel-gif](https://github.com/wuisabel-gif)** — bounded reproduction
+  attempts for the macOS filtered-suite hang note on #5056
+
+</details>
+
+<details>
 <summary><strong>v0.9.8 — marketplace, Google, Ollama Cloud</strong></summary>
 
 **Merged or adapted contributions**

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,7 +8,7 @@ If you just want the short version, see the
 [main README](../README.md#install) or
 [简体中文 README](../README.zh-CN.md#安装).
 
-This branch describes the **v0.9.8 source candidate**. Install commands that use
+This branch describes the **v0.9.9 source candidate**. Install commands that use
 `latest` resolve to the latest published package or GitHub Release, which may
 trail the source candidate. A candidate is not a published install until the
 matching package, tag, checksums, and release assets exist.
@@ -28,7 +28,7 @@ verifies them against `codewhale-artifacts-sha256.txt`, installs to
 ## 1. Supported platforms
 
 Published Codewhale releases ship matched `codewhale` and `codew` prebuilt binaries for their supported platform/architecture
-combinations. The table below is the intended v0.9.8 candidate matrix;
+combinations. The table below is the intended v0.9.9 candidate matrix;
 Android/Termux is preview pending real-device QA. Linux ARM64 is available from
 v0.8.8 onward. Linux RISC-V prebuilts are temporarily paused because the locked
 `rquickjs-sys` dependency does not ship `riscv64gc-unknown-linux-gnu` bindings.
@@ -52,7 +52,7 @@ v0.8.8 onward. Linux RISC-V prebuilts are temporarily paused because the locked
   [Build from source](#7-build-from-source) below.
 ³ RISC-V source builds currently need upstream `rquickjs-sys` RISC-V bindings or
   a bindgen-enabled dependency build.
-⁴ The v0.9.8 source-candidate npm wrapper recognizes Android arm64 and resolves
+⁴ The v0.9.9 source-candidate npm wrapper recognizes Android arm64 and resolves
   the matching `codewhale` and `codew` Android assets. npm
   installation works only for a package version whose GitHub Release publishes
   those matching assets. The Android/Termux path remains preview-only until the

--- a/docs/public-surface-facts.json
+++ b/docs/public-surface-facts.json
@@ -221,10 +221,10 @@
       "web/lib/release-credits.ts"
     ],
     "requiredCandidateCredits": [
-      "@EvanProgramming",
-      "@Lstarsky0",
-      "@mvanhorn",
-      "@buiducnhat"
+      "@h3c-hexin",
+      "@hardy922",
+      "@all-lopezg",
+      "@alitvak69"
     ]
   },
   "screenshot": {

--- a/docs/public-surface-facts.json
+++ b/docs/public-surface-facts.json
@@ -20,7 +20,7 @@
     ]
   },
   "sourceCandidate": {
-    "version": "0.9.8",
+    "version": "0.9.9",
     "providerCount": 45,
     "toolCount": 74,
     "sandboxBackends": [

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codewhale-vscode",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codewhale-vscode",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.19.27",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "codewhale-vscode",
   "displayName": "CodeWhale",
   "description": "Official CodeWhale VS Code integration scaffold for local runtime attach and terminal launch.",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "publisher": "codewhale",
   "license": "MIT",
   "repository": {

--- a/npm/codewhale/package.json
+++ b/npm/codewhale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codewhale",
-  "version": "0.9.8",
-  "codewhaleBinaryVersion": "0.9.8",
+  "version": "0.9.9",
+  "codewhaleBinaryVersion": "0.9.9",
   "description": "Terminal coding agent for supported hosted and local models. One runtime on your machine. Rust, MIT.",
   "author": "Hmbown",
   "license": "MIT",

--- a/npm/runtime-sdk/package.json
+++ b/npm/runtime-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codewhale/runtime-sdk",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Typed JavaScript helpers for Codewhale Runtime API Fleet endpoints.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,7 +1559,7 @@
       }
     },
     "npm/codewhale": {
-      "version": "0.9.8",
+      "version": "0.9.9",
       "funding": [
         {
           "type": "github",
@@ -1600,7 +1600,7 @@
     },
     "npm/runtime-sdk": {
       "name": "@codewhale/runtime-sdk",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/scripts/remote-smoke/setup-vm.sh
+++ b/scripts/remote-smoke/setup-vm.sh
@@ -20,7 +20,7 @@
 # Uses prebuilt release binaries instead of a Rust build.
 set -euo pipefail
 
-RELEASE_TAG="${RELEASE_TAG:-v0.9.8}"
+RELEASE_TAG="${RELEASE_TAG:-v0.9.9}"
 REPO_URL="${REPO_URL:-https://github.com/Hmbown/CodeWhale.git}"
 REPO_BRANCH="${REPO_BRANCH:-main}"
 SECRETS_FILE="${SECRETS_FILE:-/tmp/cw-secrets.env}"

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -30,7 +30,7 @@ export const FACTS: RepoFacts = {
   "generatedAt": "2026-08-17T06:09:37.228Z",
   "sourceRevision": null,
   "sourceCommittedAt": null,
-  "version": "0.9.8",
+  "version": "0.9.9",
   "crates": [
     "agent",
     "app-server",

--- a/web/lib/release-credits.ts
+++ b/web/lib/release-credits.ts
@@ -19,15 +19,13 @@
  */
 
 /** Contributors whose PRs were merged or harvested into this release. */
-export const RELEASE_CONTRIBUTORS: string[] = [
-  "@EvanProgramming",
-  "@Lstarsky0",
-  "@mvanhorn",
-  "@buiducnhat",
-  "@SparkofSpike",
-  "@redstar",
-  "@wuisabel-gif",
-];
+export const RELEASE_CONTRIBUTORS: string[] = ["@h3c-hexin"];
 
 /** Contributors who helped with reports, reproductions, and verification. */
-export const RELEASE_HELPERS: string[] = [];
+export const RELEASE_HELPERS: string[] = [
+  "@hardy922",
+  "@redstar",
+  "@all-lopezg",
+  "@alitvak69",
+  "@wuisabel-gif",
+];


### PR DESCRIPTION
## Theme

Codewhale v0.9.9 is a truth-and-resilience release: the shell tool can no longer wedge a session when the host runs out of disk/descriptors (#5465 — the bug that took out the owner's own 0.9.9 session), unverified context windows / output ceilings / telemetry defaults are labeled honestly everywhere (#5459), DeepSeek V4 is priced on the published peak/off-peak tiers (#5470), SSE UTF-8 fails closed in every dialect (#5468), Fleet shadowing is visible (#5466), bwrap gets container essentials + extra roots (#5462), the `dsh` skin is applied through the bundle profile (#5469), the `agent` tool schema is 12 fields (#5458), and 18 README locales / 8 web locales landed (#5452, #5454).

## Punch list (merges since v0.9.8)

#5469 #5470 #5465 #5471 #5466 #5468 #5462 #5459 #5467 #5463 #5448 #5438 #5461 #5454 #5452 #5458 #5450 #5444 #5457 #5445 #5446 #5449 #5389 #5388 #5435 #5433 #5432 #5431 #5428 — full text in the `## [0.9.9]` CHANGELOG section on this branch.

**Security-adjacent:** #5463 closes the CodeQL cache-poisoning Highs #88–#107 in the release workflows (no cache restore after checking out a caller-supplied SHA); #5462 hardens bwrap defaults; #5468 fails closed on invalid SSE UTF-8.

## Contributors

Thanks @h3c-hexin (#5461, explicit route output limit), @Pinvou (branch host for #5461), Cursor-lane harvests (#5450 via #5402; #5468 supersedes #5404), dependabot (#5388, #5389). @wuisabel-gif's #5437 status-bar slice is in flight and rolls to 0.9.10 if it does not land before the tag.

## What ran where (owner's rule for this cut: no local cargo builds on the thrashed host)

Local, on this branch head:
- `cargo fmt --all -- --check` ✔
- `./scripts/release/check-versions.sh` → `Version state OK: workspace=0.9.9, npm=0.9.9, lockfile in sync.` ✔
- `./scripts/sync-changelog.sh --check` → up to date ✔

CI (this PR + main): full workspace test/build/clippy/doctest matrix, plus — after merge — the exact-head `ci.yml` and non-publishing `release-candidate.yml` dispatches per RELEASE_CHECKLIST §6 carry the workspace-test and 7-target artifact evidence. `cargo check/clippy/test --workspace`, `publish-crates.sh dry-run`, `cargo build --release`, and `npm-wrapper-smoke.js` were **not** run on the owner's machine for this cut; they are covered by CI's Lint/Test/Release-candidate jobs (evidence links go in the approval packet).

## Known issues

- `release_runtime_qa::release_four_read_only_fleet_roles_launch_with_canonical_prompts` was a macOS-only timing flake until #5471 (fixed on main; refs #5056).
- Memory retention hot spots found by a read-only audit are filed as #5472 (0.9.10).

No-Issue: release branch for v0.9.9.
