### PR TITLE
fix(tui): forward MCP image results as typed content

### DIFF
--- a/crates/tui/src/core/engine/tool_execution.rs
+++ b/crates/tui/src/core/engine/tool_execution.rs
@@ -217,14 +217,15 @@ impl Engine {
         pool: Arc<AsyncMutex<McpPool>>,
         name: &str,
         input: serde_json::Value,
-    ) -> Result<ToolResult, ToolError> {
+    ) -> Result<RichToolResult, ToolError> {
         let mut pool = pool.lock().await;
         let result = pool
             .call_tool(name, input)
             .await
             .map_err(|e| ToolError::execution_failed(format!("MCP tool failed: {e}")))?;
-        let content = serde_json::to_string(&result).unwrap_or_else(|_| result.to_string());
-        Ok(ToolResult::success(content))
+        Ok(crate::image_attach::bound_rich_tool_result(
+            crate::tools::registry::mcp_result_to_rich_tool_result(result),
+        ))
     }
 
     pub(super) async fn execute_parallel_tool(
@@ -461,9 +462,7 @@ impl Engine {
 
         let outcome: Result<RichToolResult, ToolError> = if McpPool::is_mcp_tool(&tool_name) {
             if let Some(pool) = mcp_pool {
-                Engine::execute_mcp_tool_with_pool(pool, &tool_name, tool_input)
-                    .await
-                    .map(RichToolResult::plain)
+                Engine::execute_mcp_tool_with_pool(pool, &tool_name, tool_input).await
             } else {
                 Err(ToolError::not_available(format!(
                     "tool '{tool_name}' is not registered"

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -22,7 +22,7 @@ use super::schema_canonicalize;
 use super::schema_sanitize;
 use super::spec::{
     ApprovalRequirement, RichToolResult, ToolCapability, ToolContext, ToolError, ToolResult,
-    ToolSpec,
+    ToolResultContentBlock, ToolSpec,
 };
 
 // === Types ===
@@ -1484,43 +1484,86 @@ impl ToolSpec for McpToolAdapter {
         !is_mcp_read_helper(&self.name)
     }
 
-    async fn execute(&self, input: Value, _context: &ToolContext) -> Result<ToolResult, ToolError> {
+    async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
+        self.execute_rich(input, context)
+            .await
+            .map(RichToolResult::into_result)
+    }
+
+    async fn execute_rich(
+        &self,
+        input: Value,
+        _context: &ToolContext,
+    ) -> Result<RichToolResult, ToolError> {
         let mut pool = self.pool.lock().await;
         let result = pool
             .call_tool(&self.name, input)
             .await
             .map_err(|e| ToolError::execution_failed(format!("MCP tool failed: {e}")))?;
-        Ok(mcp_result_to_tool_result(&result))
+        Ok(mcp_result_to_rich_tool_result(result))
     }
 }
 
-/// Map an MCP `tools/call` result to a `ToolResult`. MCP servers signal tool
-/// failure with `isError: true` on an otherwise successful JSON-RPC response;
-/// wrapping that in `ToolResult::success` tells the model a rejected call
-/// worked (#5123-class). Error results keep their text payload verbatim so
-/// the model still sees the server's message.
-fn mcp_result_to_tool_result(result: &Value) -> ToolResult {
-    let content = serde_json::to_string(result).unwrap_or_else(|_| result.to_string());
+const MCP_IMAGE_TEXT_PLACEHOLDER: &str = "[MCP image payload removed from text output]";
+
+/// Map an MCP `tools/call` result to the provider-neutral rich result used by
+/// native tools. Image payloads travel as typed blocks instead of being
+/// duplicated into the JSON text as multi-megabyte base64 strings.
+///
+/// MCP servers signal tool failure with `isError: true` on an otherwise
+/// successful JSON-RPC response. Error results keep their text payload
+/// verbatim so the model still sees the server's message (#5123-class).
+pub(crate) fn mcp_result_to_rich_tool_result(mut result: Value) -> RichToolResult {
+    let mut content_blocks = Vec::new();
+    if let Some(items) = result.get_mut("content").and_then(Value::as_array_mut) {
+        for item in items {
+            let Some(object) = item.as_object_mut() else {
+                continue;
+            };
+            if object.get("type").and_then(Value::as_str) != Some("image") {
+                continue;
+            }
+
+            let mime_type = object
+                .get("mimeType")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let data = object.remove("data");
+            if data.is_some() {
+                object.insert(
+                    "data".to_string(),
+                    Value::String(MCP_IMAGE_TEXT_PLACEHOLDER.to_string()),
+                );
+            }
+            if let (Some(mime_type), Some(Value::String(data))) = (mime_type, data) {
+                content_blocks.push(ToolResultContentBlock::Image { mime_type, data });
+            }
+        }
+    }
+
+    let content = serde_json::to_string(&result).unwrap_or_else(|_| result.to_string());
     let is_error = result
         .get("isError")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    if !is_error {
-        return ToolResult::success(content);
-    }
-    let text = result
-        .get("content")
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(|item| item.get("text").and_then(Value::as_str))
-                .collect::<Vec<_>>()
-                .join("\n")
-        })
-        .filter(|text| !text.is_empty())
-        .unwrap_or(content);
-    ToolResult::error(text)
+    let result = if is_error {
+        let text = result
+            .get("content")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item.get("text").and_then(Value::as_str))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+            .filter(|text| !text.is_empty())
+            .unwrap_or(content);
+        ToolResult::error(text)
+    } else {
+        ToolResult::success(content)
+    };
+    RichToolResult::with_content_blocks(result, content_blocks)
 }
 
 #[cfg(test)]

--- a/crates/tui/src/tools/registry/tests.rs
+++ b/crates/tui/src/tools/registry/tests.rs
@@ -13,7 +13,7 @@ use crate::tools::spec::{
 };
 
 use super::{
-    ToolRegistry, enforce_tool_authority, mcp_result_to_tool_result, mcp_tool_adapter_for_test,
+    ToolRegistry, enforce_tool_authority, mcp_result_to_rich_tool_result, mcp_tool_adapter_for_test,
 };
 
 #[test]
@@ -27,22 +27,70 @@ fn mcp_iserror_result_maps_to_tool_error_preserving_text() {
         ],
         "isError": true
     });
-    let result = mcp_result_to_tool_result(&error_payload);
+    let result = mcp_result_to_rich_tool_result(error_payload).result;
     assert!(!result.success, "isError must not be reported as success");
     assert_eq!(result.content, "delete failed: permission denied");
 
     let ok_payload = json!({
         "content": [{"type": "text", "text": "wrote 3 rows"}]
     });
-    let result = mcp_result_to_tool_result(&ok_payload);
+    let result = mcp_result_to_rich_tool_result(ok_payload).result;
     assert!(result.success);
     assert!(result.content.contains("wrote 3 rows"));
 
     // isError without text content falls back to the serialized payload.
     let bare_error = json!({"isError": true, "content": []});
-    let result = mcp_result_to_tool_result(&bare_error);
+    let result = mcp_result_to_rich_tool_result(bare_error).result;
     assert!(!result.success);
     assert!(result.content.contains("isError"));
+}
+
+#[test]
+fn mcp_image_result_uses_typed_block_without_base64_in_text() {
+    let image_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQotsAAAAABJRU5ErkJggg==";
+    let payload = json!({
+        "content": [
+            {"type": "text", "text": "screenshot captured"},
+            {"type": "image", "data": image_data, "mimeType": "image/png"}
+        ],
+        "structuredContent": {"page": "https://example.com"},
+        "isError": false
+    });
+
+    let rich = crate::image_attach::bound_rich_tool_result(mcp_result_to_rich_tool_result(payload));
+
+    assert!(rich.result.success);
+    assert!(rich.result.content.contains("screenshot captured"));
+    assert!(rich.result.content.contains("https://example.com"));
+    assert!(rich.result.content.contains("MCP image payload removed"));
+    assert!(!rich.result.content.contains(image_data));
+    assert_eq!(
+        rich.content_blocks,
+        vec![codewhale_tools::ToolResultContentBlock::Image {
+            mime_type: "image/png".to_string(),
+            data: image_data.to_string(),
+        }]
+    );
+}
+
+#[test]
+fn invalid_mcp_image_is_removed_with_a_visible_receipt() {
+    let payload = json!({
+        "content": [
+            {"type": "image", "data": "not base64", "mimeType": "image/png"}
+        ]
+    });
+
+    let rich = crate::image_attach::bound_rich_tool_result(mcp_result_to_rich_tool_result(payload));
+
+    assert!(rich.content_blocks.is_empty());
+    assert!(rich.result.content.contains("MCP image payload removed"));
+    assert!(
+        rich.result
+            .content
+            .contains("1 tool-result image block(s) omitted")
+    );
+    assert!(!rich.result.content.contains("not base64"));
 }
 
 /// A simple test tool for unit testing


### PR DESCRIPTION
## Summary

- convert standard MCP `image` content into CodeWhale's existing provider-neutral rich tool-result block
- remove inline base64 from the text receipt while preserving text, `structuredContent`, and `isError` semantics
- reuse the existing image validation, 5 MiB limit, one-image bound, provider adapters, and non-vision fallback
- cover valid and invalid MCP image results with regression tests

## Root cause

`McpPool::call_tool` returns the complete MCP result as JSON. The engine serialized that value directly into `ToolResult.content`, so an MCP screenshot reached the next model request as ordinary base64 text instead of image input.

The conversion now takes ownership of the MCP JSON and moves image payload strings into typed content blocks without cloning the base64 data. Non-image JSON remains available to the model as before.

## Impact

Vision-capable routes can inspect screenshots returned by MCP tools. Routes without image input support continue to use the existing explicit text fallback instead of failing the request.

Refs #5102 (partial)

No-Issue: #5102 is a broader screenshot/ingest epic; this narrow MCP bridge must not close it.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui tools::registry::tests::mcp_ --lib --locked` (4 passed)
- `cargo test -p codewhale-tui tool_result_image --lib --locked` (5 passed)
- `cargo test -p codewhale-tui image_attach::tests --lib --locked` (26 passed)
- `cargo clippy -p codewhale-tui --lib --locked -- -D warnings -A clippy::needless-return`

Broader registry tests passed 43/44 on Windows; the remaining existing test expects a canonical `pwd` executable and is unrelated to this change. Strict Clippy without the targeted allowance stops at the existing Windows-only `needless_return` in `crates/tui/src/mcp.rs:264`.