### PR TITLE
fix(tui): hide the session metrics strip on compact rows

### DIFF
--- a/crates/tui/src/tui/phase_strip.rs
+++ b/crates/tui/src/tui/phase_strip.rs
@@ -243,7 +243,7 @@ pub fn render(area: Rect, buf: &mut Buffer, app: &mut App) {
     // columns are genuinely free after the phase marker, the ledger chips, a
     // floor for any live toast, and the key hints, and sheds its
     // lowest-value groups to fit rather than truncating a number.
-    if metrics_enabled {
+    if metrics_enabled && tier != ShellTier::Compact {
         let snapshot = crate::tui::session_metrics::snapshot_from_app(app);
         if !snapshot.is_empty() {
             let toast_reserve = status_toast
@@ -731,6 +731,18 @@ mod tests {
         }
         assert!(!compact.contains("Tool call"), "{compact}");
         assert!(!compact.contains("tok/s"), "{compact}");
+    }
+
+    #[test]
+    fn session_metrics_strip_is_hidden_when_compact() {
+        let mut app = app_with_session_metrics();
+        // 59 columns is the widest Compact row. The working detail and the
+        // cache chip already stand down here, so the metrics strip claiming
+        // the leftovers is the one thing still crowding the label.
+        let text = strip_text(&mut app, 59);
+        assert!(!text.contains("turns"), "compact strip: {text}");
+        assert!(!text.contains("LLM"), "compact strip: {text}");
+        assert!(!text.contains('│'), "compact strip: {text}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Below 60 columns the phase strip stands down the working detail, the cache chip and status toasts, but keeps painting the session metrics strip. A 59-column row renders:

`▌· idle │ LLM 3.5s │ Cache hit 99% │ Input 9.3M     F1:keys`

`SessionMetrics` is in `default_footer()`, so that is the out-of-the-box narrow terminal.

The metrics block is the only optional element on that row without a `tier != ShellTier::Compact` guard — it decides on leftover columns instead, so it takes whatever the elements that did stand down left behind. Added the guard.

The same gap looks like what reddened `Test (macos-latest)` on `9d2a6e4c5`, the v0.9.9 merge commit: `qa_pty::semantic_activity_motion_crosses_reasoning_reading_and_tool_use_in_a_real_unix_pty` asserts a sub-60 semantic row carries no `×` and no `s`, and saw `"▌⣤ reading │ LLM 1.1s"` — that `s` is the metrics segment. I could not reproduce that one here: it passes on this machine both with and without the guard, so the connection is read off the frame text rather than measured.

`session_metrics_strip_sheds_groups_on_narrow_rows_and_never_truncates` pins width 60, which `for_chrome_width` classes as `Normal` (`< 60` is compact), so it is unaffected.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked` — clean
- [ ] `cargo test --workspace --all-features --locked` — ran `cargo test -p codewhale-tui --lib` and `cargo test -p codewhale-config -p codewhale-protocol` instead, plus `check-dead-code-budget.py` and `check-tui-locale-parity.py`. The diff is one line and one test in `codewhale-tui`.

`session_metrics_strip_is_hidden_when_compact` fails on unmodified main with the row quoted above and passes with the guard; taking the guard back out brings the same failure back.

`--lib` is 10710 passed / 1 failed here. The failure is `tools::pdf::tests::shared_adapter_forwards_page_window_and_returns_stdout`, which fails identically on a stashed clean tree on this machine — same one I measured on #5355, not something this branch introduces.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

No-Issue: found from the Test (macos-latest) failure on 9d2a6e4c5, the v0.9.9 merge commit.
