### PR TITLE
fix(tui): persist approval outcomes before execution

### DIFF
--- a/crates/tui/src/approval_log.rs
+++ b/crates/tui/src/approval_log.rs
@@ -1,0 +1,417 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::sandbox::SandboxPolicy;
+
+const APPROVAL_LOG_FILE: &str = "approval_receipts.jsonl";
+const APPROVAL_LOCK_FILE: &str = "approval_receipts.lock";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub(crate) enum ApprovalOutcome {
+    ApprovedOnce,
+    Denied,
+    Cancelled,
+    Unavailable,
+    RetryWithPolicy { policy: SandboxPolicy },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub(crate) enum ApprovalReceipt {
+    Asked {
+        approval_id: String,
+        tool_call_id: String,
+        tool_name: String,
+        created_at: DateTime<Utc>,
+    },
+    Decided {
+        approval_id: String,
+        tool_call_id: String,
+        outcome: ApprovalOutcome,
+        created_at: DateTime<Utc>,
+    },
+}
+
+impl ApprovalReceipt {
+    pub(crate) fn asked(tool_call_id: impl Into<String>, tool_name: impl Into<String>) -> Self {
+        let tool_call_id = tool_call_id.into();
+        Self::Asked {
+            approval_id: tool_call_id.clone(),
+            tool_call_id,
+            tool_name: tool_name.into(),
+            created_at: Utc::now(),
+        }
+    }
+
+    pub(crate) fn decided(tool_call_id: impl Into<String>, outcome: ApprovalOutcome) -> Self {
+        let tool_call_id = tool_call_id.into();
+        Self::Decided {
+            approval_id: tool_call_id.clone(),
+            tool_call_id,
+            outcome,
+            created_at: Utc::now(),
+        }
+    }
+
+    fn approval_id(&self) -> &str {
+        match self {
+            Self::Asked { approval_id, .. } | Self::Decided { approval_id, .. } => approval_id,
+        }
+    }
+
+    fn tool_call_id(&self) -> &str {
+        match self {
+            Self::Asked { tool_call_id, .. } | Self::Decided { tool_call_id, .. } => tool_call_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CompletedApproval {
+    pub(crate) ask: ApprovalReceipt,
+    pub(crate) outcome: ApprovalOutcome,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ApprovalReplay {
+    pub(crate) completed: Vec<CompletedApproval>,
+    pub(crate) unmatched_asks: Vec<ApprovalReceipt>,
+}
+
+impl ApprovalReplay {
+    pub(crate) fn from_receipts(receipts: &[ApprovalReceipt]) -> Result<Self, String> {
+        let mut open = BTreeMap::<String, ApprovalReceipt>::new();
+        let mut closed = BTreeSet::<String>::new();
+        let mut completed = Vec::new();
+
+        for receipt in receipts {
+            let approval_id = receipt.approval_id();
+            if approval_id.trim().is_empty() || receipt.tool_call_id().trim().is_empty() {
+                return Err("approval receipt has an empty correlation id".to_string());
+            }
+            match receipt {
+                ApprovalReceipt::Asked {
+                    approval_id,
+                    tool_call_id,
+                    tool_name,
+                    ..
+                } => {
+                    if tool_name.trim().is_empty() {
+                        return Err(format!(
+                            "approval ask '{approval_id}' has an empty tool name"
+                        ));
+                    }
+                    if approval_id != tool_call_id {
+                        return Err(format!(
+                            "approval ask '{approval_id}' does not match tool call '{tool_call_id}'"
+                        ));
+                    }
+                    if closed.contains(approval_id) || open.contains_key(approval_id) {
+                        return Err(format!("approval '{approval_id}' was asked more than once"));
+                    }
+                    open.insert(approval_id.clone(), receipt.clone());
+                }
+                ApprovalReceipt::Decided {
+                    approval_id,
+                    tool_call_id,
+                    outcome,
+                    ..
+                } => {
+                    if approval_id != tool_call_id {
+                        return Err(format!(
+                            "approval decision '{approval_id}' does not match tool call '{tool_call_id}'"
+                        ));
+                    }
+                    let Some(ask) = open.remove(approval_id) else {
+                        return Err(format!(
+                            "approval decision '{approval_id}' has no unmatched ask"
+                        ));
+                    };
+                    closed.insert(approval_id.clone());
+                    completed.push(CompletedApproval {
+                        ask,
+                        outcome: outcome.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(Self {
+            completed,
+            unmatched_asks: open.into_values().collect(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ApprovalReceiptStore {
+    sessions_dir: PathBuf,
+}
+
+impl ApprovalReceiptStore {
+    pub(crate) fn new(sessions_dir: PathBuf) -> Self {
+        Self { sessions_dir }
+    }
+
+    #[cfg_attr(test, allow(dead_code))]
+    pub(crate) fn default_location() -> io::Result<Self> {
+        crate::session_manager::default_sessions_dir().map(Self::new)
+    }
+
+    fn validated_session_id(session_id: &str) -> io::Result<&str> {
+        let trimmed = session_id.trim();
+        if trimmed.is_empty()
+            || !trimmed
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Invalid session id '{session_id}'"),
+            ));
+        }
+        Ok(trimmed)
+    }
+
+    fn log_path(&self, session_id: &str) -> io::Result<PathBuf> {
+        let session_id = Self::validated_session_id(session_id)?;
+        Ok(self.sessions_dir.join(session_id).join(APPROVAL_LOG_FILE))
+    }
+
+    fn lock_path(&self, session_id: &str) -> io::Result<PathBuf> {
+        let session_id = Self::validated_session_id(session_id)?;
+        Ok(self.sessions_dir.join(session_id).join(APPROVAL_LOCK_FILE))
+    }
+
+    fn open_lock_file(&self, session_id: &str) -> io::Result<File> {
+        let path = self.lock_path(session_id)?;
+        let parent = path.parent().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "approval lock has no parent")
+        })?;
+        fs::create_dir_all(parent)?;
+        OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(path)
+    }
+
+    fn open_existing_lock_file(&self, session_id: &str) -> io::Result<Option<File>> {
+        let path = self.lock_path(session_id)?;
+        match OpenOptions::new().read(true).open(path) {
+            Ok(file) => Ok(Some(file)),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn load_unlocked(&self, session_id: &str) -> io::Result<Vec<ApprovalReceipt>> {
+        let path = self.log_path(session_id)?;
+        let file = match File::open(path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(err),
+        };
+        let mut receipts = Vec::new();
+        for (index, line) in BufReader::new(file).lines().enumerate() {
+            let line = line?;
+            let receipt = serde_json::from_str(&line).map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid approval receipt at line {}: {err}", index + 1),
+                )
+            })?;
+            receipts.push(receipt);
+        }
+        ApprovalReplay::from_receipts(&receipts)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        Ok(receipts)
+    }
+
+    pub(crate) fn load(&self, session_id: &str) -> io::Result<Vec<ApprovalReceipt>> {
+        if !self.log_path(session_id)?.exists() {
+            return Ok(Vec::new());
+        }
+        let Some(lock_file) = self.open_existing_lock_file(session_id)? else {
+            // Imported or legacy snapshots can contain a receipt log without
+            // its ephemeral lock file. Preserve read-only session loading;
+            // live writers always publish the lock before creating the log.
+            return self.load_unlocked(session_id);
+        };
+        let lock = fd_lock::RwLock::new(lock_file);
+        let _guard = lock.read()?;
+        self.load_unlocked(session_id)
+    }
+
+    pub(crate) fn replay(&self, session_id: &str) -> io::Result<ApprovalReplay> {
+        let receipts = self.load(session_id)?;
+        ApprovalReplay::from_receipts(&receipts)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    }
+
+    pub(crate) fn append(&self, session_id: &str, receipt: &ApprovalReceipt) -> io::Result<()> {
+        let lock_file = self.open_lock_file(session_id)?;
+        let mut lock = fd_lock::RwLock::new(lock_file);
+        let _guard = lock.write()?;
+        let path = self.log_path(session_id)?;
+        let mut candidate = self.load_unlocked(session_id)?;
+        candidate.push(receipt.clone());
+        ApprovalReplay::from_receipts(&candidate)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+
+        let parent = path.parent().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "approval log has no parent")
+        })?;
+        fs::create_dir_all(parent)?;
+        let mut line = serde_json::to_vec(receipt)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        line.push(b'\n');
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        file.write_all(&line)?;
+        file.sync_all()?;
+        if let Ok(dir) = File::open(parent) {
+            let _ = dir.sync_all();
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sessions_dir(&self) -> &std::path::Path {
+        &self.sessions_dir
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn completed_receipts(outcome: ApprovalOutcome) -> Vec<ApprovalReceipt> {
+        vec![
+            ApprovalReceipt::asked("tool-1", "exec_shell"),
+            ApprovalReceipt::decided("tool-1", outcome),
+        ]
+    }
+
+    #[test]
+    fn replay_reconstructs_every_closed_outcome() {
+        let outcomes = [
+            ApprovalOutcome::ApprovedOnce,
+            ApprovalOutcome::Denied,
+            ApprovalOutcome::Cancelled,
+            ApprovalOutcome::Unavailable,
+            ApprovalOutcome::RetryWithPolicy {
+                policy: crate::sandbox::SandboxPolicy::DangerFullAccess,
+            },
+        ];
+
+        for outcome in outcomes {
+            let replay = ApprovalReplay::from_receipts(&completed_receipts(outcome.clone()))
+                .expect("closed approval log replays");
+            assert_eq!(replay.completed.len(), 1);
+            assert_eq!(replay.completed[0].outcome, outcome);
+            assert!(replay.unmatched_asks.is_empty());
+        }
+    }
+
+    #[test]
+    fn replay_detects_an_unmatched_ask_after_interruption() {
+        let ask = ApprovalReceipt::asked("tool-interrupted", "write_file");
+        let replay = ApprovalReplay::from_receipts(std::slice::from_ref(&ask))
+            .expect("an unmatched ask is valid crash evidence");
+
+        assert!(replay.completed.is_empty());
+        assert_eq!(replay.unmatched_asks, vec![ask]);
+    }
+
+    #[test]
+    fn replay_rejects_decisions_without_one_open_ask() {
+        let orphan = ApprovalReceipt::decided("tool-orphan", ApprovalOutcome::ApprovedOnce);
+        assert!(ApprovalReplay::from_receipts(&[orphan]).is_err());
+
+        let duplicate = vec![
+            ApprovalReceipt::asked("tool-duplicate", "exec_shell"),
+            ApprovalReceipt::decided("tool-duplicate", ApprovalOutcome::Denied),
+            ApprovalReceipt::decided("tool-duplicate", ApprovalOutcome::ApprovedOnce),
+        ];
+        assert!(ApprovalReplay::from_receipts(&duplicate).is_err());
+    }
+
+    #[test]
+    fn store_appends_and_replays_a_session_owned_log() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = ApprovalReceiptStore::new(tmp.path().join("sessions"));
+        let ask = ApprovalReceipt::asked("tool-persisted", "edit_file");
+        let decision = ApprovalReceipt::decided("tool-persisted", ApprovalOutcome::ApprovedOnce);
+
+        store
+            .append("session-1", &ask)
+            .expect("persist approval ask");
+        store
+            .append("session-1", &decision)
+            .expect("persist approval decision");
+
+        let receipts = store.load("session-1").expect("load approval log");
+        assert_eq!(receipts, vec![ask, decision]);
+        let replay = ApprovalReplay::from_receipts(&receipts).expect("replay approval log");
+        assert_eq!(replay.completed.len(), 1);
+        assert!(replay.unmatched_asks.is_empty());
+    }
+
+    #[test]
+    fn loading_missing_or_imported_logs_is_read_only() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let store = ApprovalReceiptStore::new(sessions_dir.clone());
+
+        assert!(store.load("session-empty").expect("missing log").is_empty());
+        assert!(!sessions_dir.join("session-empty").exists());
+
+        let imported_dir = sessions_dir.join("session-imported");
+        fs::create_dir_all(&imported_dir).expect("imported session dir");
+        let ask = ApprovalReceipt::asked("tool-imported", "exec_shell");
+        let mut line = serde_json::to_vec(&ask).expect("serialize imported ask");
+        line.push(b'\n');
+        fs::write(imported_dir.join(APPROVAL_LOG_FILE), line).expect("imported log");
+
+        assert_eq!(
+            store.load("session-imported").expect("load imported log"),
+            vec![ask]
+        );
+        assert!(!imported_dir.join(APPROVAL_LOCK_FILE).exists());
+    }
+
+    #[test]
+    fn store_serializes_competing_writers() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = ApprovalReceiptStore::new(tmp.path().join("sessions"));
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+        let mut writers = Vec::new();
+
+        for _ in 0..8 {
+            let store = store.clone();
+            let barrier = barrier.clone();
+            writers.push(std::thread::spawn(move || {
+                barrier.wait();
+                store.append(
+                    "session-race",
+                    &ApprovalReceipt::asked("tool-race", "exec_shell"),
+                )
+            }));
+        }
+
+        let results = writers
+            .into_iter()
+            .map(|writer| writer.join().expect("writer thread"))
+            .collect::<Vec<_>>();
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(results.iter().filter(|result| result.is_err()).count(), 7);
+        assert_eq!(store.load("session-race").expect("load receipts").len(), 1);
+    }
+}

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -23,6 +23,7 @@ use serde_json::{Value, json};
 use tokio::sync::{Mutex as AsyncMutex, RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 
+use crate::approval_log::ApprovalReceiptStore;
 use crate::client::DeepSeekClient;
 use crate::compaction::{CompactionConfig, PreparedCompactionEnvelope, compact_messages_safe};
 use crate::config::{ApiProvider, Config, DEFAULT_MAX_SUBAGENTS, DEFAULT_TEXT_MODEL};
@@ -627,6 +628,10 @@ pub struct Engine {
     scheduled_goal_continuation: Option<ScheduledGoalContinuation>,
     goal_continuation_schedule_seq: u64,
     rx_approval: mpsc::Receiver<ApprovalDecision>,
+    /// Canonical per-session approval evidence. A missing/unwritable store is
+    /// retained as an error so construction can stay infallible while every
+    /// approval gate still fails closed.
+    approval_receipt_store: Result<ApprovalReceiptStore, String>,
     rx_user_input: mpsc::Receiver<UserInputDecision>,
     rx_steer: mpsc::Receiver<String>,
     tx_event: mpsc::Sender<Event>,
@@ -1318,6 +1323,13 @@ impl Engine {
 
         let active_route_limits = config.active_route_limits;
         let shared_auto_review_policy = Arc::new(config.auto_review_policy.clone());
+        #[cfg(not(test))]
+        let approval_receipt_store =
+            ApprovalReceiptStore::default_location().map_err(|err| err.to_string());
+        #[cfg(test)]
+        let approval_receipt_store = Ok(ApprovalReceiptStore::new(
+            std::env::temp_dir().join(format!("codewhale-approval-tests-{}", uuid::Uuid::new_v4())),
+        ));
         let engine = Engine {
             config,
             api_config: api_config.clone(),
@@ -1346,6 +1358,7 @@ impl Engine {
             scheduled_goal_continuation: None,
             goal_continuation_schedule_seq: 0,
             rx_approval,
+            approval_receipt_store,
             rx_user_input,
             rx_steer,
             tx_event,

--- a/crates/tui/src/core/engine/approval.rs
+++ b/crates/tui/src/core/engine/approval.rs
@@ -7,6 +7,7 @@
 
 use std::time::Duration;
 
+use crate::approval_log::{ApprovalOutcome, ApprovalReceipt};
 use crate::core::events::Event;
 use crate::tools::spec::ToolError;
 use crate::tools::user_input::{UserInputRequest, UserInputResponse};
@@ -53,6 +54,71 @@ pub(super) enum ApprovalResult {
 }
 
 impl Engine {
+    async fn commit_approval_receipt(&self, receipt: ApprovalReceipt) -> Result<(), ToolError> {
+        let store = self.approval_receipt_store.clone().map_err(|error| {
+            tracing::warn!(
+                target: "approval",
+                %error,
+                "approval receipt store is unavailable"
+            );
+            ToolError::execution_failed(
+                "Approval evidence could not be committed; tool execution was blocked.".to_string(),
+            )
+        })?;
+        let session_id = self.session.id.clone();
+        let write = tokio::task::spawn_blocking(move || store.append(&session_id, &receipt))
+            .await
+            .map_err(|error| {
+                tracing::warn!(
+                    target: "approval",
+                    %error,
+                    "approval receipt writer did not complete"
+                );
+                ToolError::execution_failed(
+                    "Approval evidence could not be committed; tool execution was blocked."
+                        .to_string(),
+                )
+            })?;
+        write.map_err(|error| {
+            tracing::warn!(
+                target: "approval",
+                error_kind = ?error.kind(),
+                "approval receipt write failed"
+            );
+            ToolError::execution_failed(
+                "Approval evidence could not be committed; tool execution was blocked.".to_string(),
+            )
+        })
+    }
+
+    async fn commit_approval_outcome(
+        &self,
+        tool_id: &str,
+        outcome: ApprovalOutcome,
+    ) -> Result<(), ToolError> {
+        self.commit_approval_receipt(ApprovalReceipt::decided(tool_id, outcome))
+            .await
+    }
+
+    pub(super) async fn request_tool_approval(
+        &mut self,
+        tool_id: &str,
+        tool_name: &str,
+        event: Event,
+    ) -> Result<ApprovalResult, ToolError> {
+        self.commit_approval_receipt(ApprovalReceipt::asked(tool_id, tool_name))
+            .await?;
+        if self.tx_event.send(event).await.is_err() {
+            self.commit_approval_outcome(tool_id, ApprovalOutcome::Unavailable)
+                .await?;
+            return Err(ToolError::execution_failed(
+                "Approval request could not reach its decision host; tool execution was blocked."
+                    .to_string(),
+            ));
+        }
+        self.await_tool_approval(tool_id).await
+    }
+
     /// Format a cancellation suffix when the engine knows the cause.
     /// Some internal cancellation paths still use the raw token while
     /// #1541 is open; those keep the legacy message without a guessed
@@ -76,12 +142,14 @@ impl Engine {
             tokio::select! {
                 _ = self.cancel_token.cancelled() => {
                     let suffix = self.cancel_reason_suffix();
+                    self.commit_approval_outcome(tool_id, ApprovalOutcome::Cancelled).await?;
                     return Err(ToolError::cancelled(
                         format!("Request cancelled while awaiting approval{suffix}"),
                     ));
                 }
                 decision = self.rx_approval.recv() => {
                     let Some(decision) = decision else {
+                        self.commit_approval_outcome(tool_id, ApprovalOutcome::Unavailable).await?;
                         return Err(ToolError::execution_failed(
                             "Approval channel closed — engine is shutting down. \
                              The approval modal can no longer reach the engine; \
@@ -91,12 +159,18 @@ impl Engine {
                     };
                     match decision {
                         ApprovalDecision::Approved { id } if id == tool_id => {
+                            self.commit_approval_outcome(tool_id, ApprovalOutcome::ApprovedOnce).await?;
                             return Ok(ApprovalResult::Approved);
                         }
                         ApprovalDecision::Denied { id } if id == tool_id => {
+                            self.commit_approval_outcome(tool_id, ApprovalOutcome::Denied).await?;
                             return Ok(ApprovalResult::Denied);
                         }
                         ApprovalDecision::RetryWithPolicy { id, policy } if id == tool_id => {
+                            self.commit_approval_outcome(
+                                tool_id,
+                                ApprovalOutcome::RetryWithPolicy { policy: policy.clone() },
+                            ).await?;
                             return Ok(ApprovalResult::RetryWithPolicy(policy));
                         }
                         // A child prompt answered while the parent itself is
@@ -170,5 +244,221 @@ impl Engine {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::core::engine::EngineConfig;
+    use crate::sandbox::SandboxPolicy;
+
+    fn approval_event(tool_id: &str) -> Event {
+        Event::ApprovalRequired {
+            id: tool_id.to_string(),
+            tool_name: "exec_shell".to_string(),
+            description: "run a keyless approval test".to_string(),
+            input: serde_json::json!({"command": "true"}),
+            approval_key: format!("key-{tool_id}"),
+            approval_grouping_key: "exec_shell:true".to_string(),
+            intent_summary: None,
+            approval_force_prompt: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn keyless_engine_persists_every_closed_approval_outcome() {
+        enum Decision {
+            Approve,
+            Deny,
+            Cancel,
+            Retry,
+        }
+        let cases = [
+            (Decision::Approve, ApprovalOutcome::ApprovedOnce),
+            (Decision::Deny, ApprovalOutcome::Denied),
+            (Decision::Cancel, ApprovalOutcome::Cancelled),
+            (
+                Decision::Retry,
+                ApprovalOutcome::RetryWithPolicy {
+                    policy: SandboxPolicy::DangerFullAccess,
+                },
+            ),
+        ];
+
+        for (index, (decision, expected)) in cases.into_iter().enumerate() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
+            let store = crate::approval_log::ApprovalReceiptStore::new(tmp.path().join("sessions"));
+            engine.approval_receipt_store = Ok(store.clone());
+            let session_id = engine.session.id.clone();
+            let tool_id = format!("tool-{index}");
+            let event = approval_event(&tool_id);
+            let pending_tool_id = tool_id.clone();
+            let task = tokio::spawn(async move {
+                engine
+                    .request_tool_approval(&pending_tool_id, "exec_shell", event)
+                    .await
+            });
+
+            let emitted = handle
+                .rx_event
+                .write()
+                .await
+                .recv()
+                .await
+                .expect("approval event");
+            assert!(matches!(emitted, Event::ApprovalRequired { .. }));
+            match decision {
+                Decision::Approve => handle.approve_tool_call(&tool_id).await.expect("approve"),
+                Decision::Deny => handle.deny_tool_call(&tool_id).await.expect("deny"),
+                Decision::Cancel => handle.cancel(),
+                Decision::Retry => handle
+                    .retry_tool_with_policy(&tool_id, SandboxPolicy::DangerFullAccess)
+                    .await
+                    .expect("retry"),
+            }
+
+            let result = task.await.expect("approval task");
+            match expected {
+                ApprovalOutcome::ApprovedOnce => {
+                    assert!(matches!(result, Ok(ApprovalResult::Approved)));
+                }
+                ApprovalOutcome::Denied => {
+                    assert!(matches!(result, Ok(ApprovalResult::Denied)));
+                }
+                ApprovalOutcome::Cancelled => assert!(result.is_err()),
+                ApprovalOutcome::RetryWithPolicy { .. } => {
+                    assert!(matches!(result, Ok(ApprovalResult::RetryWithPolicy(_))));
+                }
+                ApprovalOutcome::Unavailable => unreachable!(),
+            }
+            let replay = store.replay(&session_id).expect("replay approvals");
+            assert_eq!(replay.completed.len(), 1);
+            assert_eq!(replay.completed[0].outcome, expected);
+            assert!(replay.unmatched_asks.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn closed_approval_channel_is_persisted_as_unavailable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
+        let store = crate::approval_log::ApprovalReceiptStore::new(tmp.path().join("sessions"));
+        engine.approval_receipt_store = Ok(store.clone());
+        let session_id = engine.session.id.clone();
+        let events = handle.rx_event.clone();
+        drop(handle);
+
+        let task = tokio::spawn(async move {
+            engine
+                .request_tool_approval(
+                    "tool-unavailable",
+                    "exec_shell",
+                    approval_event("tool-unavailable"),
+                )
+                .await
+        });
+        let emitted = events
+            .write()
+            .await
+            .recv()
+            .await
+            .expect("approval event before channel closure is observed");
+        assert!(matches!(emitted, Event::ApprovalRequired { .. }));
+        assert!(task.await.expect("approval task").is_err());
+
+        let replay = store.replay(&session_id).expect("replay approvals");
+        assert_eq!(replay.completed.len(), 1);
+        assert_eq!(replay.completed[0].outcome, ApprovalOutcome::Unavailable);
+    }
+
+    #[tokio::test]
+    async fn stale_approval_decision_cannot_grant_current_request() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
+        let store = crate::approval_log::ApprovalReceiptStore::new(tmp.path().join("sessions"));
+        engine.approval_receipt_store = Ok(store.clone());
+        let session_id = engine.session.id.clone();
+        let mut task = tokio::spawn(async move {
+            engine
+                .request_tool_approval("tool-current", "exec_shell", approval_event("tool-current"))
+                .await
+        });
+
+        let emitted = handle
+            .rx_event
+            .write()
+            .await
+            .recv()
+            .await
+            .expect("approval event");
+        assert!(matches!(emitted, Event::ApprovalRequired { .. }));
+        handle
+            .approve_tool_call("tool-stale")
+            .await
+            .expect("deliver stale decision");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut task)
+                .await
+                .is_err(),
+            "a stale decision must not grant or close the current request"
+        );
+        handle
+            .deny_tool_call("tool-current")
+            .await
+            .expect("deny current request");
+        assert!(matches!(
+            task.await.expect("approval task"),
+            Ok(ApprovalResult::Denied)
+        ));
+
+        let replay = store.replay(&session_id).expect("replay approvals");
+        assert_eq!(replay.completed.len(), 1);
+        assert_eq!(replay.completed[0].outcome, ApprovalOutcome::Denied);
+        assert!(replay.unmatched_asks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn terminal_receipt_failure_never_returns_a_grant() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
+        let store = crate::approval_log::ApprovalReceiptStore::new(tmp.path().join("sessions"));
+        engine.approval_receipt_store = Ok(store.clone());
+        let session_id = engine.session.id.clone();
+        let task = tokio::spawn(async move {
+            engine
+                .request_tool_approval(
+                    "tool-write-fails",
+                    "exec_shell",
+                    approval_event("tool-write-fails"),
+                )
+                .await
+        });
+
+        let emitted = handle
+            .rx_event
+            .write()
+            .await
+            .recv()
+            .await
+            .expect("approval event");
+        assert!(matches!(emitted, Event::ApprovalRequired { .. }));
+        let log_path = store
+            .sessions_dir()
+            .join(session_id)
+            .join("approval_receipts.jsonl");
+        std::fs::remove_file(&log_path).expect("remove log after durable ask");
+        std::fs::create_dir(&log_path).expect("replace log with unwritable directory");
+        handle
+            .approve_tool_call("tool-write-fails")
+            .await
+            .expect("deliver approval decision");
+
+        assert!(
+            task.await.expect("approval task").is_err(),
+            "an approval decision without a committed terminal receipt must not grant execution"
+        );
     }
 }

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -3538,25 +3538,25 @@ impl Engine {
                                     &tool_input,
                                 )
                                 .0;
-                            let _ = self
-                                .tx_event
-                                .send(Event::ApprovalRequired {
-                                    id: tool_id.clone(),
-                                    tool_name: tool_name.clone(),
-                                    input: tool_input.clone(),
-                                    description: plan.approval_description.clone(),
-                                    approval_key,
-                                    approval_grouping_key,
-                                    intent_summary: if plan.read_only {
-                                        None
-                                    } else {
-                                        intent_summary.clone()
-                                    },
-                                    approval_force_prompt: plan.approval_force_prompt,
-                                })
-                                .await;
+                            let approval_event = Event::ApprovalRequired {
+                                id: tool_id.clone(),
+                                tool_name: tool_name.clone(),
+                                input: tool_input.clone(),
+                                description: plan.approval_description.clone(),
+                                approval_key,
+                                approval_grouping_key,
+                                intent_summary: if plan.read_only {
+                                    None
+                                } else {
+                                    intent_summary.clone()
+                                },
+                                approval_force_prompt: plan.approval_force_prompt,
+                            };
 
-                            match self.await_tool_approval(&tool_id).await {
+                            match self
+                                .request_tool_approval(&tool_id, &tool_name, approval_event)
+                                .await
+                            {
                                 Ok(ApprovalResult::Approved) => {
                                     let decision = if model_requested_policy.is_some() {
                                         "approved_with_requested_policy"

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -22,6 +22,7 @@ i18n!("locales", fallback = ["en"]);
 
 mod acp_server;
 mod agy_credentials;
+mod approval_log;
 mod artifacts;
 mod audit;
 mod auto_reasoning;

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -231,6 +231,7 @@ fn saved_session_with_blocks(blocks: Vec<crate::models::ContentBlock>) -> SavedS
         system_prompt: None,
         context_references: Vec::new(),
         artifacts: Vec::new(),
+        approval_receipts: Vec::new(),
         work_state: None,
         last_auto_route: None,
     }

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -6,6 +6,7 @@
 //! - Resuming sessions by ID
 //! - Managing session lifecycle
 
+use crate::approval_log::{ApprovalReceipt, ApprovalReceiptStore, ApprovalReplay};
 use crate::artifacts::ArtifactRecord;
 use crate::config::ApiProvider;
 use crate::model_routing::AutoRouteReceipt;
@@ -533,6 +534,11 @@ pub struct SavedSession {
     /// Artifact contents are stored in the session-owned artifact directory.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<ArtifactRecord>,
+    /// Session-owned approval evidence. The append-only sidecar is canonical
+    /// during a live turn; this projection makes saved snapshots self-
+    /// describing without putting receipts in the model transcript.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) approval_receipts: Vec<ApprovalReceipt>,
     /// To-do and plan state shown in the Work sidebar.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_state: Option<SessionWorkState>,
@@ -674,6 +680,7 @@ impl SavedSession {
             system_prompt: None,
             context_references: Vec::new(),
             artifacts: Vec::new(),
+            approval_receipts: Vec::new(),
             work_state: None,
             last_auto_route: None,
         })
@@ -716,6 +723,26 @@ const LEGACY_CHECKPOINT_FILE: &str = "latest.json";
 const OFFLINE_QUEUE_FILE: &str = "offline_queue.json";
 
 impl SessionManager {
+    fn approval_receipt_store(&self) -> ApprovalReceiptStore {
+        ApprovalReceiptStore::new(self.sessions_dir.clone())
+    }
+
+    fn hydrate_approval_receipts(&self, session: &mut SavedSession) -> io::Result<()> {
+        let durable = self.approval_receipt_store().load(&session.metadata.id)?;
+        if !durable.is_empty() {
+            session.approval_receipts = durable;
+        }
+        ApprovalReplay::from_receipts(&session.approval_receipts)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        Ok(())
+    }
+
+    /// Reconstruct completed approvals and interrupted unmatched asks for one
+    /// session without consulting the model transcript.
+    pub(crate) fn replay_approvals(&self, session_id: &str) -> io::Result<ApprovalReplay> {
+        self.approval_receipt_store().replay(session_id)
+    }
+
     fn validated_session_id<'a>(&self, id: &'a str) -> std::io::Result<&'a str> {
         let trimmed = id.trim();
         if trimmed.is_empty() {
@@ -794,7 +821,9 @@ impl SessionManager {
 
         self.archive_before_first_graph_write(session, &path)?;
 
-        let content = serialize_saved_session(session)?;
+        let mut durable_session = session.clone();
+        self.hydrate_approval_receipts(&mut durable_session)?;
+        let content = serialize_saved_session(&durable_session)?;
 
         // Atomic write via write_atomic (NamedTempFile + fsync + persist)
         write_atomic(&path, content.as_bytes())?;
@@ -816,7 +845,9 @@ impl SessionManager {
         self.archive_before_first_graph_write(session, &session_path)?;
         fs::create_dir_all(self.checkpoints_dir())?;
         let already_persisted = path.exists() || session_path.exists();
-        let content = serialize_saved_session(session)?;
+        let mut durable_session = session.clone();
+        self.hydrate_approval_receipts(&mut durable_session)?;
+        let content = serialize_saved_session(&durable_session)?;
         write_atomic(&path, content.as_bytes())?;
         self.stamp_session_boot_owner_for_new_record(&session.metadata.id, already_persisted);
         Ok(path)
@@ -964,6 +995,7 @@ impl SessionManager {
             ));
         }
         session.system_prompt = strip_legacy_truncation_note(session.system_prompt);
+        self.hydrate_approval_receipts(&mut session)?;
         Ok(Some(session))
     }
 
@@ -1139,6 +1171,7 @@ impl SessionManager {
 
         session.system_prompt = strip_legacy_truncation_note(session.system_prompt);
         session.ensure_journal();
+        self.hydrate_approval_receipts(&mut session)?;
 
         Ok(session)
     }
@@ -1796,6 +1829,7 @@ pub fn create_saved_session_with_id_and_mode(
         system_prompt: system_prompt_to_string(system_prompt),
         context_references: Vec::new(),
         artifacts: Vec::new(),
+        approval_receipts: Vec::new(),
         work_state: None,
         last_auto_route: None,
     }
@@ -2112,6 +2146,7 @@ fn format_age(dt: &DateTime<Utc>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::approval_log::ApprovalOutcome;
     use crate::models::ContentBlock;
     use crate::tools::plan::StepStatus;
     use crate::tui::history::{HistoryCell, ToolCell, history_cells_from_message};
@@ -2362,6 +2397,7 @@ mod tests {
             system_prompt: None,
             context_references: Vec::new(),
             artifacts: Vec::new(),
+            approval_receipts: Vec::new(),
             work_state: None,
             last_auto_route: None,
         };
@@ -2401,10 +2437,67 @@ mod tests {
             system_prompt: None,
             context_references: Vec::new(),
             artifacts: Vec::new(),
+            approval_receipts: Vec::new(),
             work_state: None,
             last_auto_route: None,
         };
         manager.save_session(&session).expect("save empty");
+    }
+
+    #[test]
+    fn save_and_resume_reconstructs_closed_and_interrupted_approvals() {
+        let tmp = tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        let session = create_saved_session(
+            &[make_test_message("user", "approval recovery")],
+            "test-model",
+            tmp.path(),
+            0,
+            None,
+        );
+        let session_id = session.metadata.id.clone();
+        let store = ApprovalReceiptStore::new(sessions_dir);
+        store
+            .append(
+                &session_id,
+                &ApprovalReceipt::asked("tool-complete", "exec_shell"),
+            )
+            .expect("persist completed ask");
+        store
+            .append(
+                &session_id,
+                &ApprovalReceipt::decided("tool-complete", ApprovalOutcome::Denied),
+            )
+            .expect("persist completed decision");
+        store
+            .append(
+                &session_id,
+                &ApprovalReceipt::asked("tool-interrupted", "write_file"),
+            )
+            .expect("persist interrupted ask");
+
+        manager.save_session(&session).expect("save session");
+        let resumed = manager
+            .load_session_snapshot(&session_id)
+            .expect("resume session");
+        let replay = ApprovalReplay::from_receipts(&resumed.approval_receipts)
+            .expect("replay resumed approval evidence");
+
+        assert_eq!(resumed.messages, session.messages);
+        assert_eq!(replay.completed.len(), 1);
+        assert_eq!(replay.completed[0].outcome, ApprovalOutcome::Denied);
+        assert_eq!(replay.unmatched_asks.len(), 1);
+        assert!(matches!(
+            &replay.unmatched_asks[0],
+            ApprovalReceipt::Asked { tool_call_id, .. } if tool_call_id == "tool-interrupted"
+        ));
+        assert_eq!(
+            manager
+                .replay_approvals(&session_id)
+                .expect("replay canonical sidecar"),
+            replay
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5414,6 +5414,7 @@ fn saved_session_with_messages(messages: Vec<Message>) -> SavedSession {
         system_prompt: None,
         context_references: Vec::new(),
         artifacts: Vec::new(),
+        approval_receipts: Vec::new(),
         work_state: None,
         last_auto_route: None,
     }


### PR DESCRIPTION
## Summary

- persist approval requests and terminal outcomes in a session-owned log before execution can proceed
- deny execution when a terminal approval receipt cannot be persisted, and reject stale decisions
- reconstruct closed and interrupted approval state when a session resumes

Closes #5360

## Verification

- `cargo test -p codewhale-tui --lib approval` (257 passed)
- `cargo test -p codewhale-tui --lib session_manager` (61 passed)
- `cargo test -p codewhale-tui --all-targets --no-run`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`