### PR TITLE
test(ci): harden release gate concurrency

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,7 +27,11 @@ pty = { max-threads = 1 }
 # Integration tests that spawn the real `codewhale` binary and wait on
 # service start-up deadlines; bounded so a fully parallel run on a busy
 # machine cannot starve them past their 30 s budgets.
-spawns-binaries = { max-threads = 4 }
+spawns-binaries = { max-threads = 3 }
+# Telemetry contract tests also spawn the real binary, and their fixture's
+# in-process mutex cannot serialize nextest's one-process-per-test workers.
+# Keep one telemetry process alongside the other three integration workers.
+telemetry-contract = { max-threads = 1 }
 
 [[profile.default.overrides]]
 # The PTY test binary (`crates/tui/tests/pty`) drives real pseudo-terminals
@@ -36,6 +40,10 @@ spawns-binaries = { max-threads = 4 }
 filter = 'binary(pty)'
 test-group = 'pty'
 slow-timeout = { period = "120s" }
+
+[[profile.default.overrides]]
+filter = 'binary(integration) & test(/^telemetry_contract::/)'
+test-group = 'telemetry-contract'
 
 [[profile.default.overrides]]
 filter = 'binary(integration)'

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -8383,7 +8383,8 @@ async fn closed_engine_event_stream_fails_turn_items_and_evicts_engine() -> Resu
     assert!(matches!(rx_op.recv().await, Some(Op::SendMessage { .. })));
     drop(tx_event);
 
-    let terminal = wait_for_terminal_turn(&manager, &turn.id, Duration::from_secs(2)).await?;
+    let terminal =
+        wait_for_terminal_turn(&manager, &turn.id, TURN_SETTLEMENT_DEADLOCK_TIMEOUT).await?;
     assert_eq!(terminal.status, RuntimeTurnStatus::Failed);
     let terminal_error = terminal.error.as_deref().unwrap_or_default();
     assert!(
@@ -8402,7 +8403,7 @@ async fn closed_engine_event_stream_fails_turn_items_and_evicts_engine() -> Resu
                 TurnItemLifecycleStatus::Queued | TurnItemLifecycleStatus::InProgress
             ))
     );
-    let deadline = Instant::now() + Duration::from_secs(2);
+    let deadline = Instant::now() + TURN_SETTLEMENT_DEADLOCK_TIMEOUT;
     loop {
         if !manager.active.lock().await.engines.contains_key(&thread.id) {
             break;

--- a/crates/tui/tests/integration/telemetry_contract.rs
+++ b/crates/tui/tests/integration/telemetry_contract.rs
@@ -889,12 +889,26 @@ impl LockHolder {
             .open(path)
             .expect("open the telemetry lock");
         let fd = std::os::unix::io::AsRawFd::as_raw_fd(&file);
-        // SAFETY: `fd` is owned by `file` and outlives the call.
-        let taken = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
-        assert_eq!(
-            taken, 0,
-            "the telemetry lock must be free before the test takes it"
-        );
+        let started = Instant::now();
+        loop {
+            // SAFETY: `fd` is owned by `file` and outlives the call.
+            let taken = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
+            if taken == 0 {
+                break;
+            }
+
+            let err = std::io::Error::last_os_error();
+            let retryable = err
+                .raw_os_error()
+                .is_some_and(|code| code == libc::EWOULDBLOCK || code == libc::EAGAIN);
+            assert!(retryable, "failed to take the telemetry lock: {err}");
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "the telemetry arming lock remained held for {:?}",
+                started.elapsed()
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
         Self { file }
     }
 }


### PR DESCRIPTION
## Summary

- serialize `telemetry_contract` processes under nextest while retaining the existing four-process integration-test budget
- retry the telemetry fixture lock during its short arming transition instead of asserting in the race window
- use the runtime-thread suite's existing 10-second deadlock watchdog for closed-engine settlement and eviction on loaded Windows runners

This is test/CI hardening only; runtime product behavior is unchanged. It addresses the deterministic four-test telemetry collision in exact-head CI run 32103671377 and the lone Windows timing failure in the same run.

## Verification

- `cargo fmt --all -- --check`
- `cargo nextest show-config test-groups --profile ci --groups telemetry-contract` (all 15 telemetry contract tests assigned to max-threads=1)
- targeted telemetry contract nextest run (15 passed)
- targeted closed-engine runtime-thread nextest run (1 passed)

No-Issue: release exact-head CI flake hardening
