### PR TITLE
chore(tui): drop a single-argument concat!

### DIFF
--- a/crates/tui/src/runtime_handoff.rs
+++ b/crates/tui/src/runtime_handoff.rs
@@ -80,9 +80,8 @@ const RESTORED_COMPLETIONS_HEADER: &str = "[Codewhale restored sub-agent checkpo
 const RESTORED_RUNNING_HEADER: &str = "[Codewhale restored sub-agent runtime checkpoint]";
 const RESTORED_TOPOLOGY_HEADER: &str = "[Codewhale restored Agent topology checkpoint]";
 
-const AGENT_TOPOLOGY_EVENT_PREFIX: &str = concat!(
-    "<codewhale:runtime_state kind=\"agent_topology\" schema=\"v1\" visibility=\"internal\">\n",
-);
+const AGENT_TOPOLOGY_EVENT_PREFIX: &str =
+    "<codewhale:runtime_state kind=\"agent_topology\" schema=\"v1\" visibility=\"internal\">\n";
 const AGENT_TOPOLOGY_EVENT_SUFFIX: &str = "\n</codewhale:runtime_state>";
 const AGENT_TOPOLOGY_TURN_META: &str = concat!(
     "<turn_meta>\n",


### PR DESCRIPTION
`main` at 3b221c7a6 still fails `Lint` on one thing:

```
error: unneeded use of `concat!` macro
  --> crates/tui/src/runtime_handoff.rs:83:43
   = note: `-D clippy::useless-concat` implied by `-D warnings`
```

The replacement is clippy's own suggestion. The two-argument `concat!` right below it is untouched.

This branch started out covering the rustfmt and dead-code failures as well; 5689f0dde and 4d99f30da landed those first, and the rebase dropped my formatting commit as already applied, so this is what is left. `RUSTFLAGS=-Dwarnings cargo clippy -p codewhale-tui` is clean afterwards and fails with exactly the error above on a clean checkout of 3b221c7a6.

No-Issue: unbreaking a red `main`, no tracking issue.
