### PR TITLE
fix(tui): wrap bare URLs in rustdoc comments

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -4483,7 +4483,7 @@ mod alias_thinking_detection_tests {
     //! assistant messages and DeepSeek returns a 400 ("the `reasoning_content`
     //! in the thinking mode must be passed back to the API") on the second
     //! turn. See upstream API docs:
-    //! https://api-docs.deepseek.com/guides/thinking_mode
+    //! <https://api-docs.deepseek.com/guides/thinking_mode>
     use super::{
         ReasoningStreamStyle, apply_direct_moonshot_k3_fixed_sampling,
         apply_inkling_reasoning_effort, apply_kimi_code_k3_reasoning_effort,

--- a/crates/tui/src/plugins/marketplace/parsers/claude.rs
+++ b/crates/tui/src/plugins/marketplace/parsers/claude.rs
@@ -1,6 +1,6 @@
 //! Claude `.claude-plugin/marketplace.json` parser.
 //!
-//! Schema source: https://code.claude.com/docs/en/plugin-marketplaces
+//! Schema source: <https://code.claude.com/docs/en/plugin-marketplaces>
 //!
 //! Top level: `name` (kebab-case, required), `owner` (`{name`, `email?`,
 //! `url?}`, required), `plugins[]` (required); optional `$schema`,


### PR DESCRIPTION
No-Issue: docs lint fix — two prose URLs tripped rustdoc::bare-urls under -D warnings, failing the forced Documentation job in the exact-head 0.9.9 CI.

The 0.9.9 tag (ed39b0446) itself is unaffected: `cargo build` does not run rustdoc, and the release-candidate built all 7 targets green on that exact SHA. This lands on main for 0.9.10 and unbreaks `cargo doc`.

- `crates/tui/src/plugins/marketplace/parsers/claude.rs` — schema-source URL
- `crates/tui/src/client/chat.rs` — DeepSeek thinking-mode API docs URL

Both wrapped in `<…>` so rustdoc emits explicit links.