### PR TITLE
refactor(tui): adopt command shapes in utility group (FEAT-018)

### DIFF
--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -5,7 +5,7 @@
 //! `codewhale-tui` one command group at a time. Only after every group uses
 //! these shapes will groups move physically into a commands crate.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use codewhale_core::request::{Message, SystemPrompt};
 
@@ -73,4 +73,41 @@ pub trait CommandSkillsContext {
 pub trait CommandWorkspaceContext {
     fn workspace(&self) -> PathBuf;
     fn work_state_snapshot(&self) -> Result<Option<String>, String>;
+    /// Session-aware canonical operation digest. Returns the final user-facing
+    /// digest text or a safe explicit error; never a serialized snapshot.
+    /// No-active-work and temporary-unavailability semantics are preserved by
+    /// the host implementation (FEAT-018 D5).
+    fn operation_digest(&mut self) -> Result<String, String>;
+}
+
+/// Stable-key translation with named replacements (FEAT-018 D3).
+///
+/// Message identity uses stable snake_case keys plus named replacements. The
+/// TUI host maps those keys to the current catalog and preserves the existing
+/// English fallback for intentionally incomplete locale packs. Unknown keys or
+/// invalid replacement contracts fail safely and produce a command error; they
+/// never panic and never display a raw lookup key.
+pub trait CommandPresentationContext {
+    /// Resolve a stable message key with its named replacements.
+    fn translate(&self, key: &str, replacements: &[(&str, &str)]) -> Result<String, String>;
+}
+
+/// Portable receipt for a successful atomic media attachment (FEAT-018 D4).
+/// Carries only the information needed for the existing confirmation text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaAttachmentReceipt {
+    pub kind: String,
+    pub path: std::path::PathBuf,
+}
+
+/// Atomic composer/media capability (FEAT-018 D4).
+///
+/// The host performs media validation and composer insertion as one atomic
+/// operation. Rejected, missing, unsupported, corrupt, or oversized media
+/// leaves composer state unchanged and returns a safe error. Only portable
+/// success information crosses the boundary; composer markup, mutable input
+/// text, decoder internals, and TUI types never do.
+pub trait CommandMediaContext {
+    /// Validate and insert a resolved media path atomically.
+    fn attach_media(&mut self, resolved_path: &Path) -> Result<MediaAttachmentReceipt, String>;
 }

--- a/crates/command-contract/src/handler.rs
+++ b/crates/command-contract/src/handler.rs
@@ -10,11 +10,47 @@ use crate::facets::{
     CommandSystemPromptContext, CommandWorkspaceContext,
 };
 
+/// Exact host capabilities exposed to one contextual command handler.
+///
+/// The set lives in the external contract crate so command registrations can
+/// declare least authority without naming the TUI host. The dispatcher uses
+/// the declaration to populate only those slots in [`CommandContexts`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CommandCapabilities(u16);
+
+impl CommandCapabilities {
+    pub const NONE: Self = Self(0);
+    pub const SESSION: Self = Self(1 << 0);
+    pub const MODEL: Self = Self(1 << 1);
+    pub const COST: Self = Self(1 << 2);
+    pub const MODE_POLICY: Self = Self(1 << 3);
+    pub const SYSTEM_PROMPT: Self = Self(1 << 4);
+    pub const SKILLS: Self = Self(1 << 5);
+    pub const WORKSPACE: Self = Self(1 << 6);
+    pub const PRESENTATION: Self = Self(1 << 7);
+    pub const MEDIA: Self = Self(1 << 8);
+
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    pub const fn contains(self, capability: Self) -> bool {
+        self.0 & capability.0 == capability.0
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
 /// A command handler that is either argument-only or capability-scoped.
 #[derive(Clone, Copy)]
 pub enum CommandHandler<R> {
     Pure(fn(Option<&str>) -> R),
-    Contextual(fn(CommandContexts<'_>, Option<&str>) -> R),
+    Contextual {
+        capabilities: CommandCapabilities,
+        handler: fn(CommandContexts<'_>, Option<&str>) -> R,
+    },
 }
 
 /// Transport envelope with one independently optional facet slot.

--- a/crates/command-contract/src/handler.rs
+++ b/crates/command-contract/src/handler.rs
@@ -5,8 +5,9 @@
 //! `CommandHandler<crate::commands::CommandResult>`.
 
 use crate::facets::{
-    CommandCostContext, CommandModePolicyContext, CommandModelContext, CommandSessionContext,
-    CommandSkillsContext, CommandSystemPromptContext, CommandWorkspaceContext,
+    CommandCostContext, CommandMediaContext, CommandModePolicyContext, CommandModelContext,
+    CommandPresentationContext, CommandSessionContext, CommandSkillsContext,
+    CommandSystemPromptContext, CommandWorkspaceContext,
 };
 
 /// A command handler that is either argument-only or capability-scoped.
@@ -25,6 +26,8 @@ pub struct CommandContexts<'a> {
     system_prompt: Option<&'a mut dyn CommandSystemPromptContext>,
     skills: Option<&'a mut dyn CommandSkillsContext>,
     workspace: Option<&'a mut dyn CommandWorkspaceContext>,
+    presentation: Option<&'a mut dyn CommandPresentationContext>,
+    media: Option<&'a mut dyn CommandMediaContext>,
 }
 
 /// Consumed envelope used when one handler needs several independent facets.
@@ -36,6 +39,8 @@ pub struct ContextParts<'a> {
     pub system_prompt: Option<&'a mut dyn CommandSystemPromptContext>,
     pub skills: Option<&'a mut dyn CommandSkillsContext>,
     pub workspace: Option<&'a mut dyn CommandWorkspaceContext>,
+    pub presentation: Option<&'a mut dyn CommandPresentationContext>,
+    pub media: Option<&'a mut dyn CommandMediaContext>,
 }
 
 impl<'a> CommandContexts<'a> {
@@ -48,6 +53,8 @@ impl<'a> CommandContexts<'a> {
             system_prompt: None,
             skills: None,
             workspace: None,
+            presentation: None,
+            media: None,
         }
     }
 
@@ -60,6 +67,8 @@ impl<'a> CommandContexts<'a> {
             system_prompt: self.system_prompt,
             skills: self.skills,
             workspace: self.workspace,
+            presentation: self.presentation,
+            media: self.media,
         }
     }
 
@@ -112,6 +121,22 @@ impl<'a> CommandContexts<'a> {
         assert!(
             self.workspace.replace(value).is_none(),
             "workspace facet already set"
+        );
+        self
+    }
+
+    pub fn with_presentation(mut self, value: &'a mut dyn CommandPresentationContext) -> Self {
+        assert!(
+            self.presentation.replace(value).is_none(),
+            "presentation facet already set"
+        );
+        self
+    }
+
+    pub fn with_media(mut self, value: &'a mut dyn CommandMediaContext) -> Self {
+        assert!(
+            self.media.replace(value).is_none(),
+            "media facet already set"
         );
         self
     }

--- a/crates/command-contract/src/lib.rs
+++ b/crates/command-contract/src/lib.rs
@@ -12,7 +12,7 @@ pub mod metadata;
 pub mod types;
 
 pub use facets::*;
-pub use handler::{CommandContexts, CommandHandler, ContextParts};
+pub use handler::{CommandCapabilities, CommandContexts, CommandHandler, ContextParts};
 pub use metadata::{CommandDiscovery, CommandInfo, RegisterCommand};
 pub use types::*;
 

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -156,17 +156,34 @@ fn contextual(_contexts: CommandContexts<'_>, value: Option<&str>) -> String {
 #[test]
 fn handlers_are_plain_function_pointers() {
     let pure_handler = CommandHandler::Pure(pure);
-    let contextual_handler = CommandHandler::Contextual(contextual);
+    let contextual_handler = CommandHandler::Contextual {
+        capabilities: CommandCapabilities::WORKSPACE,
+        handler: contextual,
+    };
     match pure_handler {
         CommandHandler::Pure(handler) => assert_eq!(handler(Some("x")), "x"),
         _ => unreachable!(),
     }
     match contextual_handler {
-        CommandHandler::Contextual(handler) => {
+        CommandHandler::Contextual {
+            capabilities,
+            handler,
+        } => {
+            assert_eq!(capabilities, CommandCapabilities::WORKSPACE);
             assert_eq!(handler(CommandContexts::empty(), Some("y")), "y")
         }
         _ => unreachable!(),
     }
+}
+
+#[test]
+fn capability_sets_compose_without_host_types() {
+    let attach = CommandCapabilities::WORKSPACE.union(CommandCapabilities::MEDIA);
+    assert!(attach.contains(CommandCapabilities::WORKSPACE));
+    assert!(attach.contains(CommandCapabilities::MEDIA));
+    assert!(!attach.contains(CommandCapabilities::PRESENTATION));
+    assert!(!attach.is_empty());
+    assert!(CommandCapabilities::NONE.is_empty());
 }
 
 struct Sample;

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -209,7 +209,8 @@ impl CommandPresentationContext for Presentation {
                 .unwrap_or("/mcp recommendations");
             return Ok(format!("Unknown recommended MCP ID (try {command})"));
         }
-        Err(format!("unknown presentation key {key:?}"))
+        // D3: unknown keys fail safely without echoing the raw lookup key.
+        Err("unknown translation key".to_string())
     }
 }
 
@@ -282,7 +283,10 @@ fn translation_contract_resolves_known_keys_and_fails_safely() {
     let unknown = presentation.translate("no_such_key", &[]);
     assert!(unknown.is_err(), "unknown key must fail safely");
     let err = unknown.unwrap_err();
-    assert!(!err.contains("raw"), "no raw lookup key exposure");
+    assert!(
+        !err.contains("no_such_key"),
+        "no raw lookup key exposure (D3)"
+    );
 }
 
 #[test]

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use codewhale_core::request::{Message, SystemPrompt};
 
@@ -109,6 +109,9 @@ impl CommandWorkspaceContext for Workspace {
     fn work_state_snapshot(&self) -> Result<Option<String>, String> {
         Ok(None)
     }
+    fn operation_digest(&mut self) -> Result<String, String> {
+        Ok("No active operations or to-do items.".to_string())
+    }
 }
 
 #[test]
@@ -186,4 +189,154 @@ impl RegisterCommand<String> for Sample {
 fn registration_shape_has_no_app_dependency() {
     assert_eq!(Sample::info().name, "sample");
     assert!(matches!(Sample::handler(), CommandHandler::Pure(_)));
+}
+
+// ---------------------------------------------------------------------------
+// FEAT-018: presentation, media, and digest capabilities (D2-D5)
+// ---------------------------------------------------------------------------
+
+struct Presentation;
+impl CommandPresentationContext for Presentation {
+    fn translate(&self, key: &str, replacements: &[(&str, &str)]) -> Result<String, String> {
+        if key == "automation_usage" {
+            return Ok("Usage: /automation [list|show <id>]".to_string());
+        }
+        if key == "mcp_recommended_unknown_id" {
+            let command = replacements
+                .iter()
+                .find(|(name, _)| *name == "recommendations_command")
+                .map(|(_, value)| *value)
+                .unwrap_or("/mcp recommendations");
+            return Ok(format!("Unknown recommended MCP ID (try {command})"));
+        }
+        Err(format!("unknown presentation key {key:?}"))
+    }
+}
+
+struct Media;
+impl CommandMediaContext for Media {
+    fn attach_media(&mut self, path: &Path) -> Result<MediaAttachmentReceipt, String> {
+        if path.extension().and_then(|ext| ext.to_str()) == Some("png") {
+            Ok(MediaAttachmentReceipt {
+                kind: "image".to_string(),
+                path: path.to_path_buf(),
+            })
+        } else {
+            Err("Unsupported attachment type".to_string())
+        }
+    }
+}
+
+struct DigestWorkspace;
+impl CommandWorkspaceContext for DigestWorkspace {
+    fn workspace(&self) -> PathBuf {
+        PathBuf::from(".")
+    }
+    fn work_state_snapshot(&self) -> Result<Option<String>, String> {
+        Ok(None)
+    }
+    fn operation_digest(&mut self) -> Result<String, String> {
+        Ok("No active operations or to-do items.".to_string())
+    }
+}
+
+#[test]
+fn new_capabilities_are_object_safe_and_independently_transportable() {
+    fn presentation(_: &dyn CommandPresentationContext) {}
+    fn media(_: &dyn CommandMediaContext) {}
+    fn digest_workspace(_: &dyn CommandWorkspaceContext) {}
+
+    presentation(&Presentation);
+    media(&Media);
+    digest_workspace(&DigestWorkspace);
+
+    let mut presentation = Presentation;
+    let mut media = Media;
+    let parts = CommandContexts::empty()
+        .with_presentation(&mut presentation)
+        .with_media(&mut media)
+        .into_parts();
+    assert!(parts.presentation.is_some());
+    assert!(parts.media.is_some());
+    assert!(parts.session.is_none());
+}
+
+#[test]
+fn translation_contract_resolves_known_keys_and_fails_safely() {
+    let presentation = Presentation;
+    assert_eq!(
+        presentation
+            .translate("automation_usage", &[])
+            .expect("known key"),
+        "Usage: /automation [list|show <id>]"
+    );
+    assert_eq!(
+        presentation
+            .translate(
+                "mcp_recommended_unknown_id",
+                &[("recommendations_command", "/mcp recommendations")],
+            )
+            .expect("known key with named replacement"),
+        "Unknown recommended MCP ID (try /mcp recommendations)"
+    );
+    let unknown = presentation.translate("no_such_key", &[]);
+    assert!(unknown.is_err(), "unknown key must fail safely");
+    let err = unknown.unwrap_err();
+    assert!(!err.contains("raw"), "no raw lookup key exposure");
+}
+
+#[test]
+fn media_contract_is_atomic_and_returns_only_portable_data() {
+    let mut media = Media;
+    let ok = media
+        .attach_media(Path::new("/tmp/photo.png"))
+        .expect("png");
+    assert_eq!(ok.kind, "image");
+    assert_eq!(ok.path, PathBuf::from("/tmp/photo.png"));
+
+    let err = media.attach_media(Path::new("/tmp/notes.txt")).unwrap_err();
+    assert!(!err.is_empty(), "safe error string");
+}
+
+#[test]
+fn digest_operation_returns_final_text_and_safe_errors() {
+    let mut workspace = DigestWorkspace;
+    assert_eq!(
+        workspace.operation_digest().expect("digest"),
+        "No active operations or to-do items."
+    );
+}
+
+#[test]
+fn envelope_rejects_duplicate_new_slots_deterministically() {
+    struct SecondPresentation;
+    impl CommandPresentationContext for SecondPresentation {
+        fn translate(&self, _key: &str, _r: &[(&str, &str)]) -> Result<String, String> {
+            Ok(String::new())
+        }
+    }
+    struct SecondMedia;
+    impl CommandMediaContext for SecondMedia {
+        fn attach_media(&mut self, _p: &Path) -> Result<MediaAttachmentReceipt, String> {
+            Err("unused".to_string())
+        }
+    }
+
+    let mut a = Presentation;
+    let mut b = SecondPresentation;
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        CommandContexts::empty()
+            .with_presentation(&mut a)
+            .with_presentation(&mut b);
+    }));
+    assert!(result.is_err(), "duplicate presentation slot must assert");
+
+    let mut a = Media;
+    let mut b = SecondMedia;
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        CommandContexts::empty()
+            .with_media(&mut a)
+            .with_media(&mut b);
+    }));
+    assert!(result.is_err(), "duplicate media slot must assert");
 }

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -1,20 +1,22 @@
 //! FEAT-015 TUI command-boundary surface.
 //!
 //! This module holds the TUI-owned pieces of the staged command migration:
-//! the pending-frontier projection (D4), the seven capability facet adapters
+//! the pending-frontier projection (D4), the capability facet adapters
 //! (D1), boundary-value and localization-key mappings (D3/D8), the envelope
 //! construction helper (D1), and the seam helpers (D7-D9). It is deliberately
 //! the only new TUI module for the migration surface; the production
 //! registry/dispatch stay in `traits.rs` / `mod.rs`.
 //!
-//! FEAT-015 does NOT migrate any production command. The adapters below wrap
-//! App-owned state behind the FEAT-014 contract shapes so later FEATs
-//! (FEAT-018+) can adopt them one group at a time. Handlers only ever see
-//! `&mut dyn` facets — concrete `App` is never exposed through an envelope.
+//! FEAT-015 introduced this boundary without migrating a production command;
+//! FEAT-018 is the first production slice to adopt it. The adapters below wrap
+//! App-owned state behind the FEAT-014 contract shapes so later FEATs can adopt
+//! them one group at a time. Handlers only ever see `&mut dyn` facets — concrete
+//! `App` is never exposed through an envelope.
 //!
 //! ## Authoritative host-proxy design (D1)
 //!
-//! `CommandContexts` holds seven independently borrowed facet objects, while
+//! `CommandContexts` holds only the independently borrowed facets declared by
+//! the active command registration, while
 //! important behavior (mode transitions, model invalidation, cost accounting,
 //! skill refresh) is authoritative on `App`. The adapters therefore share a
 //! synchronous TUI-owned host proxy. Each trait call borrows `App` only for the
@@ -23,9 +25,9 @@
 //!
 //! ## Dead-code note
 //!
-//! FEAT-015 intentionally wires no production contextual command. Some bridge
-//! helpers remain production-dead until the first slice migrates (FEAT-018+),
-//! so this transitional module keeps a bounded dead-code allow.
+//! FEAT-015 intentionally wired no production contextual command. FEAT-018
+//! removes that limitation for the utility group; any remaining dead-code
+//! allowance is bounded to still-transitional bridge helpers.
 
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
@@ -36,9 +38,9 @@ use codewhale_command_contract::facets::{
     CommandPresentationContext, CommandSessionContext, CommandSkillsContext,
     CommandSystemPromptContext, CommandWorkspaceContext, MediaAttachmentReceipt,
 };
-use codewhale_command_contract::handler::CommandContexts;
 #[cfg(test)]
 use codewhale_command_contract::handler::ContextParts;
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts};
 use codewhale_command_contract::types::{
     CommandApprovalMode, CommandCurrency, CommandMode, CommandProviderId, CommandReasoningEffort,
 };
@@ -46,7 +48,7 @@ use codewhale_config::AppMode;
 use codewhale_core::request::{Message, SystemPrompt};
 use codewhale_execpolicy::ApprovalMode;
 
-use crate::localization::{MessageId, tr};
+use crate::localization::{Locale, MessageId, tr};
 use crate::pricing::CostCurrency;
 use crate::tui::app::{App, ReasoningEffort};
 
@@ -255,7 +257,7 @@ pub(crate) fn key_to_message_id(key: &'static str) -> Option<MessageId> {
 
 /// Shared TUI host hidden behind the portable command facets.
 ///
-/// The envelope needs seven independently borrowed facet objects, while the
+/// The envelope needs nine independently borrowed facet objects, while the
 /// authoritative mutation methods live on `App`. Each adapter therefore owns
 /// an `Rc` clone of this synchronous host proxy. Trait calls borrow `App` only
 /// for the duration of one method, delegate to the real TUI authority, and
@@ -508,9 +510,9 @@ impl CommandWorkspaceContext for WorkspaceAdapter<'_> {
 /// Stable-key translation adapter (FEAT-018 D3).
 ///
 /// Maps stable snake_case utility message keys to the current catalog and
-/// preserves the existing English fallback for intentionally incomplete locale
-/// packs. Unknown keys and invalid replacement contracts fail safely; a raw
-/// lookup key is never exposed.
+/// preserves the existing English fallback for intentionally incomplete or
+/// malformed locale entries. Unknown keys and invalid replacement contracts
+/// fail safely; a raw lookup key is never exposed.
 pub(crate) struct PresentationAdapter<'a> {
     host: SharedCommandHost<'a>,
 }
@@ -522,7 +524,8 @@ impl CommandPresentationContext for PresentationAdapter<'_> {
         };
         let locale = self.host.app.borrow().ui_locale;
         let template = tr(locale, message_id);
-        apply_named_replacements(&template, replacements)
+        let english = tr(Locale::En, message_id);
+        apply_named_replacements_with_english_fallback(&template, &english, replacements)
             .ok_or_else(|| "invalid translation replacement contract".to_string())
     }
 }
@@ -576,6 +579,17 @@ fn apply_named_replacements(template: &str, replacements: &[(&str, &str)]) -> Op
     Some(out)
 }
 
+/// Render the selected locale, falling back through the authoritative English
+/// catalog entry when that locale's placeholder contract is malformed.
+fn apply_named_replacements_with_english_fallback(
+    localized: &str,
+    english: &str,
+    replacements: &[(&str, &str)],
+) -> Option<String> {
+    apply_named_replacements(localized, replacements)
+        .or_else(|| apply_named_replacements(english, replacements))
+}
+
 /// Atomic composer/media adapter (FEAT-018 D4).
 ///
 /// Performs media validation and composer insertion as one host operation by
@@ -599,6 +613,11 @@ impl CommandMediaContext for MediaAdapter<'_> {
                     .to_string(),
             );
         };
+        // Validate an image here, not only at send time. The extension check
+        // above trusts the filename; this reads the bytes, so a mislabelled,
+        // oversized or corrupt file is refused while the user is still
+        // looking at the command that caused it, rather than becoming a notice
+        // buried in a turn they have already sent.
         if kind == "image"
             && let Err(error) = crate::image_attach::attach_image_from_path(&path)
         {
@@ -627,7 +646,7 @@ fn media_kind(path: &Path) -> Option<&'static str> {
 // Envelope construction (D1)
 // ---------------------------------------------------------------------------
 
-/// Owns seven facet objects sharing one synchronous TUI host proxy.
+/// Owns nine facet objects sharing one synchronous TUI host proxy.
 ///
 /// Handlers borrow only these adapters. Every method delegates to the real App
 /// authority and releases its `RefCell` borrow before returning, so facets can
@@ -645,23 +664,52 @@ pub(crate) struct CommandContextBundle<'a> {
 }
 
 impl<'a> CommandContextBundle<'a> {
-    pub(crate) fn contexts(&mut self) -> CommandContexts<'_> {
-        CommandContexts::empty()
-            .with_session(&mut self.session)
-            .with_model(&mut self.model)
-            .with_cost(&mut self.cost)
-            .with_mode_policy(&mut self.mode_policy)
-            .with_system_prompt(&mut self.system_prompt)
-            .with_skills(&mut self.skills)
-            .with_workspace(&mut self.workspace)
-            .with_presentation(&mut self.presentation)
-            .with_media(&mut self.media)
+    /// Expose exactly the capabilities declared by the command registration.
+    pub(crate) fn contexts(&mut self, capabilities: CommandCapabilities) -> CommandContexts<'_> {
+        let mut contexts = CommandContexts::empty();
+        if capabilities.contains(CommandCapabilities::SESSION) {
+            contexts = contexts.with_session(&mut self.session);
+        }
+        if capabilities.contains(CommandCapabilities::MODEL) {
+            contexts = contexts.with_model(&mut self.model);
+        }
+        if capabilities.contains(CommandCapabilities::COST) {
+            contexts = contexts.with_cost(&mut self.cost);
+        }
+        if capabilities.contains(CommandCapabilities::MODE_POLICY) {
+            contexts = contexts.with_mode_policy(&mut self.mode_policy);
+        }
+        if capabilities.contains(CommandCapabilities::SYSTEM_PROMPT) {
+            contexts = contexts.with_system_prompt(&mut self.system_prompt);
+        }
+        if capabilities.contains(CommandCapabilities::SKILLS) {
+            contexts = contexts.with_skills(&mut self.skills);
+        }
+        if capabilities.contains(CommandCapabilities::WORKSPACE) {
+            contexts = contexts.with_workspace(&mut self.workspace);
+        }
+        if capabilities.contains(CommandCapabilities::PRESENTATION) {
+            contexts = contexts.with_presentation(&mut self.presentation);
+        }
+        if capabilities.contains(CommandCapabilities::MEDIA) {
+            contexts = contexts.with_media(&mut self.media);
+        }
+        contexts
     }
 
-    /// Test-only: consume the bundle into independent facet parts.
+    /// Test-only: expose every adapter for focused delegation tests.
     #[cfg(test)]
     pub(crate) fn parts(&mut self) -> ContextParts<'_> {
-        self.contexts().into_parts()
+        let all_test_capabilities = CommandCapabilities::SESSION
+            .union(CommandCapabilities::MODEL)
+            .union(CommandCapabilities::COST)
+            .union(CommandCapabilities::MODE_POLICY)
+            .union(CommandCapabilities::SYSTEM_PROMPT)
+            .union(CommandCapabilities::SKILLS)
+            .union(CommandCapabilities::WORKSPACE)
+            .union(CommandCapabilities::PRESENTATION)
+            .union(CommandCapabilities::MEDIA);
+        self.contexts(all_test_capabilities).into_parts()
     }
 }
 
@@ -689,7 +737,6 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::localization::Locale;
 
     fn test_app() -> App {
         crate::test_support::test_app_with_options(crate::test_support::test_tui_options(
@@ -912,16 +959,22 @@ mod tests {
     }
 
     #[test]
-    fn envelope_exposes_all_facets_without_app_in_handler_surface() {
+    fn envelope_exposes_only_declared_facets_without_app_in_handler_surface() {
         let mut app = test_app();
         let mut bundle = app.command_contexts();
-        let parts = bundle.parts();
-        assert!(parts.session.is_some());
-        assert!(parts.model.is_some());
-        assert!(parts.cost.is_some());
-        assert!(parts.mode_policy.is_some());
-        assert!(parts.system_prompt.is_some());
-        assert!(parts.skills.is_some());
+        let parts = bundle
+            .contexts(
+                CommandCapabilities::WORKSPACE
+                    .union(CommandCapabilities::PRESENTATION)
+                    .union(CommandCapabilities::MEDIA),
+            )
+            .into_parts();
+        assert!(parts.session.is_none());
+        assert!(parts.model.is_none());
+        assert!(parts.cost.is_none());
+        assert!(parts.mode_policy.is_none());
+        assert!(parts.system_prompt.is_none());
+        assert!(parts.skills.is_none());
         assert!(parts.workspace.is_some());
         assert!(parts.presentation.is_some());
         assert!(parts.media.is_some());
@@ -1023,6 +1076,25 @@ mod tests {
                 )
                 .is_err()
         );
+    }
+
+    #[test]
+    fn malformed_localized_placeholders_use_authoritative_english_fallback() {
+        let rendered = apply_named_replacements_with_english_fallback(
+            "Prüfen Sie vor dem Neustart.",
+            "Review before {restart_command} connects the server.",
+            &[("restart_command", "/mcp restart")],
+        )
+        .expect("valid English catalog fallback");
+        assert_eq!(rendered, "Review before /mcp restart connects the server.");
+
+        let localized = apply_named_replacements_with_english_fallback(
+            "Vor {restart_command} prüfen.",
+            "Review before {restart_command}.",
+            &[("restart_command", "/mcp restart")],
+        )
+        .expect("valid localized template");
+        assert_eq!(localized, "Vor /mcp restart prüfen.");
     }
 
     #[test]

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -29,12 +29,13 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use codewhale_command_contract::facets::{
-    CommandCostContext, CommandModePolicyContext, CommandModelContext, CommandSessionContext,
-    CommandSkillsContext, CommandSystemPromptContext, CommandWorkspaceContext,
+    CommandCostContext, CommandMediaContext, CommandModePolicyContext, CommandModelContext,
+    CommandPresentationContext, CommandSessionContext, CommandSkillsContext,
+    CommandSystemPromptContext, CommandWorkspaceContext, MediaAttachmentReceipt,
 };
 use codewhale_command_contract::handler::{CommandContexts, ContextParts};
 use codewhale_command_contract::types::{
@@ -44,7 +45,7 @@ use codewhale_config::AppMode;
 use codewhale_core::request::{Message, SystemPrompt};
 use codewhale_execpolicy::ApprovalMode;
 
-use crate::localization::MessageId;
+use crate::localization::{Locale, MessageId, tr};
 use crate::pricing::CostCurrency;
 use crate::tui::app::{App, ReasoningEffort};
 
@@ -481,6 +482,139 @@ impl CommandWorkspaceContext for WorkspaceAdapter<'_> {
             state.and_then(|state| crate::todo_snapshot::todo_snapshot_body(&state.todos))
         })
     }
+
+    fn operation_digest(&mut self) -> Result<String, String> {
+        let app = self.host.app.borrow();
+        let Some(work) = app.runtime_services.work.as_ref() else {
+            return Ok("No active operations or to-do items.".to_string());
+        };
+        match work.capture(app.current_session_id.as_deref()) {
+            Ok(snapshot) => Ok(crate::work_graph::format_operation_digest(
+                snapshot.as_ref(),
+            )),
+            Err(error) => Err(format!(
+                "Operation digest is temporarily unavailable: {error}"
+            )),
+        }
+    }
+}
+
+/// Stable-key translation adapter (FEAT-018 D3).
+///
+/// Maps stable snake_case utility message keys to the current catalog and
+/// preserves the existing English fallback for intentionally incomplete locale
+/// packs. Unknown keys and invalid replacement contracts fail safely; a raw
+/// lookup key is never exposed.
+pub(crate) struct PresentationAdapter<'a> {
+    host: SharedCommandHost<'a>,
+}
+
+impl CommandPresentationContext for PresentationAdapter<'_> {
+    fn translate(&self, key: &str, replacements: &[(&str, &str)]) -> Result<String, String> {
+        let Some(message_id) = key_to_utility_message_id(key) else {
+            return Err("unknown translation key".to_string());
+        };
+        let locale = self.host.app.borrow().ui_locale;
+        let template = tr(locale, message_id);
+        apply_named_replacements(&template, replacements)
+            .ok_or_else(|| "invalid translation replacement contract".to_string())
+    }
+}
+
+/// Resolve a stable utility message key to the current catalog id.
+fn key_to_utility_message_id(key: &str) -> Option<MessageId> {
+    Some(match key {
+        "automation_usage" => MessageId::AutomationUsage,
+        "mcp_recommended_unknown_id" => MessageId::McpRecommendedUnknownId,
+        "mcp_recommendations_heading" => MessageId::McpRecommendationsHeading,
+        "mcp_recommendations_safety" => MessageId::McpRecommendationsSafety,
+        "mcp_recommendation_github" => MessageId::McpRecommendationGithub,
+        "mcp_recommendation_chrome" => MessageId::McpRecommendationChrome,
+        "mcp_recommendation_playwright" => MessageId::McpRecommendationPlaywright,
+        "mcp_recommendation_cua" => MessageId::McpRecommendationCua,
+        "mcp_recommendation_container_use" => MessageId::McpRecommendationContainerUse,
+        _ => return None,
+    })
+}
+
+/// Replace `{name}` placeholders with the supplied named values.
+///
+/// Returns `None` when the replacement set does not exactly cover every
+/// placeholder in the template (missing, extra, or duplicate names).
+fn apply_named_replacements(template: &str, replacements: &[(&str, &str)]) -> Option<String> {
+    let supplied: std::collections::BTreeMap<&str, &str> = replacements.iter().copied().collect();
+    if supplied.len() != replacements.len() {
+        return None; // duplicate replacement name
+    }
+    let mut placeholders = std::collections::BTreeSet::new();
+    let mut cursor = 0usize;
+    while let Some(start) = template[cursor..].find('{') {
+        let start = cursor + start;
+        let Some(end) = template[start + 1..].find('}') else {
+            break;
+        };
+        let end = start + 1 + end;
+        let name = &template[start + 1..end];
+        if !name.is_empty() {
+            placeholders.insert(name);
+        }
+        cursor = end + 1;
+    }
+    if placeholders != supplied.keys().copied().collect() {
+        return None;
+    }
+    let mut out = template.to_string();
+    for (name, value) in replacements {
+        out = out.replace(&format!("{{{name}}}"), value);
+    }
+    Some(out)
+}
+
+/// Atomic composer/media adapter (FEAT-018 D4).
+///
+/// Performs media validation and composer insertion as one host operation by
+/// delegating to the authoritative image-validation and attachment behavior.
+pub(crate) struct MediaAdapter<'a> {
+    host: SharedCommandHost<'a>,
+}
+
+impl CommandMediaContext for MediaAdapter<'_> {
+    fn attach_media(&mut self, resolved_path: &Path) -> Result<MediaAttachmentReceipt, String> {
+        let Ok(path) = resolved_path.canonicalize() else {
+            return Err(format!("Attachment not found: {}", resolved_path.display()));
+        };
+        if !path.is_file() {
+            return Err(format!("Attachment is not a file: {}", path.display()));
+        }
+        let Some(kind) = media_kind(&path) else {
+            return Err(
+                "Unsupported attachment type. /attach is for image/video paths; use @path for \
+                 text files or directories."
+                    .to_string(),
+            );
+        };
+        if kind == "image"
+            && let Err(error) = crate::image_attach::attach_image_from_path(&path)
+        {
+            return Err(error.to_string());
+        }
+        let mut app = self.host.app.borrow_mut();
+        app.insert_media_attachment(kind, &path, None);
+        Ok(MediaAttachmentReceipt {
+            kind: kind.to_string(),
+            path,
+        })
+    }
+}
+
+/// Classify a media path by extension (image or video).
+fn media_kind(path: &Path) -> Option<&'static str> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "tif" | "tiff" | "ppm" => Some("image"),
+        "mp4" | "mov" | "m4v" | "webm" | "avi" | "mkv" => Some("video"),
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -500,6 +634,8 @@ pub(crate) struct CommandContextBundle<'a> {
     system_prompt: SystemPromptAdapter<'a>,
     skills: SkillsAdapter<'a>,
     workspace: WorkspaceAdapter<'a>,
+    presentation: PresentationAdapter<'a>,
+    media: MediaAdapter<'a>,
 }
 
 impl<'a> CommandContextBundle<'a> {
@@ -512,6 +648,8 @@ impl<'a> CommandContextBundle<'a> {
             .with_system_prompt(&mut self.system_prompt)
             .with_skills(&mut self.skills)
             .with_workspace(&mut self.workspace)
+            .with_presentation(&mut self.presentation)
+            .with_media(&mut self.media)
     }
 
     pub(crate) fn parts(&mut self) -> ContextParts<'_> {
@@ -533,7 +671,9 @@ impl App {
             mode_policy: ModePolicyAdapter { host: host.clone() },
             system_prompt: SystemPromptAdapter { host: host.clone() },
             skills: SkillsAdapter { host: host.clone() },
-            workspace: WorkspaceAdapter { host },
+            workspace: WorkspaceAdapter { host: host.clone() },
+            presentation: PresentationAdapter { host: host.clone() },
+            media: MediaAdapter { host },
         }
     }
 }
@@ -547,6 +687,15 @@ mod tests {
             PathBuf::from("."),
         ))
     }
+
+    /// A 1x1 PNG for media adapter tests.
+    const PNG_1X1: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
+        0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ];
 
     #[test]
     fn pending_groups_is_sorted_unique_and_matches_checked_in_frontier() {
@@ -754,7 +903,7 @@ mod tests {
     }
 
     #[test]
-    fn envelope_exposes_all_seven_facets_without_app_in_handler_surface() {
+    fn envelope_exposes_all_facets_without_app_in_handler_surface() {
         let mut app = test_app();
         let mut bundle = app.command_contexts();
         let parts = bundle.parts();
@@ -765,5 +914,213 @@ mod tests {
         assert!(parts.system_prompt.is_some());
         assert!(parts.skills.is_some());
         assert!(parts.workspace.is_some());
+        assert!(parts.presentation.is_some());
+        assert!(parts.media.is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // FEAT-018 adapter tests: presentation (D3), media (D4), digest (D5)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn presentation_adapter_resolves_utility_keys_with_english_fallback() {
+        let mut app = test_app();
+        app.ui_locale = Locale::En;
+        let mut bundle = app.command_contexts();
+        let mut parts = bundle.parts();
+        let presentation = parts.presentation.as_mut().expect("presentation facet");
+
+        // automation_usage has no placeholders.
+        let usage = presentation
+            .translate("automation_usage", &[])
+            .expect("automation usage key");
+        assert!(
+            usage.contains("/automation"),
+            "expected usage text, got {usage}"
+        );
+
+        // mcp_recommended_unknown_id needs {recommendations_command}.
+        let unknown = presentation
+            .translate(
+                "mcp_recommended_unknown_id",
+                &[("recommendations_command", "/mcp recommendations")],
+            )
+            .expect("mcp unknown-id key");
+        assert!(
+            unknown.contains("/mcp recommendations"),
+            "expected replacement text, got {unknown}"
+        );
+
+        // mcp_recommendation_github needs {endpoint}, {login_command}, {add_command}.
+        let github = presentation
+            .translate(
+                "mcp_recommendation_github",
+                &[
+                    ("endpoint", "https://api.githubcopilot.com/mcp/"),
+                    ("login_command", "/mcp login github"),
+                    ("add_command", "/mcp add recommended github"),
+                ],
+            )
+            .expect("github recommendation key");
+        assert!(
+            github.contains("https://api.githubcopilot.com/mcp/"),
+            "{github}"
+        );
+        assert!(
+            !github.contains("{endpoint}"),
+            "placeholder must be replaced"
+        );
+    }
+
+    #[test]
+    fn presentation_adapter_rejects_unknown_keys_and_invalid_replacements() {
+        let mut app = test_app();
+        app.ui_locale = Locale::En;
+        let mut bundle = app.command_contexts();
+        let mut parts = bundle.parts();
+        let presentation = parts.presentation.as_mut().expect("presentation facet");
+
+        let unknown = presentation.translate("no_such_key", &[]);
+        assert!(unknown.is_err(), "unknown key must fail safely");
+        let err = unknown.unwrap_err();
+        assert!(
+            !err.contains("no_such_key"),
+            "no raw lookup key exposure (D3): {err}"
+        );
+
+        // Missing required replacement.
+        assert!(
+            presentation
+                .translate("mcp_recommendation_github", &[])
+                .is_err()
+        );
+        // Extra replacement not present in the template.
+        assert!(
+            presentation
+                .translate("automation_usage", &[("no_such_placeholder", "value")],)
+                .is_err()
+        );
+        // Duplicate replacement names.
+        assert!(
+            presentation
+                .translate(
+                    "mcp_recommendation_github",
+                    &[
+                        ("endpoint", "a"),
+                        ("endpoint", "b"),
+                        ("login_command", "c"),
+                        ("add_command", "d"),
+                    ],
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn media_adapter_attaches_valid_image_and_preserves_confirm() {
+        let tmpdir = tempfile::TempDir::new().expect("tempdir");
+        let image_path = tmpdir.path().join("photo.png");
+        std::fs::write(&image_path, PNG_1X1).expect("write image fixture");
+
+        let mut app = test_app();
+        let mut bundle = app.command_contexts();
+        let mut parts = bundle.parts();
+        let media = parts.media.as_mut().expect("media facet");
+        let receipt = media
+            .attach_media(&image_path)
+            .expect("valid image attaches");
+        assert_eq!(receipt.kind, "image");
+        assert_eq!(receipt.path, image_path.canonicalize().expect("canonical"));
+        assert!(
+            app.input.contains("[Attached image:"),
+            "composer must contain the attachment reference"
+        );
+    }
+
+    #[test]
+    fn media_adapter_rejects_invalid_media_atomically() {
+        let tmpdir = tempfile::TempDir::new().expect("tempdir");
+
+        // Missing path.
+        let mut app = test_app();
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let media = parts.media.as_mut().expect("media facet");
+            let missing = tmpdir.path().join("missing.png");
+            let err = media.attach_media(&missing).unwrap_err();
+            assert!(err.contains("Attachment not found"), "{err}");
+        }
+        assert!(
+            app.input.is_empty(),
+            "refused attachment must not reach composer"
+        );
+
+        // Directory is not a file.
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let media = parts.media.as_mut().expect("media facet");
+            let dir = tmpdir.path().to_path_buf();
+            let err = media.attach_media(&dir).unwrap_err();
+            assert!(err.contains("Attachment is not a file"), "{err}");
+        }
+        assert!(app.input.is_empty());
+
+        // Unsupported extension.
+        std::fs::write(tmpdir.path().join("notes.txt"), b"text").expect("write fixture");
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let media = parts.media.as_mut().expect("media facet");
+            let err = media
+                .attach_media(&tmpdir.path().join("notes.txt"))
+                .unwrap_err();
+            assert!(err.contains("Unsupported attachment type"), "{err}");
+        }
+        assert!(app.input.is_empty());
+
+        // Corrupt image with a valid extension.
+        std::fs::write(tmpdir.path().join("bad.png"), b"not an image").expect("write fixture");
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let media = parts.media.as_mut().expect("media facet");
+            let err = media
+                .attach_media(&tmpdir.path().join("bad.png"))
+                .unwrap_err();
+            assert!(!err.is_empty(), "corrupt image must fail");
+        }
+        assert!(app.input.is_empty());
+    }
+
+    #[test]
+    fn workspace_digest_adapter_preserves_no_active_and_failure_semantics() {
+        let mut app = test_app();
+        app.runtime_services.work = None;
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let workspace = parts.workspace.as_mut().expect("workspace facet");
+            assert_eq!(
+                workspace.operation_digest().expect("no-runtime digest"),
+                "No active operations or to-do items."
+            );
+        }
+    }
+
+    #[test]
+    fn bundle_construction_performs_no_eager_work() {
+        let mut app = test_app();
+        let input_before = app.input.clone();
+        {
+            let mut bundle = app.command_contexts();
+            let parts = bundle.parts();
+            // Merely constructing the bundle must not mutate composer state or
+            // perform capability work; the adapters only run on method calls.
+            let _ = parts.media.is_some();
+            let _ = parts.presentation.is_some();
+        }
+        assert_eq!(app.input, input_before, "no eager composer mutation");
     }
 }

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -1104,6 +1104,25 @@ mod tests {
     }
 
     #[test]
+    fn media_adapter_attaches_valid_video_reference() {
+        // A real (non-image) media file with a video extension passes the
+        // extension gate without byte validation, matching baseline /attach.
+        let tmpdir = tempfile::TempDir::new().expect("tempdir");
+        let video_path = tmpdir.path().join("clip.mp4");
+        std::fs::write(&video_path, b"not a real mp4 but extension-gated").expect("write");
+
+        let mut app = test_app();
+        let mut bundle = app.command_contexts();
+        let mut parts = bundle.parts();
+        let media = parts.media.as_mut().expect("media facet");
+        let receipt = media
+            .attach_media(&video_path)
+            .expect("video path attaches by extension");
+        assert_eq!(receipt.kind, "video");
+        assert!(app.input.contains("[Attached video:"), "{}", app.input);
+    }
+
+    #[test]
     fn workspace_digest_adapter_preserves_no_active_and_failure_semantics() {
         let mut app = test_app();
         app.runtime_services.work = None;

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -45,7 +45,7 @@ use codewhale_config::AppMode;
 use codewhale_core::request::{Message, SystemPrompt};
 use codewhale_execpolicy::ApprovalMode;
 
-use crate::localization::{Locale, MessageId, tr};
+use crate::localization::{MessageId, tr};
 use crate::pricing::CostCurrency;
 use crate::tui::app::{App, ReasoningEffort};
 
@@ -681,6 +681,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::localization::Locale;
 
     fn test_app() -> App {
         crate::test_support::test_app_with_options(crate::test_support::test_tui_options(

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -26,7 +26,6 @@
 //! FEAT-015 intentionally wires no production contextual command. Some bridge
 //! helpers remain production-dead until the first slice migrates (FEAT-018+),
 //! so this transitional module keeps a bounded dead-code allow.
-#![allow(dead_code)]
 
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
@@ -37,7 +36,9 @@ use codewhale_command_contract::facets::{
     CommandPresentationContext, CommandSessionContext, CommandSkillsContext,
     CommandSystemPromptContext, CommandWorkspaceContext, MediaAttachmentReceipt,
 };
-use codewhale_command_contract::handler::{CommandContexts, ContextParts};
+use codewhale_command_contract::handler::CommandContexts;
+#[cfg(test)]
+use codewhale_command_contract::handler::ContextParts;
 use codewhale_command_contract::types::{
     CommandApprovalMode, CommandCurrency, CommandMode, CommandProviderId, CommandReasoningEffort,
 };
@@ -57,8 +58,13 @@ use crate::tui::app::{App, ReasoningEffort};
 /// handlers. This is the TUI-visible projection of the checked-in migration
 /// topology (`scripts/command-migration-topology.json`); the CI gate performs
 /// the authoritative bidirectional source scan against that artifact.
+///
+/// Not referenced by production dispatch code — the fail-closed Python gate
+/// (`scripts/check-command-migration-manifest.py`) reads this exact
+/// declaration by source regex and the Rust frontier tests assert it.
+#[allow(dead_code)]
 pub(crate) const PENDING_GROUPS: &[&str] = &[
-    "config", "core", "debug", "memory", "plugins", "project", "session", "skills", "utility",
+    "config", "core", "debug", "memory", "plugins", "project", "session", "skills",
 ];
 
 // ---------------------------------------------------------------------------
@@ -652,6 +658,8 @@ impl<'a> CommandContextBundle<'a> {
             .with_media(&mut self.media)
     }
 
+    /// Test-only: consume the bundle into independent facet parts.
+    #[cfg(test)]
     pub(crate) fn parts(&mut self) -> ContextParts<'_> {
         self.contexts().into_parts()
     }

--- a/crates/tui/src/commands/groups/core/voice.rs
+++ b/crates/tui/src/commands/groups/core/voice.rs
@@ -234,7 +234,9 @@ fn record_audio() -> Option<(Vec<i16>, Duration)> {
         match reader.read_exact(&mut buf) {
             Ok(()) => {
                 let chunk: Vec<i16> = buf
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|b| i16::from_le_bytes([b[0], b[1]]))
                     .collect();
 

--- a/crates/tui/src/commands/groups/utility/attachment.rs
+++ b/crates/tui/src/commands/groups/utility/attachment.rs
@@ -2,62 +2,56 @@
 
 use std::path::{Path, PathBuf};
 
+use codewhale_command_contract::facets::CommandMediaContext;
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
+
 use crate::commands::CommandResult;
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
-use crate::tui::app::App;
 
 pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "attach",
     aliases: &["image", "media", "fujian"],
     usage: "/attach <path>",
-    description_id: MessageId::CmdAttachDescription,
+    description_key: "cmd_attach_description",
 };
 
 pub(in crate::commands) struct AttachCmd;
 
-impl RegisterCommand for AttachCmd {
+impl RegisterCommand<CommandResult> for AttachCmd {
     fn info() -> &'static CommandInfo {
         &COMMAND_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        attach(app, arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual(attach_contextual)
     }
 }
 
-fn attach(app: &mut App, arg: Option<&str>) -> CommandResult {
+fn attach_contextual(contexts: CommandContexts<'_>, arg: Option<&str>) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let workspace = parts.workspace.as_deref().expect("workspace facet");
+    let media = parts.media.as_deref_mut().expect("media facet");
+    attach(workspace.workspace(), media, arg)
+}
+
+fn attach(
+    workspace: PathBuf,
+    media: &mut dyn CommandMediaContext,
+    arg: Option<&str>,
+) -> CommandResult {
     let Some(raw_path) = arg.map(str::trim).filter(|value| !value.is_empty()) else {
         return CommandResult::error("Usage: /attach <image-or-video-path>");
     };
 
-    let path = resolve_attachment_path(raw_path, &app.workspace);
-    let Ok(path) = path.canonicalize() else {
-        return CommandResult::error(format!("Attachment not found: {}", path.display()));
-    };
-    if !path.is_file() {
-        return CommandResult::error(format!("Attachment is not a file: {}", path.display()));
+    let path = resolve_attachment_path(raw_path, &workspace);
+    match media.attach_media(&path) {
+        Ok(receipt) => CommandResult::message(format!(
+            "Attached {}: {}",
+            receipt.kind,
+            receipt.path.display()
+        )),
+        Err(error) => CommandResult::error(error),
     }
-
-    let Some(kind) = media_kind(&path) else {
-        return CommandResult::error(
-            "Unsupported attachment type. /attach is for image/video paths; use @path for text files or directories.",
-        );
-    };
-
-    // Validate an image here, not only at send time. The extension check above
-    // trusts the filename; this reads the bytes, so a mislabelled, oversized or
-    // corrupt file is refused while the user is still looking at the command
-    // that caused it — rather than becoming a notice buried in a turn they have
-    // already sent.
-    if kind == "image"
-        && let Err(error) = crate::image_attach::attach_image_from_path(&path)
-    {
-        return CommandResult::error(error.to_string());
-    }
-
-    app.insert_media_attachment(kind, &path, None);
-    CommandResult::message(format!("Attached {kind}: {}", path.display()))
 }
 
 fn resolve_attachment_path(raw_path: &str, workspace: &Path) -> PathBuf {
@@ -83,113 +77,97 @@ fn expand_home(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
-fn media_kind(path: &Path) -> Option<&'static str> {
-    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
-    match ext.as_str() {
-        "png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "tif" | "tiff" | "ppm" => Some("image"),
-        "mp4" | "mov" | "m4v" | "webm" | "avi" | "mkv" => Some("video"),
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
-    use crate::tui::app::TuiOptions;
-    use tempfile::TempDir;
 
-    fn app_with_workspace(tmpdir: &TempDir) -> App {
-        App::new(
-            TuiOptions {
-                use_alt_screen: false,
-                skills_dir: tmpdir.path().join("skills"),
-                memory_path: tmpdir.path().join("memory.md"),
-                notes_path: tmpdir.path().join("notes.txt"),
-                mcp_config_path: tmpdir.path().join("mcp.json"),
-                ..crate::test_support::test_tui_options(tmpdir.path())
-            },
-            &Config::default(),
-        )
+    struct FakeMedia;
+    impl CommandMediaContext for FakeMedia {
+        fn attach_media(
+            &mut self,
+            path: &Path,
+        ) -> Result<codewhale_command_contract::facets::MediaAttachmentReceipt, String> {
+            if path.extension().and_then(|ext| ext.to_str()) == Some("png") {
+                Ok(codewhale_command_contract::facets::MediaAttachmentReceipt {
+                    kind: "image".to_string(),
+                    path: path.to_path_buf(),
+                })
+            } else if path.extension().and_then(|ext| ext.to_str()) == Some("mp4") {
+                Ok(codewhale_command_contract::facets::MediaAttachmentReceipt {
+                    kind: "video".to_string(),
+                    path: path.to_path_buf(),
+                })
+            } else {
+                Err("Unsupported attachment type".to_string())
+            }
+        }
     }
 
-    /// A 1x1 PNG. `/attach` now reads the bytes, so the fixture has to be a
-    /// real image rather than a plausible filename.
-    const PNG_1X1: &[u8] = &[
-        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
-        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
-        0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00,
-        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
-        0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
-    ];
+    fn workspace() -> PathBuf {
+        PathBuf::from("/workspace")
+    }
 
     #[test]
-    fn attach_inserts_image_reference() {
-        let tmpdir = TempDir::new().expect("tempdir");
-        let image_path = tmpdir.path().join("photo.png");
-        std::fs::write(&image_path, PNG_1X1).expect("write image fixture");
-        let mut app = app_with_workspace(&tmpdir);
+    fn attach_resolves_relative_and_absolute_paths() {
+        let relative = resolve_attachment_path("photo.png", &workspace());
+        assert_eq!(relative, PathBuf::from("/workspace/photo.png"));
 
-        let result = attach(&mut app, Some("photo.png"));
+        let absolute = resolve_attachment_path("/tmp/photo.png", &workspace());
+        assert_eq!(absolute, PathBuf::from("/tmp/photo.png"));
 
+        let quoted = resolve_attachment_path("\"photo.png\"", &workspace());
+        assert_eq!(quoted, PathBuf::from("/workspace/photo.png"));
+
+        let home = resolve_attachment_path("~/photo.png", &workspace());
+        if let Some(home_dir) = std::env::var_os("HOME") {
+            assert_eq!(home, PathBuf::from(home_dir).join("photo.png"));
+        }
+    }
+
+    #[test]
+    fn attach_delegates_to_media_facet_and_composes_confirm() {
+        let result = attach(workspace(), &mut FakeMedia, Some("photo.png"));
         assert!(result.message.expect("message").contains("Attached image"));
-        assert!(app.input.contains("[Attached image:"));
-        let canonical_path = image_path.canonicalize().expect("canonical image path");
-        assert!(app.input.contains(&canonical_path.display().to_string()));
+        assert!(!result.is_error);
+
+        let video = attach(workspace(), &mut FakeMedia, Some("clip.mp4"));
+        assert!(video.message.expect("message").contains("Attached video"));
     }
 
     #[test]
-    fn attach_rejects_a_png_that_is_not_actually_an_image() {
-        // The failure this guards against is a user attaching a file that
-        // looks right, the turn going out, and the model reporting it cannot
-        // see anything — with no clue why.
-        let tmpdir = TempDir::new().expect("tempdir");
-        std::fs::write(tmpdir.path().join("photo.png"), b"not actually decoded")
-            .expect("write fixture");
-        let mut app = app_with_workspace(&tmpdir);
-
-        let result = attach(&mut app, Some("photo.png"));
-
-        let message = result.message.expect("message");
+    fn attach_requires_a_path() {
+        let result = attach(workspace(), &mut FakeMedia, None);
+        assert!(result.is_error);
         assert!(
-            message.contains("not a PNG, JPEG, GIF or WebP"),
-            "{message}"
-        );
-        assert!(
-            app.input.is_empty(),
-            "a refused attachment must not reach the composer"
+            result
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Usage: /attach"),
+            "{:?}",
+            result.message
         );
     }
 
     #[test]
-    fn attach_rejects_an_image_over_the_size_limit() {
-        let tmpdir = TempDir::new().expect("tempdir");
-        let mut oversized = PNG_1X1.to_vec();
-        oversized.resize(crate::image_attach::MAX_IMAGE_BYTES + 1, 0);
-        std::fs::write(tmpdir.path().join("huge.png"), &oversized).expect("write fixture");
-        let mut app = app_with_workspace(&tmpdir);
-
-        let result = attach(&mut app, Some("huge.png"));
-
-        let message = result.message.expect("message");
-        assert!(message.contains("per-image limit"), "{message}");
-        assert!(app.input.is_empty());
-    }
-
-    #[test]
-    fn attach_rejects_unsupported_extension() {
-        let tmpdir = TempDir::new().expect("tempdir");
-        std::fs::write(tmpdir.path().join("notes.txt"), b"text").expect("write fixture");
-        let mut app = app_with_workspace(&tmpdir);
-
-        let result = attach(&mut app, Some("notes.txt"));
-
+    fn attach_forwards_media_facet_error() {
+        let result = attach(workspace(), &mut FakeMedia, Some("notes.txt"));
+        assert!(result.is_error);
         assert!(
             result
                 .message
                 .expect("message")
                 .contains("Unsupported attachment type")
         );
-        assert!(app.input.is_empty());
+    }
+
+    #[test]
+    fn handler_is_contextual() {
+        assert!(matches!(
+            AttachCmd::handler(),
+            CommandHandler::Contextual(_)
+        ));
+        assert_eq!(AttachCmd::info().description_key, "cmd_attach_description");
+        assert_eq!(AttachCmd::info().aliases, &["image", "media", "fujian"]);
     }
 }

--- a/crates/tui/src/commands/groups/utility/attachment.rs
+++ b/crates/tui/src/commands/groups/utility/attachment.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use codewhale_command_contract::facets::CommandMediaContext;
-use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
 use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
@@ -23,14 +23,21 @@ impl RegisterCommand<CommandResult> for AttachCmd {
     }
 
     fn handler() -> CommandHandler<CommandResult> {
-        CommandHandler::Contextual(attach_contextual)
+        CommandHandler::Contextual {
+            capabilities: CommandCapabilities::WORKSPACE.union(CommandCapabilities::MEDIA),
+            handler: attach_contextual,
+        }
     }
 }
 
 fn attach_contextual(contexts: CommandContexts<'_>, arg: Option<&str>) -> CommandResult {
     let mut parts = contexts.into_parts();
-    let workspace = parts.workspace.as_deref().expect("workspace facet");
-    let media = parts.media.as_deref_mut().expect("media facet");
+    let Some(workspace) = parts.workspace.as_deref() else {
+        return CommandResult::error("Command capability unavailable: workspace");
+    };
+    let Some(media) = parts.media.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: media");
+    };
     attach(workspace.workspace(), media, arg)
 }
 
@@ -163,10 +170,23 @@ mod tests {
 
     #[test]
     fn handler_is_contextual() {
-        assert!(matches!(
-            AttachCmd::handler(),
-            CommandHandler::Contextual(_)
-        ));
+        let CommandHandler::Contextual {
+            capabilities,
+            handler,
+        } = AttachCmd::handler()
+        else {
+            panic!("attach must be contextual");
+        };
+        assert_eq!(
+            capabilities,
+            CommandCapabilities::WORKSPACE.union(CommandCapabilities::MEDIA)
+        );
+        let missing = handler(CommandContexts::empty(), Some("photo.png"));
+        assert!(missing.is_error);
+        assert_eq!(
+            missing.message.as_deref(),
+            Some("Error: Command capability unavailable: workspace")
+        );
         assert_eq!(AttachCmd::info().description_key, "cmd_attach_description");
         assert_eq!(AttachCmd::info().aliases, &["image", "media", "fujian"]);
     }

--- a/crates/tui/src/commands/groups/utility/automation.rs
+++ b/crates/tui/src/commands/groups/utility/automation.rs
@@ -1,7 +1,7 @@
 //! Operator controls for durable scheduled automations.
 
 use codewhale_command_contract::facets::CommandPresentationContext;
-use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
 use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
@@ -22,16 +22,18 @@ impl RegisterCommand<CommandResult> for AutomationCmd {
     }
 
     fn handler() -> CommandHandler<CommandResult> {
-        CommandHandler::Contextual(automation_contextual)
+        CommandHandler::Contextual {
+            capabilities: CommandCapabilities::PRESENTATION,
+            handler: automation_contextual,
+        }
     }
 }
 
 fn automation_contextual(contexts: CommandContexts<'_>, arg: Option<&str>) -> CommandResult {
     let mut parts = contexts.into_parts();
-    let presentation = parts
-        .presentation
-        .as_deref_mut()
-        .expect("presentation facet");
+    let Some(presentation) = parts.presentation.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: presentation");
+    };
     automation(presentation, arg)
 }
 
@@ -207,10 +209,20 @@ mod tests {
 
     #[test]
     fn handler_is_contextual_and_requests_presentation_facet() {
-        assert!(matches!(
-            AutomationCmd::handler(),
-            CommandHandler::Contextual(_)
-        ));
+        let CommandHandler::Contextual {
+            capabilities,
+            handler,
+        } = AutomationCmd::handler()
+        else {
+            panic!("automation must be contextual");
+        };
+        assert_eq!(capabilities, CommandCapabilities::PRESENTATION);
+        let missing = handler(CommandContexts::empty(), Some("bad-verb"));
+        assert!(missing.is_error);
+        assert_eq!(
+            missing.message.as_deref(),
+            Some("Error: Command capability unavailable: presentation")
+        );
         assert_eq!(
             AutomationCmd::info().description_key,
             "cmd_automation_description"

--- a/crates/tui/src/commands/groups/utility/automation.rs
+++ b/crates/tui/src/commands/groups/utility/automation.rs
@@ -1,30 +1,44 @@
 //! Operator controls for durable scheduled automations.
 
+use codewhale_command_contract::facets::CommandPresentationContext;
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
+
 use crate::commands::CommandResult;
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::{Locale, MessageId, tr};
-use crate::tui::app::{App, AppAction, AutomationAction};
+use crate::tui::app::{AppAction, AutomationAction};
 
 pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "automation",
     aliases: &["automations", "scheduled"],
     usage: "/automation [list|show <id>|pause <id>|resume <id>|delete <id> [--confirm <token>]|run <id>]",
-    description_id: MessageId::CmdAutomationDescription,
+    description_key: "cmd_automation_description",
 };
 
 pub(in crate::commands) struct AutomationCmd;
 
-impl RegisterCommand for AutomationCmd {
+impl RegisterCommand<CommandResult> for AutomationCmd {
     fn info() -> &'static CommandInfo {
         &COMMAND_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        automation(app.ui_locale, arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual(automation_contextual)
     }
 }
 
-fn automation(locale: Locale, args: Option<&str>) -> CommandResult {
+fn automation_contextual(contexts: CommandContexts<'_>, arg: Option<&str>) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let presentation = parts
+        .presentation
+        .as_deref_mut()
+        .expect("presentation facet");
+    automation(presentation, arg)
+}
+
+fn automation(
+    presentation: &mut dyn CommandPresentationContext,
+    args: Option<&str>,
+) -> CommandResult {
     let raw = args.unwrap_or("").trim();
     if raw.is_empty() || raw.eq_ignore_ascii_case("list") {
         return action(AutomationAction::List);
@@ -34,39 +48,42 @@ fn automation(locale: Locale, args: Option<&str>) -> CommandResult {
     let verb = parts.next().unwrap_or("").to_ascii_lowercase();
 
     match verb.as_str() {
-        "show" | "status" => single_id(locale, &mut parts, AutomationAction::Show),
-        "pause" => single_id(locale, &mut parts, AutomationAction::Pause),
-        "resume" => single_id(locale, &mut parts, AutomationAction::Resume),
-        "delete" | "remove" | "rm" => delete(locale, &mut parts),
-        "run" | "trigger" => single_id(locale, &mut parts, AutomationAction::Run),
-        _ => usage_error(locale),
+        "show" | "status" => single_id(presentation, &mut parts, AutomationAction::Show),
+        "pause" => single_id(presentation, &mut parts, AutomationAction::Pause),
+        "resume" => single_id(presentation, &mut parts, AutomationAction::Resume),
+        "delete" | "remove" | "rm" => delete(presentation, &mut parts),
+        "run" | "trigger" => single_id(presentation, &mut parts, AutomationAction::Run),
+        _ => usage_error(presentation),
     }
 }
 
 fn single_id<'a>(
-    locale: Locale,
+    presentation: &mut dyn CommandPresentationContext,
     parts: &mut impl Iterator<Item = &'a str>,
     make_action: fn(String) -> AutomationAction,
 ) -> CommandResult {
     let Some(id) = parts.next() else {
-        return usage_error(locale);
+        return usage_error(presentation);
     };
     if parts.next().is_some() {
-        return usage_error(locale);
+        return usage_error(presentation);
     }
     action(make_action(id.to_string()))
 }
 
-fn delete<'a>(locale: Locale, parts: &mut impl Iterator<Item = &'a str>) -> CommandResult {
+fn delete<'a>(
+    presentation: &mut dyn CommandPresentationContext,
+    parts: &mut impl Iterator<Item = &'a str>,
+) -> CommandResult {
     let Some(id) = parts.next() else {
-        return usage_error(locale);
+        return usage_error(presentation);
     };
     let confirmation = match (parts.next(), parts.next(), parts.next()) {
         (None, None, None) => None,
         (Some(flag), Some(token), None) if flag.eq_ignore_ascii_case("--confirm") => {
             Some(token.to_string())
         }
-        _ => return usage_error(locale),
+        _ => return usage_error(presentation),
     };
     action(AutomationAction::Delete {
         id: id.to_string(),
@@ -74,8 +91,15 @@ fn delete<'a>(locale: Locale, parts: &mut impl Iterator<Item = &'a str>) -> Comm
     })
 }
 
-fn usage_error(locale: Locale) -> CommandResult {
-    CommandResult::error(tr(locale, MessageId::AutomationUsage).into_owned())
+fn usage_error(presentation: &mut dyn CommandPresentationContext) -> CommandResult {
+    match presentation.translate("automation_usage", &[]) {
+        Ok(text) => CommandResult::error(text),
+        // The key is catalog-known; a translation failure must still fail
+        // safely without exposing a raw lookup key (D3).
+        Err(_) => CommandResult::error(
+            "Usage: /automation [list|show <id>|pause <id>|resume <id>|delete <id> [--confirm <token>]|run <id>]",
+        ),
+    }
 }
 
 fn action(action: AutomationAction) -> CommandResult {
@@ -86,8 +110,19 @@ fn action(action: AutomationAction) -> CommandResult {
 mod tests {
     use super::*;
 
+    struct FakePresentation;
+    impl CommandPresentationContext for FakePresentation {
+        fn translate(&self, key: &str, _r: &[(&str, &str)]) -> Result<String, String> {
+            if key == "automation_usage" {
+                Ok("Usage: /automation [list|show <id>|pause <id>|resume <id>|delete <id> [--confirm <token>]|run <id>]".to_string())
+            } else {
+                Err("unknown translation key".to_string())
+            }
+        }
+    }
+
     fn parsed(args: Option<&str>) -> Option<AutomationAction> {
-        match automation(Locale::En, args).action {
+        match automation(&mut FakePresentation, args).action {
             Some(AppAction::Automation(action)) => Some(action),
             _ => None,
         }
@@ -144,7 +179,7 @@ mod tests {
     #[test]
     fn validates_missing_ids_and_unknown_actions() {
         for verb in ["show", "pause", "resume", "delete", "run", "unknown"] {
-            let result = automation(Locale::En, Some(verb));
+            let result = automation(&mut FakePresentation, Some(verb));
             assert!(result.message.is_some(), "{verb} should show usage");
             assert!(result.action.is_none());
         }
@@ -164,9 +199,22 @@ mod tests {
             "delete auto_1 receipt",
             "delete auto_1 --confirm receipt extra",
         ] {
-            let result = automation(Locale::En, Some(invalid));
+            let result = automation(&mut FakePresentation, Some(invalid));
             assert!(result.is_error, "{invalid} should be rejected");
             assert!(result.action.is_none());
         }
+    }
+
+    #[test]
+    fn handler_is_contextual_and_requests_presentation_facet() {
+        assert!(matches!(
+            AutomationCmd::handler(),
+            CommandHandler::Contextual(_)
+        ));
+        assert_eq!(
+            AutomationCmd::info().description_key,
+            "cmd_automation_description"
+        );
+        assert_eq!(AutomationCmd::info().aliases, &["automations", "scheduled"]);
     }
 }

--- a/crates/tui/src/commands/groups/utility/jobs.rs
+++ b/crates/tui/src/commands/groups/utility/jobs.rs
@@ -1,31 +1,31 @@
 //! Shell job-center commands.
 
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
-use crate::tui::app::{App, AppAction, ShellJobAction};
+use codewhale_command_contract::handler::CommandHandler;
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
+use crate::tui::app::{AppAction, ShellJobAction};
 
 pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "jobs",
     aliases: &["job", "zuoye"],
     usage: "/jobs [list|show <id>|poll <id>|wait <id>|stdin <id> <input>|cancel <id>]",
-    description_id: MessageId::CmdJobsDescription,
+    description_key: "cmd_jobs_description",
 };
 
 pub(in crate::commands) struct JobsCmd;
 
-impl RegisterCommand for JobsCmd {
+impl RegisterCommand<CommandResult> for JobsCmd {
     fn info() -> &'static CommandInfo {
         &COMMAND_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        jobs(app, arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Pure(jobs)
     }
 }
 
-fn jobs(_app: &mut App, args: Option<&str>) -> CommandResult {
+fn jobs(args: Option<&str>) -> CommandResult {
     let raw = args.unwrap_or("").trim();
     if raw.is_empty() || raw.eq_ignore_ascii_case("list") {
         return CommandResult::action(AppAction::ShellJob(ShellJobAction::List));
@@ -87,41 +87,33 @@ fn jobs(_app: &mut App, args: Option<&str>) -> CommandResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
-    use crate::tui::app::TuiOptions;
-    use std::path::PathBuf;
-
-    fn app() -> App {
-        App::new(
-            TuiOptions {
-                use_alt_screen: false,
-                max_subagents: 2,
-                ..crate::test_support::test_tui_options(PathBuf::from("."))
-            },
-            &Config::default(),
-        )
-    }
 
     #[test]
     fn parses_job_actions() {
-        let mut app = app();
-        let show = jobs(&mut app, Some("show shell_abcd"));
+        let show = jobs(Some("show shell_abcd"));
         assert!(matches!(
             show.action,
             Some(AppAction::ShellJob(ShellJobAction::Show { id })) if id == "shell_abcd"
         ));
 
-        let send = jobs(&mut app, Some("stdin shell_abcd y"));
+        let send = jobs(Some("stdin shell_abcd y"));
         assert!(matches!(
             send.action,
             Some(AppAction::ShellJob(ShellJobAction::SendStdin { id, input, close: false }))
                 if id == "shell_abcd" && input == "y"
         ));
 
-        let cancel_all = jobs(&mut app, Some("cancel-all"));
+        let cancel_all = jobs(Some("cancel-all"));
         assert!(matches!(
             cancel_all.action,
             Some(AppAction::ShellJob(ShellJobAction::CancelAll))
         ));
+    }
+
+    #[test]
+    fn handler_is_pure_and_argument_only() {
+        assert!(matches!(JobsCmd::handler(), CommandHandler::Pure(_)));
+        assert_eq!(JobsCmd::info().description_key, "cmd_jobs_description");
+        assert_eq!(JobsCmd::info().aliases, &["job", "zuoye"]);
     }
 }

--- a/crates/tui/src/commands/groups/utility/mcp.rs
+++ b/crates/tui/src/commands/groups/utility/mcp.rs
@@ -1,10 +1,11 @@
 //! In-TUI MCP manager command parser.
 
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::{Locale, MessageId, tr};
-use crate::tui::app::{App, AppAction, McpUiAction};
+use codewhale_command_contract::facets::CommandPresentationContext;
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
+use crate::tui::app::{AppAction, McpUiAction};
 
 const GITHUB_MCP_URL: &str = "https://api.githubcopilot.com/mcp/";
 const CHROME_DEVTOOLS_MCP_PACKAGE: &str = "chrome-devtools-mcp@1.7.0";
@@ -17,22 +18,31 @@ pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "mcp",
     aliases: &[],
     usage: "/mcp [init|import|import approve <name>|import decline <name>|recommendations|add recommended <id>|add stdio <name> <command> [args...]|add http <name> <url>|enable <name>|disable <name>|remove <name>|doctor|validate|restart|reload]",
-    description_id: MessageId::CmdMcpDescription,
+    description_key: "cmd_mcp_description",
 };
 
 pub(in crate::commands) struct McpCmd;
 
-impl RegisterCommand for McpCmd {
+impl RegisterCommand<CommandResult> for McpCmd {
     fn info() -> &'static CommandInfo {
         &COMMAND_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        mcp(app, arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual(mcp_contextual)
     }
 }
 
-fn mcp(app: &mut App, args: Option<&str>) -> CommandResult {
+fn mcp_contextual(contexts: CommandContexts<'_>, args: Option<&str>) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let presentation = parts
+        .presentation
+        .as_deref_mut()
+        .expect("presentation facet");
+    mcp(presentation, args)
+}
+
+fn mcp(presentation: &mut dyn CommandPresentationContext, args: Option<&str>) -> CommandResult {
     let raw = args.unwrap_or("").trim();
     if raw.is_empty() || raw.eq_ignore_ascii_case("status") || raw.eq_ignore_ascii_case("list") {
         return CommandResult::action(AppAction::Mcp(McpUiAction::Show));
@@ -45,9 +55,9 @@ fn mcp(app: &mut App, args: Option<&str>) -> CommandResult {
             force: parts.any(|part| part == "--force" || part == "-f"),
         })),
         "recommend" | "recommended" | "recommendations" => {
-            CommandResult::message(recommended_mcp_text(app.ui_locale))
+            CommandResult::message(recommended_mcp_text(presentation))
         }
-        "add" => parse_add(app.ui_locale, parts.collect()),
+        "add" => parse_add(presentation, parts.collect()),
         "enable" => match parse_name(parts.next(), "Usage: /mcp enable <name>") {
             Ok(name) => CommandResult::action(AppAction::Mcp(McpUiAction::Enable { name })),
             Err(msg) => CommandResult::error(msg),
@@ -119,11 +129,15 @@ fn parse_name(name: Option<&str>, usage: &str) -> Result<String, String> {
     }
 }
 
-fn parse_add(locale: Locale, parts: Vec<&str>) -> CommandResult {
-    parse_add_for_platform(locale, parts, cfg!(windows))
+fn parse_add(presentation: &mut dyn CommandPresentationContext, parts: Vec<&str>) -> CommandResult {
+    parse_add_for_platform(presentation, parts, cfg!(windows))
 }
 
-fn parse_add_for_platform(locale: Locale, parts: Vec<&str>, windows: bool) -> CommandResult {
+fn parse_add_for_platform(
+    presentation: &mut dyn CommandPresentationContext,
+    parts: Vec<&str>,
+    windows: bool,
+) -> CommandResult {
     if parts
         .first()
         .is_some_and(|part| part.eq_ignore_ascii_case("recommended"))
@@ -181,10 +195,7 @@ fn parse_add_for_platform(locale: Locale, parts: Vec<&str>, windows: bool) -> Co
                     args: vec!["stdio".to_string()],
                 }))
             }
-            [_, _] => CommandResult::error(
-                tr(locale, MessageId::McpRecommendedUnknownId)
-                    .replace("{recommendations_command}", "/mcp recommendations"),
-            ),
+            [_, _] => CommandResult::error(mcp_unknown_id(presentation)),
             _ => CommandResult::error("Usage: /mcp add recommended <id>"),
         };
     }
@@ -215,33 +226,93 @@ fn parse_add_for_platform(locale: Locale, parts: Vec<&str>, windows: bool) -> Co
     }
 }
 
-fn recommended_mcp_text(locale: Locale) -> String {
-    let heading = tr(locale, MessageId::McpRecommendationsHeading);
-    let safety = tr(locale, MessageId::McpRecommendationsSafety)
-        .replace("{restart_command}", "/mcp restart");
-    let github = tr(locale, MessageId::McpRecommendationGithub)
-        .replace("{endpoint}", GITHUB_MCP_URL)
-        .replace("{login_command}", "/mcp login github")
-        .replace("{add_command}", "/mcp add recommended github");
-    let chrome = tr(locale, MessageId::McpRecommendationChrome)
-        .replace("{package}", CHROME_DEVTOOLS_MCP_PACKAGE)
-        .replace("{launcher}", "npx/npx.cmd")
-        .replace("{restart_command}", "/mcp restart")
-        .replace("{add_command}", "/mcp add recommended chrome-devtools");
-    let playwright = tr(locale, MessageId::McpRecommendationPlaywright)
-        .replace("{package}", PLAYWRIGHT_MCP_PACKAGE)
-        .replace("{source}", PLAYWRIGHT_MCP_SOURCE)
-        .replace("{launcher}", "npx/npx.cmd")
-        .replace("{restart_command}", "/mcp restart")
-        .replace("{add_command}", "/mcp add recommended playwright");
-    let cua = tr(locale, MessageId::McpRecommendationCua)
-        .replace("{source}", CUA_DRIVER_SOURCE)
-        .replace("{restart_command}", "/mcp restart")
-        .replace("{add_command}", "/mcp add recommended cua");
-    let container_use = tr(locale, MessageId::McpRecommendationContainerUse)
-        .replace("{source}", CONTAINER_USE_SOURCE)
-        .replace("{restart_command}", "/mcp restart")
-        .replace("{add_command}", "/mcp add recommended container-use");
+/// Localized unknown-recommendation error through the presentation facet (D3).
+fn mcp_unknown_id(presentation: &mut dyn CommandPresentationContext) -> String {
+    presentation
+        .translate(
+            "mcp_recommended_unknown_id",
+            &[("recommendations_command", "/mcp recommendations")],
+        )
+        .unwrap_or_else(|_| {
+            "Unknown recommended MCP ID. Run /mcp recommendations to inspect the curated list."
+                .to_string()
+        })
+}
+
+fn recommended_mcp_text(presentation: &mut dyn CommandPresentationContext) -> String {
+    let heading = presentation
+        .translate("mcp_recommendations_heading", &[])
+        .unwrap_or_else(|_| {
+            "Suggested Codewhale plugins (MCP components; nothing is installed automatically)"
+                .to_string()
+        });
+    let safety = presentation
+        .translate(
+            "mcp_recommendations_safety",
+            &[("restart_command", "/mcp restart")],
+        )
+        .unwrap_or_else(|_| "Viewing this list adds or enables nothing.".to_string());
+    let github = presentation
+        .translate(
+            "mcp_recommendation_github",
+            &[
+                ("endpoint", GITHUB_MCP_URL),
+                ("login_command", "/mcp login github"),
+                ("add_command", "/mcp add recommended github"),
+            ],
+        )
+        .unwrap_or_else(|_| {
+            format!(
+                "• github — GitHub's official remote MCP endpoint\n  endpoint: {GITHUB_MCP_URL}"
+            )
+        });
+    let chrome = presentation
+        .translate(
+            "mcp_recommendation_chrome",
+            &[
+                ("package", CHROME_DEVTOOLS_MCP_PACKAGE),
+                ("launcher", "npx/npx.cmd"),
+                ("restart_command", "/mcp restart"),
+                ("add_command", "/mcp add recommended chrome-devtools"),
+            ],
+        )
+        .unwrap_or_else(|_| {
+            format!("• chrome-devtools — official Chrome DevTools MCP via pinned npm package\n  package: {CHROME_DEVTOOLS_MCP_PACKAGE}")
+        });
+    let playwright = presentation
+        .translate(
+            "mcp_recommendation_playwright",
+            &[
+                ("package", PLAYWRIGHT_MCP_PACKAGE),
+                ("source", PLAYWRIGHT_MCP_SOURCE),
+                ("launcher", "npx/npx.cmd"),
+                ("restart_command", "/mcp restart"),
+                ("add_command", "/mcp add recommended playwright"),
+            ],
+        )
+        .unwrap_or_else(|_| {
+            format!("• playwright — Microsoft's official Playwright MCP via pinned npm package\n  package: {PLAYWRIGHT_MCP_PACKAGE}")
+        });
+    let cua = presentation
+        .translate(
+            "mcp_recommendation_cua",
+            &[
+                ("source", CUA_DRIVER_SOURCE),
+                ("restart_command", "/mcp restart"),
+                ("add_command", "/mcp add recommended cua"),
+            ],
+        )
+        .unwrap_or_else(|_| format!("• cua — Cua Driver computer-use plugin (MCP server component)\n  source: {CUA_DRIVER_SOURCE}"));
+    let container_use = presentation
+        .translate(
+            "mcp_recommendation_container_use",
+            &[
+                ("source", CONTAINER_USE_SOURCE),
+                ("restart_command", "/mcp restart"),
+                ("add_command", "/mcp add recommended container-use"),
+            ],
+        )
+        .unwrap_or_else(|_| format!("• container-use — Dagger's experimental container-use MCP\n  source: {CONTAINER_USE_SOURCE}"));
     format!(
         "{heading}\n\
          {safety}\n\
@@ -312,49 +383,76 @@ fn parse_scopes(parts: Vec<&str>) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
-    use crate::tui::app::TuiOptions;
-    use std::path::PathBuf;
 
-    fn app() -> App {
-        App::new(
-            TuiOptions {
-                use_alt_screen: false,
-                max_subagents: 2,
-                ..crate::test_support::test_tui_options(PathBuf::from("."))
-            },
-            &Config::default(),
-        )
+    struct FakePresentation;
+    impl CommandPresentationContext for FakePresentation {
+        fn translate(&self, key: &str, r: &[(&str, &str)]) -> Result<String, String> {
+            let mut out = match key {
+                "mcp_recommended_unknown_id" => {
+                    "Unknown recommended MCP ID. Run {recommendations_command} to inspect the curated list.".to_string()
+                }
+                "mcp_recommendations_heading" => {
+                    "Suggested Codewhale plugins (MCP components; nothing is installed automatically)"
+                        .to_string()
+                }
+                "mcp_recommendations_safety" => {
+                    "Viewing this list adds or enables nothing. An explicit add writes config only; review it before {restart_command} connects the server."
+                        .to_string()
+                }
+                "mcp_recommendation_github" => {
+                    "• github — GitHub's official remote MCP endpoint\n  endpoint: {endpoint}\n  auth is separate: use {login_command} only when the server advertises OAuth;\n  otherwise configure a least-privilege PAT outside command history.\n  add: {add_command}".to_string()
+                }
+                "mcp_recommendation_chrome" => {
+                    "• chrome-devtools — official Chrome DevTools MCP via pinned npm package\n  package: {package} ({launcher})\n  it can inspect/control Chrome and read authenticated pages.\n  add: {add_command}".to_string()
+                }
+                "mcp_recommendation_playwright" => {
+                    "• playwright — Microsoft's official Playwright MCP via pinned npm package\n  package: {package} ({launcher})\n  source: {source}\n  --isolated starts a fresh browser profile. It can browse/control pages and read authenticated pages.\n  add: {add_command}".to_string()
+                }
+                "mcp_recommendation_cua" => {
+                    "• cua — Cua Driver computer-use plugin (MCP server component)\n  command: cua-driver mcp\n  source: {source}\n  preview: install and verify Cua Driver separately; Codewhale never downloads it. It can control the desktop and requires operating-system permissions.\n  add: {add_command}".to_string()
+                }
+                "mcp_recommendation_container_use" => {
+                    "• container-use — Dagger's experimental container-use MCP\n  command: container-use stdio\n  source: {source}\n  requires the separately installed container-use binary; Codewhale never downloads or installs this binary.\n  add: {add_command}".to_string()
+                }
+                _ => return Err("unknown translation key".to_string()),
+            };
+            for (name, value) in r {
+                out = out.replace(&format!("{{{name}}}"), value);
+            }
+            Ok(out)
+        }
     }
 
     #[test]
     fn parses_add_and_validate() {
-        let mut app = app();
-        let add = mcp(&mut app, Some("add stdio local node server.js"));
+        let add = mcp(
+            &mut FakePresentation,
+            Some("add stdio local node server.js"),
+        );
         assert!(matches!(
             add.action,
             Some(AppAction::Mcp(McpUiAction::AddStdio { name, command, args }))
                 if name == "local" && command == "node" && args == vec!["server.js".to_string()]
         ));
 
-        let validate = mcp(&mut app, Some("validate"));
+        let validate = mcp(&mut FakePresentation, Some("validate"));
         assert!(matches!(
             validate.action,
             Some(AppAction::Mcp(McpUiAction::Validate))
         ));
 
-        let doctor = mcp(&mut app, Some("doctor"));
+        let doctor = mcp(&mut FakePresentation, Some("doctor"));
         assert!(matches!(
             doctor.action,
             Some(AppAction::Mcp(McpUiAction::Validate))
         ));
-        let restart = mcp(&mut app, Some("restart"));
+        let restart = mcp(&mut FakePresentation, Some("restart"));
         assert!(matches!(
             restart.action,
             Some(AppAction::Mcp(McpUiAction::Reload))
         ));
 
-        let recommended = mcp(&mut app, Some("recommendations"))
+        let recommended = mcp(&mut FakePresentation, Some("recommendations"))
             .message
             .expect("recommendations text");
         assert!(recommended.contains("nothing is installed automatically"));
@@ -368,36 +466,29 @@ mod tests {
         assert!(recommended.contains("least-privilege PAT outside command history"));
         assert!(recommended.contains("read authenticated pages"));
 
-        app.ui_locale = Locale::Es419;
-        let localized = mcp(&mut app, Some("recommendations"))
-            .message
-            .expect("localized recommendations text");
-        assert!(localized.contains("páginas autenticadas"), "{localized}");
-        assert!(
-            !localized.contains("read authenticated pages"),
-            "{localized}"
-        );
-        let unknown = mcp(&mut app, Some("add recommended unknown"))
+        let unknown = mcp(&mut FakePresentation, Some("add recommended unknown"))
             .message
             .expect("localized unknown recommendation error");
-        assert!(unknown.contains("ID de MCP recomendado"), "{unknown}");
-        app.ui_locale = Locale::En;
+        assert!(unknown.contains("Unknown recommended MCP ID"), "{unknown}");
 
-        let add_recommended = mcp(&mut app, Some("add recommended hugging-face"));
+        let add_recommended = mcp(&mut FakePresentation, Some("add recommended hugging-face"));
         assert!(matches!(
             add_recommended.action,
             Some(AppAction::Mcp(McpUiAction::AddHttp { name, url, transport: None }))
                 if name == "hugging-face" && url == "https://huggingface.co/mcp"
         ));
 
-        let add_github = mcp(&mut app, Some("add recommended github"));
+        let add_github = mcp(&mut FakePresentation, Some("add recommended github"));
         assert!(matches!(
             add_github.action,
             Some(AppAction::Mcp(McpUiAction::AddHttp { name, url, transport: None }))
                 if name == "github" && url == GITHUB_MCP_URL
         ));
 
-        let add_chrome = mcp(&mut app, Some("add recommended chrome-devtools"));
+        let add_chrome = mcp(
+            &mut FakePresentation,
+            Some("add recommended chrome-devtools"),
+        );
         assert!(matches!(
             add_chrome.action,
             Some(AppAction::Mcp(McpUiAction::AddStdio { name, command, args }))
@@ -406,7 +497,7 @@ mod tests {
                     && args == vec!["-y".to_string(), CHROME_DEVTOOLS_MCP_PACKAGE.to_string()]
         ));
 
-        let add_playwright = mcp(&mut app, Some("add recommended playwright"));
+        let add_playwright = mcp(&mut FakePresentation, Some("add recommended playwright"));
         assert!(matches!(
             add_playwright.action,
             Some(AppAction::Mcp(McpUiAction::AddStdio { name, command, args }))
@@ -419,7 +510,7 @@ mod tests {
                     ]
         ));
 
-        let add_container = mcp(&mut app, Some("add recommended container-use"));
+        let add_container = mcp(&mut FakePresentation, Some("add recommended container-use"));
         assert!(matches!(
             add_container.action,
             Some(AppAction::Mcp(McpUiAction::AddStdio { name, command, args }))
@@ -428,7 +519,7 @@ mod tests {
                     && args == vec!["stdio".to_string()]
         ));
 
-        let add_cua = mcp(&mut app, Some("add recommended cua"));
+        let add_cua = mcp(&mut FakePresentation, Some("add recommended cua"));
         assert!(matches!(
             add_cua.action,
             Some(AppAction::Mcp(McpUiAction::AddStdio { name, command, args }))
@@ -437,32 +528,31 @@ mod tests {
                     && args == vec!["mcp".to_string()]
         ));
 
-        let import_list = mcp(&mut app, Some("import"));
+        let import_list = mcp(&mut FakePresentation, Some("import"));
         assert!(matches!(
             import_list.action,
             Some(AppAction::Mcp(McpUiAction::ImportList))
         ));
-        let import_approve = mcp(&mut app, Some("import approve local-tools"));
+        let import_approve = mcp(&mut FakePresentation, Some("import approve local-tools"));
         assert!(matches!(
             import_approve.action,
             Some(AppAction::Mcp(McpUiAction::ImportApprove { name }))
                 if name == "local-tools"
         ));
-        let import_decline = mcp(&mut app, Some("import decline local-tools"));
+        let import_decline = mcp(&mut FakePresentation, Some("import decline local-tools"));
         assert!(matches!(
             import_decline.action,
             Some(AppAction::Mcp(McpUiAction::ImportDecline { name }))
                 if name == "local-tools"
         ));
-        let marketplace = mcp(&mut app, Some("marketplace"));
+        let marketplace = mcp(&mut FakePresentation, Some("marketplace"));
         assert!(matches!(
             marketplace.action,
             Some(AppAction::Mcp(McpUiAction::ImportList))
         ));
-        assert!(recommended.contains("/mcp import"));
 
         let login = mcp(
-            &mut app,
+            &mut FakePresentation,
             Some("login remote --scope tools/read,tools/write"),
         );
         assert!(matches!(
@@ -478,7 +568,11 @@ mod tests {
         assert_eq!(recommended_npx_command_for(false), "npx");
         assert_eq!(recommended_npx_command_for(true), "npx.cmd");
 
-        let windows = parse_add_for_platform(Locale::En, vec!["recommended", "playwright"], true);
+        let windows = parse_add_for_platform(
+            &mut FakePresentation,
+            vec!["recommended", "playwright"],
+            true,
+        );
         assert!(matches!(
             windows.action,
             Some(AppAction::Mcp(McpUiAction::AddStdio { name, command, args }))
@@ -494,7 +588,7 @@ mod tests {
 
     #[test]
     fn recommendations_state_execution_and_install_boundaries() {
-        let text = recommended_mcp_text(Locale::En);
+        let text = recommended_mcp_text(&mut FakePresentation);
         assert!(text.contains("nothing is installed automatically"));
         assert!(text.contains("Suggested Codewhale plugins"));
         assert!(text.contains("never downloads or"));
@@ -502,15 +596,12 @@ mod tests {
         assert!(text.contains("experimental"));
         assert!(text.contains("--isolated"));
         assert!(text.contains("operating-system permissions"));
+    }
 
-        let mut app = app();
-        let unknown = mcp(&mut app, Some("add recommended not-in-the-list"));
-        assert!(unknown.action.is_none());
-        assert!(
-            unknown
-                .message
-                .expect("unknown ID error")
-                .contains("Unknown recommended MCP ID")
-        );
+    #[test]
+    fn handler_is_contextual_and_requests_presentation_facet() {
+        assert!(matches!(McpCmd::handler(), CommandHandler::Contextual(_)));
+        assert_eq!(McpCmd::info().description_key, "cmd_mcp_description");
+        assert_eq!(McpCmd::info().aliases, &[] as &[&str]);
     }
 }

--- a/crates/tui/src/commands/groups/utility/mcp.rs
+++ b/crates/tui/src/commands/groups/utility/mcp.rs
@@ -1,7 +1,7 @@
 //! In-TUI MCP manager command parser.
 
 use codewhale_command_contract::facets::CommandPresentationContext;
-use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
 use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
@@ -29,16 +29,18 @@ impl RegisterCommand<CommandResult> for McpCmd {
     }
 
     fn handler() -> CommandHandler<CommandResult> {
-        CommandHandler::Contextual(mcp_contextual)
+        CommandHandler::Contextual {
+            capabilities: CommandCapabilities::PRESENTATION,
+            handler: mcp_contextual,
+        }
     }
 }
 
 fn mcp_contextual(contexts: CommandContexts<'_>, args: Option<&str>) -> CommandResult {
     let mut parts = contexts.into_parts();
-    let presentation = parts
-        .presentation
-        .as_deref_mut()
-        .expect("presentation facet");
+    let Some(presentation) = parts.presentation.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: presentation");
+    };
     mcp(presentation, args)
 }
 
@@ -600,7 +602,20 @@ mod tests {
 
     #[test]
     fn handler_is_contextual_and_requests_presentation_facet() {
-        assert!(matches!(McpCmd::handler(), CommandHandler::Contextual(_)));
+        let CommandHandler::Contextual {
+            capabilities,
+            handler,
+        } = McpCmd::handler()
+        else {
+            panic!("mcp must be contextual");
+        };
+        assert_eq!(capabilities, CommandCapabilities::PRESENTATION);
+        let missing = handler(CommandContexts::empty(), Some("recommendations"));
+        assert!(missing.is_error);
+        assert_eq!(
+            missing.message.as_deref(),
+            Some("Error: Command capability unavailable: presentation")
+        );
         assert_eq!(McpCmd::info().description_key, "cmd_mcp_description");
         assert_eq!(McpCmd::info().aliases, &[] as &[&str]);
     }

--- a/crates/tui/src/commands/groups/utility/mod.rs
+++ b/crates/tui/src/commands/groups/utility/mod.rs
@@ -9,41 +9,36 @@ mod network;
 mod task;
 mod update;
 
-use crate::commands::traits::{Command, CommandGroup, FunctionCommand, RegisterCommand};
+use crate::commands::traits::{Command, CommandGroup, ContextualCommand};
 
 pub struct UtilityCommands;
 
 impl CommandGroup for UtilityCommands {
     fn commands(&self) -> &'static [Box<dyn Command>] {
         cached_command_list!(vec![
-            Box::new(FunctionCommand::new(
-                attachment::AttachCmd::info(),
-                attachment::AttachCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                automation::AutomationCmd::info(),
-                automation::AutomationCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                task::TaskCmd::info(),
-                task::TaskCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                jobs::JobsCmd::info(),
-                jobs::JobsCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                mcp::McpCmd::info(),
-                mcp::McpCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                network::NetworkCmd::info(),
-                network::NetworkCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                update::UpdateCmd::info(),
-                update::UpdateCmd::execute,
-            )),
+            Box::new(
+                ContextualCommand::from_contract::<attachment::AttachCmd>()
+                    .expect("attach registration"),
+            ),
+            Box::new(
+                ContextualCommand::from_contract::<automation::AutomationCmd>()
+                    .expect("automation registration"),
+            ),
+            Box::new(
+                ContextualCommand::from_contract::<task::TaskCmd>().expect("task registration"),
+            ),
+            Box::new(
+                ContextualCommand::from_contract::<jobs::JobsCmd>().expect("jobs registration"),
+            ),
+            Box::new(ContextualCommand::from_contract::<mcp::McpCmd>().expect("mcp registration"),),
+            Box::new(
+                ContextualCommand::from_contract::<network::NetworkCmd>()
+                    .expect("network registration"),
+            ),
+            Box::new(
+                ContextualCommand::from_contract::<update::UpdateCmd>()
+                    .expect("update registration"),
+            ),
         ])
     }
 }

--- a/crates/tui/src/commands/groups/utility/network.rs
+++ b/crates/tui/src/commands/groups/utility/network.rs
@@ -1,37 +1,36 @@
 //! Slash commands for the persistent network allow/deny list.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
 use toml::Value;
 
+use codewhale_command_contract::handler::CommandHandler;
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
+
 use crate::commands::CommandResult;
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
-use crate::network_policy::host_from_url;
-use crate::tui::app::App;
 
 pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "network",
     aliases: &[],
     usage: "/network [list|allow <host>|deny <host>|remove <host>|default <allow|deny|prompt>]",
-    description_id: MessageId::CmdNetworkDescription,
+    description_key: "cmd_network_description",
 };
 
 pub(in crate::commands) struct NetworkCmd;
 
-impl RegisterCommand for NetworkCmd {
+impl RegisterCommand<CommandResult> for NetworkCmd {
     fn info() -> &'static CommandInfo {
         &COMMAND_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        network(app, arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Pure(network)
     }
 }
 
-fn network(_app: &mut App, arg: Option<&str>) -> CommandResult {
+fn network(arg: Option<&str>) -> CommandResult {
     match network_inner(arg) {
         Ok(message) => CommandResult::message(message),
         Err(err) => CommandResult::error(err.to_string()),
@@ -90,8 +89,14 @@ enum NetworkEdit {
     Remove,
 }
 
+/// Resolve the active config document path through the leaf configuration
+/// crate (acyclic; no TUI persistence helper).
+fn config_toml_path() -> anyhow::Result<PathBuf> {
+    codewhale_config::resolve_config_path(None)
+}
+
 fn list_policy() -> anyhow::Result<String> {
-    let path = crate::config_persistence::config_toml_path(None)?;
+    let path = config_toml_path()?;
     let doc = load_config_doc(&path)?;
     let network = doc.get("network").and_then(Value::as_table);
     let default = network
@@ -118,8 +123,8 @@ fn list_policy() -> anyhow::Result<String> {
 }
 
 fn update_host(edit: NetworkEdit, host: &str) -> anyhow::Result<String> {
-    let path = crate::config_persistence::config_toml_path(None)?;
-    crate::config_persistence::mutate_config_document(&path, |doc| {
+    let path = config_toml_path()?;
+    codewhale_config::mutate_config_document(&path, |doc| {
         ensure_network_defaults(doc)?;
         let mut allow = document_string_array(doc, "allow")?;
         let mut deny = document_string_array(doc, "deny")?;
@@ -137,12 +142,12 @@ fn update_host(edit: NetworkEdit, host: &str) -> anyhow::Result<String> {
                 remove_host(&mut deny, host);
             }
         }
-        crate::config_persistence::set_document_value(
+        codewhale_config::set_config_document_value(
             doc,
             &["network", "allow"],
             string_array_value(&allow),
         )?;
-        crate::config_persistence::set_document_value(
+        codewhale_config::set_config_document_value(
             doc,
             &["network", "deny"],
             string_array_value(&deny),
@@ -167,10 +172,10 @@ fn update_default(value: &str) -> anyhow::Result<String> {
         _ => bail!("Usage: /network default <allow|deny|prompt>"),
     };
 
-    let path = crate::config_persistence::config_toml_path(None)?;
-    crate::config_persistence::mutate_config_document(&path, |doc| {
+    let path = config_toml_path()?;
+    codewhale_config::mutate_config_document(&path, |doc| {
         ensure_network_defaults(doc)?;
-        crate::config_persistence::set_document_value(doc, &["network", "default"], normalized)
+        codewhale_config::set_config_document_value(doc, &["network", "default"], normalized)
     })?;
 
     Ok(format!(
@@ -200,7 +205,7 @@ fn ensure_network_defaults(doc: &mut toml_edit::DocumentMut) -> anyhow::Result<(
         .and_then(|table| table.get("default"))
         .is_none()
     {
-        crate::config_persistence::set_document_value(doc, &["network", "default"], "prompt")?;
+        codewhale_config::set_config_document_value(doc, &["network", "default"], "prompt")?;
     }
     if doc
         .get("network")
@@ -208,7 +213,7 @@ fn ensure_network_defaults(doc: &mut toml_edit::DocumentMut) -> anyhow::Result<(
         .and_then(|table| table.get("audit"))
         .is_none()
     {
-        crate::config_persistence::set_document_value(doc, &["network", "audit"], true)?;
+        codewhale_config::set_config_document_value(doc, &["network", "audit"], true)?;
     }
     Ok(())
 }
@@ -281,6 +286,13 @@ fn normalize_host_arg(input: &str) -> anyhow::Result<String> {
     Ok(normalized)
 }
 
+/// Extract the host portion of a URL, lowercased (leaf `reqwest::Url` parse;
+/// no TUI helper dependency).
+fn host_from_url(url: &str) -> Option<String> {
+    let parsed = reqwest::Url::parse(url.trim()).ok()?;
+    parsed.host_str().map(str::to_ascii_lowercase)
+}
+
 fn normalize_host_for_compare(host: &str) -> String {
     let trimmed = host.trim().trim_end_matches('.').to_ascii_lowercase();
     if let Some(rest) = trimmed.strip_prefix("*.") {
@@ -301,10 +313,7 @@ fn display_list(values: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
-    use crate::tui::app::{App, TuiOptions};
     use std::env;
-    use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     struct EnvGuard {
@@ -348,18 +357,6 @@ mod tests {
         path
     }
 
-    fn create_test_app(home: &Path) -> App {
-        let options = TuiOptions {
-            model: "test-model".to_string(),
-            skills_dir: home.join("skills"),
-            memory_path: home.join("memory.md"),
-            notes_path: home.join("notes.txt"),
-            mcp_config_path: home.join("mcp.json"),
-            ..crate::test_support::test_tui_options(home)
-        };
-        App::new(options, &Config::default())
-    }
-
     #[test]
     fn network_allow_persists_host_and_removes_exact_deny() {
         let home = temp_home("allow");
@@ -372,8 +369,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut app = create_test_app(&home);
-        let result = network(&mut app, Some("allow GitHub.COM"));
+        let result = network(Some("allow GitHub.COM"));
 
         assert!(!result.is_error, "{:?}", result.message);
         let body = fs::read_to_string(config_path).unwrap();
@@ -386,8 +382,7 @@ mod tests {
         let home = temp_home("url");
         let _guard = EnvGuard::new(&home);
 
-        let mut app = create_test_app(&home);
-        let result = network(&mut app, Some("allow https://github.com/obra/superpowers"));
+        let result = network(Some("allow https://github.com/obra/superpowers"));
 
         assert!(!result.is_error, "{:?}", result.message);
         let body = fs::read_to_string(home.join(".deepseek").join("config.toml")).unwrap();
@@ -399,8 +394,7 @@ mod tests {
         let home = temp_home("default");
         let _guard = EnvGuard::new(&home);
 
-        let mut app = create_test_app(&home);
-        let result = network(&mut app, Some("default maybe"));
+        let result = network(Some("default maybe"));
 
         assert!(result.is_error);
         assert!(
@@ -431,5 +425,15 @@ mod tests {
             diagnostic.contains("file contents were omitted"),
             "{diagnostic}"
         );
+    }
+
+    #[test]
+    fn handler_is_pure_and_argument_only() {
+        assert!(matches!(NetworkCmd::handler(), CommandHandler::Pure(_)));
+        assert_eq!(
+            NetworkCmd::info().description_key,
+            "cmd_network_description"
+        );
+        assert_eq!(NetworkCmd::info().aliases, &[] as &[&str]);
     }
 }

--- a/crates/tui/src/commands/groups/utility/network.rs
+++ b/crates/tui/src/commands/groups/utility/network.rs
@@ -436,4 +436,47 @@ mod tests {
         );
         assert_eq!(NetworkCmd::info().aliases, &[] as &[&str]);
     }
+
+    #[test]
+    fn host_normalization_handles_wildcard_trailing_dot_and_url_paths() {
+        // Wildcard prefix normalizes to a leading-dot suffix form.
+        assert_eq!(normalize_host_for_compare("*.example.com"), ".example.com");
+        // Trailing dot and case are normalized away.
+        assert_eq!(normalize_host_for_compare("Example.COM."), "example.com");
+        // A bare wildcard suffix compares equal to its explicit form.
+        assert_eq!(normalize_host_for_compare("*.github.com"), ".github.com");
+
+        // URL input extracts the host; a URL path is rejected.
+        assert_eq!(
+            host_from_url("https://API.Github.com/path").as_deref(),
+            Some("api.github.com")
+        );
+        assert_eq!(host_from_url("not a url"), None);
+        assert!(normalize_host_arg("https://github.com/path").is_ok());
+        assert!(normalize_host_arg("a/b").is_err(), "URL path rejected");
+        assert!(
+            normalize_host_arg("https://").is_err(),
+            "hostless URL rejected"
+        );
+    }
+
+    #[test]
+    fn exact_conflict_removal_is_case_and_wildcard_aware() {
+        let mut allow = vec!["github.com".to_string()];
+        let mut deny = vec!["GitHub.COM".to_string(), "*.example.com".to_string()];
+        // Production normalizes the host argument before update_host; the
+        // normalized form then removes the exact deny entry (case-insensitive).
+        let host = normalize_host_arg("GitHub.COM").expect("normalize");
+        assert_eq!(host, "github.com");
+        remove_host(&mut deny, &host);
+        assert_eq!(deny, vec!["*.example.com".to_string()]);
+        // Denying removes the exact allow entry.
+        remove_host(&mut allow, &host);
+        assert!(allow.is_empty());
+        // Adding an existing normalized host is a no-op (production passes
+        // the already-normalized host into add_host).
+        add_host(&mut allow, "github.com");
+        add_host(&mut allow, "github.com");
+        assert_eq!(allow, vec!["github.com".to_string()]);
+    }
 }

--- a/crates/tui/src/commands/groups/utility/task.rs
+++ b/crates/tui/src/commands/groups/utility/task.rs
@@ -1,31 +1,40 @@
 //! Task commands: add/list/show/cancel
 
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
-use crate::tui::app::{App, AppAction};
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
+use crate::tui::app::AppAction;
 
 pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "task",
     aliases: &["tasks"],
     usage: "/task [add <prompt>|list|digest|show <id>|cancel <id>]",
-    description_id: MessageId::CmdTaskDescription,
+    description_key: "cmd_task_description",
 };
 
 pub(in crate::commands) struct TaskCmd;
 
-impl RegisterCommand for TaskCmd {
+impl RegisterCommand<CommandResult> for TaskCmd {
     fn info() -> &'static CommandInfo {
         &COMMAND_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        task(app, arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual(task_contextual)
     }
 }
 
-fn task(app: &mut App, args: Option<&str>) -> CommandResult {
+fn task_contextual(contexts: CommandContexts<'_>, arg: Option<&str>) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let workspace = parts.workspace.as_deref_mut().expect("workspace facet");
+    task(workspace, arg)
+}
+
+fn task(
+    workspace: &mut dyn codewhale_command_contract::facets::CommandWorkspaceContext,
+    args: Option<&str>,
+) -> CommandResult {
     let raw = args.unwrap_or("").trim();
     if raw.is_empty() || raw.eq_ignore_ascii_case("list") {
         return CommandResult::action(AppAction::TaskList);
@@ -45,19 +54,10 @@ fn task(app: &mut App, args: Option<&str>) -> CommandResult {
             })
         }
         "list" => CommandResult::action(AppAction::TaskList),
-        "digest" => {
-            let Some(work) = app.runtime_services.work.as_ref() else {
-                return CommandResult::message("No active operations or to-do items.");
-            };
-            match work.capture(app.current_session_id.as_deref()) {
-                Ok(snapshot) => CommandResult::message(crate::work_graph::format_operation_digest(
-                    snapshot.as_ref(),
-                )),
-                Err(error) => CommandResult::error(format!(
-                    "Operation digest is temporarily unavailable: {error}"
-                )),
-            }
-        }
+        "digest" => match workspace.operation_digest() {
+            Ok(text) => CommandResult::message(text),
+            Err(error) => CommandResult::error(error),
+        },
         "show" => {
             let Some(id) = remainder else {
                 return CommandResult::error("Usage: /task show <id>");
@@ -77,31 +77,43 @@ fn task(app: &mut App, args: Option<&str>) -> CommandResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
-    use crate::tui::app::TuiOptions;
     use std::path::PathBuf;
 
-    fn app() -> App {
-        App::new(
-            TuiOptions {
-                use_alt_screen: false,
-                max_subagents: 2,
-                ..crate::test_support::test_tui_options(PathBuf::from("."))
-            },
-            &Config::default(),
-        )
+    struct FakeWorkspace;
+    impl codewhale_command_contract::facets::CommandWorkspaceContext for FakeWorkspace {
+        fn workspace(&self) -> PathBuf {
+            PathBuf::from(".")
+        }
+        fn work_state_snapshot(&self) -> Result<Option<String>, String> {
+            Ok(None)
+        }
+        fn operation_digest(&mut self) -> Result<String, String> {
+            Ok("No active operations or to-do items.".to_string())
+        }
+    }
+
+    struct FailingWorkspace;
+    impl codewhale_command_contract::facets::CommandWorkspaceContext for FailingWorkspace {
+        fn workspace(&self) -> PathBuf {
+            PathBuf::from(".")
+        }
+        fn work_state_snapshot(&self) -> Result<Option<String>, String> {
+            Ok(None)
+        }
+        fn operation_digest(&mut self) -> Result<String, String> {
+            Err("Operation digest is temporarily unavailable: boom".to_string())
+        }
     }
 
     #[test]
     fn parses_add_and_cancel() {
-        let mut app = app();
-        let add = task(&mut app, Some("add write tests"));
+        let add = task(&mut FakeWorkspace, Some("add write tests"));
         assert!(matches!(
             add.action,
             Some(AppAction::TaskAdd { prompt }) if prompt == "write tests"
         ));
 
-        let cancel = task(&mut app, Some("cancel task_1234"));
+        let cancel = task(&mut FakeWorkspace, Some("cancel task_1234"));
         assert!(matches!(
             cancel.action,
             Some(AppAction::TaskCancel { id }) if id == "task_1234"
@@ -110,20 +122,35 @@ mod tests {
 
     #[test]
     fn validates_usage() {
-        let mut app = app();
-        let result = task(&mut app, Some("add"));
+        let result = task(&mut FakeWorkspace, Some("add"));
         assert!(result.message.is_some());
         assert!(result.action.is_none());
     }
 
     #[test]
     fn digest_uses_canonical_work_runtime_without_another_state_store() {
-        let mut app = app();
-        let result = task(&mut app, Some("digest"));
+        let result = task(&mut FakeWorkspace, Some("digest"));
         assert_eq!(
             result.message.as_deref(),
             Some("No active operations or to-do items.")
         );
         assert!(result.action.is_none());
+
+        let failing = task(&mut FailingWorkspace, Some("digest"));
+        assert!(failing.is_error);
+        assert!(
+            failing
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Operation digest is temporarily unavailable: boom")
+        );
+    }
+
+    #[test]
+    fn handler_is_contextual() {
+        assert!(matches!(TaskCmd::handler(), CommandHandler::Contextual(_)));
+        assert_eq!(TaskCmd::info().description_key, "cmd_task_description");
+        assert_eq!(TaskCmd::info().aliases, &["tasks"]);
     }
 }

--- a/crates/tui/src/commands/groups/utility/task.rs
+++ b/crates/tui/src/commands/groups/utility/task.rs
@@ -1,6 +1,6 @@
 //! Task commands: add/list/show/cancel
 
-use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
 use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
@@ -21,13 +21,18 @@ impl RegisterCommand<CommandResult> for TaskCmd {
     }
 
     fn handler() -> CommandHandler<CommandResult> {
-        CommandHandler::Contextual(task_contextual)
+        CommandHandler::Contextual {
+            capabilities: CommandCapabilities::WORKSPACE,
+            handler: task_contextual,
+        }
     }
 }
 
 fn task_contextual(contexts: CommandContexts<'_>, arg: Option<&str>) -> CommandResult {
     let mut parts = contexts.into_parts();
-    let workspace = parts.workspace.as_deref_mut().expect("workspace facet");
+    let Some(workspace) = parts.workspace.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: workspace");
+    };
     task(workspace, arg)
 }
 
@@ -149,7 +154,20 @@ mod tests {
 
     #[test]
     fn handler_is_contextual() {
-        assert!(matches!(TaskCmd::handler(), CommandHandler::Contextual(_)));
+        let CommandHandler::Contextual {
+            capabilities,
+            handler,
+        } = TaskCmd::handler()
+        else {
+            panic!("task must be contextual");
+        };
+        assert_eq!(capabilities, CommandCapabilities::WORKSPACE);
+        let missing = handler(CommandContexts::empty(), Some("digest"));
+        assert!(missing.is_error);
+        assert_eq!(
+            missing.message.as_deref(),
+            Some("Error: Command capability unavailable: workspace")
+        );
         assert_eq!(TaskCmd::info().description_key, "cmd_task_description");
         assert_eq!(TaskCmd::info().aliases, &["tasks"]);
     }

--- a/crates/tui/src/commands/groups/utility/update.rs
+++ b/crates/tui/src/commands/groups/utility/update.rs
@@ -21,29 +21,28 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use codewhale_command_contract::handler::CommandHandler;
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 use codewhale_release::InstallMethod;
 
 use crate::commands::CommandResult;
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
-use crate::tui::app::App;
 
 pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "update",
     aliases: &["upgrade"],
     usage: "/update [check|install]",
-    description_id: MessageId::CmdUpdateDescription,
+    description_key: "cmd_update_description",
 };
 
 pub(in crate::commands) struct UpdateCmd;
 
-impl RegisterCommand for UpdateCmd {
+impl RegisterCommand<CommandResult> for UpdateCmd {
     fn info() -> &'static CommandInfo {
         &COMMAND_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        update(app, arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Pure(update)
     }
 }
 
@@ -160,7 +159,7 @@ fn install_preamble(updater: &Path) -> String {
     )
 }
 
-fn update(_app: &mut App, arg: Option<&str>) -> CommandResult {
+fn update(arg: Option<&str>) -> CommandResult {
     let mode = match parse_mode(arg) {
         Ok(mode) => mode,
         Err(message) => return CommandResult::error(message),
@@ -379,5 +378,12 @@ mod tests {
         let bounded = updater_transcript(flood.as_bytes(), b"");
         assert!(bounded.ends_with("… output truncated."));
         assert!(bounded.chars().count() < flood.chars().count());
+    }
+
+    #[test]
+    fn handler_is_pure_and_argument_only() {
+        assert!(matches!(UpdateCmd::handler(), CommandHandler::Pure(_)));
+        assert_eq!(UpdateCmd::info().description_key, "cmd_update_description");
+        assert_eq!(UpdateCmd::info().aliases, &["upgrade"]);
     }
 }

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -1866,7 +1866,13 @@ mod tests {
         // concrete-App path. The seven utility entries are asserted separately
         // by the FEAT-018 public-dispatch and inventory tests (Phase 6).
         const FEAT_018_UTILITY: &[&str] = &[
-            "attach", "automation", "jobs", "mcp", "network", "task", "update",
+            "attach",
+            "automation",
+            "jobs",
+            "mcp",
+            "network",
+            "task",
+            "update",
         ];
         for info in command_infos() {
             if info.name == "feat015ctx" || FEAT_018_UTILITY.contains(&info.name) {
@@ -1878,5 +1884,104 @@ mod tests {
                 info.name
             );
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // FEAT-018: public pure/contextual dispatch and seven-entry inventory
+    // (Task 6.2). These tests enter through the public registry/dispatch seam
+    // and prove both handler variants plus all seven utility metadata records.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn feat018_all_seven_utility_entries_are_registered_with_portable_handlers() {
+        for name in [
+            "attach",
+            "automation",
+            "jobs",
+            "mcp",
+            "network",
+            "task",
+            "update",
+        ] {
+            let info = registry()
+                .get_info(name)
+                .unwrap_or_else(|| panic!("/{name} must be registered"));
+            assert_eq!(info.name, name, "canonical name");
+            assert!(
+                registry().has_contextual_handler(name),
+                "/{name} must carry a portable handler"
+            );
+        }
+    }
+
+    #[test]
+    fn feat018_pure_utility_command_dispatches_through_public_seam() {
+        let mut app = create_test_app();
+        // /jobs is a Pure handler: it must execute without building an
+        // envelope and return the same action as the parser.
+        let result = execute("/jobs list", &mut app);
+        assert!(!result.is_error, "{result:?}");
+        assert!(
+            matches!(
+                result.action,
+                Some(crate::tui::app::AppAction::ShellJob(
+                    crate::tui::app::ShellJobAction::List
+                ))
+            ),
+            "{result:?}"
+        );
+
+        // /update is Pure too; a bare check should reach the plan resolver and
+        // return a message (or a safe error in a test environment), never a panic.
+        let result = execute("/update", &mut app);
+        assert!(result.message.is_some() || result.is_error, "{result:?}");
+    }
+
+    #[test]
+    fn feat018_contextual_utility_commands_dispatch_through_public_seam() {
+        let mut app = create_test_app();
+
+        // /automation (contextual, presentation facet): list action.
+        let automation = execute("/automation list", &mut app);
+        assert!(
+            matches!(
+                automation.action,
+                Some(crate::tui::app::AppAction::Automation(
+                    crate::tui::app::AutomationAction::List
+                ))
+            ),
+            "{automation:?}"
+        );
+
+        // /task (contextual, workspace facet): digest without a runtime must
+        // produce the canonical no-active text.
+        let task = execute("/task digest", &mut app);
+        assert_eq!(
+            task.message.as_deref(),
+            Some("No active operations or to-do items."),
+            "{task:?}"
+        );
+
+        // /mcp (contextual, presentation facet): status maps to Show action.
+        let mcp = execute("/mcp status", &mut app);
+        assert!(
+            matches!(
+                mcp.action,
+                Some(crate::tui::app::AppAction::Mcp(
+                    crate::tui::app::McpUiAction::Show
+                ))
+            ),
+            "{mcp:?}"
+        );
+
+        // /attach (contextual, workspace + media facets): missing path is a
+        // safe error, never a panic, and the composer is untouched.
+        let attach = execute("/attach", &mut app);
+        assert!(attach.is_error, "{attach:?}");
+        assert!(app.input.is_empty(), "composer must stay unchanged");
+
+        // /network (pure): list produces a message.
+        let network = execute("/network list", &mut app);
+        assert!(network.message.is_some() || network.is_error, "{network:?}");
     }
 }

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -1860,10 +1860,16 @@ mod tests {
 
     #[test]
     fn feat015_all_production_entries_remain_legacy() {
-        // Every non-fixture registered command must still use the legacy
-        // concrete-App path (no production group is migrated in FEAT-015).
+        // FEAT-015 shipped no production contextual command, so the assertion
+        // below used to exclude nothing. FEAT-018 migrates the utility group;
+        // the remaining non-fixture commands must still use the legacy
+        // concrete-App path. The seven utility entries are asserted separately
+        // by the FEAT-018 public-dispatch and inventory tests (Phase 6).
+        const FEAT_018_UTILITY: &[&str] = &[
+            "attach", "automation", "jobs", "mcp", "network", "task", "update",
+        ];
         for info in command_infos() {
-            if info.name == "feat015ctx" {
+            if info.name == "feat015ctx" || FEAT_018_UTILITY.contains(&info.name) {
                 continue;
             }
             assert!(

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -130,7 +130,13 @@ impl codewhale_command_contract::metadata::RegisterCommand<CommandResult> for Fe
     }
 
     fn handler() -> codewhale_command_contract::handler::CommandHandler<CommandResult> {
-        codewhale_command_contract::handler::CommandHandler::Contextual(feat015_contextual)
+        use codewhale_command_contract::handler::{CommandCapabilities, CommandHandler};
+        CommandHandler::Contextual {
+            capabilities: CommandCapabilities::WORKSPACE
+                .union(CommandCapabilities::MODE_POLICY)
+                .union(CommandCapabilities::COST),
+            handler: feat015_contextual,
+        }
     }
 }
 
@@ -260,19 +266,21 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         } else {
             arg
         };
-        // FEAT-015 dual-path seam (D2): a migrated entry with a
-        // capability-scoped handler receives the envelope built from `app`;
-        // everything else keeps the legacy `execute(app, args)` path. No
-        // production entry is migrated in FEAT-015, so the contextual branch
-        // is only reachable by the test-only fixture (D6).
+        // FEAT-015 introduced this dual-path seam (D2); FEAT-018 is the first
+        // production slice to use it. A migrated entry receives only its
+        // declared capabilities, while every unmigrated entry keeps the
+        // legacy `execute(app, args)` path.
         if let Some(handler) = command_object.contextual_handler() {
-            let mut bundle = app.command_contexts();
             return match handler {
                 codewhale_command_contract::handler::CommandHandler::Pure(pure_fn) => {
                     pure_fn(command_arg)
                 }
-                codewhale_command_contract::handler::CommandHandler::Contextual(contextual) => {
-                    contextual(bundle.contexts(), command_arg)
+                codewhale_command_contract::handler::CommandHandler::Contextual {
+                    capabilities,
+                    handler: contextual,
+                } => {
+                    let mut bundle = app.command_contexts();
+                    contextual(bundle.contexts(capabilities), command_arg)
                 }
             };
         }

--- a/crates/tui/src/commands/traits.rs
+++ b/crates/tui/src/commands/traits.rs
@@ -221,7 +221,7 @@ impl Command for FunctionCommand {
     }
 }
 
-/// A registry entry that carries an optional capability-scoped handler.
+/// A registry entry that carries an optional least-capability handler.
 ///
 /// FEAT-015's dual-path seam (D2): migrated registrations may supply a
 /// `CommandHandler<CommandResult>` (App-free; built from `CommandContexts`),
@@ -229,10 +229,9 @@ impl Command for FunctionCommand {
 /// This entry type is App-free — only the dispatcher in `commands/mod.rs`
 /// touches `App` when it builds the envelope from the bundle.
 ///
-/// FEAT-015 ships no production contextual registration, so in production
-/// builds this type is only referenced through the trait; the test fixture
-/// (D6) constructs it under `#[cfg(test)]`. The allow is removed once a
-/// production group migrates (FEAT-018+).
+/// FEAT-015 shipped no production contextual registration. FEAT-018 is the
+/// first production group to construct this bridge, while the original D6
+/// fixture remains available under `#[cfg(test)]`.
 pub(crate) struct ContextualCommand {
     info: &'static CommandInfo,
     handler: Option<codewhale_command_contract::handler::CommandHandler<CommandResult>>,
@@ -253,14 +252,28 @@ impl ContextualCommand {
 
     /// Bridge one portable contract registration into the TUI-owned registry.
     ///
-    /// The command supplies only contract metadata and an App-free handler;
-    /// the TUI resolves the localization key and owns the resulting registry
-    /// entry. This is the dependency inversion later command crates reuse.
+    /// The command supplies only contract metadata and an App-free handler.
+    /// Contextual handlers carry their exact external capability set; the TUI
+    /// resolves localization and exposes only those declared facets. This is
+    /// the dependency inversion later command crates reuse.
     pub(crate) fn from_contract<C>() -> Result<Self, String>
     where
         C: codewhale_command_contract::metadata::RegisterCommand<CommandResult>,
     {
         let portable = C::info();
+        let handler = C::handler();
+        if matches!(
+            handler,
+            codewhale_command_contract::handler::CommandHandler::Contextual {
+                capabilities,
+                ..
+            } if capabilities.is_empty()
+        ) {
+            return Err(format!(
+                "contextual command /{} must declare at least one capability; use Pure otherwise",
+                portable.name
+            ));
+        }
         let description_id = super::contract::key_to_message_id(portable.description_key)
             .ok_or_else(|| {
                 format!(
@@ -274,7 +287,7 @@ impl ContextualCommand {
             usage: portable.usage,
             description_id,
         }));
-        Ok(Self::contextual(info, C::handler()))
+        Ok(Self::contextual(info, handler))
     }
 }
 impl Command for ContextualCommand {
@@ -345,9 +358,8 @@ impl CommandRegistry {
     }
 
     /// FEAT-015: whether the named entry has a capability-scoped handler.
-    /// Used by test assertions under `#[cfg(test)]`; production builds have
-    /// no contextual entries, so the method is dead there until a group
-    /// migrates (FEAT-018+).
+    /// Used by migration-boundary tests to distinguish contextual entries
+    /// from commands that still use the concrete-App path.
     #[allow(dead_code)]
     pub(crate) fn has_contextual_handler(&self, name: &str) -> bool {
         self.get(name)
@@ -360,5 +372,56 @@ impl CommandRegistry {
 
     pub fn infos(&self) -> Vec<&'static CommandInfo> {
         self.iter().map(Command::info).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codewhale_command_contract::handler::{
+        CommandCapabilities, CommandContexts, CommandHandler as PortableHandler,
+    };
+    use codewhale_command_contract::metadata::{
+        CommandInfo as PortableCommandInfo, RegisterCommand as PortableRegisterCommand,
+    };
+
+    struct EmptyCapabilityCommand;
+
+    fn empty_capability_handler(
+        _contexts: CommandContexts<'_>,
+        _args: Option<&str>,
+    ) -> CommandResult {
+        CommandResult::message("unused")
+    }
+
+    impl PortableRegisterCommand<CommandResult> for EmptyCapabilityCommand {
+        fn info() -> &'static PortableCommandInfo {
+            static INFO: PortableCommandInfo = PortableCommandInfo {
+                name: "empty-capability",
+                aliases: &[],
+                usage: "/empty-capability",
+                description_key: "cmd_workspace_description",
+            };
+            &INFO
+        }
+
+        fn handler() -> PortableHandler<CommandResult> {
+            PortableHandler::Contextual {
+                capabilities: CommandCapabilities::NONE,
+                handler: empty_capability_handler,
+            }
+        }
+    }
+
+    #[test]
+    fn portable_bridge_rejects_contextual_handler_without_capabilities() {
+        let error = ContextualCommand::from_contract::<EmptyCapabilityCommand>()
+            .err()
+            .expect("empty contextual capability declaration must be rejected");
+        assert!(
+            error.contains("must declare at least one capability"),
+            "{error}"
+        );
+        assert!(error.contains("use Pure otherwise"), "{error}");
     }
 }

--- a/crates/tui/src/commands/traits.rs
+++ b/crates/tui/src/commands/traits.rs
@@ -233,23 +233,13 @@ impl Command for FunctionCommand {
 /// builds this type is only referenced through the trait; the test fixture
 /// (D6) constructs it under `#[cfg(test)]`. The allow is removed once a
 /// production group migrates (FEAT-018+).
-#[allow(dead_code)]
 pub(crate) struct ContextualCommand {
     info: &'static CommandInfo,
     handler: Option<codewhale_command_contract::handler::CommandHandler<CommandResult>>,
     legacy: Option<CommandHandler>,
 }
 
-#[allow(dead_code)]
 impl ContextualCommand {
-    pub(crate) const fn legacy(info: &'static CommandInfo, legacy: CommandHandler) -> Self {
-        Self {
-            info,
-            handler: None,
-            legacy: Some(legacy),
-        }
-    }
-
     pub(crate) const fn contextual(
         info: &'static CommandInfo,
         handler: codewhale_command_contract::handler::CommandHandler<CommandResult>,
@@ -285,18 +275,6 @@ impl ContextualCommand {
             description_id,
         }));
         Ok(Self::contextual(info, C::handler()))
-    }
-
-    /// The capability-scoped handler, if this entry is migrated.
-    pub(crate) fn command_handler(
-        &self,
-    ) -> Option<codewhale_command_contract::handler::CommandHandler<CommandResult>> {
-        self.handler.clone()
-    }
-
-    /// Whether this entry still uses the legacy concrete-App path.
-    pub(crate) fn is_legacy(&self) -> bool {
-        self.handler.is_none()
     }
 }
 impl Command for ContextualCommand {

--- a/crates/tui/src/llm_client/mod.rs
+++ b/crates/tui/src/llm_client/mod.rs
@@ -1164,6 +1164,9 @@ pub type RetryCallback = Box<dyn Fn(&LlmError, u32, Duration) + Send + Sync>;
 ///     })),
 /// ).await;
 /// ```
+// RetryError intentionally preserves the concrete LlmError for callers that
+// inspect provider-specific failures; boxing it here would change that API.
+#[allow(clippy::result_large_err)]
 pub async fn with_retry<F, Fut, T>(
     config: &RetryConfig,
     mut operation: F,

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -1153,7 +1153,7 @@ pub(crate) async fn run_event_loop(
                         }
 
                         let thinking = app.last_reasoning.take();
-                        let tool_uses = app.pending_tool_uses.drain(..).collect::<Vec<_>>();
+                        let tool_uses = std::mem::take(&mut app.pending_tool_uses);
                         let history_index = completed_message_index;
 
                         if app.translation_enabled

--- a/crates/tui/src/tui/views/status_picker.rs
+++ b/crates/tui/src/tui/views/status_picker.rs
@@ -153,16 +153,12 @@ impl ModalView for StatusPickerView {
             {
                 // Quality-of-life: 'a' selects all so the user can quickly
                 // see every chip available before paring back.
-                for slot in &mut self.selected {
-                    *slot = true;
-                }
+                self.selected.fill(true);
                 ViewAction::Emit(self.live_preview_event())
             }
             KeyCode::Char('n') | KeyCode::Char('N') => {
                 // 'n' clears all so the user can build up from scratch.
-                for slot in &mut self.selected {
-                    *slot = false;
-                }
+                self.selected.fill(false);
                 ViewAction::Emit(self.live_preview_event())
             }
             _ => ViewAction::None,

--- a/crates/tui/tests/integration/eval_harness.rs
+++ b/crates/tui/tests/integration/eval_harness.rs
@@ -27,7 +27,10 @@ fn runs_offline_tool_loop_successfully() {
     assert!(run.metrics.success, "expected success metrics: {run:#?}");
     assert_eq!(run.metrics.tool_errors, 0);
     assert_eq!(run.metrics.steps, 6);
-    assert!(run.metrics.duration.as_millis() > 0);
+    // Nanosecond granularity: the offline loop performs real fs/tempdir work,
+    // so a sub-millisecond total is legitimate; `as_millis() > 0` flaked under
+    // saturated test runs (pre-existing timing flake, fixed for FEAT-018).
+    assert!(run.metrics.duration.as_nanos() > 0);
     assert!(!run.scenario_name.is_empty());
     assert!(run.workspace_summary.file_count >= 3);
 

--- a/scripts/command-migration-topology.json
+++ b/scripts/command-migration-topology.json
@@ -286,7 +286,6 @@
     "plugins",
     "project",
     "session",
-    "skills",
-    "utility"
+    "skills"
   ]
 }

--- a/scripts/test_check_command_migration_manifest.py
+++ b/scripts/test_check_command_migration_manifest.py
@@ -362,7 +362,12 @@ class LiveGateTests(unittest.TestCase):
         frontier = doc["frontier"]
         self.assertEqual(frontier, sorted(frontier))
         self.assertEqual(len(frontier), len(set(frontier)))
-        self.assertEqual(set(frontier), {"utility", "memory", "plugins", "project", "skills", "session", "config", "debug", "core"})
+        # FEAT-018 removed the utility group from the frontier (Stage B first
+        # slice); the remaining eight groups stay pending.
+        self.assertEqual(
+            set(frontier),
+            {"memory", "plugins", "project", "skills", "session", "config", "debug", "core"},
+        )
 
 
 class SourceScanTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

FEAT-018 converts the complete TUI utility command group to the external command shapes introduced by FEAT-014 and hosted by FEAT-015. The seven command files remain under `codewhale-tui`; this PR changes their execution boundary without physically moving them.

This PR:

- registers `/attach`, `/automation`, `/jobs`, `/mcp`, `/network`, `/task`, and `/update` through `RegisterCommand<CommandResult>` and the existing `ContextualCommand::from_contract` bridge;
- removes concrete `App` and executable TUI-helper access from every utility handler;
- adds narrowly scoped presentation, atomic media-attachment, and canonical operation-digest capabilities to `codewhale-command-contract`;
- keeps `/jobs`, `/network`, and `/update` argument-only (`CommandHandler::Pure`), while `/attach`, `/automation`, `/mcp`, and `/task` declare and receive only their exact minimum external facets;
- removes `utility` from the migration frontier only after the whole group is portable;
- preserves the existing registry, precedence, aliases, messages, localization, actions, persistence behavior, and safety checks.

Tracking: EPIC-005 / EPIC-006 / FEAT-018 in #5316.

No-Issue: FEAT-018 is tracked in umbrella #5316, which must remain open for the remaining decomposition FEATs.

## Dependency boundary

The intended dependency direction remains acyclic:

```text
future codewhale-commands utility group
                 |
                 v
codewhale-command-contract ---> codewhale-core / other acyclic leaf crates
                 ^
                 |
codewhale-tui implements the host facets
```

Utility handlers no longer name or call concrete `App`, TUI services, TUI state, localization enums, composer helpers, work-runtime helpers, config-persistence helpers, or other executable TUI behavior. The concrete implementations remain on the TUI-owned adapter side and expose only external trait objects to handlers. `codewhale-command-contract` has no dependency on `codewhale-tui`, enforced by the existing boundary gate.

## Temporary FEAT-037 compatibility references

This PR intentionally does **not** move shared command outcome/action ownership. The following TUI-owned data-only references remain temporarily:

- `CommandResult` in all seven utility modules;
- `AppAction` in `automation.rs`, `jobs.rs`, `mcp.rs`, and `task.rs`;
- `AutomationAction` in `automation.rs`;
- `ShellJobAction` in `jobs.rs`;
- `McpUiAction` in `mcp.rs`.

These types describe handler outputs; they provide no access to `App` or executable TUI behavior. They are therefore the bounded compatibility exception defined by FEAT-018, not a reverse executable dependency and not circular-dependency debt.

The mandatory retirement sequence is:

1. FEAT-018 through FEAT-035 remove executable TUI dependencies while command files remain in TUI.
2. FEAT-036 moves localization ownership behind its compatibility path.
3. **FEAT-037** moves `CommandResult`, `AppAction`, and only the proven action payload data into external ownership, retaining compatibility re-exports as needed.
4. FEAT-016 bootstraps `codewhale-commands` after those ownership prerequisites are external.
5. **FEAT-038** physically moves the utility group only after the temporary data references are gone.

Keeping that ownership move out of FEAT-018 is deliberate: one FEAT remains one independently reviewable structural PR, without mixing command rewiring, shared-type relocation, and physical file movement.

## Capability additions

- `CommandPresentationContext`: stable translation keys with exact named replacements and safe failure behavior.
- `CommandMediaContext`: validates and inserts media atomically, returning only a portable receipt.
- `CommandWorkspaceContext::operation_digest`: delegates session-aware capture and canonical digest formatting to the host.
- `CommandCapabilities`: each contextual registration declares its exact minimum external facet set; the dispatcher exposes only those facets, rejects empty contextual declarations, and pure handlers build no host bundle.
- `CommandContexts` / `ContextParts`: add presentation and media slots without a command-specific envelope, host escape hatch, or second registry.

## Review hardening

Commit `643b76c5f` incorporates the first-production-slice review findings: exact capability declarations are enforced by the external contract; undeclared facets remain absent; missing required facets return safe command errors; malformed localized placeholder contracts fall back through the authoritative English catalog; the nine-facet comment is current; and the attachment validation rationale is retained beside the moved validation block. The same invariant is now recorded for FEAT-019 through FEAT-046 and the EPIC-006 final gate. Commit `e4aad4c06` repairs the Rust 1.98 strict-Clippy diagnostics exposed after rebasing onto current `main`, without changing the FEAT-018 behavior or dependency boundary. The complete GitHub Actions matrix is green on this head.

## Scope and behavior

- Only `groups/utility` is migrated.
- No command file moves out of `codewhale-tui`.
- No shared result/action type moves in this PR.
- No localization system extraction occurs.
- Names, aliases, usage strings, registry order, discovery, returned actions, user messages, network redaction, attachment validation, operation-digest semantics, and bounded updater output remain unchanged.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-command-contract --lib --locked` — 10 passed
- [x] `cargo test -p codewhale-tui --lib --locked` — 10,865 passed, 13 ignored in the review-hardening gate
- [x] Focused FEAT-018 public-dispatch tests — 3 passed
- [x] TUI command-adapter tests — 17 passed
- [x] Utility-group tests — 37 passed
- [x] `python3 scripts/test_check_command_crate_boundaries.py` — 8 passed
- [x] `python3 scripts/check-command-crate-boundaries.py`
- [x] `python3 scripts/test_check_command_migration_manifest.py` — 54 passed
- [x] `python3 scripts/check-command-migration-manifest.py --baseline-ref origin/main`
- [x] `python3 scripts/test_ci_migration_wiring.py` — 11 passed
- [x] Strict workspace Clippy with `-D warnings` — 0 warnings
- [x] `cargo test --workspace --all-features --locked` — 13,074 passed in the final serialized gate
- [x] Release build for `codewhale-cli` and `codewhale-tui`
- [x] `git diff --check`

## Checklist

- [x] All seven utility registrations use the portable contract path
- [x] Zero concrete-`App` utility handlers
- [x] Zero executable TUI dependencies in utility handlers
- [x] Exact least-capability declarations; undeclared facets unavailable; pure handlers build no host bundle
- [x] Exact temporary FEAT-037 data references documented
- [x] `utility` removed from both migration-frontier representations
- [x] No physical group move or shared-type ownership move
- [x] No manual UI verification required for this structural change

Paulo Aboim Pinto
