### PR TITLE
fix(cli): route legacy completions through public binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   restating it never changed anything. Shipped binaries were never affected;
   `release-artifacts.yml` builds `--profile dist` with fat LTO and
   `codegen-units = 1`.
+- The legacy `codewhale completions <shell>` command now generates scripts
+  from the public `codewhale` CLI instead of delegating to `codewhale-tui`, so
+  PowerShell and other shell completions no longer teach the retired binary
+  name (#5526).
 
 ## [0.9.10] - 2026-08-19
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -385,8 +385,12 @@ New integrations should prefer `codewhale app-server`.")]
         after_help = "The browser receives a one-time loopback bootstrap capability, never the Runtime token.\nThe capability is exchanged for a bounded, process-local HttpOnly, SameSite=Strict web session and then invalidated."
     )]
     Web(WebArgs),
-    /// Generate shell completions.
-    Completions(TuiPassthroughArgs),
+    /// Generate shell completions. Compatibility alias for `completion`.
+    Completions {
+        /// Shell to generate completions for.
+        #[arg(value_enum)]
+        shell: Shell,
+    },
     /// Configure provider credentials.
     Login(LoginArgs),
     /// Remove saved authentication state.
@@ -545,6 +549,18 @@ struct RunArgs {
 struct TuiPassthroughArgs {
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     args: Vec<String>,
+}
+
+fn completion_script(shell: Shell) -> Vec<u8> {
+    let mut command = Cli::command();
+    let mut output = Vec::new();
+    generate(shell, &mut command, "codewhale", &mut output);
+    output
+}
+
+fn generate_completions(shell: Shell) {
+    let output = completion_script(shell);
+    let _ = io::stdout().write_all(&output);
 }
 
 #[derive(Debug, Args)]
@@ -1878,9 +1894,9 @@ fn run() -> Result<()> {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
             run_tui_server_in_process(&cli, &resolved_runtime, web_serve_passthrough(&args))
         }
-        Some(Commands::Completions(args)) => {
-            let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
-            run_tui_in_process(&cli, &resolved_runtime, tui_args("completions", args))
+        Some(Commands::Completions { shell }) => {
+            generate_completions(shell);
+            Ok(())
         }
         Some(Commands::Login(args)) => run_login_command(&mut store, args),
         Some(Commands::Logout) => run_logout_command(&mut store),
@@ -1980,8 +1996,7 @@ fn run() -> Result<()> {
             run_app_server_command(&cli, &resolved_runtime, args)
         }
         Some(Commands::Completion { shell }) => {
-            let mut cmd = Cli::command();
-            generate(shell, &mut cmd, "codewhale", &mut io::stdout());
+            generate_completions(shell);
             Ok(())
         }
         Some(Commands::Metrics(args)) => run_metrics_command(args),
@@ -4924,6 +4939,32 @@ mod tests {
 
     fn parse_ok(argv: &[&str]) -> Cli {
         Cli::try_parse_from(argv).unwrap_or_else(|err| panic!("parse failed for {argv:?}: {err}"))
+    }
+
+    #[test]
+    fn legacy_completions_alias_parses_shell_without_tui_passthrough() {
+        let cli = parse_ok(&["codewhale", "completions", "powershell"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Completions {
+                shell: Shell::PowerShell
+            })
+        ));
+    }
+
+    #[test]
+    fn every_completion_shell_uses_the_public_binary_name() {
+        for shell in [Shell::Bash, Shell::Fish, Shell::PowerShell, Shell::Zsh] {
+            let script = String::from_utf8(completion_script(shell)).expect("completion UTF-8");
+            assert!(
+                script.contains("codewhale"),
+                "{shell:?} completion must name the public binary"
+            );
+            assert!(
+                !script.contains("codewhale-tui"),
+                "{shell:?} completion must not teach the runtime binary name"
+            );
+        }
     }
 
     fn help_for(argv: &[&str]) -> String {

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   restating it never changed anything. Shipped binaries were never affected;
   `release-artifacts.yml` builds `--profile dist` with fat LTO and
   `codegen-units = 1`.
+- The legacy `codewhale completions <shell>` command now generates scripts
+  from the public `codewhale` CLI instead of delegating to `codewhale-tui`, so
+  PowerShell and other shell completions no longer teach the retired binary
+  name (#5526).
 
 ## [0.9.10] - 2026-08-19
 


### PR DESCRIPTION
## Summary

Addresses the approved scope of #5526.

The legacy `codewhale completions <shell>` command now uses the same canonical completion generator as `codewhale completion <shell>` instead of forwarding to the `codewhale-tui` runtime. Generated scripts use the public `codewhale` command name.

The legacy plural command remains available as a compatibility alias. The canonical singular command is unchanged.

## Coverage

Added provider-free CLI tests that verify:

- `codewhale completions powershell` parses directly in the CLI;
- Bash, Fish, PowerShell, and Zsh scripts contain `codewhale`;
- generated scripts do not teach the retired `codewhale-tui` binary name.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-cli --lib --locked` (217 passed)

No provider credentials or network access are required.

No-Issue: This PR addresses the approved compatibility slice of #5526 without automatically closing the broader report.
