### PR TITLE
test(fleet): isolate delete flow from user state

### DIFF
--- a/crates/tui/src/tui/views/fleet_list.rs
+++ b/crates/tui/src/tui/views/fleet_list.rs
@@ -655,6 +655,8 @@ mod tests {
     #[test]
     fn delete_requires_confirmation_and_removes_the_file() {
         let _lock = crate::test_support::lock_test_env();
+        let home = tempfile::TempDir::new().unwrap();
+        let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", home.path());
         let ws = tempfile::TempDir::new().unwrap();
 
         save_in(ws.path(), FleetScope::Workspace, "Temp Fleet");


### PR DESCRIPTION
## Summary

- give the Fleet delete-confirmation test a temporary `CODEWHALE_HOME`
- stop the test from reading a maintainer's real personal Fleets
- preserve the production behavior; this is test-state isolation only

## Evidence

- reproduced on a populated maintainer machine: expected 1 Fleet, observed 2
- exact formerly failing test: pass
- complete `tui::views::fleet_list::tests` module: 6 passed
- `cargo fmt --all -- --check`: pass

No-Issue: release preflight exposed non-hermetic test state.