### PR TITLE
ci: cap every ci.yml job with timeout-minutes so dead runners fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ env:
 jobs:
   changes:
     name: Change detection
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       heavy: ${{ steps.detect.outputs.heavy }}
@@ -157,6 +158,7 @@ jobs:
 
   versions:
     name: Version drift
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -190,6 +192,7 @@ jobs:
 
   integrations:
     name: Integrations
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -210,6 +213,7 @@ jobs:
   lint:
     name: Lint
     needs: changes
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -352,6 +356,7 @@ jobs:
     name: Workflow RLM cache
     needs: changes
     if: needs.changes.outputs.workflow == 'true'
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -383,6 +388,7 @@ jobs:
     # macOS/Windows runners. Heavy changes use the real matrix OS as before.
     # The ternary is safe: matrix.os is always a non-empty literal, so
     # runs-on can never evaluate to empty.
+    timeout-minutes: 90
     runs-on: ${{ needs.changes.outputs.heavy == 'true' && matrix.os || 'ubuntu-latest' }}
     strategy:
       # A failure on one desktop platform must not erase evidence from the
@@ -508,6 +514,7 @@ jobs:
     # them off macOS/Windows runners. On pull_request the matrix is
     # ubuntu-only, so the required "npm wrapper smoke (ubuntu-latest)"
     # context is unaffected.
+    timeout-minutes: 30
     runs-on: ${{ needs.changes.outputs.heavy == 'true' && matrix.os || 'ubuntu-latest' }}
     strategy:
       matrix:
@@ -581,6 +588,7 @@ jobs:
       github.event_name != 'schedule' &&
       needs.changes.outputs.heavy == 'true' &&
       (github.event_name != 'pull_request' || needs.changes.outputs.mobile == 'true')
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -625,6 +633,7 @@ jobs:
     name: Workflow lint
     needs: changes
     if: needs.changes.outputs.actions == 'true'
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -641,6 +650,7 @@ jobs:
   docs:
     name: Documentation
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

None of the ten ci.yml jobs set `timeout-minutes`, so GitHub's **360-minute default** applied. A runner that gets assigned but never executes — logs 404 forever, job stuck `in_progress` — can sit on a required gate for up to **six hours**.

Tonight that happened live: the #5492 Lint job was in_progress for 73+ minutes with zero log output (job logs 404 = the runner never connected) until a human noticed, cancelled the run, and reran it. This change makes that self-healing: the job fails fast and visibly instead of hanging the gate.

## Caps (generous vs observed cold-run maxima)

| Job | Timeout | Observed max |
| --- | --- | --- |
| Change detection | 10m | <1m |
| Version drift / Integrations / actionlint | 15m | <5m |
| Lint / Workflow RLM cache / npm smoke / mobile smoke | 30m | ~15m cold |
| Documentation | 60m | ~35m |
| Test matrix | 90m | ~60m cold macOS |

Legitimate slow builds keep their headroom; only a dead or logless runner fails now.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` ✓
- `actionlint .github/workflows/ci.yml` — no new findings (only pre-existing style notes at line 54, untouched)
- Diff is exactly 10 inserted `timeout-minutes` lines, one per job.

No-Issue: hardening discovered while merging the 0.9.9 fold-in queue (#5492 Lint hung runner).