### PR TITLE
feat(web): move docs/constitution and docs/runtime-api onto the dictionary spine (#5337)

### DIFF
--- a/web/app/[locale]/docs/constitution/page.tsx
+++ b/web/app/[locale]/docs/constitution/page.tsx
@@ -1,102 +1,93 @@
+import { Fragment } from "react";
 import Link from "next/link";
+import { getDocsConstitution, splitTokens } from "@/lib/i18n/dictionaries";
 import { buildPageMetadata } from "@/lib/page-meta";
+
+/**
+ * Paths and commands the overview sentence typesets as inline `<code>`.
+ * `docs/VOICE.md` keeps these code-owned, so the dictionaries carry a
+ * `{token}` for each one instead of the literal.
+ */
+const CODE_SPANS: Record<string, string> = {
+  constitutionCommand: "/constitution",
+  homeConfig: "$CODEWHALE_HOME/constitution.json",
+  repoConfig: ".codewhale/constitution.json",
+};
+
+/**
+ * The en/zh badge on each principle row. Both halves render in every locale —
+ * it is a fixed bilingual glyph rather than copy — so it stays here and the
+ * dictionaries key their rows by the same names.
+ */
+const PRINCIPLE_BADGES: Record<string, [string, string]> = {
+  userGlobal: ["User-global", "用户全局"],
+  repoLocal: ["Repo-local", "仓库本地"],
+  runtime: ["Runtime", "运行时"],
+};
+
+const CONFIG_DOCS_HREF =
+  "https://github.com/Hmbown/CodeWhale/blob/main/docs/CONFIGURATION.md#constitution-project-instructions-and-repo-authority";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
+  const t = getDocsConstitution(locale);
   return buildPageMetadata({
     path: "/docs/constitution",
     locale,
-    title: isZh ? "宪章与 /constitution · Codewhale 文档" : "Constitution and /constitution · Codewhale Docs",
-    description: isZh
-      ? "用户全局宪章、仓库本地法、项目说明和运行时边界。"
-      : "User-global constitution, repo-local law, project instructions, and runtime boundaries.",
+    title: t.metaTitle,
+    description: t.metaDescription,
   });
 }
 
 export default async function ConstitutionPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
+  const t = getDocsConstitution(locale);
 
   return (
     <section className="space-y-10">
       <section id="overview" className="scroll-mt-32">
         <h2 className="font-display text-3xl mb-1">
-          {isZh ? "宪章与 /constitution" : "Constitution and /constitution"}{" "}
-          <span className="font-cjk text-indigo text-2xl ml-2">
-            {isZh ? "Constitution" : "宪章与 /constitution"}
-          </span>
+          {t.overviewTitle}{" "}
+          <span className="font-cjk text-indigo text-2xl ml-2">{t.overviewTitleAside}</span>
         </h2>
-        {isZh ? (
-          <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
-            Codewhale 先给 Agent 一个可追责的地址，再给上下文冲突一套法律。
-            <code className="inline">/constitution</code> 是管理个人常驻宪章的主入口：
-            它把结构化的用户全局设置保存在 <code className="inline">$CODEWHALE_HOME/constitution.json</code>，
-            再渲染成模型可读的 prose block。仓库仍可通过{" "}
-            <code className="inline">.codewhale/constitution.json</code> 增加本地 law；runtime
-            policy 独立负责模式、审批、沙箱、成本和工具边界。
-          </p>
-        ) : (
-          <p className="text-ink-soft mt-3 leading-relaxed">
-            Codewhale gives the agent an accountable address, then a legal system for
-            context conflicts. <code className="inline">/constitution</code> is the
-            primary personal constitution surface: guided setup stores structured
-            user-global data in <code className="inline">$CODEWHALE_HOME/constitution.json</code>
-            and renders it as model-facing prose. Repos can still add local law via{" "}
-            <code className="inline">.codewhale/constitution.json</code>; runtime policy
-            separately encodes modes, approval, sandbox, cost, and tool boundaries.
-          </p>
-        )}
+        <p className={`${t.bodyClassName} mt-3`}>
+          {splitTokens(t.overviewLead).map((part, i) =>
+            "token" in part ? (
+              <code key={`${i}-${part.token}`} className="inline">
+                {CODE_SPANS[part.token] ?? `{${part.token}}`}
+              </code>
+            ) : (
+              <Fragment key={`${i}-text`}>{part.text}</Fragment>
+            ),
+          )}
+        </p>
         <div className="hairline-t hairline-b mt-6 grid md:grid-cols-3 col-rule">
-          {[
-            {
-              name: "User-global",
-              cn: "用户全局",
-              en: "Use /constitution for standing personal law across projects. It is structured data rendered to prose, not a raw prompt editor.",
-              zh: "用 /constitution 管理跨项目个人常驻法。它是结构化数据渲染成 prose，不是裸 prompt 编辑器。",
-            },
-            {
-              name: "Repo-local",
-              cn: "仓库本地",
-              en: ".codewhale/constitution.json is optional project policy for protected invariants, branch rules, verification, and escalation.",
-              zh: ".codewhale/constitution.json 是可选项目 law，用于不变量、分支规则、验证和升级条件。",
-            },
-            {
-              name: "Runtime",
-              cn: "运行时",
-              en: "Constitution text may express preferences, but approval, sandbox, shell, network, trust, and MCP permissions remain enforced config.",
-              zh: "宪章文本可以表达偏好；审批、沙箱、Shell、网络、信任和 MCP 权限仍由运行时配置强制执行。",
-            },
-          ].map((row) => (
-            <div key={row.name} className="p-5">
-              <div className="font-display text-lg text-indigo mb-1">
-                {row.name} <span className="font-cjk text-sm ml-1.5">{row.cn}</span>
+          {t.principles.map(([key, detail]) => {
+            const [name, cn] = PRINCIPLE_BADGES[key] ?? [key, ""];
+            return (
+              <div key={key} className="p-5">
+                <div className="font-display text-lg text-indigo mb-1">
+                  {name} <span className="font-cjk text-sm ml-1.5">{cn}</span>
+                </div>
+                <p className={`text-sm ${t.bodyClassName}`}>{detail}</p>
               </div>
-              <p className={`text-sm text-ink-soft ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
-                {isZh ? row.zh : row.en}
-              </p>
-            </div>
-          ))}
+            );
+          })}
         </div>
-        <p className={`mt-4 text-sm text-ink-soft ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
-          {isZh
-            ? "普通项目说明仍放在 AGENTS.md；记忆和交接低于宪章与项目说明；完整 base prompt Markdown 覆盖只是专家逃生口，不是普通设置路径。详见 "
-            : "Standard project instructions still live in AGENTS.md; memory and handoffs rank below constitutions and project instructions; the full base-prompt Markdown override is an expert escape hatch, not the normal setup path. See "}
-          <Link
-            href="https://github.com/Hmbown/CodeWhale/blob/main/docs/CONFIGURATION.md#constitution-project-instructions-and-repo-authority"
-            className="body-link"
-          >
-            {isZh ? "配置文档" : "configuration docs"}
-          </Link>
-          {isZh ? "。" : "."}
+        <p className={`mt-4 text-sm ${t.bodyClassName}`}>
+          {splitTokens(t.authorityNote).map((part, i) =>
+            "token" in part ? (
+              <Link key={`${i}-${part.token}`} href={CONFIG_DOCS_HREF} className="body-link">
+                {t.configDocsLabel}
+              </Link>
+            ) : (
+              <Fragment key={`${i}-text`}>{part.text}</Fragment>
+            ),
+          )}
         </p>
       </section>
       <section id="source" className="hairline-t pt-8">
-        <p className="text-sm text-ink-mute">
-          {isZh
-            ? "来源文档：docs/ARCHITECTURE.md · 更新时请同步修改 docs-map.ts。"
-            : "Source document: docs/ARCHITECTURE.md · Update docs-map.ts when changing."}
-        </p>
+        <p className="text-sm text-ink-mute">{t.sourceNote}</p>
       </section>
     </section>
   );

--- a/web/app/[locale]/docs/runtime-api/page.tsx
+++ b/web/app/[locale]/docs/runtime-api/page.tsx
@@ -1,115 +1,89 @@
+import { Fragment } from "react";
+import { getDocsRuntimeApi, splitTokens } from "@/lib/i18n/dictionaries";
 import { buildPageMetadata } from "@/lib/page-meta";
+
+/**
+ * The command each entry row is headed by, and the flags and environment
+ * variables the security paragraph typesets as inline `<code>`. `docs/VOICE.md`
+ * keeps commands, key names and paths code-owned, so the dictionaries carry
+ * keys and `{token}`s rather than the literals.
+ */
+const ENTRY_COMMANDS: Record<string, string> = {
+  http: "codewhale app-server --http",
+  mobile: "codewhale app-server --mobile",
+  stdio: "codewhale app-server --stdio",
+  web: "codewhale web [--port 7878]",
+  doctor: "codewhale doctor --json",
+  acp: "codewhale serve --acp",
+  exec: "codewhale exec [args]",
+};
+
+const CODE_SPANS: Record<string, string> = {
+  authToken: "--auth-token",
+  runtimeTokenEnv: "CODEWHALE_RUNTIME_TOKEN",
+  legacyTokenEnv: "DEEPSEEK_RUNTIME_TOKEN",
+  insecureFlag: "--insecure-no-auth",
+  mobileFlag: "app-server --mobile",
+};
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
+  const t = getDocsRuntimeApi(locale);
   return buildPageMetadata({
     path: "/docs/runtime-api",
     locale,
-    title: isZh ? "运行时 API · Codewhale 文档" : "Runtime API · Codewhale Docs",
-    description: isZh
-      ? "面向集成、桥接和自动化的本地 HTTP/SSE、JSON-RPC stdio 与 ACP 入口。"
-      : "Local HTTP/SSE, JSON-RPC stdio, and ACP entrypoints for integrations, bridges, and automation.",
+    title: t.metaTitle,
+    description: t.metaDescription,
   });
 }
 
 export default async function RuntimeApiPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
-  const bodyClass = isZh
-    ? "text-ink-soft leading-[1.9] tracking-wide"
-    : "text-ink-soft leading-relaxed";
-  const entries = isZh
-    ? [
-        { cmd: "codewhale app-server --http", detail: "完整 /v1/* HTTP/SSE 运行时 API（canonical 入口），默认 127.0.0.1:7878。" },
-        { cmd: "codewhale app-server --mobile", detail: "运行时 API 加 /mobile 手机控制页。" },
-        { cmd: "codewhale app-server --stdio", detail: "换行分隔的 JSON-RPC 2.0 控制传输，无监听端口，适合本地 SDK 和探针。" },
-        { cmd: "codewhale web [--port 7878]", detail: "仅回环的浏览器客户端，内嵌于二进制并打开默认浏览器。" },
-        { cmd: "codewhale doctor --json", detail: "机器可读的健康与能力报告。" },
-        { cmd: "codewhale serve --acp", detail: "面向 Zed 等编辑器的 ACP（Agent Client Protocol）stdio 适配器。" },
-        { cmd: "codewhale exec [args]", detail: "一次性无头 worker（stream-json、Fleet 子进程、CI 原语）——不属于本 API，但共享同一运行时与事件词汇。" },
-      ]
-    : [
-        { cmd: "codewhale app-server --http", detail: "The full /v1/* HTTP/SSE runtime API (canonical entry), default 127.0.0.1:7878." },
-        { cmd: "codewhale app-server --mobile", detail: "The runtime API plus the /mobile phone control page." },
-        { cmd: "codewhale app-server --stdio", detail: "Newline-delimited JSON-RPC 2.0 control transport with no listener, for local SDKs and probes." },
-        { cmd: "codewhale web [--port 7878]", detail: "The loopback-only browser client, embedded in the binary and opened in the default browser." },
-        { cmd: "codewhale doctor --json", detail: "Machine-readable health and capability report." },
-        { cmd: "codewhale serve --acp", detail: "ACP (Agent Client Protocol) stdio adapter for editors such as Zed." },
-        { cmd: "codewhale exec [args]", detail: "The one-shot headless worker (stream-json, fleet subprocess, CI primitive) — not part of this API, but it shares the same runtime and event vocabulary." },
-      ];
+  const t = getDocsRuntimeApi(locale);
 
   return (
     <section className="space-y-10">
       <section id="overview" className="scroll-mt-32">
-        <h2 className="font-display text-3xl mb-1">{isZh ? "运行时 API" : "Runtime API"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "codewhale app-server 是 canonical 的本地运行时 API 与控制平面。本地 SDK、移动/远控客户端和编辑器集成直接与它对话，而不是抓终端输出。引擎只作为本地进程运行：所有 API 默认绑定 localhost——没有托管中继，不托管 provider 令牌，不泄露秘密。codewhale serve --http / --mobile 保留为 app-server --http / --mobile 的兼容别名，启动的是同一个服务器；新集成应面向 app-server。"
-            : "codewhale app-server is the canonical local runtime API and control plane. Local SDKs, mobile/remote-control clients, and editor integrations talk to it instead of screen-scraping terminal output. The engine runs as a local-only process: every API binds to localhost by default — no hosted relay, no provider-token custody, no secret leakage. codewhale serve --http / --mobile remain compatibility aliases for app-server --http / --mobile and launch the identical server; new integrations should target app-server."}
-        </p>
+        <h2 className="font-display text-3xl mb-1">{t.overviewTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{t.overviewLead}</p>
         <div className="hairline-t mt-6">
-          {entries.map((row) => (
-            <section key={row.cmd} className="py-4 hairline-b">
-              <h3 className="font-mono text-sm font-semibold">{row.cmd}</h3>
-              <p className={`${bodyClass} mt-1 text-sm`}>{row.detail}</p>
+          {t.entries.map(([key, detail]) => (
+            <section key={key} className="py-4 hairline-b">
+              <h3 className="font-mono text-sm font-semibold">{ENTRY_COMMANDS[key] ?? key}</h3>
+              <p className={`${t.bodyClassName} mt-1 text-sm`}>{detail}</p>
             </section>
           ))}
         </div>
       </section>
 
       <section id="stdio" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "零成本探测" : "Probe without model tokens"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "stdio 控制传输可以不花模型 token 地探测。capabilities 返回声明的方法族（thread/*、app/*、prompt/*）和完整方法列表；方法集由 crates/app-server/src/lib.rs 中的漂移测试固定，SDK 和本地集成可以放心依赖它不会悄悄变化。"
-            : "The stdio control transport can be probed without spending model tokens. capabilities returns the advertised method families (thread/*, app/*, prompt/*) and the full method list; the method set is pinned by a drift test in crates/app-server/src/lib.rs, so SDK and local integration clients can rely on it not changing silently."}
-        </p>
+        <h2 className="font-display text-2xl mb-1">{t.stdioTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{t.stdioLead}</p>
         <pre className="code-block mt-4">{`printf '%s\n' \\
   '{"jsonrpc":"2.0","id":1,"method":"healthz"}' \\
   '{"jsonrpc":"2.0","id":2,"method":"capabilities"}' \\
   '{"jsonrpc":"2.0","id":3,"method":"shutdown"}' \\
   | codewhale app-server --stdio`}</pre>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "进行中的回合可以用 thread/interrupt（或 HTTP 的 POST /v1/threads/{id}/turns/{turn_id}/interrupt）请求中断；没有正在流式输出的回合时返回 interrupted: false——这不是错误，只是没有可停的东西。"
-            : "A live turn can be asked to stop with thread/interrupt (or POST /v1/threads/{id}/turns/{turn_id}/interrupt over HTTP); when no turn is streaming the reply carries interrupted: false — not an error, just nothing to stop."}
-        </p>
+        <p className={`${t.bodyClassName} mt-3`}>{t.interruptNote}</p>
       </section>
 
       <section id="security" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "安全边界" : "Security boundary"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh ? (
-            <>
-              运行时 API 令牌按 <code className="inline">--auth-token</code>、
-              <code className="inline">CODEWHALE_RUNTIME_TOKEN</code>、
-              <code className="inline">DEEPSEEK_RUNTIME_TOKEN</code> 的顺序读取；
-              <code className="inline">--insecure-no-auth</code> 只允许与回环绑定一起使用。浏览器侧的跨源请求会被
-              CORS 允许列表拒绝。选择非回环绑定（尤其是{" "}
-              <code className="inline">app-server --mobile</code>）之前，请阅读 docs/RUNTIME_API.md
-              的完整部署与认证约定。
-            </>
-          ) : (
-            <>
-              The runtime API token is read from <code className="inline">--auth-token</code>, then{" "}
-              <code className="inline">CODEWHALE_RUNTIME_TOKEN</code>, then{" "}
-              <code className="inline">DEEPSEEK_RUNTIME_TOKEN</code>;{" "}
-              <code className="inline">--insecure-no-auth</code> is only accepted with a loopback bind.
-              Cross-origin browser requests are rejected by the CORS allow-list. Before selecting a
-              non-loopback bind — especially <code className="inline">app-server --mobile</code> — read
-              the full deployment and authentication contract in docs/RUNTIME_API.md.
-            </>
+        <h2 className="font-display text-2xl mb-1">{t.securityTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>
+          {splitTokens(t.securityLead).map((part, i) =>
+            "token" in part ? (
+              <code key={`${i}-${part.token}`} className="inline">
+                {CODE_SPANS[part.token] ?? `{${part.token}}`}
+              </code>
+            ) : (
+              <Fragment key={`${i}-text`}>{part.text}</Fragment>
+            ),
           )}
         </p>
       </section>
 
       <section id="source" className="hairline-t pt-8">
-        <p className="text-sm text-ink-mute">
-          {isZh
-            ? "来源文档：docs/RUNTIME_API.md · 更新时请同步修改 docs-map.ts。"
-            : "Source document: docs/RUNTIME_API.md · Update docs-map.ts when changing."}
-        </p>
+        <p className="text-sm text-ink-mute">{t.sourceNote}</p>
       </section>
     </section>
   );

--- a/web/lib/i18n/dictionaries.test.ts
+++ b/web/lib/i18n/dictionaries.test.ts
@@ -3,14 +3,18 @@ import {
   DICTIONARY_LOCALES,
   EN_CHROME,
   EN_DOCS_GUIDE,
+  EN_DOCS_CONSTITUTION,
   EN_DOCS_HOOKS,
+  EN_DOCS_RUNTIME_API,
   EN_DOCS_SHELL,
   EN_DOCS_TROUBLESHOOTING,
   EN_HOME,
   fill,
   getChrome,
   getDocsGuide,
+  getDocsConstitution,
   getDocsHooks,
+  getDocsRuntimeApi,
   getDocsShell,
   getDocsTroubleshooting,
   getHome,
@@ -241,6 +245,8 @@ describe("website dictionaries", () => {
     for (const [label, get, reference] of [
       ["docs-hooks", getDocsHooks, EN_DOCS_HOOKS],
       ["docs-troubleshooting", getDocsTroubleshooting, EN_DOCS_TROUBLESHOOTING],
+      ["docs-constitution", getDocsConstitution, EN_DOCS_CONSTITUTION],
+      ["docs-runtime-api", getDocsRuntimeApi, EN_DOCS_RUNTIME_API],
     ] as const) {
       const enKeys = Object.keys(reference).sort();
       for (const locale of [...DICTIONARY_LOCALES, "fr", "und"]) {
@@ -263,6 +269,14 @@ describe("website dictionaries", () => {
         getDocsTroubleshooting(locale).incidents,
         `${locale} triage entries`,
       ).toHaveLength(5);
+      expect(
+        getDocsConstitution(locale).principles.map(([key]) => key),
+        `${locale} constitution principles`,
+      ).toEqual(["userGlobal", "repoLocal", "runtime"]);
+      expect(
+        getDocsRuntimeApi(locale).entries.map(([key]) => key),
+        `${locale} runtime entries`,
+      ).toEqual(["http", "mobile", "stdio", "web", "doctor", "acp", "exec"]);
     }
   });
 
@@ -274,6 +288,31 @@ describe("website dictionaries", () => {
         "hooksTable",
         "hooksCommand",
         "enabledKey",
+      ]);
+    }
+  });
+
+  it("carries every code-span token through the constitution and runtime-api copy", () => {
+    const tokensOf = (template: string) =>
+      splitTokens(template).flatMap((part) => ("token" in part ? [part.token] : []));
+    for (const locale of [...DICTIONARY_LOCALES, "und"]) {
+      const constitution = getDocsConstitution(locale);
+      expect(tokensOf(constitution.overviewLead), `${locale} overviewLead`).toEqual([
+        "constitutionCommand",
+        "homeConfig",
+        "repoConfig",
+      ]);
+      // Exactly one link slot, so the translated label is never concatenated
+      // onto a fragment the call site owns.
+      expect(tokensOf(constitution.authorityNote), `${locale} authorityNote`).toEqual([
+        "configDocs",
+      ]);
+      expect(tokensOf(getDocsRuntimeApi(locale).securityLead), `${locale} securityLead`).toEqual([
+        "authToken",
+        "runtimeTokenEnv",
+        "legacyTokenEnv",
+        "insecureFlag",
+        "mobileFlag",
       ]);
     }
   });

--- a/web/lib/i18n/dictionaries/en/docs-constitution.ts
+++ b/web/lib/i18n/dictionaries/en/docs-constitution.ts
@@ -1,0 +1,35 @@
+import type { DocsConstitutionDict } from "../types";
+
+/**
+ * English reference dictionary for `app/[locale]/docs/constitution/page.tsx`.
+ * Copy moved verbatim from the page's `isZh` ternaries — any wording change
+ * belongs in its own commit, never mixed into a structural move.
+ */
+export const docsConstitution: DocsConstitutionDict = {
+  metaTitle: "Constitution and /constitution · Codewhale Docs",
+  metaDescription:
+    "User-global constitution, repo-local law, project instructions, and runtime boundaries.",
+  bodyClassName: "text-ink-soft leading-relaxed",
+  overviewTitle: "Constitution and /constitution",
+  overviewTitleAside: "宪章与 /constitution",
+  overviewLead:
+    "Codewhale gives the agent an accountable address, then a legal system for context conflicts. {constitutionCommand} is the primary personal constitution surface: guided setup stores structured user-global data in {homeConfig} and renders it as model-facing prose. Repos can still add local law via {repoConfig}; runtime policy separately encodes modes, approval, sandbox, cost, and tool boundaries.",
+  principles: [
+    [
+      "userGlobal",
+      "Use /constitution for standing personal law across projects. It is structured data rendered to prose, not a raw prompt editor.",
+    ],
+    [
+      "repoLocal",
+      ".codewhale/constitution.json is optional project policy for protected invariants, branch rules, verification, and escalation.",
+    ],
+    [
+      "runtime",
+      "Constitution text may express preferences, but approval, sandbox, shell, network, trust, and MCP permissions remain enforced config.",
+    ],
+  ],
+  authorityNote:
+    "Standard project instructions still live in AGENTS.md; memory and handoffs rank below constitutions and project instructions; the full base-prompt Markdown override is an expert escape hatch, not the normal setup path. See {configDocs}.",
+  configDocsLabel: "configuration docs",
+  sourceNote: "Source document: docs/ARCHITECTURE.md · Update docs-map.ts when changing.",
+};

--- a/web/lib/i18n/dictionaries/en/docs-runtime-api.ts
+++ b/web/lib/i18n/dictionaries/en/docs-runtime-api.ts
@@ -1,0 +1,43 @@
+import type { DocsRuntimeApiDict } from "../types";
+
+/**
+ * English reference dictionary for `app/[locale]/docs/runtime-api/page.tsx`.
+ * Copy moved verbatim from the page's `isZh` ternaries — any wording change
+ * belongs in its own commit, never mixed into a structural move.
+ */
+export const docsRuntimeApi: DocsRuntimeApiDict = {
+  metaTitle: "Runtime API · Codewhale Docs",
+  metaDescription:
+    "Local HTTP/SSE, JSON-RPC stdio, and ACP entrypoints for integrations, bridges, and automation.",
+  bodyClassName: "text-ink-soft leading-relaxed",
+  overviewTitle: "Runtime API",
+  overviewLead:
+    "codewhale app-server is the canonical local runtime API and control plane. Local SDKs, mobile/remote-control clients, and editor integrations talk to it instead of screen-scraping terminal output. The engine runs as a local-only process: every API binds to localhost by default — no hosted relay, no provider-token custody, no secret leakage. codewhale serve --http / --mobile remain compatibility aliases for app-server --http / --mobile and launch the identical server; new integrations should target app-server.",
+  entries: [
+    ["http", "The full /v1/* HTTP/SSE runtime API (canonical entry), default 127.0.0.1:7878."],
+    ["mobile", "The runtime API plus the /mobile phone control page."],
+    [
+      "stdio",
+      "Newline-delimited JSON-RPC 2.0 control transport with no listener, for local SDKs and probes.",
+    ],
+    [
+      "web",
+      "The loopback-only browser client, embedded in the binary and opened in the default browser.",
+    ],
+    ["doctor", "Machine-readable health and capability report."],
+    ["acp", "ACP (Agent Client Protocol) stdio adapter for editors such as Zed."],
+    [
+      "exec",
+      "The one-shot headless worker (stream-json, fleet subprocess, CI primitive) — not part of this API, but it shares the same runtime and event vocabulary.",
+    ],
+  ],
+  stdioTitle: "Probe without model tokens",
+  stdioLead:
+    "The stdio control transport can be probed without spending model tokens. capabilities returns the advertised method families (thread/*, app/*, prompt/*) and the full method list; the method set is pinned by a drift test in crates/app-server/src/lib.rs, so SDK and local integration clients can rely on it not changing silently.",
+  interruptNote:
+    "A live turn can be asked to stop with thread/interrupt (or POST /v1/threads/{id}/turns/{turn_id}/interrupt over HTTP); when no turn is streaming the reply carries interrupted: false — not an error, just nothing to stop.",
+  securityTitle: "Security boundary",
+  securityLead:
+    "The runtime API token is read from {authToken}, then {runtimeTokenEnv}, then {legacyTokenEnv}; {insecureFlag} is only accepted with a loopback bind. Cross-origin browser requests are rejected by the CORS allow-list. Before selecting a non-loopback bind — especially {mobileFlag} — read the full deployment and authentication contract in docs/RUNTIME_API.md.",
+  sourceNote: "Source document: docs/RUNTIME_API.md · Update docs-map.ts when changing.",
+};

--- a/web/lib/i18n/dictionaries/index.ts
+++ b/web/lib/i18n/dictionaries/index.ts
@@ -14,8 +14,10 @@
  */
 import type {
   ChromeDict,
+  DocsConstitutionDict,
   DocsGuideDict,
   DocsHooksDict,
+  DocsRuntimeApiDict,
   DocsShellDict,
   DocsTroubleshootingDict,
   HomeDict,
@@ -30,6 +32,10 @@ import { docsHooks as enDocsHooks } from "./en/docs-hooks";
 import { docsHooks as zhDocsHooks } from "./zh/docs-hooks";
 import { docsTroubleshooting as enDocsTroubleshooting } from "./en/docs-troubleshooting";
 import { docsTroubleshooting as zhDocsTroubleshooting } from "./zh/docs-troubleshooting";
+import { docsConstitution as enDocsConstitution } from "./en/docs-constitution";
+import { docsConstitution as zhDocsConstitution } from "./zh/docs-constitution";
+import { docsRuntimeApi as enDocsRuntimeApi } from "./en/docs-runtime-api";
+import { docsRuntimeApi as zhDocsRuntimeApi } from "./zh/docs-runtime-api";
 import { chrome as zhChrome } from "./zh/chrome";
 import { home as zhHome } from "./zh/home";
 import { chrome as jaChrome } from "./ja/chrome";
@@ -147,6 +153,14 @@ const DOCS_TROUBLESHOOTING: Record<string, DocsTroubleshootingDict> = {
   zh: zhDocsTroubleshooting,
 };
 
+const DOCS_CONSTITUTION: Record<string, DocsConstitutionDict> = {
+  zh: zhDocsConstitution,
+};
+
+const DOCS_RUNTIME_API: Record<string, DocsRuntimeApiDict> = {
+  zh: zhDocsRuntimeApi,
+};
+
 export function getChrome(locale: string): ChromeDict {
   return CHROME[locale] ?? enChrome;
 }
@@ -171,6 +185,14 @@ export function getDocsTroubleshooting(locale: string): DocsTroubleshootingDict 
   return DOCS_TROUBLESHOOTING[locale] ?? enDocsTroubleshooting;
 }
 
+export function getDocsConstitution(locale: string): DocsConstitutionDict {
+  return DOCS_CONSTITUTION[locale] ?? enDocsConstitution;
+}
+
+export function getDocsRuntimeApi(locale: string): DocsRuntimeApiDict {
+  return DOCS_RUNTIME_API[locale] ?? enDocsRuntimeApi;
+}
+
 /**
  * Select one side of a legacy `{ en, zh }` content pair by locale. This is
  * the transitional bridge for `web/lib/content/` modules that still carry
@@ -189,6 +211,8 @@ export const EN_DOCS_GUIDE = enDocsGuide;
 export const EN_DOCS_SHELL = enDocsShell;
 export const EN_DOCS_HOOKS = enDocsHooks;
 export const EN_DOCS_TROUBLESHOOTING = enDocsTroubleshooting;
+export const EN_DOCS_CONSTITUTION = enDocsConstitution;
+export const EN_DOCS_RUNTIME_API = enDocsRuntimeApi;
 
 /** Interpolate `{name}` tokens in a dictionary template. Unknown tokens are
  * left intact so a template/variable drift is visible in review, not silent. */

--- a/web/lib/i18n/dictionaries/types.ts
+++ b/web/lib/i18n/dictionaries/types.ts
@@ -360,3 +360,53 @@ export interface DocsTroubleshootingDict {
   dockerToolboxNote: string;
   sourceNote: string;
 }
+
+/**
+ * `app/[locale]/docs/constitution/page.tsx`.
+ *
+ * `overviewLead` carries three `{token}` placeholders and `authorityNote` one
+ * more. Per `docs/VOICE.md` — keep commands, key names and paths as code-owned
+ * placeholders — the literals themselves live in the page, along with the
+ * en/zh badge pair on each principle row, which is a fixed bilingual glyph
+ * rather than copy.
+ */
+export interface DocsConstitutionDict {
+  metaTitle: string;
+  metaDescription: string;
+  /** Body-copy typography for this locale (CJK needs looser leading). */
+  bodyClassName: string;
+  overviewTitle: string;
+  /** Opposite-language echo the heading prints beside the title. */
+  overviewTitleAside: string;
+  overviewLead: string;
+  /** Three `[key, detail]` rows; the key selects the page's badge pair. */
+  principles: [string, string][];
+  authorityNote: string;
+  /** Link text inside `authorityNote`'s `{configDocs}` slot. */
+  configDocsLabel: string;
+  sourceNote: string;
+}
+
+/**
+ * `app/[locale]/docs/runtime-api/page.tsx`.
+ *
+ * Only `securityLead` is tokenized. The command names elsewhere on the page
+ * are set as prose rather than `<code>`, so they stay inside the sentences
+ * exactly as the `isZh` ternaries had them.
+ */
+export interface DocsRuntimeApiDict {
+  metaTitle: string;
+  metaDescription: string;
+  /** Body-copy typography for this locale (CJK needs looser leading). */
+  bodyClassName: string;
+  overviewTitle: string;
+  overviewLead: string;
+  /** Seven `[key, detail]` rows; the key selects the page's command literal. */
+  entries: [string, string][];
+  stdioTitle: string;
+  stdioLead: string;
+  interruptNote: string;
+  securityTitle: string;
+  securityLead: string;
+  sourceNote: string;
+}

--- a/web/lib/i18n/dictionaries/zh/docs-constitution.ts
+++ b/web/lib/i18n/dictionaries/zh/docs-constitution.ts
@@ -1,0 +1,36 @@
+import type { DocsConstitutionDict } from "../types";
+
+/**
+ * 中文对照见 `en/docs-constitution.ts`,文案自页面的 `isZh` 三元逐字迁入。
+ *
+ * `overviewLead` 在「主入口：」和「constitution.json，」之后各有一个空格。
+ * 那是旧 JSX 在这两处换行、被 JSX 合成空格的结果,不是笔误 —— 保留它是为了
+ * 让这次迁移在渲染上是纯粹的 no-op。
+ */
+export const docsConstitution: DocsConstitutionDict = {
+  metaTitle: "宪章与 /constitution · Codewhale 文档",
+  metaDescription: "用户全局宪章、仓库本地法、项目说明和运行时边界。",
+  bodyClassName: "text-ink-soft leading-[1.9] tracking-wide",
+  overviewTitle: "宪章与 /constitution",
+  overviewTitleAside: "Constitution",
+  overviewLead:
+    "Codewhale 先给 Agent 一个可追责的地址，再给上下文冲突一套法律。{constitutionCommand} 是管理个人常驻宪章的主入口： 它把结构化的用户全局设置保存在 {homeConfig}， 再渲染成模型可读的 prose block。仓库仍可通过 {repoConfig} 增加本地 law；runtime policy 独立负责模式、审批、沙箱、成本和工具边界。",
+  principles: [
+    [
+      "userGlobal",
+      "用 /constitution 管理跨项目个人常驻法。它是结构化数据渲染成 prose，不是裸 prompt 编辑器。",
+    ],
+    [
+      "repoLocal",
+      ".codewhale/constitution.json 是可选项目 law，用于不变量、分支规则、验证和升级条件。",
+    ],
+    [
+      "runtime",
+      "宪章文本可以表达偏好；审批、沙箱、Shell、网络、信任和 MCP 权限仍由运行时配置强制执行。",
+    ],
+  ],
+  authorityNote:
+    "普通项目说明仍放在 AGENTS.md；记忆和交接低于宪章与项目说明；完整 base prompt Markdown 覆盖只是专家逃生口，不是普通设置路径。详见 {configDocs}。",
+  configDocsLabel: "配置文档",
+  sourceNote: "来源文档：docs/ARCHITECTURE.md · 更新时请同步修改 docs-map.ts。",
+};

--- a/web/lib/i18n/dictionaries/zh/docs-runtime-api.ts
+++ b/web/lib/i18n/dictionaries/zh/docs-runtime-api.ts
@@ -1,0 +1,32 @@
+import type { DocsRuntimeApiDict } from "../types";
+
+/** 中文对照见 `en/docs-runtime-api.ts`,文案自页面的 `isZh` 三元逐字迁入。 */
+export const docsRuntimeApi: DocsRuntimeApiDict = {
+  metaTitle: "运行时 API · Codewhale 文档",
+  metaDescription: "面向集成、桥接和自动化的本地 HTTP/SSE、JSON-RPC stdio 与 ACP 入口。",
+  bodyClassName: "text-ink-soft leading-[1.9] tracking-wide",
+  overviewTitle: "运行时 API",
+  overviewLead:
+    "codewhale app-server 是 canonical 的本地运行时 API 与控制平面。本地 SDK、移动/远控客户端和编辑器集成直接与它对话，而不是抓终端输出。引擎只作为本地进程运行：所有 API 默认绑定 localhost——没有托管中继，不托管 provider 令牌，不泄露秘密。codewhale serve --http / --mobile 保留为 app-server --http / --mobile 的兼容别名，启动的是同一个服务器；新集成应面向 app-server。",
+  entries: [
+    ["http", "完整 /v1/* HTTP/SSE 运行时 API（canonical 入口），默认 127.0.0.1:7878。"],
+    ["mobile", "运行时 API 加 /mobile 手机控制页。"],
+    ["stdio", "换行分隔的 JSON-RPC 2.0 控制传输，无监听端口，适合本地 SDK 和探针。"],
+    ["web", "仅回环的浏览器客户端，内嵌于二进制并打开默认浏览器。"],
+    ["doctor", "机器可读的健康与能力报告。"],
+    ["acp", "面向 Zed 等编辑器的 ACP（Agent Client Protocol）stdio 适配器。"],
+    [
+      "exec",
+      "一次性无头 worker（stream-json、Fleet 子进程、CI 原语）——不属于本 API，但共享同一运行时与事件词汇。",
+    ],
+  ],
+  stdioTitle: "零成本探测",
+  stdioLead:
+    "stdio 控制传输可以不花模型 token 地探测。capabilities 返回声明的方法族（thread/*、app/*、prompt/*）和完整方法列表；方法集由 crates/app-server/src/lib.rs 中的漂移测试固定，SDK 和本地集成可以放心依赖它不会悄悄变化。",
+  interruptNote:
+    "进行中的回合可以用 thread/interrupt（或 HTTP 的 POST /v1/threads/{id}/turns/{turn_id}/interrupt）请求中断；没有正在流式输出的回合时返回 interrupted: false——这不是错误，只是没有可停的东西。",
+  securityTitle: "安全边界",
+  securityLead:
+    "运行时 API 令牌按 {authToken}、{runtimeTokenEnv}、{legacyTokenEnv} 的顺序读取；{insecureFlag} 只允许与回环绑定一起使用。浏览器侧的跨源请求会被 CORS 允许列表拒绝。选择非回环绑定（尤其是 {mobileFlag}）之前，请阅读 docs/RUNTIME_API.md 的完整部署与认证约定。",
+  sourceNote: "来源文档：docs/RUNTIME_API.md · 更新时请同步修改 docs-map.ts。",
+};

--- a/web/scripts/check-locales.mjs
+++ b/web/scripts/check-locales.mjs
@@ -30,6 +30,8 @@ const OPTIONAL_FILES = [
   "docs-shell.ts",
   "docs-hooks.ts",
   "docs-troubleshooting.ts",
+  "docs-constitution.ts",
+  "docs-runtime-api.ts",
 ];
 
 /** Top-level keys of the exported object literal (two-space indented `key:`). */


### PR DESCRIPTION
Phase 2 continues with `docs/constitution` and `docs/runtime-api`, 14 `isZh` branches each, both now zero. Same shape as #5504: two dictionaries, `types.ts` and `index.ts` wired, and both files added to `check-locales.mjs`'s `OPTIONAL_FILES` so zh is held to key and token parity while the other sixteen locales fall back to English exactly as the ternaries did.

Two things stayed in the page rather than moving. The paths and flags that these pages typeset as inline `<code>` go through `splitTokens` with the literals code-owned, which is what `docs/VOICE.md` asks for; the same goes for the seven command headings in the runtime-api entry list and the en/zh badge pair on each constitution principle row, since those render identically in every locale and translating them would be wrong.

One oddity worth flagging. `interruptNote` contains `{id}` and `{turn_id}`, which are an HTTP path rather than tokens. The string is rendered as plain text and never passed to `splitTokens`, but `check-locales.mjs` does read them as tokens and holds en and zh to the same two — which happens to be the behaviour you want here.

Rendered output is unchanged. I built a clean worktree at the same base and compared all 36 pages (18 locales × 2) on visible text, `<title>` and meta description; the difference is empty. That comparison earned its keep this time: the first run flagged zh/constitution, because the old JSX wrapped lines after `主入口：` and `constitution.json，` and JSX folds those newlines into spaces. The dictionary now carries both spaces so this is a pure no-op. They look like typos in Chinese and I would happily drop them, but not in a commit that is supposed to move copy without touching it. As a control, three one-word edits — one in a token sentence, one in an array row, one in a plain string — do make the comparison report differences.

`npm run lint`, `npm test` (272 passing) and `npm run check:locales` are clean.


No-Issue: one page group of the #5337 series — the epic stays open until the last group lands.
