### PR TITLE
feat(tui): show repository context in git chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The TUI header now identifies the active repository or linked worktree before
+  the branch and dirty marker, so operators can see where the agent is working
+  without opening the worktree manager (#5437).
+
 ## [0.9.9] - 2026-08-18
 
 Codewhale v0.9.9 is a truth-and-resilience release: the shell tool can no

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -181,6 +181,10 @@ locales grow to 18 and 8.
 
 ### Added
 
+- The TUI header now identifies the active repository or linked worktree before
+  the branch and dirty marker, so operators can see where the agent is working
+  without opening the worktree manager (#5437).
+
 - `[transcript] prose_measure` (positive integer, optional): caps prose
   wrap at N columns for owners who want a bounded reading measure on
   ultrawide terminals. `0` or absent keeps the full width; negative or

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The TUI header now identifies the active repository or linked worktree before
+  the branch and dirty marker, so operators can see where the agent is working
+  without opening the worktree manager (#5437).
+
 ## [0.9.9] - 2026-08-18
 
 Codewhale v0.9.9 is a truth-and-resilience release: the shell tool can no
@@ -180,10 +186,6 @@ locales grow to 18 and 8.
   descriptions, and line anchors now match the current code (#5481).
 
 ### Added
-
-- The TUI header now identifies the active repository or linked worktree before
-  the branch and dirty marker, so operators can see where the agent is working
-  without opening the worktree manager (#5437).
 
 - `[transcript] prose_measure` (positive integer, optional): caps prose
   wrap at N columns for owners who want a bounded reading measure on

--- a/crates/tui/src/tui/git_status.rs
+++ b/crates/tui/src/tui/git_status.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GitStatusSnapshot {
     pub root: Option<PathBuf>,
+    pub repository_name: Option<String>,
     pub branch: Option<String>,
     pub dirty: bool,
     pub ahead: u32,
@@ -91,6 +92,7 @@ fn probe_status(workspace: &Path) -> GitStatusSnapshot {
         return snap;
     };
     snap.root = Some(root.clone());
+    snap.repository_name = repository_name(&root);
 
     // Branch (symbolic-ref first, then short HEAD for detached).
     snap.branch = git_output(&root, &["symbolic-ref", "--short", "HEAD"])
@@ -165,11 +167,42 @@ fn git_output(cwd: &Path, args: &[&str]) -> Result<String, String> {
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-/// Compact chrome label: `main* ↑2` or `detached`.
+fn repository_name(worktree_root: &Path) -> Option<String> {
+    let common_dir = git_output(worktree_root, &["rev-parse", "--git-common-dir"]).ok()?;
+    repository_name_from_common_dir(worktree_root, Path::new(common_dir.trim()))
+}
+
+fn repository_name_from_common_dir(worktree_root: &Path, common_dir: &Path) -> Option<String> {
+    let common_dir = if common_dir.is_absolute() {
+        common_dir.to_path_buf()
+    } else {
+        worktree_root.join(common_dir)
+    };
+    common_dir
+        .parent()
+        .and_then(Path::file_name)
+        .map(|name| name.to_string_lossy().into_owned())
+}
+
+/// Compact chrome label: `CodeWhale · main* ↑2` or
+/// `CodeWhale/feature · feature*` for a linked worktree.
 #[must_use]
 pub fn chrome_label(snap: &GitStatusSnapshot) -> Option<String> {
     let branch = snap.branch.as_deref()?;
-    let mut label = branch.to_string();
+    let worktree_name = snap
+        .root
+        .as_deref()
+        .and_then(Path::file_name)
+        .map(|name| name.to_string_lossy());
+    let location = match (snap.repository_name.as_deref(), worktree_name.as_deref()) {
+        (Some(repository), Some(worktree)) if repository != worktree => {
+            format!("{repository}/{worktree}")
+        }
+        (Some(repository), _) => repository.to_string(),
+        (None, Some(worktree)) => worktree.to_string(),
+        (None, None) => return Some(branch.to_string()),
+    };
+    let mut label = format!("{location} · {branch}");
     if snap.dirty {
         label.push('*');
     }
@@ -236,12 +269,46 @@ locked
     #[test]
     fn chrome_label_marks_dirty_and_divergence() {
         let snap = GitStatusSnapshot {
+            root: Some("/repo".into()),
+            repository_name: Some("repo".into()),
             branch: Some("main".into()),
             dirty: true,
             ahead: 2,
             behind: 1,
             ..GitStatusSnapshot::default()
         };
-        assert_eq!(chrome_label(&snap).as_deref(), Some("main* ↑2 ↓1"));
+        assert_eq!(chrome_label(&snap).as_deref(), Some("repo · main* ↑2 ↓1"));
+    }
+
+    #[test]
+    fn chrome_label_identifies_a_linked_worktree() {
+        let snap = GitStatusSnapshot {
+            root: Some("/repo/.cw-worktrees/feature".into()),
+            repository_name: Some("repo".into()),
+            branch: Some("feature".into()),
+            dirty: true,
+            ..GitStatusSnapshot::default()
+        };
+
+        assert_eq!(
+            chrome_label(&snap).as_deref(),
+            Some("repo/feature · feature*")
+        );
+    }
+
+    #[test]
+    fn repository_name_uses_the_common_git_directory_for_worktrees() {
+        assert_eq!(
+            repository_name_from_common_dir(
+                Path::new("/repo/.cw-worktrees/feature"),
+                Path::new("/repo/.git")
+            )
+            .as_deref(),
+            Some("repo")
+        );
+        assert_eq!(
+            repository_name_from_common_dir(Path::new("/repo"), Path::new(".git")).as_deref(),
+            Some("repo")
+        );
     }
 }

--- a/crates/tui/src/tui/underwater.rs
+++ b/crates/tui/src/tui/underwater.rs
@@ -935,6 +935,16 @@ fn push_chrome(spans: &mut Vec<Span<'static>>, span: Span<'static>) {
 /// Render the one-line shell header. Route, mode, requested/effective effort,
 /// permission, active-agent count, and context each have exactly one owner.
 pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
+    let git_status = crate::tui::git_status::cached_status();
+    render_header_with_git_status(area, buf, app, &git_status);
+}
+
+fn render_header_with_git_status(
+    area: Rect,
+    buf: &mut Buffer,
+    app: &App,
+    git_status: &crate::tui::git_status::GitStatusSnapshot,
+) {
     if area.width == 0 || area.height == 0 {
         return;
     }
@@ -1103,10 +1113,19 @@ pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
             Style::default().fg(app.ui_theme.text_hint),
         )
     });
-    // Cached git branch/status only — never probe from the render path.
+    // Cached repository/worktree status only — never probe from the render path.
     // Background refresh is scheduled from the event loop / idle ticks.
-    let git_label = crate::tui::git_status::chrome_label(&crate::tui::git_status::cached_status())
-        .map(|label| Span::styled(label, Style::default().fg(app.ui_theme.text_muted)));
+    let git_label = crate::tui::git_status::chrome_label(git_status).map(|label| {
+        let max_width = match tier {
+            ShellTier::Compact => 24,
+            ShellTier::Normal => 36,
+            ShellTier::Wide => 52,
+        };
+        Span::styled(
+            truncate_to_width(&label, max_width),
+            Style::default().fg(app.ui_theme.text_muted),
+        )
+    });
 
     // Baseline right-hand chrome: git, context meter, version. Exact route
     // identity outranks this auxiliary chrome when the full line cannot fit.
@@ -1799,6 +1818,46 @@ mod tests {
         let mut buf = Buffer::empty(area);
         render_header(area, &mut buf, app);
         (0..width).map(|x| buf[(x, 0)].symbol()).collect()
+    }
+
+    fn header_text_with_git_status(
+        app: &App,
+        width: u16,
+        git_status: &crate::tui::git_status::GitStatusSnapshot,
+    ) -> String {
+        let area = Rect::new(0, 0, width, 1);
+        let mut buf = Buffer::empty(area);
+        render_header_with_git_status(area, &mut buf, app, git_status);
+        (0..width).map(|x| buf[(x, 0)].symbol()).collect()
+    }
+
+    #[test]
+    fn header_surfaces_repository_and_worktree_without_wrapping() {
+        let app = test_app();
+        let git_status = crate::tui::git_status::GitStatusSnapshot {
+            root: Some("/repo/.cw-worktrees/feature".into()),
+            repository_name: Some("repo".into()),
+            branch: Some("feature".into()),
+            dirty: true,
+            ..Default::default()
+        };
+
+        let wide = header_text_with_git_status(&app, 130, &git_status);
+        assert!(
+            wide.contains("repo/feature · feature*"),
+            "wide header: {wide:?}"
+        );
+
+        let narrow = header_text_with_git_status(&app, 60, &git_status);
+        assert!(!narrow.contains('\n'), "narrow header must stay one line");
+        assert!(
+            narrow.to_ascii_lowercase().contains("work"),
+            "mode: {narrow:?}"
+        );
+        assert!(
+            narrow.to_ascii_lowercase().contains("ask"),
+            "permission: {narrow:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Addresses the approved repository and worktree status slice of #5437.

The TUI header now identifies where the agent is operating:

- Normal checkout: `repo · branch*`
- Linked worktree: `repo/worktree · branch*`
- Ahead and behind counts remain visible when available
- Long repository and worktree names are capped by shell density tier
- Existing semantic colors and the broader palette grammar are unchanged

Repository identity is derived from Git's common directory, so linked worktrees can be distinguished from their parent repository. Git probing remains cached and off the render path.

## Scope

This PR intentionally covers only:

- repository and worktree identity in the header;
- branch and dirty-state presentation;
- existing refresh behavior;
- wide and narrow header coverage;
- synchronized root and TUI changelog entries.

The broader color grammar documentation and palette refactor remain separate follow-up work.

## Verification

Passed:

- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/release/check-versions.sh`
- `CARGO_INCREMENTAL=0 cargo test -p codewhale-tui --lib 'tui::git_status' --locked`
- `CARGO_INCREMENTAL=0 cargo test -p codewhale-tui --lib 'tui::underwater::tests::header_surfaces_repository_and_worktree_without_wrapping' --locked`
- `CARGO_INCREMENTAL=0 cargo test -p codewhale-tui --lib --locked` (10,741 passed, 12 ignored)

The strict clippy run reports three unrelated existing diagnostics in `client/chat.rs`, `commands/groups/session/structcopy.rs`, and `tui/history/latex_render.rs`; none point to this diff.

No provider credentials or network access are required.

No-Issue: This PR addresses only the approved repository/worktree status slice of #5437. The broader color grammar and palette work remain open.
