### PR TITLE
feat(web): move docs/hooks and docs/troubleshooting onto the dictionary spine (#5337)

### DIFF
--- a/web/app/[locale]/docs/hooks/page.tsx
+++ b/web/app/[locale]/docs/hooks/page.tsx
@@ -1,120 +1,66 @@
+import { Fragment } from "react";
+import { getDocsHooks, splitTokens } from "@/lib/i18n/dictionaries";
 import { buildPageMetadata } from "@/lib/page-meta";
+
+/**
+ * Config syntax the overview sentence typesets as inline `<code>`. These are
+ * literals, not copy, so they stay here rather than in the dictionaries —
+ * `configIntro` carries a `{token}` for each one.
+ */
+const CODE_SPANS: Record<string, string> = {
+  hooksTable: "[[hooks.hooks]]",
+  hooksCommand: "/hooks",
+  enabledKey: "[hooks].enabled",
+};
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
+  const t = getDocsHooks(locale);
   return buildPageMetadata({
     path: "/docs/hooks",
     locale,
-    title: isZh ? "钩子 · Codewhale 文档" : "Hooks · Codewhale Docs",
-    description: isZh
-      ? "已发布的生命周期钩子：可变 message_submit、tool_call_before 决策、turn_end 与子 Agent 观察事件。"
-      : "The shipped lifecycle hooks: mutable message_submit, tool_call_before decisions, turn_end, and sub-agent observer events.",
+    title: t.metaTitle,
+    description: t.metaDescription,
   });
 }
 
 export default async function HooksPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
-  const bodyClass = isZh
-    ? "text-ink-soft leading-[1.9] tracking-wide"
-    : "text-ink-soft leading-relaxed";
-  const events = isZh
-    ? [
-        {
-          name: "message_submit（可变）",
-          detail:
-            "在用户消息进入历史或发给模型之前运行。钩子从 stdin 收到 JSON；exit 0 且 stdout 打印含非空 text 字段的 JSON 时替换提交文本；exit 2 在回合开始前阻止提交。多个钩子按配置顺序串行执行，每个钩子收到上一个钩子的输出文本。标记 background = true 的钩子只能观察，不能改写或阻止。",
-        },
-        {
-          name: "tool_call_before（决策）",
-          detail:
-            "在每次工具调用执行前运行。除 exit 2 硬拒绝（始终生效）外，前台钩子可在 exit 0 时用 stdout JSON 给出决策：allow / deny / ask，并可附带 updatedInput 改写工具输入、additionalContext 追加进给模型的工具结果。多个钩子命中时优先级为 deny > ask > allow；tool_name 条件支持 * 通配（如 mcp__* 匹配所有 MCP 工具）。Full Access 不打开工具审批提示，因此 ask 不会降低该姿态。",
-        },
-        {
-          name: "turn_end（观察）",
-          detail:
-            "在每个模型回合结束后触发，此时用量、成本、通知、收据和队列恢复状态都已更新。stdin 收到包含 status、duration_ms、usage、totals、queued_message_count 等字段的 JSON。stdout 被忽略，失败只记警告——不能阻止输入、改写 transcript 或改变下一个排队消息。",
-        },
-        {
-          name: "subagent_spawn / subagent_complete（观察）",
-          detail:
-            "观察子 Agent 的启动与完成，stdin 收到有界的 JSON 元数据（agent_id、状态、截断后的 prompt/result 预览）。失败只记警告，不阻塞调度、不改 prompt 或结果；需要完整细节时使用 agent 返回的 transcript 句柄。",
-        },
-      ]
-    : [
-        {
-          name: "message_submit (mutable)",
-          detail:
-            "Runs before a submitted message is added to history or sent to the model. The hook receives JSON on stdin; exit 0 with stdout JSON carrying a non-empty text field replaces the submitted text, and exit 2 blocks the submission before the turn starts. Multiple hooks run serially in config order, each receiving the previous hook's output. Hooks marked background = true are observer-only and cannot transform or block.",
-        },
-        {
-          name: "tool_call_before (decision)",
-          detail:
-            "Runs before each tool call executes. Beyond the exit-2 hard deny (which always wins), a foreground hook may print a JSON decision on stdout with exit 0: allow / deny / ask, plus updatedInput to rewrite the tool input and additionalContext appended to the tool result the model sees. When several hooks match, precedence is deny > ask > allow; tool_name conditions support * globs (mcp__* matches every MCP tool). Full Access does not open tool-approval prompts, so ask does not downgrade that posture.",
-        },
-        {
-          name: "turn_end (observer)",
-          detail:
-            "Fires after each model turn ends, once usage, cost, notifications, receipts, and queue-recovery state have settled. The stdin JSON carries fields such as status, duration_ms, usage, totals, and queued_message_count. Stdout is ignored and failures are warn-only — the hook cannot block input, mutate the transcript, or change the next queued follow-up.",
-        },
-        {
-          name: "subagent_spawn / subagent_complete (observer)",
-          detail:
-            "Observe sub-agent start and completion with bounded JSON metadata on stdin (agent_id, status, truncated prompt/result previews). Failures are warn-only and never block scheduling or change prompts or results; use the transcript handle returned by agent when full detail is needed.",
-        },
-      ];
+  const t = getDocsHooks(locale);
 
   return (
     <section className="space-y-10">
       <section id="overview" className="scroll-mt-32">
-        <h2 className="font-display text-3xl mb-1">{isZh ? "钩子" : "Hooks"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "钩子让你把自己的命令挂进 Codewhale 的生命周期：在消息提交前注入上下文、在工具调用前执行策略、在回合结束或子 Agent 启停时做审计。本页描述当前已发布的行为；docs/rfcs/1364-hooks-lifecycle.md 是这组能力的设计 RFC，完整配置 schema 见 docs/CONFIGURATION.md。"
-            : "Hooks attach your own commands to Codewhale's lifecycle: inject context before a message is submitted, enforce policy before a tool call, and audit turns or sub-agent activity. This page describes what currently ships; docs/rfcs/1364-hooks-lifecycle.md is the design RFC for this surface, and docs/CONFIGURATION.md carries the full configuration schema."}
-        </p>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh ? (
-            <>
-              钩子配置在 config.toml 的 <code className="inline">[[hooks.hooks]]</code> 条目下；TUI 里运行{" "}
-              <code className="inline">/hooks</code> 可以按事件分组查看每个钩子的名称、命令预览、超时和条件，以及{" "}
-              <code className="inline">[hooks].enabled</code> 的全局开关状态。
-            </>
-          ) : (
-            <>
-              Hooks are configured under <code className="inline">[[hooks.hooks]]</code> entries in
-              config.toml; run <code className="inline">/hooks</code> in the TUI to see every configured
-              hook grouped by event — name, command preview, timeout, and condition — plus the global{" "}
-              <code className="inline">[hooks].enabled</code> state.
-            </>
+        <h2 className="font-display text-3xl mb-1">{t.overviewTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{t.overviewLead}</p>
+        <p className={`${t.bodyClassName} mt-3`}>
+          {splitTokens(t.configIntro).map((part, i) =>
+            "token" in part ? (
+              <code key={`${i}-${part.token}`} className="inline">
+                {CODE_SPANS[part.token] ?? `{${part.token}}`}
+              </code>
+            ) : (
+              <Fragment key={`${i}-text`}>{part.text}</Fragment>
+            ),
           )}
         </p>
         <div className="hairline-t mt-6">
-          {events.map((row) => (
-            <section key={row.name} className="py-4 hairline-b">
-              <h3 className="font-display text-lg">{row.name}</h3>
-              <p className={`${bodyClass} mt-1 text-sm`}>{row.detail}</p>
+          {t.events.map(([name, detail]) => (
+            <section key={name} className="py-4 hairline-b">
+              <h3 className="font-display text-lg">{name}</h3>
+              <p className={`${t.bodyClassName} mt-1 text-sm`}>{detail}</p>
             </section>
           ))}
         </div>
       </section>
 
       <section id="project" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "项目级钩子" : "Project-local hooks"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "仓库可以在 <workspace>/.codewhale/hooks.toml 中携带策略。因为项目钩子是可执行的 shell 配置，Codewhale 只有在工作区通过信任提示或用户配置中的 trust_level = \"trusted\" 被信任后才加载它们——会话内的 /trust on 和旧版 .deepseek/trusted 标记都不会单独启用项目钩子。受信任后，项目钩子追加在 config.toml 的全局钩子之后运行，因此对 updatedInput 而言最后生效。格式错误但已受信任的项目文件会记警告并回退到只用全局钩子。"
-            : "Repositories can ship policy in <workspace>/.codewhale/hooks.toml. Because project hooks are executable shell configuration, Codewhale loads them only after the workspace is trusted through the trust prompt or a trust_level = \"trusted\" entry in user-owned config — session /trust on and legacy .deepseek/trusted markers do not enable project hooks by themselves. Once trusted, project hooks are appended after the global hooks from config.toml, so they run last and win updatedInput ties. A malformed trusted project file logs a warning and startup falls back to global hooks only."}
-        </p>
+        <h2 className="font-display text-2xl mb-1">{t.projectTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{t.projectLead}</p>
       </section>
 
       <section id="source" className="hairline-t pt-8">
-        <p className="text-sm text-ink-mute">
-          {isZh
-            ? "来源文档：docs/rfcs/1364-hooks-lifecycle.md（设计 RFC）, docs/CONFIGURATION.md（配置 schema）· 更新时请同步修改 docs-map.ts。"
-            : "Source documents: docs/rfcs/1364-hooks-lifecycle.md (design RFC), docs/CONFIGURATION.md (configuration schema) · Update docs-map.ts when changing."}
-        </p>
+        <p className="text-sm text-ink-mute">{t.sourceNote}</p>
       </section>
     </section>
   );

--- a/web/app/[locale]/docs/troubleshooting/page.tsx
+++ b/web/app/[locale]/docs/troubleshooting/page.tsx
@@ -1,15 +1,14 @@
+import { getDocsTroubleshooting } from "@/lib/i18n/dictionaries";
 import { buildPageMetadata } from "@/lib/page-meta";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
+  const t = getDocsTroubleshooting(locale);
   return buildPageMetadata({
     path: "/docs/troubleshooting",
     locale,
-    title: isZh ? "排障 · Codewhale 文档" : "Troubleshooting · Codewhale Docs",
-    description: isZh
-      ? "常见问题的快速分诊：挂起的回合、离线队列、崩溃恢复、schema 错误、MCP 故障与 Docker 说明。"
-      : "Quick triage for common issues: hung turns, the offline queue, crash recovery, schema errors, MCP failures, and Docker notes.",
+    title: t.metaTitle,
+    description: t.metaDescription,
   });
 }
 
@@ -19,92 +18,26 @@ export default async function TroubleshootingPage({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
-  const bodyClass = isZh
-    ? "text-ink-soft leading-[1.9] tracking-wide"
-    : "text-ink-soft leading-relaxed";
-  const incidents = isZh
-    ? [
-        {
-          name: "回合挂起或流停止",
-          detail:
-            "前台 shell 命令还在跑时按 Ctrl+B 把它移到后台（回合继续，命令变成 /jobs 下的后台任务）；想取消回合本身用 Esc 或 Ctrl+C。检查 deepseek_cli::client 的重试日志和端点连通性，重启后确认此前在途的回合被标记为中断，而不是停在运行态。",
-        },
-        {
-          name: "网络中断 / 离线行为",
-          detail:
-            "离线时新提示词会排队，队列持久化在 ~/.codewhale/sessions/checkpoints/offline_queue.json。用 /queue list 查看，恢复连接后重新发送（/queue edit <n> 加回车，或走正常输入流程），队列清空后文件随之清除。",
-        },
-        {
-          name: "崩溃恢复",
-          detail:
-            "检查点保存在 ~/.codewhale/sessions/checkpoints/latest.json；除非传入 --resume/--continue，启动会开新会话。用 codewhale --resume <id> 或 TUI 里的 Ctrl+R 显式恢复；若检查点 schema 比二进制新，升级二进制或移除过期检查点。",
-        },
-        {
-          name: "持久状态 schema 错误",
-          detail:
-            "形如 schema vX is newer than supported vY 的错误涉及 sessions、运行时 thread/turn/item 记录和 tasks。先确认二进制版本，编辑前备份状态目录，然后用更新的兼容二进制运行，或归档不兼容记录并重建状态。",
-        },
-        {
-          name: "MCP / 工具执行失败",
-          detail:
-            "校验 ~/.codewhale/mcp.json 的 schema 和服务器命令路径，手动确认服务器进程能启动，并在 TUI 历史/日志中检查沙箱拒绝。用 /mcp validate 诊断，可暂时禁用出问题的服务器隔离原因，验证后再启用。",
-        },
-      ]
-    : [
-        {
-          name: "Turn hangs or the stream stops",
-          detail:
-            "If a foreground shell command is still running, press Ctrl+B to move it to the background (the turn keeps running and the command becomes a background job under /jobs); use Esc or Ctrl+C to cancel the turn itself. Inspect deepseek_cli::client retry logs and endpoint connectivity, and after a restart confirm the previously in-flight turn shows as interrupted rather than running.",
-        },
-        {
-          name: "Network outage / offline behavior",
-          detail:
-            "New prompts queue while offline, persisted to ~/.codewhale/sessions/checkpoints/offline_queue.json. Inspect with /queue list, restore connectivity, then re-send queued entries (/queue edit <n> plus Enter, or the normal input flow); the queue file clears when the queue empties.",
-        },
-        {
-          name: "Crash recovery",
-          detail:
-            "The checkpoint lives at ~/.codewhale/sessions/checkpoints/latest.json; startup begins a fresh session unless --resume/--continue is supplied. Resume explicitly with codewhale --resume <id> or Ctrl+R in the TUI; if the checkpoint schema is newer than the binary supports, upgrade the binary or remove the stale checkpoint.",
-        },
-        {
-          name: "Persistent state schema errors",
-          detail:
-            "Errors like schema vX is newer than supported vY affect sessions, runtime thread/turn/item records, and tasks. Confirm the binary version, back up the state directory before editing, then either run a newer compatible binary or archive the incompatible records and regenerate state.",
-        },
-        {
-          name: "MCP / tool execution failures",
-          detail:
-            "Validate the ~/.codewhale/mcp.json schema and server command paths, confirm the server process starts manually, and check sandbox denials in TUI history/logs. Use /mcp validate for diagnostics, temporarily disable a failing server to isolate the issue, and re-enable after verification.",
-        },
-      ];
+  const t = getDocsTroubleshooting(locale);
 
   return (
     <section className="space-y-10">
       <section id="overview" className="scroll-mt-32">
-        <h2 className="font-display text-3xl mb-1">{isZh ? "排障" : "Troubleshooting"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "先快速分诊：确认二进制与配置（codewhale --version、~/.codewhale/config.toml），需要更详细日志时用 RUST_LOG=deepseek_cli=debug 启动（HTTP 重试/重连用 RUST_LOG=deepseek_cli::client=debug），并看一眼 ~/.codewhale/sessions 与 ~/.codewhale/tasks 的当前状态。"
-            : "Start with quick triage: confirm the binary and config (codewhale --version, ~/.codewhale/config.toml), enable verbose logs with RUST_LOG=deepseek_cli=debug when needed (RUST_LOG=deepseek_cli::client=debug for HTTP retries/reconnects), and capture the current state of ~/.codewhale/sessions and ~/.codewhale/tasks."}
-        </p>
+        <h2 className="font-display text-3xl mb-1">{t.overviewTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{t.overviewLead}</p>
         <div className="hairline-t mt-6">
-          {incidents.map((row) => (
-            <section key={row.name} className="py-4 hairline-b">
-              <h3 className="font-display text-lg">{row.name}</h3>
-              <p className={`${bodyClass} mt-1 text-sm`}>{row.detail}</p>
+          {t.incidents.map(([name, detail]) => (
+            <section key={name} className="py-4 hairline-b">
+              <h3 className="font-display text-lg">{name}</h3>
+              <p className={`${t.bodyClassName} mt-1 text-sm`}>{detail}</p>
             </section>
           ))}
         </div>
       </section>
 
       <section id="docker" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "Docker 说明" : "Docker notes"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "每个发布都会向 GitHub Container Registry 推送多架构 Linux 镜像。默认镜像是保守的运行时镜像：以非 root 的 codewhale 用户（UID/GID 1000:1000）运行，不授予免密 sudo，用户状态放在挂载到 /home/codewhale/.codewhale 的卷里。可复现的安装请固定发布标签而不是 latest。"
-            : "Each release publishes a multi-arch Linux image to GitHub Container Registry. The default image is a conservative runtime image: it runs as the non-root codewhale user (UID/GID 1000:1000), grants no passwordless sudo, and keeps user state in a volume mounted at /home/codewhale/.codewhale. Pin a release tag instead of latest for reproducible installs."}
-        </p>
+        <h2 className="font-display text-2xl mb-1">{t.dockerTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{t.dockerLead}</p>
         <pre className="code-block mt-4">{`docker volume create codewhale-home
 
 docker run --rm -it \\
@@ -113,19 +46,11 @@ docker run --rm -it \\
   -v "$PWD:/workspace" \\
   -w /workspace \\
   ghcr.io/hmbown/codewhale:latest`}</pre>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "需要在容器内使用 apt-get、编译工具链或包管理器时，不要改默认镜像约定——基于 docs/examples/Dockerfile.toolbox 构建显式的 toolbox 镜像，并为每个项目使用独立的命名状态卷，避免会话、配置和离线队列跨工作区串扰。不要把 API 密钥或 SSH 私钥烘进自定义镜像。"
-            : "When a project needs apt-get, compiler toolchains, or package managers inside the container, do not change the default image contract — build an explicit toolbox image from docs/examples/Dockerfile.toolbox, and use one named state volume per project so sessions, config, and the offline queue do not bleed across workspaces. Never bake API keys or SSH private keys into custom images."}
-        </p>
+        <p className={`${t.bodyClassName} mt-3`}>{t.dockerToolboxNote}</p>
       </section>
 
       <section id="source" className="hairline-t pt-8">
-        <p className="text-sm text-ink-mute">
-          {isZh
-            ? "来源文档：docs/OPERATIONS_RUNBOOK.md, docs/DOCKER.md · 更新时请同步修改 docs-map.ts。"
-            : "Source documents: docs/OPERATIONS_RUNBOOK.md, docs/DOCKER.md · Update docs-map.ts when changing."}
-        </p>
+        <p className="text-sm text-ink-mute">{t.sourceNote}</p>
       </section>
     </section>
   );

--- a/web/lib/i18n/dictionaries.test.ts
+++ b/web/lib/i18n/dictionaries.test.ts
@@ -3,15 +3,20 @@ import {
   DICTIONARY_LOCALES,
   EN_CHROME,
   EN_DOCS_GUIDE,
+  EN_DOCS_HOOKS,
   EN_DOCS_SHELL,
+  EN_DOCS_TROUBLESHOOTING,
   EN_HOME,
   fill,
   getChrome,
   getDocsGuide,
+  getDocsHooks,
   getDocsShell,
+  getDocsTroubleshooting,
   getHome,
   pickText,
   splitToken,
+  splitTokens,
 } from "./dictionaries";
 import { locales, partialLocales } from "./config";
 import type { ChromeDict, HomeDict } from "./dictionaries/types";
@@ -230,6 +235,60 @@ describe("website dictionaries", () => {
     for (const locale of ["ja", "fr", "ar", "und"]) {
       expect(getDocsShell(locale), `${locale} docs-shell`).toBe(EN_DOCS_SHELL);
     }
+  });
+
+  it("holds the docs page-body dictionaries to the same contract (#5337)", () => {
+    for (const [label, get, reference] of [
+      ["docs-hooks", getDocsHooks, EN_DOCS_HOOKS],
+      ["docs-troubleshooting", getDocsTroubleshooting, EN_DOCS_TROUBLESHOOTING],
+    ] as const) {
+      const enKeys = Object.keys(reference).sort();
+      for (const locale of [...DICTIONARY_LOCALES, "fr", "und"]) {
+        expect(Object.keys(get(locale)).sort(), `${locale} ${label} keys`).toEqual(enKeys);
+      }
+      // zh ships a real translation, not an English pass-through.
+      expect(get("zh").overviewTitle, `zh ${label}`).not.toBe(reference.overviewTitle);
+      // Every other locale renders English today, exactly as the `isZh`
+      // ternaries in the page did before the move.
+      for (const locale of ["ja", "fr", "ar", "und"]) {
+        expect(get(locale), `${locale} ${label}`).toBe(reference);
+      }
+    }
+  });
+
+  it("keeps the docs page lists structurally aligned", () => {
+    for (const locale of [...DICTIONARY_LOCALES, "und"]) {
+      expect(getDocsHooks(locale).events, `${locale} hook events`).toHaveLength(4);
+      expect(
+        getDocsTroubleshooting(locale).incidents,
+        `${locale} triage entries`,
+      ).toHaveLength(5);
+    }
+  });
+
+  it("carries every code-span token through the hooks intro for splitTokens()", () => {
+    for (const locale of [...DICTIONARY_LOCALES, "und"]) {
+      const parts = splitTokens(getDocsHooks(locale).configIntro);
+      const tokens = parts.flatMap((part) => ("token" in part ? [part.token] : []));
+      expect(tokens, `${locale} configIntro tokens`).toEqual([
+        "hooksTable",
+        "hooksCommand",
+        "enabledKey",
+      ]);
+    }
+  });
+
+  it("splitTokens interleaves literal text and token names in template order", () => {
+    expect(splitTokens("a {one} b {two}")).toEqual([
+      { text: "a " },
+      { token: "one" },
+      { text: " b " },
+      { token: "two" },
+    ]);
+    // A template with no token is one literal run, and an empty run between
+    // adjacent tokens is dropped rather than rendered as an empty node.
+    expect(splitTokens("plain")).toEqual([{ text: "plain" }]);
+    expect(splitTokens("{one}{two}")).toEqual([{ token: "one" }, { token: "two" }]);
   });
 
   it("pickText selects the locale side of legacy { en, zh } pairs", () => {

--- a/web/lib/i18n/dictionaries/en/docs-hooks.ts
+++ b/web/lib/i18n/dictionaries/en/docs-hooks.ts
@@ -1,0 +1,41 @@
+import type { DocsHooksDict } from "../types";
+
+/**
+ * English reference dictionary for `app/[locale]/docs/hooks/page.tsx`.
+ * Copy moved verbatim from the page's `isZh` ternaries — any wording change
+ * belongs in its own commit, never mixed into a structural move.
+ */
+export const docsHooks: DocsHooksDict = {
+  metaTitle: "Hooks · Codewhale Docs",
+  metaDescription:
+    "The shipped lifecycle hooks: mutable message_submit, tool_call_before decisions, turn_end, and sub-agent observer events.",
+  bodyClassName: "text-ink-soft leading-relaxed",
+  overviewTitle: "Hooks",
+  overviewLead:
+    "Hooks attach your own commands to Codewhale's lifecycle: inject context before a message is submitted, enforce policy before a tool call, and audit turns or sub-agent activity. This page describes what currently ships; docs/rfcs/1364-hooks-lifecycle.md is the design RFC for this surface, and docs/CONFIGURATION.md carries the full configuration schema.",
+  configIntro:
+    "Hooks are configured under {hooksTable} entries in config.toml; run {hooksCommand} in the TUI to see every configured hook grouped by event — name, command preview, timeout, and condition — plus the global {enabledKey} state.",
+  events: [
+    [
+      "message_submit (mutable)",
+      "Runs before a submitted message is added to history or sent to the model. The hook receives JSON on stdin; exit 0 with stdout JSON carrying a non-empty text field replaces the submitted text, and exit 2 blocks the submission before the turn starts. Multiple hooks run serially in config order, each receiving the previous hook's output. Hooks marked background = true are observer-only and cannot transform or block.",
+    ],
+    [
+      "tool_call_before (decision)",
+      "Runs before each tool call executes. Beyond the exit-2 hard deny (which always wins), a foreground hook may print a JSON decision on stdout with exit 0: allow / deny / ask, plus updatedInput to rewrite the tool input and additionalContext appended to the tool result the model sees. When several hooks match, precedence is deny > ask > allow; tool_name conditions support * globs (mcp__* matches every MCP tool). Full Access does not open tool-approval prompts, so ask does not downgrade that posture.",
+    ],
+    [
+      "turn_end (observer)",
+      "Fires after each model turn ends, once usage, cost, notifications, receipts, and queue-recovery state have settled. The stdin JSON carries fields such as status, duration_ms, usage, totals, and queued_message_count. Stdout is ignored and failures are warn-only — the hook cannot block input, mutate the transcript, or change the next queued follow-up.",
+    ],
+    [
+      "subagent_spawn / subagent_complete (observer)",
+      "Observe sub-agent start and completion with bounded JSON metadata on stdin (agent_id, status, truncated prompt/result previews). Failures are warn-only and never block scheduling or change prompts or results; use the transcript handle returned by agent when full detail is needed.",
+    ],
+  ],
+  projectTitle: "Project-local hooks",
+  projectLead:
+    'Repositories can ship policy in <workspace>/.codewhale/hooks.toml. Because project hooks are executable shell configuration, Codewhale loads them only after the workspace is trusted through the trust prompt or a trust_level = "trusted" entry in user-owned config — session /trust on and legacy .deepseek/trusted markers do not enable project hooks by themselves. Once trusted, project hooks are appended after the global hooks from config.toml, so they run last and win updatedInput ties. A malformed trusted project file logs a warning and startup falls back to global hooks only.',
+  sourceNote:
+    "Source documents: docs/rfcs/1364-hooks-lifecycle.md (design RFC), docs/CONFIGURATION.md (configuration schema) · Update docs-map.ts when changing.",
+};

--- a/web/lib/i18n/dictionaries/en/docs-troubleshooting.ts
+++ b/web/lib/i18n/dictionaries/en/docs-troubleshooting.ts
@@ -1,0 +1,46 @@
+import type { DocsTroubleshootingDict } from "../types";
+
+/**
+ * English reference dictionary for
+ * `app/[locale]/docs/troubleshooting/page.tsx`. Copy moved verbatim from the
+ * page's `isZh` ternaries — any wording change belongs in its own commit,
+ * never mixed into a structural move.
+ */
+export const docsTroubleshooting: DocsTroubleshootingDict = {
+  metaTitle: "Troubleshooting · Codewhale Docs",
+  metaDescription:
+    "Quick triage for common issues: hung turns, the offline queue, crash recovery, schema errors, MCP failures, and Docker notes.",
+  bodyClassName: "text-ink-soft leading-relaxed",
+  overviewTitle: "Troubleshooting",
+  overviewLead:
+    "Start with quick triage: confirm the binary and config (codewhale --version, ~/.codewhale/config.toml), enable verbose logs with RUST_LOG=deepseek_cli=debug when needed (RUST_LOG=deepseek_cli::client=debug for HTTP retries/reconnects), and capture the current state of ~/.codewhale/sessions and ~/.codewhale/tasks.",
+  incidents: [
+    [
+      "Turn hangs or the stream stops",
+      "If a foreground shell command is still running, press Ctrl+B to move it to the background (the turn keeps running and the command becomes a background job under /jobs); use Esc or Ctrl+C to cancel the turn itself. Inspect deepseek_cli::client retry logs and endpoint connectivity, and after a restart confirm the previously in-flight turn shows as interrupted rather than running.",
+    ],
+    [
+      "Network outage / offline behavior",
+      "New prompts queue while offline, persisted to ~/.codewhale/sessions/checkpoints/offline_queue.json. Inspect with /queue list, restore connectivity, then re-send queued entries (/queue edit <n> plus Enter, or the normal input flow); the queue file clears when the queue empties.",
+    ],
+    [
+      "Crash recovery",
+      "The checkpoint lives at ~/.codewhale/sessions/checkpoints/latest.json; startup begins a fresh session unless --resume/--continue is supplied. Resume explicitly with codewhale --resume <id> or Ctrl+R in the TUI; if the checkpoint schema is newer than the binary supports, upgrade the binary or remove the stale checkpoint.",
+    ],
+    [
+      "Persistent state schema errors",
+      "Errors like schema vX is newer than supported vY affect sessions, runtime thread/turn/item records, and tasks. Confirm the binary version, back up the state directory before editing, then either run a newer compatible binary or archive the incompatible records and regenerate state.",
+    ],
+    [
+      "MCP / tool execution failures",
+      "Validate the ~/.codewhale/mcp.json schema and server command paths, confirm the server process starts manually, and check sandbox denials in TUI history/logs. Use /mcp validate for diagnostics, temporarily disable a failing server to isolate the issue, and re-enable after verification.",
+    ],
+  ],
+  dockerTitle: "Docker notes",
+  dockerLead:
+    "Each release publishes a multi-arch Linux image to GitHub Container Registry. The default image is a conservative runtime image: it runs as the non-root codewhale user (UID/GID 1000:1000), grants no passwordless sudo, and keeps user state in a volume mounted at /home/codewhale/.codewhale. Pin a release tag instead of latest for reproducible installs.",
+  dockerToolboxNote:
+    "When a project needs apt-get, compiler toolchains, or package managers inside the container, do not change the default image contract — build an explicit toolbox image from docs/examples/Dockerfile.toolbox, and use one named state volume per project so sessions, config, and the offline queue do not bleed across workspaces. Never bake API keys or SSH private keys into custom images.",
+  sourceNote:
+    "Source documents: docs/OPERATIONS_RUNBOOK.md, docs/DOCKER.md · Update docs-map.ts when changing.",
+};

--- a/web/lib/i18n/dictionaries/index.ts
+++ b/web/lib/i18n/dictionaries/index.ts
@@ -12,13 +12,24 @@
  * than a map entry, which keeps `DICTIONARY_LOCALES` equal to the set of
  * non-reference locale directories that `check-locales.mjs` walks.
  */
-import type { ChromeDict, DocsGuideDict, DocsShellDict, HomeDict } from "./types";
+import type {
+  ChromeDict,
+  DocsGuideDict,
+  DocsHooksDict,
+  DocsShellDict,
+  DocsTroubleshootingDict,
+  HomeDict,
+} from "./types";
 import { chrome as enChrome } from "./en/chrome";
 import { home as enHome } from "./en/home";
 import { docsGuide as enDocsGuide } from "./en/docs-guide";
 import { docsGuide as zhDocsGuide } from "./zh/docs-guide";
 import { docsShell as enDocsShell } from "./en/docs-shell";
 import { docsShell as zhDocsShell } from "./zh/docs-shell";
+import { docsHooks as enDocsHooks } from "./en/docs-hooks";
+import { docsHooks as zhDocsHooks } from "./zh/docs-hooks";
+import { docsTroubleshooting as enDocsTroubleshooting } from "./en/docs-troubleshooting";
+import { docsTroubleshooting as zhDocsTroubleshooting } from "./zh/docs-troubleshooting";
 import { chrome as zhChrome } from "./zh/chrome";
 import { home as zhHome } from "./zh/home";
 import { chrome as jaChrome } from "./ja/chrome";
@@ -128,6 +139,14 @@ const DOCS_SHELL: Record<string, DocsShellDict> = {
   zh: zhDocsShell,
 };
 
+const DOCS_HOOKS: Record<string, DocsHooksDict> = {
+  zh: zhDocsHooks,
+};
+
+const DOCS_TROUBLESHOOTING: Record<string, DocsTroubleshootingDict> = {
+  zh: zhDocsTroubleshooting,
+};
+
 export function getChrome(locale: string): ChromeDict {
   return CHROME[locale] ?? enChrome;
 }
@@ -142,6 +161,14 @@ export function getDocsGuide(locale: string): DocsGuideDict {
 
 export function getDocsShell(locale: string): DocsShellDict {
   return DOCS_SHELL[locale] ?? enDocsShell;
+}
+
+export function getDocsHooks(locale: string): DocsHooksDict {
+  return DOCS_HOOKS[locale] ?? enDocsHooks;
+}
+
+export function getDocsTroubleshooting(locale: string): DocsTroubleshootingDict {
+  return DOCS_TROUBLESHOOTING[locale] ?? enDocsTroubleshooting;
 }
 
 /**
@@ -160,6 +187,8 @@ export const EN_CHROME = enChrome;
 export const EN_HOME = enHome;
 export const EN_DOCS_GUIDE = enDocsGuide;
 export const EN_DOCS_SHELL = enDocsShell;
+export const EN_DOCS_HOOKS = enDocsHooks;
+export const EN_DOCS_TROUBLESHOOTING = enDocsTroubleshooting;
 
 /** Interpolate `{name}` tokens in a dictionary template. Unknown tokens are
  * left intact so a template/variable drift is visible in review, not silent. */
@@ -178,4 +207,18 @@ export function fill(template: string, vars: Record<string, string | number>): s
  */
 export function splitToken(template: string, token: string): string[] {
   return template.split(`{${token}}`);
+}
+
+/**
+ * Split a template on every `{token}` it carries, for a sentence with more
+ * than one substituted node. Returns literal text and token names
+ * interleaved in template order, so a locale that reorders the tokens still
+ * renders correctly and no translated fragment is concatenated by the
+ * call site.
+ */
+export function splitTokens(template: string): Array<{ text: string } | { token: string }> {
+  return template
+    .split(/\{(\w+)\}/g)
+    .map((part, i) => (i % 2 === 1 ? { token: part } : { text: part }))
+    .filter((part) => "token" in part || part.text !== "");
 }

--- a/web/lib/i18n/dictionaries/types.ts
+++ b/web/lib/i18n/dictionaries/types.ts
@@ -320,3 +320,43 @@ export interface DocsShellDict {
   installCta: string;
   sourceDocsCta: string;
 }
+
+/**
+ * `app/[locale]/docs/hooks/page.tsx`.
+ *
+ * `configIntro` carries three `{token}` placeholders for the literal
+ * `[[hooks.hooks]]`, `/hooks` and `[hooks].enabled` spans the page typesets
+ * as inline `<code>`. They stay out of the prose because they are config
+ * syntax rather than copy, and the token-parity half of `check-locales.mjs`
+ * then guards the sentence for free.
+ */
+export interface DocsHooksDict {
+  metaTitle: string;
+  metaDescription: string;
+  /** Body-copy typography for this locale (CJK needs looser leading). */
+  bodyClassName: string;
+  overviewTitle: string;
+  overviewLead: string;
+  configIntro: string;
+  /** Lifecycle events as `[name, detail]`, in the order the page lists them. */
+  events: [string, string][];
+  projectTitle: string;
+  projectLead: string;
+  sourceNote: string;
+}
+
+/** `app/[locale]/docs/troubleshooting/page.tsx`. */
+export interface DocsTroubleshootingDict {
+  metaTitle: string;
+  metaDescription: string;
+  /** Body-copy typography for this locale (CJK needs looser leading). */
+  bodyClassName: string;
+  overviewTitle: string;
+  overviewLead: string;
+  /** Triage entries as `[name, detail]`, in the order the page lists them. */
+  incidents: [string, string][];
+  dockerTitle: string;
+  dockerLead: string;
+  dockerToolboxNote: string;
+  sourceNote: string;
+}

--- a/web/lib/i18n/dictionaries/zh/docs-hooks.ts
+++ b/web/lib/i18n/dictionaries/zh/docs-hooks.ts
@@ -1,0 +1,37 @@
+import type { DocsHooksDict } from "../types";
+
+/** Simplified Chinese dictionary for `app/[locale]/docs/hooks/page.tsx`. */
+export const docsHooks: DocsHooksDict = {
+  metaTitle: "钩子 · Codewhale 文档",
+  metaDescription:
+    "已发布的生命周期钩子：可变 message_submit、tool_call_before 决策、turn_end 与子 Agent 观察事件。",
+  bodyClassName: "text-ink-soft leading-[1.9] tracking-wide",
+  overviewTitle: "钩子",
+  overviewLead:
+    "钩子让你把自己的命令挂进 Codewhale 的生命周期：在消息提交前注入上下文、在工具调用前执行策略、在回合结束或子 Agent 启停时做审计。本页描述当前已发布的行为；docs/rfcs/1364-hooks-lifecycle.md 是这组能力的设计 RFC，完整配置 schema 见 docs/CONFIGURATION.md。",
+  configIntro:
+    "钩子配置在 config.toml 的 {hooksTable} 条目下；TUI 里运行 {hooksCommand} 可以按事件分组查看每个钩子的名称、命令预览、超时和条件，以及 {enabledKey} 的全局开关状态。",
+  events: [
+    [
+      "message_submit（可变）",
+      "在用户消息进入历史或发给模型之前运行。钩子从 stdin 收到 JSON；exit 0 且 stdout 打印含非空 text 字段的 JSON 时替换提交文本；exit 2 在回合开始前阻止提交。多个钩子按配置顺序串行执行，每个钩子收到上一个钩子的输出文本。标记 background = true 的钩子只能观察，不能改写或阻止。",
+    ],
+    [
+      "tool_call_before（决策）",
+      "在每次工具调用执行前运行。除 exit 2 硬拒绝（始终生效）外，前台钩子可在 exit 0 时用 stdout JSON 给出决策：allow / deny / ask，并可附带 updatedInput 改写工具输入、additionalContext 追加进给模型的工具结果。多个钩子命中时优先级为 deny > ask > allow；tool_name 条件支持 * 通配（如 mcp__* 匹配所有 MCP 工具）。Full Access 不打开工具审批提示，因此 ask 不会降低该姿态。",
+    ],
+    [
+      "turn_end（观察）",
+      "在每个模型回合结束后触发，此时用量、成本、通知、收据和队列恢复状态都已更新。stdin 收到包含 status、duration_ms、usage、totals、queued_message_count 等字段的 JSON。stdout 被忽略，失败只记警告——不能阻止输入、改写 transcript 或改变下一个排队消息。",
+    ],
+    [
+      "subagent_spawn / subagent_complete（观察）",
+      "观察子 Agent 的启动与完成，stdin 收到有界的 JSON 元数据（agent_id、状态、截断后的 prompt/result 预览）。失败只记警告，不阻塞调度、不改 prompt 或结果；需要完整细节时使用 agent 返回的 transcript 句柄。",
+    ],
+  ],
+  projectTitle: "项目级钩子",
+  projectLead:
+    '仓库可以在 <workspace>/.codewhale/hooks.toml 中携带策略。因为项目钩子是可执行的 shell 配置，Codewhale 只有在工作区通过信任提示或用户配置中的 trust_level = "trusted" 被信任后才加载它们——会话内的 /trust on 和旧版 .deepseek/trusted 标记都不会单独启用项目钩子。受信任后，项目钩子追加在 config.toml 的全局钩子之后运行，因此对 updatedInput 而言最后生效。格式错误但已受信任的项目文件会记警告并回退到只用全局钩子。',
+  sourceNote:
+    "来源文档：docs/rfcs/1364-hooks-lifecycle.md（设计 RFC）, docs/CONFIGURATION.md（配置 schema）· 更新时请同步修改 docs-map.ts。",
+};

--- a/web/lib/i18n/dictionaries/zh/docs-troubleshooting.ts
+++ b/web/lib/i18n/dictionaries/zh/docs-troubleshooting.ts
@@ -1,0 +1,44 @@
+import type { DocsTroubleshootingDict } from "../types";
+
+/**
+ * Simplified Chinese dictionary for
+ * `app/[locale]/docs/troubleshooting/page.tsx`.
+ */
+export const docsTroubleshooting: DocsTroubleshootingDict = {
+  metaTitle: "排障 · Codewhale 文档",
+  metaDescription:
+    "常见问题的快速分诊：挂起的回合、离线队列、崩溃恢复、schema 错误、MCP 故障与 Docker 说明。",
+  bodyClassName: "text-ink-soft leading-[1.9] tracking-wide",
+  overviewTitle: "排障",
+  overviewLead:
+    "先快速分诊：确认二进制与配置（codewhale --version、~/.codewhale/config.toml），需要更详细日志时用 RUST_LOG=deepseek_cli=debug 启动（HTTP 重试/重连用 RUST_LOG=deepseek_cli::client=debug），并看一眼 ~/.codewhale/sessions 与 ~/.codewhale/tasks 的当前状态。",
+  incidents: [
+    [
+      "回合挂起或流停止",
+      "前台 shell 命令还在跑时按 Ctrl+B 把它移到后台（回合继续，命令变成 /jobs 下的后台任务）；想取消回合本身用 Esc 或 Ctrl+C。检查 deepseek_cli::client 的重试日志和端点连通性，重启后确认此前在途的回合被标记为中断，而不是停在运行态。",
+    ],
+    [
+      "网络中断 / 离线行为",
+      "离线时新提示词会排队，队列持久化在 ~/.codewhale/sessions/checkpoints/offline_queue.json。用 /queue list 查看，恢复连接后重新发送（/queue edit <n> 加回车，或走正常输入流程），队列清空后文件随之清除。",
+    ],
+    [
+      "崩溃恢复",
+      "检查点保存在 ~/.codewhale/sessions/checkpoints/latest.json；除非传入 --resume/--continue，启动会开新会话。用 codewhale --resume <id> 或 TUI 里的 Ctrl+R 显式恢复；若检查点 schema 比二进制新，升级二进制或移除过期检查点。",
+    ],
+    [
+      "持久状态 schema 错误",
+      "形如 schema vX is newer than supported vY 的错误涉及 sessions、运行时 thread/turn/item 记录和 tasks。先确认二进制版本，编辑前备份状态目录，然后用更新的兼容二进制运行，或归档不兼容记录并重建状态。",
+    ],
+    [
+      "MCP / 工具执行失败",
+      "校验 ~/.codewhale/mcp.json 的 schema 和服务器命令路径，手动确认服务器进程能启动，并在 TUI 历史/日志中检查沙箱拒绝。用 /mcp validate 诊断，可暂时禁用出问题的服务器隔离原因，验证后再启用。",
+    ],
+  ],
+  dockerTitle: "Docker 说明",
+  dockerLead:
+    "每个发布都会向 GitHub Container Registry 推送多架构 Linux 镜像。默认镜像是保守的运行时镜像：以非 root 的 codewhale 用户（UID/GID 1000:1000）运行，不授予免密 sudo，用户状态放在挂载到 /home/codewhale/.codewhale 的卷里。可复现的安装请固定发布标签而不是 latest。",
+  dockerToolboxNote:
+    "需要在容器内使用 apt-get、编译工具链或包管理器时，不要改默认镜像约定——基于 docs/examples/Dockerfile.toolbox 构建显式的 toolbox 镜像，并为每个项目使用独立的命名状态卷，避免会话、配置和离线队列跨工作区串扰。不要把 API 密钥或 SSH 私钥烘进自定义镜像。",
+  sourceNote:
+    "来源文档：docs/OPERATIONS_RUNBOOK.md, docs/DOCKER.md · 更新时请同步修改 docs-map.ts。",
+};

--- a/web/scripts/check-locales.mjs
+++ b/web/scripts/check-locales.mjs
@@ -25,7 +25,12 @@ const FILES = ["chrome.ts", "home.ts"];
 // required reference; a locale that ships the file is held to the same
 // key/token parity, and a locale without it falls back to English at
 // lookup time — so absence is a valid state, never a failure.
-const OPTIONAL_FILES = ["docs-guide.ts", "docs-shell.ts"];
+const OPTIONAL_FILES = [
+  "docs-guide.ts",
+  "docs-shell.ts",
+  "docs-hooks.ts",
+  "docs-troubleshooting.ts",
+];
 
 /** Top-level keys of the exported object literal (two-space indented `key:`). */
 function extractKeys(source) {


### PR DESCRIPTION
## Summary

Continues the #5337 series after #5488. `docs/hooks` and `docs/troubleshooting` were the two smallest remaining page bodies at 12 `isZh` branches each, and both are now on the dictionary spine.

Before this, every string on both pages lived in a two-language ternary. The 16 partial locales route to those pages but had nowhere to put a translation without editing TSX, and the copy sat outside `check:locales` and `dictionaries.test.ts` — the gap that let the 宪法/宪章 drift in #4949 survive.

The copy moves verbatim into `web/lib/i18n/dictionaries/<code>/`, en plus zh, behind `DocsHooksDict` and `DocsTroubleshootingDict`. Both pages read one dictionary; every other locale resolves to the English reference exactly as the ternaries did. The `[name, detail]` lists follow the tuple shape `home.ts` already uses for `workflow` and `surfaces`.

One case needed more than a whole-string move. The hooks overview sentence typesets `[[hooks.hooks]]`, `/hooks` and `[hooks].enabled` as inline `<code>`. Those are config syntax, not copy, so they stay in the page as a lookup and the sentence carries a `{token}` for each — which also puts the sentence under the token-parity half of `check-locales.mjs` for free. `splitToken` handles one token; `splitTokens` splits a template on every token it carries and returns the literal runs and token names interleaved, so a locale that reorders them still renders correctly.

No copy edits are mixed in. Before running the gates I checked each moved string against the pre-move page source read out of git, so a transcription slip would have shown up as a miss rather than as a wording change; the rendered comparison below is the shipped evidence.

## Testing

The web gates, in the order `.github/workflows/web.yml` runs them:

- [x] `npm run check:facts` — OK
- [x] `npm run prebuild`
- [x] `npm run check:docs` — PASS
- [x] `npm run check:locales` — PASS, `zh/docs-hooks.ts: 10/10 keys — complete`, `zh/docs-troubleshooting.ts: 10/10 keys — complete`, 16 locales absent and falling back for each
- [x] `npm test` — 264 passed / 7 failed
- [x] `npm run lint` — exit 0, no output
- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run build` — exit 0, 512/512 static pages

Full sequence run twice on an identical file hash for all ten changed files.

Rendered output is unchanged, measured the same way as #5488. Building this branch and a clean worktree of the same base, 36 pages — 18 locales × `/docs/hooks` and `/docs/troubleshooting` — compare identical on visible text and on `<title>` + meta description. Raw bytes differ on every page, but only in chunk hashes and the RSC nonce, which differ between any two builds.

As a control, three one-character edits — one inside an `events` detail, one in the tokenized sentence, one inside a zh `incidents` detail — produce 18 differences under the same comparison, so it covers the array path and the `splitTokens` path, not just the plain strings.

### Correction to #5488

I wrote there that the 7 `lib/deploy-preflight.test.ts` failures need Cloudflare deploy credentials. That was wrong, and the clean base worktree here is what showed it: the base passes 267/267, so the failures are not a property of `main`.

The cause is `lib/deploy-preflight.test.ts:8` spawning the script by `script.pathname`. `URL.pathname` stays percent-encoded, so in a checkout under a path with non-ASCII characters — this one is under `开源Ds` — the spawned filename does not exist and the 7 cases in the file that spawn it exit on module-not-found. Copying the untouched base worktree to a non-ASCII path reproduces the same 7. `fileURLToPath` is the fix, and it is what the scripts under `web/scripts/` already do; sending it as its own PR (#5503) rather than folding it in here.

So the honest count for this branch: 267 on the base, 271 here, 4 of them new, and the 7 failures are that path bug rather than anything on either branch.

The Rust gates in the template do not apply — this PR touches only `web/`.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — no TUI change
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

No-Issue: one page group of the #5337 series — the epic stays open until the last group lands.
