### PR TITLE
feat(web): route shared components' locale picks through pickText (#5337)

### DIFF
--- a/web/components/getting-started-steps.tsx
+++ b/web/components/getting-started-steps.tsx
@@ -9,10 +9,9 @@
 
 import Link from "next/link";
 import { GETTING_STARTED_STEPS } from "@/lib/content/getting-started";
+import { pickText } from "@/lib/i18n/dictionaries";
 
 export function GettingStartedSteps({ locale = "en" }: { locale?: string }) {
-  const isZh = locale === "zh";
-
   return (
     // data-reveal-group: the homepage's <RevealOnScroll> settles the four
     // steps in sequence. On /docs/guide no observer is mounted and the
@@ -23,13 +22,13 @@ export function GettingStartedSteps({ locale = "en" }: { locale?: string }) {
           <span className="gs-step-index" aria-hidden="true">
             {String(index + 1).padStart(2, "0")}
           </span>
-          <h3>{isZh ? step.title.zh : step.title.en}</h3>
-          <p>{isZh ? step.body.zh : step.body.en}</p>
+          <h3>{pickText(step.title, locale)}</h3>
+          <p>{pickText(step.body, locale)}</p>
           {step.commands.length > 0 && (
             <pre className="code-block gs-step-commands"><code>{step.commands.join("\n")}</code></pre>
           )}
           <Link href={`/${locale}${step.link.href}`} className="gs-step-link">
-            {isZh ? step.link.label.zh : step.link.label.en} →
+            {pickText(step.link.label, locale)} →
           </Link>
         </li>
       ))}

--- a/web/components/session-media.tsx
+++ b/web/components/session-media.tsx
@@ -19,6 +19,7 @@
  */
 
 import { REDUCED_MOTION_POLICY, type MediaAsset } from "@/lib/media-manifest";
+import { pickText } from "@/lib/i18n/dictionaries";
 import { StatusBadge } from "./status-badge";
 
 const MEDIA_PLAN_DOC =
@@ -45,8 +46,8 @@ export function SessionMedia({ asset, locale = "en" }: { asset: MediaAsset; loca
           </p>
         </div>
         <figcaption className="session-media-caption">
-          <strong>{isZh ? asset.title.zh : asset.title.en}</strong>
-          <span>{isZh ? asset.description.zh : asset.description.en}</span>
+          <strong>{pickText(asset.title, locale)}</strong>
+          <span>{pickText(asset.description, locale)}</span>
           <a href={MEDIA_PLAN_DOC} target="_blank" rel="noreferrer">
             {isZh ? "录制计划与验收清单 ↗" : "Recording plan and acceptance checklist ↗"}
           </a>
@@ -75,7 +76,7 @@ export function SessionMedia({ asset, locale = "en" }: { asset: MediaAsset; loca
         poster={`/${poster.src}`}
         width={video.width}
         height={video.height}
-        aria-label={isZh ? poster.alt.zh : poster.alt.en}
+        aria-label={pickText(poster.alt, locale)}
       >
         <source src={`/${video.src}`} type="video/mp4" />
         {captions.map((track) => (
@@ -90,8 +91,8 @@ export function SessionMedia({ asset, locale = "en" }: { asset: MediaAsset; loca
         ))}
       </video>
       <figcaption className="session-media-caption">
-        <strong>{isZh ? asset.title.zh : asset.title.en}</strong>
-        <span>{isZh ? asset.description.zh : asset.description.en}</span>
+        <strong>{pickText(asset.title, locale)}</strong>
+        <span>{pickText(asset.description, locale)}</span>
         {asset.gifFallback && (
           <a href={`/${asset.gifFallback.src}`}>
             {isZh ? "GIF 下载回退（无视频环境）" : "GIF fallback download (no-video environments)"}

--- a/web/components/status-badge.tsx
+++ b/web/components/status-badge.tsx
@@ -8,6 +8,7 @@
  */
 
 import type { LocalizedText } from "@/lib/content/vocabulary";
+import { pickText } from "@/lib/i18n/dictionaries";
 
 export type StatusKind = "experimental" | "preview" | "pending" | "unavailable";
 
@@ -28,8 +29,7 @@ export function StatusBadge({
   /** Overrides the default per-kind label (e.g. a media entry's pendingLabel). */
   label?: LocalizedText;
 }) {
-  const isZh = locale === "zh";
-  const text = label ? (isZh ? label.zh : label.en) : isZh ? DEFAULT_LABELS[kind].zh : DEFAULT_LABELS[kind].en;
+  const text = pickText(label ?? DEFAULT_LABELS[kind], locale);
 
   return (
     <span className={`status-badge status-badge-${kind}`}>


### PR DESCRIPTION
## Summary

Three shared components still picked a side of an `{ en, zh }` content pair with their own `locale === "zh"` comparison — which is what `pickText()` was added for in #5338, and what `docs/guide/page.tsx` already uses for `GUIDE_NEXT_LINKS`.

Ten pair picks become nine `pickText` calls; the nested ternary in `StatusBadge` collapses into one. `status-badge.tsx` and `getting-started-steps.tsx` no longer reference a locale string at all.

`pickText(pair, locale)` is `locale === "zh" ? pair.zh : pair.en`, so each substitution is an identity rather than an approximation. The one shape change is `StatusBadge`'s `label ?` becoming `label ??`, equivalent here because `LocalizedText` is an object type and the parameter is optional.

`session-media.tsx` keeps its `isZh` for four hardcoded strings — those need a page dictionary rather than a pair, and belong with the next group.

### thinking-trace is deliberately not in this PR

It was, until the build said otherwise. `thinking-trace.tsx` exports `SCENES`, which the `terminal-player` client component imports, so adding `import { pickText } from "@/lib/i18n/dictionaries"` there drags the whole dictionary barrel — 18 locales of chrome + home — into the browser bundle. The homepage's First Load JS went **115 kB → 125 kB**. Reverting only that one file and rebuilding put it back at 115 kB, so the attribution is measured, not inferred.

That is a constraint on the rest of #5337, not a one-off: three of the nine shared components (`terminal-player`, `docs-sidebar`, `docs-search`) are client components, and any module they import inherits it. Making `pickText` importable without the barrel — its own leaf module, re-exported from the index — looks like the fix, but it edits `dictionaries/index.ts`, which #5488 is already touching, so I have kept it out of both.

## Testing

The web gates, in the order `.github/workflows/web.yml` runs them:

- [x] `npm run check:facts` — OK
- [x] `npm run check:docs` — PASS
- [x] `npm run check:locales` — PASS
- [x] `npm test` — 258 passed / 7 failed
- [x] `npm run lint` — exit 0, no output
- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run build` — exit 0, 512/512 static pages, `/[locale]` First Load JS 115 kB, unchanged from base

The 7 failures are all `lib/deploy-preflight.test.ts` and need Cloudflare deploy credentials; a clean checkout of the same base gives the same 7 failures and the same 258 passed. Full sequence run twice.

Rendered output is unchanged across all 487 built pages, compared on visible text plus `<title>` and meta description against a clean build of the same base — same check as #5488, widened from the docs pages to the whole site.

The Rust gates in the template do not apply — this PR touches only `web/components/`.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant — no new test; the change is an identity substitution and the existing suite plus the rendered-output comparison cover it
- [ ] Verified TUI behavior manually if UI changes — no TUI change
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

No-Issue: one group of the #5337 series — the epic stays open until the last group lands.
