### PR TITLE
test(web): spawn the deploy preflight script by a decoded path

### DIFF
--- a/web/lib/deploy-preflight.test.ts
+++ b/web/lib/deploy-preflight.test.ts
@@ -1,11 +1,15 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-const script = new URL("../scripts/check-cloudflare-deploy-env.mjs", import.meta.url);
+// fileURLToPath, not `.pathname`: the latter stays percent-encoded, so a
+// checkout under a path with non-ASCII characters spawns a filename that
+// does not exist and every case here fails on a module-not-found exit.
+const script = fileURLToPath(new URL("../scripts/check-cloudflare-deploy-env.mjs", import.meta.url));
 
 function run(overrides: Record<string, string>, args: string[] = []) {
-  return spawnSync(process.execPath, [script.pathname, ...args], {
+  return spawnSync(process.execPath, [script, ...args], {
     encoding: "utf8",
     env: {
       ...process.env,


### PR DESCRIPTION
## Summary

`web/lib/deploy-preflight.test.ts` spawns `scripts/check-cloudflare-deploy-env.mjs` by `script.pathname`. `URL.pathname` stays percent-encoded, so in a checkout under a path with non-ASCII characters the spawned filename does not exist, node exits on module-not-found, and the 7 cases in the file that spawn the script fail on the exit code. The other 5 read `package.json` and `.github/workflows/web.yml` directly and pass.

Nothing about the environment is wrong when this happens, but the failures read as missing Cloudflare credentials — I reported them that way myself in #5488, which is what sent me looking.

`fileURLToPath` decodes it. That is already the idiom in `web/scripts/`, for example `check-locales.mjs` and `check-docs.mjs`.

## Testing

My checkout sits under `开源Ds`, so it reproduces directly.

- `npm test` before: 264 passed / 7 failed, all 7 in `lib/deploy-preflight.test.ts`
- `npm test` after: 267 passed / 0 failed
- `npx tsc --noEmit` — exit 0
- `npm run lint` — exit 0

Both directions measured rather than reasoned about. A clean worktree of the same base on an ASCII path passes 267/267 unpatched; copying that same untouched worktree to a non-ASCII path fails the same 7, which isolates the path as the only variable. The patched file passes 12/12 on both paths.

Full sequence run twice on an identical file hash.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant — no new test; this fixes an existing one
- [ ] Verified TUI behavior manually if UI changes — no TUI change
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

No-Issue: no open issue tracks this; found while measuring the test baseline for the #5337 series.
