### PR TITLE
release: v0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.9] - 2026-08-17
+## [0.9.9] - 2026-08-18
 
 Codewhale v0.9.9 is a truth-and-resilience release: the shell tool can no
 longer wedge a session when the host runs out of disk or descriptors,
@@ -126,6 +126,11 @@ locales grow to 18 and 8.
 - CI: the release workflows no longer restore npm/cargo caches after
   checking out a caller-supplied SHA — the CodeQL cache-poisoning Highs
   #88–#107 are closed with a contract test over the workflow files (#5463).
+- Compact TUI rows below 60 columns no longer reserve a hidden session-metrics
+  strip, so narrow terminals reclaim the row instead of clipping the
+  transcript (#5486).
+- Strict `cargo doc` builds no longer fail on bare URLs in rustdoc comments;
+  the remaining links are explicit Markdown targets (#5489).
 
 ### Changed
 
@@ -148,6 +153,23 @@ locales grow to 18 and 8.
   now wraps at the full content width on wide terminals, matching
   tool/status cells, instead of stopping at a 105-column rail that left a
   dead right margin on ultrawide displays (#5436).
+- Configured skill prompts are stable across session roots and operating
+  systems: only custom configured roots hide their physical path, ordinary
+  workspace/global skills keep a discoverable privacy-safe path, warning
+  replacements are boundary-aware (including non-UTF-8 Unix paths), and
+  Windows separators render as `/`. The skills prompt is also 50 bytes
+  leaner without raising a runtime-contract ceiling (#5492, #5473).
+- Auto-router classifier requests accept `[auto.router] timeout_secs`, while
+  preserving the existing default when the key is absent (#5494).
+- Every `ci.yml` job now has an explicit 10–90 minute timeout appropriate to
+  its workload, bounding stale assigned runners instead of inheriting
+  GitHub's six-hour default (#5495).
+- The docs shell and shared web components now route localized copy through
+  the typed dictionary spine; these are two incremental phases of #5337,
+  not completion of the full epic (#5488, #5490).
+- Dependency: rusqlite 0.40.2 (#5391).
+- Documentation: stale A/B/C-tier references, provider defaults, module
+  descriptions, and line anchors now match the current code (#5481).
 
 ### Added
 
@@ -188,6 +210,9 @@ locales grow to 18 and 8.
 - Tests: `crates/tui/tests/README.md` states the keyless assembled-journey
   rule and maps the Auto-Review guardian acceptance items to the engine
   journeys that exercise them (#5361).
+- OrcaRouter's default endpoint is classified as an aggregator billing
+  surface, so pricing and session-cost reporting use the correct billing
+  posture instead of treating it as a first-party provider (#5493).
 - Dependencies: ratatui 0.30.2, thiserror 2.0.20.
 
 ### Removed
@@ -200,7 +225,10 @@ locales grow to 18 and 8.
 - hexin (@h3c-hexin) — a concrete route/offering output limit outranks the
   8,192-token compatibility guess for an uncatalogued model (#5461, closes
   #5460); web tool results use the noisy soft limit (#5474); owned direct
-  model casing resolves safely (#5475).
+  model casing resolves safely (#5475); and configured-skill prompts stay
+  stable across ephemeral roots and operating systems (#5492, #5473).
+- Gabriel-Degret (@Gabriel-Degret) — configurable auto-router classifier
+  timeout (#5494; first contribution).
 - @asto18089 — diagnosed the Z.ai `glm-5.2` casing collision and wrote the
   first provider-scoped fix in Pinvou/CodeWhale#14 (carried upstream in
   #5475).

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.9] - 2026-08-17
+## [0.9.9] - 2026-08-18
 
 Codewhale v0.9.9 is a truth-and-resilience release: the shell tool can no
 longer wedge a session when the host runs out of disk or descriptors,
@@ -126,6 +126,11 @@ locales grow to 18 and 8.
 - CI: the release workflows no longer restore npm/cargo caches after
   checking out a caller-supplied SHA — the CodeQL cache-poisoning Highs
   #88–#107 are closed with a contract test over the workflow files (#5463).
+- Compact TUI rows below 60 columns no longer reserve a hidden session-metrics
+  strip, so narrow terminals reclaim the row instead of clipping the
+  transcript (#5486).
+- Strict `cargo doc` builds no longer fail on bare URLs in rustdoc comments;
+  the remaining links are explicit Markdown targets (#5489).
 
 ### Changed
 
@@ -148,6 +153,23 @@ locales grow to 18 and 8.
   now wraps at the full content width on wide terminals, matching
   tool/status cells, instead of stopping at a 105-column rail that left a
   dead right margin on ultrawide displays (#5436).
+- Configured skill prompts are stable across session roots and operating
+  systems: only custom configured roots hide their physical path, ordinary
+  workspace/global skills keep a discoverable privacy-safe path, warning
+  replacements are boundary-aware (including non-UTF-8 Unix paths), and
+  Windows separators render as `/`. The skills prompt is also 50 bytes
+  leaner without raising a runtime-contract ceiling (#5492, #5473).
+- Auto-router classifier requests accept `[auto.router] timeout_secs`, while
+  preserving the existing default when the key is absent (#5494).
+- Every `ci.yml` job now has an explicit 10–90 minute timeout appropriate to
+  its workload, bounding stale assigned runners instead of inheriting
+  GitHub's six-hour default (#5495).
+- The docs shell and shared web components now route localized copy through
+  the typed dictionary spine; these are two incremental phases of #5337,
+  not completion of the full epic (#5488, #5490).
+- Dependency: rusqlite 0.40.2 (#5391).
+- Documentation: stale A/B/C-tier references, provider defaults, module
+  descriptions, and line anchors now match the current code (#5481).
 
 ### Added
 
@@ -188,6 +210,9 @@ locales grow to 18 and 8.
 - Tests: `crates/tui/tests/README.md` states the keyless assembled-journey
   rule and maps the Auto-Review guardian acceptance items to the engine
   journeys that exercise them (#5361).
+- OrcaRouter's default endpoint is classified as an aggregator billing
+  surface, so pricing and session-cost reporting use the correct billing
+  posture instead of treating it as a first-party provider (#5493).
 - Dependencies: ratatui 0.30.2, thiserror 2.0.20.
 
 ### Removed
@@ -200,7 +225,10 @@ locales grow to 18 and 8.
 - hexin (@h3c-hexin) — a concrete route/offering output limit outranks the
   8,192-token compatibility guess for an uncatalogued model (#5461, closes
   #5460); web tool results use the noisy soft limit (#5474); owned direct
-  model casing resolves safely (#5475).
+  model casing resolves safely (#5475); and configured-skill prompts stay
+  stable across ephemeral roots and operating systems (#5492, #5473).
+- Gabriel-Degret (@Gabriel-Degret) — configurable auto-router classifier
+  timeout (#5494; first contribution).
 - @asto18089 — diagnosed the Z.ai `glm-5.2` casing collision and wrote the
   first provider-scoped fix in Pinvou/CodeWhale#14 (carried upstream in
   #5475).

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -37,7 +37,10 @@ notes, and relevant issue/PR comments.
   for an uncatalogued model; routes that publish no limit stay fail-closed
   (#5461, closes #5460); every web tool surface uses the noisy-result soft
   limit (#5474); lowercase saved selectors resolve against the owning
-  Z.ai/DeepSeek catalog row (#5475)
+  Z.ai/DeepSeek catalog row (#5475); configured-skill prompt paths remain
+  stable across ephemeral roots and operating systems (#5492, #5473)
+- **[Gabriel-Degret](https://github.com/Gabriel-Degret)** — configurable
+  auto-router classifier timeout (#5494; first contribution)
 
 **Reports, reproductions, and verification**
 

--- a/docs/public-surface-facts.json
+++ b/docs/public-surface-facts.json
@@ -222,6 +222,7 @@
     ],
     "requiredCandidateCredits": [
       "@h3c-hexin",
+      "@Gabriel-Degret",
       "@hardy922",
       "@all-lopezg",
       "@alitvak69"

--- a/web/lib/release-credits.ts
+++ b/web/lib/release-credits.ts
@@ -19,7 +19,7 @@
  */
 
 /** Contributors whose PRs were merged or harvested into this release. */
-export const RELEASE_CONTRIBUTORS: string[] = ["@h3c-hexin"];
+export const RELEASE_CONTRIBUTORS: string[] = ["@h3c-hexin", "@Gabriel-Degret"];
 
 /** Contributors who helped with reports, reproductions, and verification. */
 export const RELEASE_HELPERS: string[] = [


### PR DESCRIPTION
## Release summary

Finalize CodeWhale v0.9.9 after the late fold-ins and synchronize the root/TUI changelogs plus public contributor credits.

### CHANGELOG excerpt

- **Fixed:** narrow-terminal compact-row metrics below 60 columns (#5486); strict rustdoc bare URLs (#5489)
- **Changed:** stable configured-skill prompt paths with h3c-hexin credit (#5492/#5473); configurable auto-router classifier timeout with first-time contributor Gabriel-Degret (#5494); explicit CI job timeouts (#5495); typed web dictionary spine phases (#5488/#5490); rusqlite 0.40.2 (#5391); docs cleanup (#5481)
- **Added:** OrcaRouter aggregator billing classification (#5493)
- **Maintainer fix:** isolate the Fleet delete test from real user state (#5498)

## Preflight receipts

Final branch head: `d1c99270f9222aaa4cefc0bfc8c5f874434fd77b`

Final tree: `828a123a4ffa2a17b9cf5b10282a26932ea4c9eb`. The Rust/package tree was fully tested at `51005ae488550246d4f3762a3d7395a44825ef43`; the only later changes are the three contributor-credit parity surfaces verified by the complete web gate below.

- `./scripts/sync-changelog.sh` — pass; root and TUI changelogs synchronized
- `./scripts/release/check-versions.sh` — pass; workspace/npm/lockfile all `0.9.9`
- `cargo fmt --all -- --check` — pass
- `cargo check --workspace --all-targets --locked` — pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — pass
- `RUST_MIN_STACK=16777216 cargo test --workspace --all-features --locked` — pass, including 264 integration cases, 83 PTY cases, and doctests
- `./scripts/release/publish-crates.sh dry-run` — pass; 21-crate order/package verification
- `cargo build --release --locked -p codewhale-cli -p codewhale-tui` — pass
- `node scripts/release/npm-wrapper-smoke.js` — pass with local v0.9.9 assets
- web gate after credit sync: facts/docs parity, 266 tests, ESLint, TypeScript, and 512-page production build — pass
- sacred untracked lane file remains unmodified and is not part of this PR

No-Issue: release