### PR TITLE
fix(pricing): classify Orcarouter as an aggregator billing surface

### DIFF
--- a/crates/tui/src/pricing.rs
+++ b/crates/tui/src/pricing.rs
@@ -380,7 +380,10 @@ pub(crate) fn billing_surface_for_route(
         ApiProvider::Moonshot => moonshot_surface(&shape),
         ApiProvider::Minimax | ApiProvider::MinimaxAnthropic => minimax_surface(&shape),
         ApiProvider::XiaomiMimo => xiaomi_surface(&shape),
-        ApiProvider::Openrouter | ApiProvider::NvidiaNim | ApiProvider::OpencodeZen => {
+        ApiProvider::Openrouter
+        | ApiProvider::NvidiaNim
+        | ApiProvider::OpencodeZen
+        | ApiProvider::Orcarouter => {
             is_official_default_endpoint(provider, &shape).then_some(AGGREGATOR_BILLING_SURFACE)
         }
         _ => is_official_default_endpoint(provider, &shape)
@@ -2271,6 +2274,12 @@ mod tests {
             (
                 ApiProvider::Openrouter,
                 "https://openrouter.ai/api/v1",
+                AGGREGATOR_BILLING_SURFACE,
+                EndpointMetering::Money,
+            ),
+            (
+                ApiProvider::Orcarouter,
+                "https://api.orcarouter.ai/v1",
                 AGGREGATOR_BILLING_SURFACE,
                 EndpointMetering::Money,
             ),


### PR DESCRIPTION
## Summary

`billing_surface_for_route` had `Openrouter | NvidiaNim | OpencodeZen` in its aggregator arm, so the official OrcaRouter endpoint fell through to the **first-party PAYG** surface — a mislabel. OrcaRouter is a zero-markup router/aggregator (Continuum AI Corp; provider kind/config/defaults landed via #5321; models.dev publishes an `orcarouter` provider with 81 rows; `api.orcarouter.ai/v1/models` verified live in this session).

## Change

- `crates/tui/src/pricing.rs`: add `ApiProvider::Orcarouter` to the aggregator arm; pin with a billing-surface table test for `https://api.orcarouter.ai/v1`.
- Truth change for the billing-surface label only; clamp values and pricing rows untouched.

## Verification

- `cargo test -p codewhale-tui --lib pricing` → 80 passed, 0 failed.

No-Issue: follow-up to the OrcaRouter wiring from #5321.