### PR TITLE
docs(readme): restore the star history chart

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 وكيل برمجة مفتوح المصدر لطرفيّتك — أحضر نموذجك بنفسك.
@@ -136,4 +136,4 @@ Operate عندما يكون المحرّر فارغًا — ومع النص يك
 
 [MIT](LICENSE). مشروع مجتمعي مستقل، غير مرتبط بأي مزوّد نماذج.
 
-![Codewhale يفتح ثلاثة وكلاء فرعيين scout للقراءة فقط في طرفية](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.ca.md
+++ b/README.ca.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Un agent de programació de codi obert per al teu terminal — porta el teu propi model.
@@ -155,4 +155,4 @@ l'experiència d'agent al terminal.
 [MIT](LICENSE). Projecte comunitari independent, no afiliat a cap proveïdor de
 models.
 
-![Codewhale desplegant tres subagents scout de només lectura en un terminal](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.de.md
+++ b/README.de.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Ein Open-Source-Programmieragent für Ihr Terminal — bringen Sie Ihr eigenes Modell mit.
@@ -165,4 +165,4 @@ Zusammenarbeit an der Terminal-Agent-Erfahrung.
 [MIT](LICENSE). Ein unabhängiges Community-Projekt, nicht verbunden mit
 einem Modellanbieter.
 
-![Codewhale fächert drei schreibgeschützte Scout-Subagenten in einem Terminal auf](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.es-419.md
+++ b/README.es-419.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Un agente de programación de código abierto para tu terminal — trae tu propio modelo.
@@ -155,4 +155,4 @@ experiencia de agente en terminal.
 [MIT](LICENSE). Proyecto comunitario independiente; sin afiliación con ningún
 proveedor de modelos.
 
-![Codewhale desplegando tres subagentes scout de solo lectura en una terminal](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Un agent de programmation open source pour votre terminal — apportez votre propre modèle.
@@ -167,4 +167,4 @@ collaboration sur l'expérience d'agent dans le terminal.
 [MIT](LICENSE). Projet communautaire indépendant, non affilié à aucun
 fournisseur de modèles.
 
-![Codewhale déployant trois sous-agents scout en lecture seule dans un terminal](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.hi.md
+++ b/README.hi.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 आपके टर्मिनल के लिए एक ओपन सोर्स कोडिंग एजेंट — मॉडल आप लाएँ।
@@ -143,4 +143,4 @@ Whale Brother परिवार में स्वागत के लिए, 
 
 [MIT](LICENSE)। एक स्वतंत्र सामुदायिक परियोजना, किसी मॉडल प्रदाता से संबद्ध नहीं।
 
-![टर्मिनल में तीन केवल-पढ़ने योग्य scout सबएजेंट फैलाता Codewhale](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.id.md
+++ b/README.id.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Sebuah coding agent sumber terbuka untuk terminal Anda — bawa model pilihan Anda sendiri.
@@ -90,4 +90,4 @@ Terima kasih kepada [DeepSeek](https://github.com/deepseek-ai) untuk model dan d
 
 [MIT](LICENSE). Sebuah proyek komunitas independen, tidak terafiliasi dengan penyedia model mana pun.
 
-![Codewhale memecah tiga subagent scout hanya-baca di terminal](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.it.md
+++ b/README.it.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Un agente di programmazione open source per il tuo terminale — porta il tuo modello.
@@ -155,4 +155,4 @@ sull'esperienza di agente nel terminale.
 [MIT](LICENSE). Progetto comunitario indipendente, non affiliato ad alcun
 fornitore di modelli.
 
-![Codewhale che dispiega tre sottoagenti scout in sola lettura in un terminale](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 ターミナルで動くオープンソースのコーディングエージェント — モデルはあなたが持ち込む。
@@ -97,4 +97,4 @@ Issue、PR、再現手順、ログ、機能要望は、どれもここでは本�
 
 [MIT](LICENSE)。独立したコミュニティプロジェクトであり、いかなるモデルプロバイダとも提携していません。
 
-![ターミナルで 3 つの読み取り専用 scout サブエージェントを並列起動する Codewhale](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 터미널에서 쓰는 오픈소스 코딩 에이전트 — 모델은 당신이 가져옵니다.
@@ -98,4 +98,4 @@ TUI 안에서: `/model`은 프로바이더와 모델을 함께 전환하고, `/f
 
 [MIT](LICENSE). 독립 커뮤니티 프로젝트이며, 어떤 모델 프로바이더와도 제휴 관계가 없습니다.
 
-![터미널에서 읽기 전용 scout 하위 에이전트 세 개를 병렬로 펼치는 Codewhale](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ terminal-agent experience.
 [MIT](LICENSE). An independent community project, not affiliated with any model
 provider.
 
-![Codewhale fanning out three read-only scout subagents in a terminal](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Otwartoźródłowy agent programistyczny do Twojego terminala — model przynosisz sam.
@@ -154,4 +154,4 @@ doświadczeniu agenta w terminalu.
 [MIT](LICENSE). Niezależny projekt społecznościowy, niezwiązany z żadnym
 dostawcą modeli.
 
-![Codewhale rozsyła trzech podrzędnych agentów scout tylko do odczytu w terminalu](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Um agente de programação de código aberto para o seu terminal — traga o seu próprio modelo.
@@ -152,4 +152,4 @@ experiência de agente no terminal.
 [MIT](LICENSE). Projeto comunitário independente; sem afiliação com nenhum
 provedor de modelos.
 
-![Codewhale distribuindo três subagentes scout somente leitura em um terminal](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Открытый агент для программирования в вашем терминале — модель приносите с собой.
@@ -152,4 +152,4 @@ Work / Operate; если в поле есть текст, `Tab` дополняе
 [MIT](LICENSE). Независимый проект сообщества, не аффилированный ни с одним
 провайдером моделей.
 
-![Codewhale запускает три read-only scout-субагента параллельно в терминале](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Terminaliniz için açık kaynak bir kodlama ajanı — modeli siz getirin.
@@ -157,4 +157,4 @@ deneyiminde iş birliği için [OpenWarp](https://github.com/zerx-lab/warp) ile
 [MIT](LICENSE). Bağımsız bir topluluk projesi; hiçbir model sağlayıcısıyla
 bağlı değildir.
 
-![Codewhale bir terminalde üç salt okunur scout alt ajanını açıyor](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.uk.md
+++ b/README.uk.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Агент для програмування з відкритим кодом у вашому терміналі — модель приносите ви.
@@ -152,4 +152,4 @@ Operate; якщо в полі є текст, `Tab` доповнює слеш-к�
 [MIT](LICENSE). Незалежний проєкт спільноти, не пов'язаний із жодним
 провайдером моделей.
 
-![Codewhale розгалужує три read-only scout-субагенти паралельно в терміналі](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 Một coding agent mã nguồn mở cho terminal của bạn — mang theo model của riêng bạn.
@@ -144,4 +144,4 @@ trải nghiệm agent trên terminal.
 [MIT](LICENSE). Dự án cộng đồng độc lập; không trực thuộc bất kỳ nhà cung cấp
 model nào.
 
-![Codewhale phân nhánh ba subagent scout chỉ đọc trong terminal](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 一个面向终端的开源编程智能体——模型由你自带。
@@ -87,4 +87,4 @@ Issue、PR、复现步骤、日志和功能请求,在这里都算真实的项目
 
 [MIT](LICENSE)。独立的社区项目,与任何模型 provider 均无隶属关系。
 
-![Codewhale 在终端中并行派出三个只读 scout 子代理](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:4fc19c5f9596 -->
+<!-- source: README.md sha256:3294a0dd6917 -->
 # Codewhale
 
 給終端機用的開源程式設計智能體——模型由你自備。
@@ -87,4 +87,4 @@ Issue、PR、重現步驟、紀錄檔和功能請求，在這裡都算真實的�
 
 [MIT](LICENSE)。獨立的社群專案，與任何模型 provider 均無隸屬關係。
 
-![Codewhale 在終端機中並行派出三個唯讀 scout 子代理](assets/fanout.gif)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Hmbown/CodeWhale&type=date&legend=top-left)](https://star-history.dera.page/#Hmbown/CodeWhale&type=date)


### PR DESCRIPTION
The star history chart that used to sit at the bottom of the README was removed in 4bc02de because GitHub restricted third-party access to star data, and the same change was carried into the translated READMEs in 585cf8b. Visitors can no longer see the project's growth at a glance, and the README now ends with a static image instead of a live chart.

This change restores a working star history chart at the same location in README.md and in all eighteen localized READMEs. The restored chart renders correctly under the current GitHub restrictions, so anyone looking at the repository sees a live history again instead of a fixed image.