### PR TITLE
feat(web): move the docs shell onto the dictionary spine (#5337)

### DIFF
--- a/web/app/[locale]/docs/layout.tsx
+++ b/web/app/[locale]/docs/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { DocsSidebar } from "@/components/docs-sidebar";
 import { Whale } from "@/components/whale";
+import { getDocsShell } from "@/lib/i18n/dictionaries";
 
 /* ------------------------------------------------------------------ */
 /*  Layout (Next.js App Router)                                        */
@@ -14,7 +15,7 @@ export default async function DocsLayout({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
+  const t = getDocsShell(locale);
 
   return (
     <div className="docs-theme docs-portal min-h-screen">
@@ -23,17 +24,13 @@ export default async function DocsLayout({
         <div className="portal-container docs-portal-hero-inner">
           <div className="portal-mark">
             <Whale size={28} />
-            <span>{isZh ? "Codewhale 文档" : "Codewhale documentation"}</span>
+            <span>{t.portalMark}</span>
           </div>
-          <h1>{isZh ? "查找准确的使用说明。" : "Find the guidance you need."}</h1>
-          <p>
-            {isZh
-              ? "从新手指引和安装开始，或直接查看名词、模式、权限、工具、提供商、Fleet、钩子、MCP 与运行时 API。每页都链接到仓库中的源文档。"
-              : "Start with the guide and install pages, or go straight to vocabulary, modes, permissions, tools, providers, Fleet, hooks, MCP, and the Runtime API. Each page links to its source document in the repository."}
-          </p>
+          <h1>{t.heroTitle}</h1>
+          <p>{t.heroLead}</p>
           <div className="portal-actions">
             <Link href={`/${locale}/install`} className="portal-button portal-button-primary">
-              {isZh ? "安装 Codewhale" : "Install Codewhale"}
+              {t.installCta}
             </Link>
             <Link
               href="https://github.com/Hmbown/CodeWhale/tree/main/docs"
@@ -41,7 +38,7 @@ export default async function DocsLayout({
               rel="noreferrer"
               className="portal-button portal-button-secondary"
             >
-              {isZh ? "浏览源文档 ↗" : "Browse source docs ↗"}
+              {t.sourceDocsCta}
             </Link>
           </div>
         </div>

--- a/web/app/[locale]/docs/page.tsx
+++ b/web/app/[locale]/docs/page.tsx
@@ -1,16 +1,15 @@
 import { DocsSearch } from "@/components/docs-search";
+import { getDocsShell } from "@/lib/i18n/dictionaries";
 import { buildPageMetadata } from "@/lib/page-meta";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
+  const t = getDocsShell(locale);
   return buildPageMetadata({
     path: "/docs",
     locale,
-    title: isZh ? "文档 · Codewhale" : "Docs · Codewhale",
-    description: isZh
-      ? "Codewhale 文档：安装、使用指南、配置、提供商、核心概念、工具、MCP、技能、沙箱、运行时 API、排障。"
-      : "Codewhale documentation: install, user guide, configuration, providers, core concepts, tools, MCP, skills, sandbox, runtime API, troubleshooting.",
+    title: t.metaTitle,
+    description: t.metaDescription,
   });
 }
 

--- a/web/lib/i18n/dictionaries.test.ts
+++ b/web/lib/i18n/dictionaries.test.ts
@@ -3,10 +3,12 @@ import {
   DICTIONARY_LOCALES,
   EN_CHROME,
   EN_DOCS_GUIDE,
+  EN_DOCS_SHELL,
   EN_HOME,
   fill,
   getChrome,
   getDocsGuide,
+  getDocsShell,
   getHome,
   pickText,
   splitToken,
@@ -212,6 +214,22 @@ describe("website dictionaries", () => {
     }
     // A locale without the file falls back to the English reference object.
     expect(getDocsGuide("ja")).toBe(EN_DOCS_GUIDE);
+  });
+
+  it("holds the docs shell dictionary to the same contract (#5337)", () => {
+    const enKeys = Object.keys(EN_DOCS_SHELL).sort();
+    for (const locale of [...DICTIONARY_LOCALES, "fr", "und"]) {
+      expect(Object.keys(getDocsShell(locale)).sort(), `${locale} docs-shell keys`).toEqual(
+        enKeys,
+      );
+    }
+    // zh ships a real translation, not an English pass-through.
+    expect(getDocsShell("zh").heroTitle).not.toBe(EN_DOCS_SHELL.heroTitle);
+    // Every other locale renders the English shell today, exactly as the
+    // `isZh` ternaries in docs/layout.tsx did before the move.
+    for (const locale of ["ja", "fr", "ar", "und"]) {
+      expect(getDocsShell(locale), `${locale} docs-shell`).toBe(EN_DOCS_SHELL);
+    }
   });
 
   it("pickText selects the locale side of legacy { en, zh } pairs", () => {

--- a/web/lib/i18n/dictionaries/en/docs-shell.ts
+++ b/web/lib/i18n/dictionaries/en/docs-shell.ts
@@ -1,0 +1,19 @@
+import type { DocsShellDict } from "../types";
+
+/**
+ * English reference dictionary for the docs shell.
+ * Copy moved verbatim from `app/[locale]/docs/layout.tsx` and the metadata
+ * of `app/[locale]/docs/page.tsx` — any wording change belongs in its own
+ * commit, never mixed into a structural move.
+ */
+export const docsShell: DocsShellDict = {
+  metaTitle: "Docs · Codewhale",
+  metaDescription:
+    "Codewhale documentation: install, user guide, configuration, providers, core concepts, tools, MCP, skills, sandbox, runtime API, troubleshooting.",
+  portalMark: "Codewhale documentation",
+  heroTitle: "Find the guidance you need.",
+  heroLead:
+    "Start with the guide and install pages, or go straight to vocabulary, modes, permissions, tools, providers, Fleet, hooks, MCP, and the Runtime API. Each page links to its source document in the repository.",
+  installCta: "Install Codewhale",
+  sourceDocsCta: "Browse source docs ↗",
+};

--- a/web/lib/i18n/dictionaries/index.ts
+++ b/web/lib/i18n/dictionaries/index.ts
@@ -12,11 +12,13 @@
  * than a map entry, which keeps `DICTIONARY_LOCALES` equal to the set of
  * non-reference locale directories that `check-locales.mjs` walks.
  */
-import type { ChromeDict, DocsGuideDict, HomeDict } from "./types";
+import type { ChromeDict, DocsGuideDict, DocsShellDict, HomeDict } from "./types";
 import { chrome as enChrome } from "./en/chrome";
 import { home as enHome } from "./en/home";
 import { docsGuide as enDocsGuide } from "./en/docs-guide";
 import { docsGuide as zhDocsGuide } from "./zh/docs-guide";
+import { docsShell as enDocsShell } from "./en/docs-shell";
+import { docsShell as zhDocsShell } from "./zh/docs-shell";
 import { chrome as zhChrome } from "./zh/chrome";
 import { home as zhHome } from "./zh/home";
 import { chrome as jaChrome } from "./ja/chrome";
@@ -122,6 +124,10 @@ const DOCS_GUIDE: Record<string, DocsGuideDict> = {
   ar: arDocsGuide,
 };
 
+const DOCS_SHELL: Record<string, DocsShellDict> = {
+  zh: zhDocsShell,
+};
+
 export function getChrome(locale: string): ChromeDict {
   return CHROME[locale] ?? enChrome;
 }
@@ -132,6 +138,10 @@ export function getHome(locale: string): HomeDict {
 
 export function getDocsGuide(locale: string): DocsGuideDict {
   return DOCS_GUIDE[locale] ?? enDocsGuide;
+}
+
+export function getDocsShell(locale: string): DocsShellDict {
+  return DOCS_SHELL[locale] ?? enDocsShell;
 }
 
 /**
@@ -149,6 +159,7 @@ export function pickText(pair: { en: string; zh: string }, locale: string): stri
 export const EN_CHROME = enChrome;
 export const EN_HOME = enHome;
 export const EN_DOCS_GUIDE = enDocsGuide;
+export const EN_DOCS_SHELL = enDocsShell;
 
 /** Interpolate `{name}` tokens in a dictionary template. Unknown tokens are
  * left intact so a template/variable drift is visible in review, not silent. */

--- a/web/lib/i18n/dictionaries/types.ts
+++ b/web/lib/i18n/dictionaries/types.ts
@@ -302,3 +302,21 @@ export interface DocsGuideDict {
   nextTitle: string;
   sourceNote: string;
 }
+
+/**
+ * The docs shell: the portal hero in `app/[locale]/docs/layout.tsx` that
+ * wraps every docs page, plus the metadata of the hub page it frames
+ * (`app/[locale]/docs/page.tsx`, whose body is the `DocsSearch` component).
+ *
+ * No `bodyClassName` here: the hero typesets through `portal-*` classes,
+ * which never varied by locale.
+ */
+export interface DocsShellDict {
+  metaTitle: string;
+  metaDescription: string;
+  portalMark: string;
+  heroTitle: string;
+  heroLead: string;
+  installCta: string;
+  sourceDocsCta: string;
+}

--- a/web/lib/i18n/dictionaries/zh/docs-shell.ts
+++ b/web/lib/i18n/dictionaries/zh/docs-shell.ts
@@ -1,0 +1,18 @@
+import type { DocsShellDict } from "../types";
+
+/**
+ * Simplified-Chinese dictionary for the docs shell.
+ * Copy moved verbatim from the former `isZh` branches in
+ * `app/[locale]/docs/layout.tsx` and `app/[locale]/docs/page.tsx`.
+ */
+export const docsShell: DocsShellDict = {
+  metaTitle: "文档 · Codewhale",
+  metaDescription:
+    "Codewhale 文档：安装、使用指南、配置、提供商、核心概念、工具、MCP、技能、沙箱、运行时 API、排障。",
+  portalMark: "Codewhale 文档",
+  heroTitle: "查找准确的使用说明。",
+  heroLead:
+    "从新手指引和安装开始，或直接查看名词、模式、权限、工具、提供商、Fleet、钩子、MCP 与运行时 API。每页都链接到仓库中的源文档。",
+  installCta: "安装 Codewhale",
+  sourceDocsCta: "浏览源文档 ↗",
+};

--- a/web/lib/public-copy.test.ts
+++ b/web/lib/public-copy.test.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { FACTS } from "./facts.generated";
 import { RELEASE_CONTRIBUTORS, RELEASE_HELPERS } from "./release-credits";
-import { EN_CHROME, EN_HOME, getChrome, getHome } from "./i18n/dictionaries";
+import { EN_CHROME, EN_DOCS_SHELL, EN_HOME, getChrome, getHome } from "./i18n/dictionaries";
 
 function pageSource(path: string): string {
   return readFileSync(new URL(`../app/[locale]/${path}`, import.meta.url), "utf8");
@@ -14,7 +14,9 @@ describe("public website copy contracts", () => {
     const search = readFileSync(new URL("../components/docs-search.tsx", import.meta.url), "utf8");
 
     expect(layout).toContain("docs-portal-hero");
-    expect(layout).toContain("Find the guidance you need.");
+    // The hero copy is dictionary-driven now (#5337), so assert it where the
+    // string actually lives rather than in the TSX.
+    expect(EN_DOCS_SHELL.heroTitle).toBe("Find the guidance you need.");
     expect(layout).not.toContain("Section 02");
     expect(layout).not.toContain("How Codewhale works: ego");
     expect(layout).not.toContain("<Seal");

--- a/web/scripts/check-locales.mjs
+++ b/web/scripts/check-locales.mjs
@@ -25,7 +25,7 @@ const FILES = ["chrome.ts", "home.ts"];
 // required reference; a locale that ships the file is held to the same
 // key/token parity, and a locale without it falls back to English at
 // lookup time — so absence is a valid state, never a failure.
-const OPTIONAL_FILES = ["docs-guide.ts"];
+const OPTIONAL_FILES = ["docs-guide.ts", "docs-shell.ts"];
 
 /** Top-level keys of the exported object literal (two-space indented `key:`). */
 function extractKeys(source) {


### PR DESCRIPTION
## Summary

`app/[locale]/docs/layout.tsx` draws the portal hero above every docs page, and its five strings were still `isZh` ternaries — so the eight partial locales (ja/vi/ko/ru/uk/es/pt-BR/id) read English there with nowhere to put a translation short of editing TSX. `docs/page.tsx`'s metadata had the same shape.

`DocsShellDict` (7 keys) carries both, on the infrastructure #5338 introduced. en + zh ship; every other locale falls back to English exactly as the ternaries did.

Two shape notes:

- The layout and the hub page share one dictionary because the hub page has no body copy of its own — it renders `DocsSearch`, and its metadata describes the surface the layout draws.
- No `bodyClassName` key, unlike `DocsGuideDict`: the hero typesets through `portal-*` classes that never varied by locale.

Rendered output is unchanged, and I measured that rather than reasoning about it. Every moved string was a whole-string ternary inside an expression container, so no JSX text whitespace was involved. Building this branch and a clean build of the same base, 36 pages — 18 locales × `/docs` and `/docs/guide` — compare byte-identical on visible text and on `<title>` + meta description. A control that alters one character in one string is caught by the same comparison.

Next in the series, per the checklist in #5337, is the docs page bodies, starting with `docs/hooks` and `docs/troubleshooting` — the two smallest at 12 `isZh` branches each.

## Testing

The web gates, in the order `.github/workflows/web.yml` runs them:

- [x] `npm run check:facts` — OK
- [x] `npm run check:docs` — PASS
- [x] `npm run check:locales` — PASS, `zh/docs-shell.ts: 7/7 keys — complete`, 16 locales absent and falling back
- [x] `npm test` — 259 passed / 7 failed
- [x] `npm run lint` — exit 0, no output
- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run build` — exit 0, 512/512 static pages

The 7 failures are all `lib/deploy-preflight.test.ts` and need Cloudflare deploy credentials. A clean checkout of the same base on this machine gives the same 7 failures and 258 passed; the difference of one is the test this PR adds. Full sequence run twice.

The Rust gates in the template do not apply — this PR touches only `web/`.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — no TUI change
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

No-Issue: one page group of the #5337 series — the epic stays open until the last group lands.
