### PR TITLE
feat(config): configurable auto-router classifier timeout

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2480,6 +2480,12 @@ pub struct AutoConfig {
     pub router: Option<AutoRouterConfig>,
 }
 
+/// Default classifier call timeout for `[auto.router]` (seconds).
+pub(crate) const DEFAULT_AUTO_ROUTER_TIMEOUT_SECS: u64 = 4;
+/// Upper clamp for a configured classifier timeout: a hung local router must
+/// not stall an Auto turn forever.
+pub(crate) const MAX_AUTO_ROUTER_TIMEOUT_SECS: u64 = 300;
+
 /// Explicit classifier route for Auto model mode (`[auto.router]`).
 ///
 /// When `provider` + `model` are set, Auto mode's classifier call goes to that
@@ -2502,6 +2508,12 @@ pub struct AutoRouterConfig {
     /// Thinking tier for the classifier call (e.g. `"off"`). Defaults to off.
     #[serde(default)]
     pub thinking: Option<String>,
+    /// Classifier call timeout in seconds. Defaults to
+    /// [`DEFAULT_AUTO_ROUTER_TIMEOUT_SECS`] (4); `0` means "use the default".
+    /// Values above [`MAX_AUTO_ROUTER_TIMEOUT_SECS`] (300) are clamped so a
+    /// hung local router cannot stall a turn indefinitely.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
 }
 
 fn default_update_check_for_updates() -> bool {
@@ -4312,6 +4324,21 @@ impl Config {
             .as_ref()
             .and_then(|a| a.cross_provider)
             .unwrap_or(false)
+    }
+
+    /// Classifier call timeout for `[auto.router]` in seconds. Defaults to
+    /// [`DEFAULT_AUTO_ROUTER_TIMEOUT_SECS`] (4); `0` means "use the default".
+    /// Values above [`MAX_AUTO_ROUTER_TIMEOUT_SECS`] (300) are clamped so a
+    /// hung local router cannot stall a turn indefinitely.
+    #[must_use]
+    pub fn auto_router_timeout_secs(&self) -> u64 {
+        self.auto
+            .as_ref()
+            .and_then(|a| a.router.as_ref())
+            .and_then(|r| r.timeout_secs)
+            .filter(|secs| *secs > 0)
+            .unwrap_or(DEFAULT_AUTO_ROUTER_TIMEOUT_SECS)
+            .min(MAX_AUTO_ROUTER_TIMEOUT_SECS)
     }
 
     #[must_use]

--- a/crates/tui/src/model_inventory.rs
+++ b/crates/tui/src/model_inventory.rs
@@ -53,6 +53,8 @@ pub(crate) struct ModelInventory {
     pub(crate) router_model: String,
     /// Thinking tier for the classifier call (None = off) (#auto.router).
     pub(crate) router_thinking: Option<String>,
+    /// Classifier call timeout in seconds (default 4; clamped at config load).
+    pub(crate) router_timeout_secs: u64,
     /// Whether an explicit legacy `[auto.router]` classifier route is
     /// configured. Absent configuration means legacy Auto stays local/free —
     /// holding a provider key never elects a network classifier by itself.
@@ -224,6 +226,7 @@ impl ModelInventory {
             .unwrap_or_else(|| (ApiProvider::Deepseek, "deepseek-v4-flash".to_string(), None));
 
         let cross_provider_auto = config.auto_cross_provider();
+        let router_timeout_secs = config.auto_router_timeout_secs();
 
         Self {
             active_provider,
@@ -232,6 +235,7 @@ impl ModelInventory {
             router_available: router_configured && has_api_key_for(config, router_provider),
             router_model,
             router_thinking,
+            router_timeout_secs,
             cross_provider_auto,
             candidates,
         }
@@ -700,6 +704,65 @@ mod tests {
     }
 
     #[test]
+    fn inventory_router_timeout_secs_respects_config_with_clamp() {
+        let _env_lock = crate::test_support::lock_test_env();
+
+        // Unset: the legacy default (4 s) survives.
+        let config = Config {
+            ..Default::default()
+        };
+        assert_eq!(ModelInventory::from_config(&config).router_timeout_secs, 4);
+
+        // Explicit value is honored.
+        let config = Config {
+            auto: Some(crate::config::AutoConfig {
+                router: Some(crate::config::AutoRouterConfig {
+                    provider: Some("custom".to_string()),
+                    model: Some("local-router".to_string()),
+                    thinking: None,
+                    timeout_secs: Some(15),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(ModelInventory::from_config(&config).router_timeout_secs, 15);
+
+        // Out-of-range values clamp to the safety ceiling, never to zero.
+        let config = Config {
+            auto: Some(crate::config::AutoConfig {
+                router: Some(crate::config::AutoRouterConfig {
+                    provider: Some("custom".to_string()),
+                    model: Some("local-router".to_string()),
+                    thinking: None,
+                    timeout_secs: Some(9_999),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            ModelInventory::from_config(&config).router_timeout_secs,
+            crate::config::MAX_AUTO_ROUTER_TIMEOUT_SECS
+        );
+
+        // Zero means "use the default", not an instant timeout.
+        let config = Config {
+            auto: Some(crate::config::AutoConfig {
+                router: Some(crate::config::AutoRouterConfig {
+                    provider: Some("custom".to_string()),
+                    model: Some("local-router".to_string()),
+                    thinking: None,
+                    timeout_secs: Some(0),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(ModelInventory::from_config(&config).router_timeout_secs, 4);
+    }
+
+    #[test]
     fn inventory_ignores_unresolved_command_and_secret_auth_metadata() {
         let _env_lock = crate::test_support::lock_test_env();
         let temp = tempfile::tempdir().expect("isolated credential home");
@@ -744,6 +807,7 @@ mod tests {
                     provider: Some("zai".to_string()),
                     model: Some("glm-5-turbo".to_string()),
                     thinking: Some("low".to_string()),
+                    timeout_secs: None,
                 }),
             }),
             ..Default::default()
@@ -791,6 +855,7 @@ mod tests {
                     provider: Some("zai".to_string()),
                     model: Some("glm-5-turbo".to_string()),
                     thinking: None,
+                    timeout_secs: None,
                 }),
                 cross_provider: None,
             }),
@@ -862,6 +927,7 @@ mod tests {
             router_provider: ApiProvider::Deepseek,
             router_model: "deepseek-v4-flash".to_string(),
             router_thinking: None,
+            router_timeout_secs: 4,
             router_configured: false,
             router_available: false,
             cross_provider_auto: false,
@@ -1025,6 +1091,7 @@ mod tests {
                     provider: Some("deepseek".to_string()),
                     model: Some("deepseek-v4-flash".to_string()),
                     thinking: None,
+                    timeout_secs: None,
                 }),
             }),
             ..zai.clone()

--- a/crates/tui/src/model_routing.rs
+++ b/crates/tui/src/model_routing.rs
@@ -1029,10 +1029,14 @@ async fn auto_route_inventory_recommendation(
     };
 
     let response = if allow_response_cache {
-        tokio::time::timeout(Duration::from_secs(4), client.create_message(request)).await??
+        tokio::time::timeout(
+            Duration::from_secs(inventory.router_timeout_secs),
+            client.create_message(request),
+        )
+        .await??
     } else {
         tokio::time::timeout(
-            Duration::from_secs(4),
+            Duration::from_secs(inventory.router_timeout_secs),
             client.create_message_without_response_cache(request),
         )
         .await??

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -3379,6 +3379,7 @@ mod tests {
                 provider: Some("deepseek".to_string()),
                 model: Some("deepseek-v4-flash".to_string()),
                 thinking: None,
+                timeout_secs: None,
             }),
             cross_provider: None,
         });


### PR DESCRIPTION
    ## What                                                                             
    Makes the auto-router classifier call timeout configurable via                      
    `[auto.router] timeout_secs` (seconds). Previously hardcoded at 4s.                 
                                                                                        
    ## Why                                                                              
    4s migth be too tight for local OpenAI-compatible routers (llama.cpp, ollama):      
    a queue delay with `-np 1` or a cold KV-cache silently downgrades Auto              
    mode to the local heuristic on a route the operator explicitly chose.               
    A slow-but-free local classifier is preferable to a faster paid fallback.           
                                                                                        
    ## How                                                                              
    - `AutoRouterConfig.timeout_secs` (config.rs) + `Config::auto_router_timeout_secs()`
      accessor: absent or `0` → 4s (unchanged default), `1..=300` honored,              
      `>300` clamped to 300s so a hung router cannot stall a turn indefinitely.         
    - Carried on `ModelInventory.router_timeout_secs`, used by both timeout             
      paths in `auto_route_inventory_recommendation` (with/without response cache).     
    - New test `inventory_router_timeout_secs_respects_config_with_clamp`.              
                                                                                        
    ## Tests                                                                            
    - `cargo check -p codewhale-tui` ✓                                                  
    - `cargo fmt --all -- --check` ✓                                                    
    - `cargo test -p codewhale-tui --lib model_inventory` → 20 passed (incl. new test) ✓   