### PR TITLE
feat(web): move docs/subagents and docs/mcp onto the dictionary spine (#5337)

### DIFF
--- a/web/app/[locale]/docs/mcp/page.tsx
+++ b/web/app/[locale]/docs/mcp/page.tsx
@@ -1,160 +1,89 @@
+import { Fragment } from "react";
+import { getDocsMcp, splitTokens } from "@/lib/i18n/dictionaries";
 import { buildPageMetadata } from "@/lib/page-meta";
+
+const CODE_SPANS: Record<string, string> = {
+  configPath: "~/.codewhale/mcp.json",
+  legacyConfigPath: "~/.deepseek/mcp.json",
+  configPathOption: "mcp_config_path",
+  configEnvVar: "DEEPSEEK_MCP_CONFIG",
+  serversKey: "mcpServers",
+  initCommand: "codewhale mcp init",
+  mcpCommand: "/mcp",
+  toolNamePattern: "mcp_<server>_<tool>",
+  gitServer: "git",
+  statusTool: "status",
+  gitStatusTool: "mcp_git_status",
+  serveMcp: "codewhale serve --mcp",
+  mcpServerCommand: "codewhale mcp-server",
+  addSelfCommand: "codewhale mcp add-self",
+  serveHttp: "serve --http",
+};
+
+function withCodeSpans(template: string) {
+  return splitTokens(template).map((part, i) =>
+    "token" in part ? (
+      <code key={`${i}-${part.token}`} className="inline">
+        {CODE_SPANS[part.token] ?? `{${part.token}}`}
+      </code>
+    ) : (
+      <Fragment key={`${i}-text`}>{part.text}</Fragment>
+    ),
+  );
+}
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
+  const t = getDocsMcp(locale);
   return buildPageMetadata({
     path: "/docs/mcp",
     locale,
-    title: isZh ? "MCP · Codewhale 文档" : "MCP · Codewhale Docs",
-    description: isZh
-      ? "通过 Model Context Protocol 消费外部工具服务器，或把 Codewhale 作为 MCP 服务器暴露。"
-      : "Consume external tool servers over the Model Context Protocol, or expose Codewhale itself as an MCP server.",
+    title: t.metaTitle,
+    description: t.metaDescription,
   });
 }
 
 export default async function McpPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
-  const bodyClass = isZh
-    ? "text-ink-soft leading-[1.9] tracking-wide"
-    : "text-ink-soft leading-relaxed";
+  const t = getDocsMcp(locale);
 
   return (
     <section className="space-y-10">
       <section id="overview" className="scroll-mt-32">
         <h1 className="font-display text-3xl mb-1">MCP</h1>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "Codewhale 可以通过 MCP（Model Context Protocol）加载额外的工具。MCP 服务器可以是由 TUI 启动的本地 stdio 进程，也可以是远程 URL 服务器（Streamable HTTP，带旧版 SSE 回退）。连接成功的服务器会把工具注册进模型目录；失败或被禁用的服务器不会作为可用工具呈现给模型。"
-            : "Codewhale can load additional tools via MCP (Model Context Protocol). MCP servers can be local stdio processes that the TUI starts, or remote URL-based servers that speak Streamable HTTP with legacy SSE fallback. A successfully connected server registers its tools into the model catalog; a failed or disabled server is never presented as an available tool."}
-        </p>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh ? (
-            <>
-              配置文件默认在 <code className="inline">~/.codewhale/mcp.json</code>
-              （新文件缺失时仍读取旧版 <code className="inline">~/.deepseek/mcp.json</code>），可用{" "}
-              <code className="inline">mcp_config_path</code> 或{" "}
-              <code className="inline">DEEPSEEK_MCP_CONFIG</code> 覆盖。也兼容其他客户端使用的{" "}
-              <code className="inline">mcpServers</code> 键名。
-            </>
-          ) : (
-            <>
-              The config file defaults to <code className="inline">~/.codewhale/mcp.json</code> (the
-              legacy <code className="inline">~/.deepseek/mcp.json</code> is still read when the
-              Codewhale file is absent), overridable with{" "}
-              <code className="inline">mcp_config_path</code> or{" "}
-              <code className="inline">DEEPSEEK_MCP_CONFIG</code>. The{" "}
-              <code className="inline">mcpServers</code> key used by other clients is accepted too.
-            </>
-          )}
-        </p>
+        <p className={`${t.bodyClassName} mt-3`}>{t.overviewLead}</p>
+        <p className={`${t.bodyClassName} mt-3`}>{withCodeSpans(t.overviewConfig)}</p>
       </section>
 
       <section id="setup" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "配置与管理" : "Setup and management"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh ? (
-            <>
-              用 <code className="inline">codewhale mcp init</code> 生成初始配置；TUI 内的{" "}
-              <code className="inline">/mcp</code>{" "}
-              打开紧凑管理器，显示每个服务器的启用状态、传输方式、命令或 URL、超时和连接错误。常用命令：
-            </>
-          ) : (
-            <>
-              Bootstrap a starter config with <code className="inline">codewhale mcp init</code>;
-              inside the TUI, <code className="inline">/mcp</code> opens a compact manager showing each
-              server's enabled state, transport, command or URL, timeouts, and connection errors. Common
-              commands:
-            </>
-          )}
-        </p>
+        <h2 className="font-display text-2xl mb-1">{t.setupTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{withCodeSpans(t.setupLead)}</p>
         <pre className="code-block mt-4">{`codewhale mcp add <name> --command "<cmd>" --arg "<arg>"
 codewhale mcp add <name> --url "https://example.com/mcp" --bearer-token-env-var MCP_TOKEN
 codewhale mcp login <name>      # OAuth for remote servers
 codewhale mcp list
 codewhale mcp validate`}</pre>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "在 TUI 里做的配置编辑会立即写盘，但模型可见的 MCP 工具池不会热加载——管理器会把它标记为需要重启。/mcp validate 和 /mcp reload 会重新连接以刷新界面快照。"
-            : "Config edits made from the TUI are written immediately, but the model-visible MCP tool pool is not hot-reloaded — the manager marks it restart-required. /mcp validate and /mcp reload reconnect to refresh the on-screen snapshot."}
-        </p>
+        <p className={`${t.bodyClassName} mt-3`}>{t.setupReload}</p>
       </section>
 
       <section id="auth" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "远程认证" : "Remote authentication"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "URL 服务器可以使用静态 headers、从环境变量派生的 env_headers、bearer_token_env_var 或 OAuth。优先级是保守的：先应用 headers 和 env_headers；bearer_token_env_var 只在尚未设置 Authorization 时添加；OAuth 登录获取的令牌同样不会覆盖已有的显式 header。应避免提交字面量 Authorization header——优先用 env_headers、bearer_token_env_var 或 OAuth 登录，让秘密留在 MCP 文件之外。"
-            : "URL-based servers can use static headers, env-derived env_headers, bearer_token_env_var, or OAuth. Precedence is conservative: headers and env_headers apply first; bearer_token_env_var adds an Authorization header only when one is not already set; OAuth login tokens likewise never override an explicit header. Avoid committing literal Authorization headers — prefer env_headers, bearer_token_env_var, or OAuth login so secrets stay outside the MCP file."}
-        </p>
+        <h2 className="font-display text-2xl mb-1">{t.authTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{t.authLead}</p>
       </section>
 
       <section id="tools" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "工具命名与安全" : "Tool naming and safety"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh ? (
-            <>
-              发现的 MCP 工具以 <code className="inline">mcp_&lt;server&gt;_&lt;tool&gt;</code>{" "}
-              的形式暴露给模型——例如名为 <code className="inline">git</code> 的服务器的{" "}
-              <code className="inline">status</code> 工具会变成{" "}
-              <code className="inline">mcp_git_status</code>。MCP
-              工具和内置工具走同一套审批框架：只读的 MCP 辅助工具在策略允许时可免提示运行，有副作用的 MCP
-              工具需要审批，Full Access 也不会绕过硬策略拦截。
-            </>
-          ) : (
-            <>
-              Discovered MCP tools are exposed to the model as{" "}
-              <code className="inline">mcp_&lt;server&gt;_&lt;tool&gt;</code> — a server named{" "}
-              <code className="inline">git</code> with a <code className="inline">status</code> tool
-              becomes <code className="inline">mcp_git_status</code>. MCP tools flow through the same
-              approval framework as built-in tools: read-only MCP helpers can run without prompts when
-              policy permits, side-effectful MCP tools require approval, and Full Access does not bypass
-              hard policy holds.
-            </>
-          )}
-        </p>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "只配置你信任的 MCP 服务器，并把 MCP 服务器配置视为等同于在本机运行代码。经过审查的本地插件包也可以贡献 MCP 服务器：它们复用同一个 MCP 管理器、审批和网络策略路径，以 <plugin>-<server> 的命名空间身份出现，边界比手写的 mcp.json 更严格。"
-            : "Only configure MCP servers you trust, and treat MCP server configuration as equivalent to running code on your machine. Reviewed local plugin bundles can also contribute MCP servers: they reuse the same MCP manager, approval, and network-policy paths, appear under namespaced <plugin>-<server> identities, and are held to a stricter boundary than hand-written mcp.json."}
-        </p>
+        <h2 className="font-display text-2xl mb-1">{t.toolsTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{withCodeSpans(t.toolsLead)}</p>
+        <p className={`${t.bodyClassName} mt-3`}>{t.toolsTrust}</p>
       </section>
 
       <section id="server" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">
-          {isZh ? "把 Codewhale 作为 MCP 服务器" : "Codewhale as an MCP server"}
-        </h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh ? (
-            <>
-              <code className="inline">codewhale serve --mcp</code> 会把 Codewhale
-              作为 stdio MCP 服务器运行，让其他会话（或任何 MCP 客户端）调用它的工具；
-              <code className="inline">codewhale mcp-server</code> 是 dispatcher
-              暴露的等价入口。<code className="inline">codewhale mcp add-self</code>{" "}
-              会自动解析当前二进制路径并把服务器写进你的 MCP 配置。注意区分：
-              <code className="inline">serve --http</code> 是运行时 HTTP/SSE API，是另一种模式。
-            </>
-          ) : (
-            <>
-              <code className="inline">codewhale serve --mcp</code> runs Codewhale as an stdio MCP
-              server so other sessions (or any MCP client) can call its tools;{" "}
-              <code className="inline">codewhale mcp-server</code> is the equivalent dispatcher
-              entrypoint. <code className="inline">codewhale mcp add-self</code> resolves the current
-              binary path and writes the server into your MCP config. Keep the modes distinct:{" "}
-              <code className="inline">serve --http</code> is the runtime HTTP/SSE API, a separate
-              surface.
-            </>
-          )}
-        </p>
+        <h2 className="font-display text-2xl mb-1">{t.serverTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{withCodeSpans(t.serverLead)}</p>
       </section>
 
       <section id="source" className="hairline-t pt-8">
-        <p className="text-sm text-ink-mute">
-          {isZh
-            ? "来源文档：docs/MCP.md · 更新时请同步修改 docs-map.ts。"
-            : "Source document: docs/MCP.md · Update docs-map.ts when changing."}
-        </p>
+        <p className="text-sm text-ink-mute">{t.sourceNote}</p>
       </section>
     </section>
   );

--- a/web/app/[locale]/docs/subagents/page.tsx
+++ b/web/app/[locale]/docs/subagents/page.tsx
@@ -1,143 +1,92 @@
+import { Fragment } from "react";
+import { getDocsSubagents, splitTokens } from "@/lib/i18n/dictionaries";
 import { buildPageMetadata } from "@/lib/page-meta";
+
+/** Role identifiers, in the order the page lists them. Not copy. */
+const ROLE_ORDER = [
+  "worker",
+  "scout",
+  "planner",
+  "reviewer",
+  "builder",
+  "verifier",
+  "consultant",
+  "custom",
+] as const;
+
+const CODE_SPANS: Record<string, string> = {
+  agentTool: "agent",
+  forkContext: "fork_context: true",
+  worktreeFlag: "worktree: true",
+  branchPattern: "codex/agent-<name>-<id>",
+  worktreeDir: ".codewhale-worktrees/",
+  writeAuthority: "write_authority",
+  writeRoots: "write_roots",
+  exactFiles: "exact_files",
+  coordinationContracts: "coordination_contracts",
+};
+
+function withCodeSpans(template: string) {
+  return splitTokens(template).map((part, i) =>
+    "token" in part ? (
+      <code key={`${i}-${part.token}`} className="inline">
+        {CODE_SPANS[part.token] ?? `{${part.token}}`}
+      </code>
+    ) : (
+      <Fragment key={`${i}-text`}>{part.text}</Fragment>
+    ),
+  );
+}
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
+  const t = getDocsSubagents(locale);
   return buildPageMetadata({
     path: "/docs/subagents",
     locale,
-    title: isZh ? "子 Agent · Codewhale 文档" : "Sub-Agents · Codewhale Docs",
-    description: isZh
-      ? "agent 工具、Fleet 角色、上下文分叉、worktree 隔离和并发上限。"
-      : "The agent tool, Fleet roles, context forking, worktree isolation, and concurrency caps.",
+    title: t.metaTitle,
+    description: t.metaDescription,
   });
 }
 
 export default async function SubagentsPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const isZh = locale === "zh";
-  const bodyClass = isZh
-    ? "text-ink-soft leading-[1.9] tracking-wide"
-    : "text-ink-soft leading-relaxed";
-  const roles = isZh
-    ? [
-        { name: "worker", detail: "灵活执行父级交代的多步任务；可写、可用 shell。默认角色。" },
-        { name: "scout", detail: "只读，快速摸清相关代码——例如“找出 Foo 的所有调用点”。" },
-        { name: "planner", detail: "分析并产出策略，不执行——“设计迁移方案，不要动手”。" },
-        { name: "reviewer", detail: "只读审查并按严重度打分——“审一遍这个 PR 的 bug”。" },
-        { name: "builder", detail: "以最小改动落地一个明确的变更；可写、可用 shell。" },
-        { name: "verifier", detail: "运行测试和校验并汇报结果，不写代码。" },
-        { name: "consultant", detail: "只读的高推理力度顾问，用于判断类问题和设计评审。" },
-        { name: "custom", detail: "手工指定狭窄的工具白名单，用于锁定的派发。" },
-      ]
-    : [
-        { name: "worker", detail: "Flexible multi-step execution of the parent's brief; writes and shell allowed. The default role." },
-        { name: "scout", detail: "Read-only, maps the relevant code fast — “find every call site of Foo.”" },
-        { name: "planner", detail: "Analyse and produce a strategy without executing — “design the migration; don't run it.”" },
-        { name: "reviewer", detail: "Read-and-grade with severity scores — “audit this PR for bugs.”" },
-        { name: "builder", detail: "Land a specific change with minimal edits; writes and shell allowed." },
-        { name: "verifier", detail: "Run tests and validation gates and report the outcome; no code edits." },
-        { name: "consultant", detail: "Read-only high-reasoning counsel for judgement calls and design critique." },
-        { name: "custom", detail: "An explicit narrow tool allowlist for locked-down dispatch." },
-      ];
+  const t = getDocsSubagents(locale);
+  const roleDetails = new Map(t.roles);
 
   return (
     <section className="space-y-10">
       <section id="overview" className="scroll-mt-32">
-        <h1 className="font-display text-3xl mb-1">{isZh ? "子 Agent" : "Sub-Agents"}</h1>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "父会话通过 agent 工具启动一个有明确职责的子 Agent，并立即拿回 agent_id、compact 收据和 transcript 句柄；子 Agent 在后台运行。子 Agent 默认继承父级的工具注册表，但它们是叶子 worker：不会再拿到 agent 或嵌套生命周期工具。agent 启动的是分离的后台工作——取消父回合会停止父级的等待路径，但不会杀死已经启动的子运行。"
-            : "A parent session launches one focused sub-agent through the agent tool and immediately gets back an agent_id, a compact receipt, and a transcript handle while the worker runs in the background. Sub-agents inherit the parent's tool registry by default, but they are leaf workers: they do not receive agent or nested lifecycle tools. agent launches detached background work — cancelling the parent turn stops the parent's wait path, but it does not kill already-opened child runs."}
-        </p>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "对于必须跨进程重启、睡眠或远程执行存活的工作，优先选择 Fleet 或 Workflow 支撑的 Fleet 运行，而不是会话内的短寿命 agent 调用。"
-            : "For work that must survive process restarts, sleep, or remote execution, prefer Fleet or a Workflow-backed fleet run over a short in-session agent call."}
-        </p>
+        <h1 className="font-display text-3xl mb-1">{t.overviewTitle}</h1>
+        <p className={`${t.bodyClassName} mt-3`}>{t.overviewLead}</p>
+        <p className={`${t.bodyClassName} mt-3`}>{t.overviewFleetNote}</p>
         <div className="hairline-t mt-6">
-          {roles.map((row) => (
-            <section key={row.name} className="py-4 hairline-b">
-              <h3 className="font-display text-lg">{row.name}</h3>
-              <p className={`${bodyClass} mt-1 text-sm`}>{row.detail}</p>
+          {ROLE_ORDER.map((role) => (
+            <section key={role} className="py-4 hairline-b">
+              <h3 className="font-display text-lg">{role}</h3>
+              <p className={`${t.bodyClassName} mt-1 text-sm`}>{roleDetails.get(role)}</p>
             </section>
           ))}
         </div>
       </section>
 
       <section id="fork" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "上下文分叉" : "Context forking"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh ? (
-            <>
-              <code className="inline">agent</code> 默认开启全新会话：子 Agent 只拿到角色提示词和你给的任务。当任务依赖父
-              transcript 里已有的决定、文件、待办或计划状态时，用{" "}
-              <code className="inline">fork_context: true</code>
-              ——运行时在可用时保持父级前缀逐字节一致（保留前缀缓存复用），追加一份结构化状态快照，再把子
-              Agent 的角色说明和任务放在末尾。独立探索用新会话，延续、审查、总结或压缩类工作用分叉会话。
-            </>
-          ) : (
-            <>
-              <code className="inline">agent</code> starts fresh by default: the child gets its role
-              prompt plus the task you pass. When the task depends on decisions, files, todos, or plan
-              state already in the parent transcript, use{" "}
-              <code className="inline">fork_context: true</code> — the runtime keeps the parent's
-              request prefix byte-identical where available (preserving prefix-cache reuse), appends a
-              structured state snapshot, then adds the sub-agent role instructions and task at the tail.
-              Use fresh sessions for independent exploration and forked sessions for continuation,
-              review, summarization, or compaction work.
-            </>
-          )}
-        </p>
+        <h2 className="font-display text-2xl mb-1">{t.forkTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{withCodeSpans(t.forkLead)}</p>
       </section>
 
       <section id="worktree" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "Worktree 隔离" : "Worktree isolation"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh ? (
-            <>
-              并行编辑通道用 <code className="inline">worktree: true</code> 启动：Codewhale
-              为子 Agent 创建新的 git worktree 和分支（默认{" "}
-              <code className="inline">codex/agent-&lt;name&gt;-&lt;id&gt;</code>，检出在父仓库旁的{" "}
-              <code className="inline">.codewhale-worktrees/</code> 下），父检出保持干净。隔离不等于写权限：只带
-              prompt 的 worker 从只读开始；要写代码的子 Agent 还需声明{" "}
-              <code className="inline">write_authority</code> 和至少一个规范化的{" "}
-              <code className="inline">write_roots</code>、<code className="inline">exact_files</code>{" "}
-              或 <code className="inline">coordination_contracts</code>
-              值；重叠的共享写声明会在任何改动之前失败。
-            </>
-          ) : (
-            <>
-              Launch parallel edit lanes with <code className="inline">worktree: true</code>: Codewhale
-              creates a fresh git worktree and branch for the child (default{" "}
-              <code className="inline">codex/agent-&lt;name&gt;-&lt;id&gt;</code>, checked out beside the
-              parent repo under <code className="inline">.codewhale-worktrees/</code>) so the parent
-              checkout stays clean. Isolation is not write authority: a prompt-only worker starts
-              read-only, and a writer also declares{" "}
-              <code className="inline">write_authority</code> plus at least one normalized{" "}
-              <code className="inline">write_roots</code>, <code className="inline">exact_files</code>,
-              or <code className="inline">coordination_contracts</code> value. Overlapping shared write
-              claims fail before any mutation.
-            </>
-          )}
-        </p>
+        <h2 className="font-display text-2xl mb-1">{t.worktreeTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{withCodeSpans(t.worktreeLead)}</p>
       </section>
 
       <section id="capacity" className="scroll-mt-32">
-        <h2 className="font-display text-2xl mb-1">{isZh ? "并发上限" : "Concurrency caps"}</h2>
-        <p className={`${bodyClass} mt-3`}>
-          {isZh
-            ? "子 Agent 容量的权威来源是 crates/tui/src/config/subagent_limits.rs：默认配置并发 64，最大配置并发 128，运行加排队的最大准入 1024。这些是容量上限，不是建议把每个槽位都派出去——管理者应使用最小的有效扇出，保持单一汇总负责人，并在汇报整体完成前验证 worker 收据。"
-            : "The sub-agent capacity source of truth is crates/tui/src/config/subagent_limits.rs: default configured concurrency is 64, maximum configured concurrency is 128, and maximum admitted running-plus-queued work is 1024. These are capacity ceilings, not advice to dispatch every slot — a manager should use the smallest useful fan-out, keep a single fan-in owner, and verify worker receipts before reporting combined completion."}
-        </p>
+        <h2 className="font-display text-2xl mb-1">{t.capacityTitle}</h2>
+        <p className={`${t.bodyClassName} mt-3`}>{t.capacityLead}</p>
       </section>
 
       <section id="source" className="hairline-t pt-8">
-        <p className="text-sm text-ink-mute">
-          {isZh
-            ? "来源文档：docs/SUBAGENTS.md · 更新时请同步修改 docs-map.ts。"
-            : "Source document: docs/SUBAGENTS.md · Update docs-map.ts when changing."}
-        </p>
+        <p className="text-sm text-ink-mute">{t.sourceNote}</p>
       </section>
     </section>
   );

--- a/web/lib/i18n/dictionaries.test.ts
+++ b/web/lib/i18n/dictionaries.test.ts
@@ -5,8 +5,10 @@ import {
   EN_DOCS_GUIDE,
   EN_DOCS_CONSTITUTION,
   EN_DOCS_HOOKS,
+  EN_DOCS_MCP,
   EN_DOCS_RUNTIME_API,
   EN_DOCS_SANDBOX,
+  EN_DOCS_SUBAGENTS,
   EN_DOCS_WEB,
   EN_DOCS_SHELL,
   EN_DOCS_TROUBLESHOOTING,
@@ -16,8 +18,10 @@ import {
   getDocsGuide,
   getDocsConstitution,
   getDocsHooks,
+  getDocsMcp,
   getDocsRuntimeApi,
   getDocsSandbox,
+  getDocsSubagents,
   getDocsWeb,
   getDocsShell,
   getDocsTroubleshooting,
@@ -246,20 +250,28 @@ describe("website dictionaries", () => {
   });
 
   it("holds the docs page-body dictionaries to the same contract (#5337)", () => {
-    for (const [label, get, reference] of [
-      ["docs-hooks", getDocsHooks, EN_DOCS_HOOKS],
-      ["docs-troubleshooting", getDocsTroubleshooting, EN_DOCS_TROUBLESHOOTING],
-      ["docs-constitution", getDocsConstitution, EN_DOCS_CONSTITUTION],
-      ["docs-runtime-api", getDocsRuntimeApi, EN_DOCS_RUNTIME_API],
-      ["docs-sandbox", getDocsSandbox, EN_DOCS_SANDBOX],
-      ["docs-web", getDocsWeb, EN_DOCS_WEB],
+    // The probe is the key checked for a real zh translation. It is
+    // `overviewTitle` everywhere except docs/mcp, whose heading is the
+    // code-owned literal `MCP` and stays in the page.
+    for (const [label, get, reference, probe] of [
+      ["docs-hooks", getDocsHooks, EN_DOCS_HOOKS, "overviewTitle"],
+      ["docs-troubleshooting", getDocsTroubleshooting, EN_DOCS_TROUBLESHOOTING, "overviewTitle"],
+      ["docs-constitution", getDocsConstitution, EN_DOCS_CONSTITUTION, "overviewTitle"],
+      ["docs-runtime-api", getDocsRuntimeApi, EN_DOCS_RUNTIME_API, "overviewTitle"],
+      ["docs-sandbox", getDocsSandbox, EN_DOCS_SANDBOX, "overviewTitle"],
+      ["docs-subagents", getDocsSubagents, EN_DOCS_SUBAGENTS, "overviewTitle"],
+      ["docs-mcp", getDocsMcp, EN_DOCS_MCP, "metaTitle"],
+      ["docs-web", getDocsWeb, EN_DOCS_WEB, "overviewTitle"],
     ] as const) {
       const enKeys = Object.keys(reference).sort();
       for (const locale of [...DICTIONARY_LOCALES, "fr", "und"]) {
         expect(Object.keys(get(locale)).sort(), `${locale} ${label} keys`).toEqual(enKeys);
       }
       // zh ships a real translation, not an English pass-through.
-      expect(get("zh").overviewTitle, `zh ${label}`).not.toBe(reference.overviewTitle);
+      expect(
+        (get("zh") as Record<string, unknown>)[probe],
+        `zh ${label} ${probe}`,
+      ).not.toBe((reference as Record<string, unknown>)[probe]);
       // Every other locale renders English today, exactly as the `isZh`
       // ternaries in the page did before the move.
       for (const locale of ["ja", "fr", "ar", "und"]) {
@@ -286,6 +298,21 @@ describe("website dictionaries", () => {
       // The platform rows are keyed by their own translated name rather than a
       // code-owned key, so only the count is comparable across locales.
       expect(getDocsSandbox(locale).platforms, `${locale} sandbox platforms`).toHaveLength(4);
+      // Role names are identifiers the page owns, so the keys are comparable
+      // across locales rather than only the count.
+      expect(
+        getDocsSubagents(locale).roles.map(([key]) => key),
+        `${locale} subagent roles`,
+      ).toEqual([
+        "worker",
+        "scout",
+        "planner",
+        "reviewer",
+        "builder",
+        "verifier",
+        "consultant",
+        "custom",
+      ]);
     }
   });
 
@@ -322,6 +349,51 @@ describe("website dictionaries", () => {
         "legacyTokenEnv",
         "insecureFlag",
         "mobileFlag",
+      ]);
+    }
+  });
+
+  it("carries every code-span token through the subagents and mcp copy", () => {
+    const tokensOf = (template: string) =>
+      splitTokens(template).flatMap((part) => ("token" in part ? [part.token] : []));
+    for (const locale of [...DICTIONARY_LOCALES, "und"]) {
+      const subagents = getDocsSubagents(locale);
+      expect(tokensOf(subagents.forkLead), `${locale} forkLead`).toEqual([
+        "agentTool",
+        "forkContext",
+      ]);
+      expect(tokensOf(subagents.worktreeLead), `${locale} worktreeLead`).toEqual([
+        "worktreeFlag",
+        "branchPattern",
+        "worktreeDir",
+        "writeAuthority",
+        "writeRoots",
+        "exactFiles",
+        "coordinationContracts",
+      ]);
+      const mcp = getDocsMcp(locale);
+      expect(tokensOf(mcp.overviewConfig), `${locale} mcp overviewConfig`).toEqual([
+        "configPath",
+        "legacyConfigPath",
+        "configPathOption",
+        "configEnvVar",
+        "serversKey",
+      ]);
+      expect(tokensOf(mcp.setupLead), `${locale} mcp setupLead`).toEqual([
+        "initCommand",
+        "mcpCommand",
+      ]);
+      expect(tokensOf(mcp.toolsLead), `${locale} mcp toolsLead`).toEqual([
+        "toolNamePattern",
+        "gitServer",
+        "statusTool",
+        "gitStatusTool",
+      ]);
+      expect(tokensOf(mcp.serverLead), `${locale} mcp serverLead`).toEqual([
+        "serveMcp",
+        "mcpServerCommand",
+        "addSelfCommand",
+        "serveHttp",
       ]);
     }
   });

--- a/web/lib/i18n/dictionaries.test.ts
+++ b/web/lib/i18n/dictionaries.test.ts
@@ -250,28 +250,24 @@ describe("website dictionaries", () => {
   });
 
   it("holds the docs page-body dictionaries to the same contract (#5337)", () => {
-    // The probe is the key checked for a real zh translation. It is
-    // `overviewTitle` everywhere except docs/mcp, whose heading is the
-    // code-owned literal `MCP` and stays in the page.
-    for (const [label, get, reference, probe] of [
-      ["docs-hooks", getDocsHooks, EN_DOCS_HOOKS, "overviewTitle"],
-      ["docs-troubleshooting", getDocsTroubleshooting, EN_DOCS_TROUBLESHOOTING, "overviewTitle"],
-      ["docs-constitution", getDocsConstitution, EN_DOCS_CONSTITUTION, "overviewTitle"],
-      ["docs-runtime-api", getDocsRuntimeApi, EN_DOCS_RUNTIME_API, "overviewTitle"],
-      ["docs-sandbox", getDocsSandbox, EN_DOCS_SANDBOX, "overviewTitle"],
-      ["docs-subagents", getDocsSubagents, EN_DOCS_SUBAGENTS, "overviewTitle"],
-      ["docs-mcp", getDocsMcp, EN_DOCS_MCP, "metaTitle"],
-      ["docs-web", getDocsWeb, EN_DOCS_WEB, "overviewTitle"],
+    for (const [label, get, reference] of [
+      ["docs-hooks", getDocsHooks, EN_DOCS_HOOKS],
+      ["docs-troubleshooting", getDocsTroubleshooting, EN_DOCS_TROUBLESHOOTING],
+      ["docs-constitution", getDocsConstitution, EN_DOCS_CONSTITUTION],
+      ["docs-runtime-api", getDocsRuntimeApi, EN_DOCS_RUNTIME_API],
+      ["docs-sandbox", getDocsSandbox, EN_DOCS_SANDBOX],
+      ["docs-subagents", getDocsSubagents, EN_DOCS_SUBAGENTS],
+      ["docs-mcp", getDocsMcp, EN_DOCS_MCP],
+      ["docs-web", getDocsWeb, EN_DOCS_WEB],
     ] as const) {
       const enKeys = Object.keys(reference).sort();
       for (const locale of [...DICTIONARY_LOCALES, "fr", "und"]) {
         expect(Object.keys(get(locale)).sort(), `${locale} ${label} keys`).toEqual(enKeys);
       }
-      // zh ships a real translation, not an English pass-through.
-      expect(
-        (get("zh") as Record<string, unknown>)[probe],
-        `zh ${label} ${probe}`,
-      ).not.toBe((reference as Record<string, unknown>)[probe]);
+      // zh ships a real translation, not an English pass-through. The probe is
+      // `metaTitle` rather than `overviewTitle` because docs/mcp's heading is
+      // the code-owned literal `MCP` and stays in the page.
+      expect(get("zh").metaTitle, `zh ${label}`).not.toBe(reference.metaTitle);
       // Every other locale renders English today, exactly as the `isZh`
       // ternaries in the page did before the move.
       for (const locale of ["ja", "fr", "ar", "und"]) {

--- a/web/lib/i18n/dictionaries/en/docs-mcp.ts
+++ b/web/lib/i18n/dictionaries/en/docs-mcp.ts
@@ -1,0 +1,34 @@
+import type { DocsMcpDict } from "../types";
+
+/**
+ * English reference dictionary for `app/[locale]/docs/mcp/page.tsx`.
+ * Copy moved verbatim from the page's `isZh` ternaries — any wording change
+ * belongs in its own commit, never mixed into a structural move.
+ */
+export const docsMcp: DocsMcpDict = {
+  metaTitle: "MCP · Codewhale Docs",
+  metaDescription:
+    "Consume external tool servers over the Model Context Protocol, or expose Codewhale itself as an MCP server.",
+  bodyClassName: "text-ink-soft leading-relaxed",
+  overviewLead:
+    "Codewhale can load additional tools via MCP (Model Context Protocol). MCP servers can be local stdio processes that the TUI starts, or remote URL-based servers that speak Streamable HTTP with legacy SSE fallback. A successfully connected server registers its tools into the model catalog; a failed or disabled server is never presented as an available tool.",
+  overviewConfig:
+    "The config file defaults to {configPath} (the legacy {legacyConfigPath} is still read when the Codewhale file is absent), overridable with {configPathOption} or {configEnvVar}. The {serversKey} key used by other clients is accepted too.",
+  setupTitle: "Setup and management",
+  setupLead:
+    "Bootstrap a starter config with {initCommand}; inside the TUI, {mcpCommand} opens a compact manager showing each server's enabled state, transport, command or URL, timeouts, and connection errors. Common commands:",
+  setupReload:
+    "Config edits made from the TUI are written immediately, but the model-visible MCP tool pool is not hot-reloaded — the manager marks it restart-required. /mcp validate and /mcp reload reconnect to refresh the on-screen snapshot.",
+  authTitle: "Remote authentication",
+  authLead:
+    "URL-based servers can use static headers, env-derived env_headers, bearer_token_env_var, or OAuth. Precedence is conservative: headers and env_headers apply first; bearer_token_env_var adds an Authorization header only when one is not already set; OAuth login tokens likewise never override an explicit header. Avoid committing literal Authorization headers — prefer env_headers, bearer_token_env_var, or OAuth login so secrets stay outside the MCP file.",
+  toolsTitle: "Tool naming and safety",
+  toolsLead:
+    "Discovered MCP tools are exposed to the model as {toolNamePattern} — a server named {gitServer} with a {statusTool} tool becomes {gitStatusTool}. MCP tools flow through the same approval framework as built-in tools: read-only MCP helpers can run without prompts when policy permits, side-effectful MCP tools require approval, and Full Access does not bypass hard policy holds.",
+  toolsTrust:
+    "Only configure MCP servers you trust, and treat MCP server configuration as equivalent to running code on your machine. Reviewed local plugin bundles can also contribute MCP servers: they reuse the same MCP manager, approval, and network-policy paths, appear under namespaced <plugin>-<server> identities, and are held to a stricter boundary than hand-written mcp.json.",
+  serverTitle: "Codewhale as an MCP server",
+  serverLead:
+    "{serveMcp} runs Codewhale as an stdio MCP server so other sessions (or any MCP client) can call its tools; {mcpServerCommand} is the equivalent dispatcher entrypoint. {addSelfCommand} resolves the current binary path and writes the server into your MCP config. Keep the modes distinct: {serveHttp} is the runtime HTTP/SSE API, a separate surface.",
+  sourceNote: "Source document: docs/MCP.md · Update docs-map.ts when changing.",
+};

--- a/web/lib/i18n/dictionaries/en/docs-subagents.ts
+++ b/web/lib/i18n/dictionaries/en/docs-subagents.ts
@@ -1,0 +1,47 @@
+import type { DocsSubagentsDict } from "../types";
+
+/**
+ * English reference dictionary for `app/[locale]/docs/subagents/page.tsx`.
+ * Copy moved verbatim from the page's `isZh` ternaries — any wording change
+ * belongs in its own commit, never mixed into a structural move.
+ */
+export const docsSubagents: DocsSubagentsDict = {
+  metaTitle: "Sub-Agents · Codewhale Docs",
+  metaDescription:
+    "The agent tool, Fleet roles, context forking, worktree isolation, and concurrency caps.",
+  bodyClassName: "text-ink-soft leading-relaxed",
+  overviewTitle: "Sub-Agents",
+  overviewLead:
+    "A parent session launches one focused sub-agent through the agent tool and immediately gets back an agent_id, a compact receipt, and a transcript handle while the worker runs in the background. Sub-agents inherit the parent's tool registry by default, but they are leaf workers: they do not receive agent or nested lifecycle tools. agent launches detached background work — cancelling the parent turn stops the parent's wait path, but it does not kill already-opened child runs.",
+  overviewFleetNote:
+    "For work that must survive process restarts, sleep, or remote execution, prefer Fleet or a Workflow-backed fleet run over a short in-session agent call.",
+  roles: [
+    [
+      "worker",
+      "Flexible multi-step execution of the parent's brief; writes and shell allowed. The default role.",
+    ],
+    ["scout", "Read-only, maps the relevant code fast — “find every call site of Foo.”"],
+    [
+      "planner",
+      "Analyse and produce a strategy without executing — “design the migration; don't run it.”",
+    ],
+    ["reviewer", "Read-and-grade with severity scores — “audit this PR for bugs.”"],
+    ["builder", "Land a specific change with minimal edits; writes and shell allowed."],
+    ["verifier", "Run tests and validation gates and report the outcome; no code edits."],
+    [
+      "consultant",
+      "Read-only high-reasoning counsel for judgement calls and design critique.",
+    ],
+    ["custom", "An explicit narrow tool allowlist for locked-down dispatch."],
+  ],
+  forkTitle: "Context forking",
+  forkLead:
+    "{agentTool} starts fresh by default: the child gets its role prompt plus the task you pass. When the task depends on decisions, files, todos, or plan state already in the parent transcript, use {forkContext} — the runtime keeps the parent's request prefix byte-identical where available (preserving prefix-cache reuse), appends a structured state snapshot, then adds the sub-agent role instructions and task at the tail. Use fresh sessions for independent exploration and forked sessions for continuation, review, summarization, or compaction work.",
+  worktreeTitle: "Worktree isolation",
+  worktreeLead:
+    "Launch parallel edit lanes with {worktreeFlag}: Codewhale creates a fresh git worktree and branch for the child (default {branchPattern}, checked out beside the parent repo under {worktreeDir}) so the parent checkout stays clean. Isolation is not write authority: a prompt-only worker starts read-only, and a writer also declares {writeAuthority} plus at least one normalized {writeRoots}, {exactFiles}, or {coordinationContracts} value. Overlapping shared write claims fail before any mutation.",
+  capacityTitle: "Concurrency caps",
+  capacityLead:
+    "The sub-agent capacity source of truth is crates/tui/src/config/subagent_limits.rs: default configured concurrency is 64, maximum configured concurrency is 128, and maximum admitted running-plus-queued work is 1024. These are capacity ceilings, not advice to dispatch every slot — a manager should use the smallest useful fan-out, keep a single fan-in owner, and verify worker receipts before reporting combined completion.",
+  sourceNote: "Source document: docs/SUBAGENTS.md · Update docs-map.ts when changing.",
+};

--- a/web/lib/i18n/dictionaries/index.ts
+++ b/web/lib/i18n/dictionaries/index.ts
@@ -19,10 +19,12 @@ import type {
   DocsFleetDict,
   DocsGuideDict,
   DocsHooksDict,
+  DocsMcpDict,
   DocsRuntimeApiDict,
   DocsSandboxDict,
   DocsShellDict,
   DocsModesDict,
+  DocsSubagentsDict,
   DocsTroubleshootingDict,
   DocsWebDict,
   HomeDict,
@@ -43,12 +45,16 @@ import { docsConstitution as enDocsConstitution } from "./en/docs-constitution";
 import { docsConstitution as zhDocsConstitution } from "./zh/docs-constitution";
 import { docsFleet as enDocsFleet } from "./en/docs-fleet";
 import { docsFleet as zhDocsFleet } from "./zh/docs-fleet";
+import { docsMcp as enDocsMcp } from "./en/docs-mcp";
+import { docsMcp as zhDocsMcp } from "./zh/docs-mcp";
 import { docsModes as enDocsModes } from "./en/docs-modes";
 import { docsModes as zhDocsModes } from "./zh/docs-modes";
 import { docsRuntimeApi as enDocsRuntimeApi } from "./en/docs-runtime-api";
 import { docsRuntimeApi as zhDocsRuntimeApi } from "./zh/docs-runtime-api";
 import { docsSandbox as enDocsSandbox } from "./en/docs-sandbox";
 import { docsSandbox as zhDocsSandbox } from "./zh/docs-sandbox";
+import { docsSubagents as enDocsSubagents } from "./en/docs-subagents";
+import { docsSubagents as zhDocsSubagents } from "./zh/docs-subagents";
 import { docsWeb as enDocsWeb } from "./en/docs-web";
 import { docsWeb as zhDocsWeb } from "./zh/docs-web";
 import { chrome as zhChrome } from "./zh/chrome";
@@ -180,6 +186,10 @@ const DOCS_FLEET: Record<string, DocsFleetDict> = {
   zh: zhDocsFleet,
 };
 
+const DOCS_MCP: Record<string, DocsMcpDict> = {
+  zh: zhDocsMcp,
+};
+
 const DOCS_MODES: Record<string, DocsModesDict> = {
   zh: zhDocsModes,
 };
@@ -190,6 +200,10 @@ const DOCS_RUNTIME_API: Record<string, DocsRuntimeApiDict> = {
 
 const DOCS_SANDBOX: Record<string, DocsSandboxDict> = {
   zh: zhDocsSandbox,
+};
+
+const DOCS_SUBAGENTS: Record<string, DocsSubagentsDict> = {
+  zh: zhDocsSubagents,
 };
 
 const DOCS_WEB: Record<string, DocsWebDict> = {
@@ -232,6 +246,10 @@ export function getDocsFleet(locale: string): DocsFleetDict {
   return DOCS_FLEET[locale] ?? enDocsFleet;
 }
 
+export function getDocsMcp(locale: string): DocsMcpDict {
+  return DOCS_MCP[locale] ?? enDocsMcp;
+}
+
 export function getDocsModes(locale: string): DocsModesDict {
   return DOCS_MODES[locale] ?? enDocsModes;
 }
@@ -242,6 +260,10 @@ export function getDocsRuntimeApi(locale: string): DocsRuntimeApiDict {
 
 export function getDocsSandbox(locale: string): DocsSandboxDict {
   return DOCS_SANDBOX[locale] ?? enDocsSandbox;
+}
+
+export function getDocsSubagents(locale: string): DocsSubagentsDict {
+  return DOCS_SUBAGENTS[locale] ?? enDocsSubagents;
 }
 
 export function getDocsWeb(locale: string): DocsWebDict {
@@ -269,9 +291,11 @@ export const EN_DOCS_TROUBLESHOOTING = enDocsTroubleshooting;
 export const EN_DOCS_CONFIGURATION = enDocsConfiguration;
 export const EN_DOCS_CONSTITUTION = enDocsConstitution;
 export const EN_DOCS_FLEET = enDocsFleet;
+export const EN_DOCS_MCP = enDocsMcp;
 export const EN_DOCS_MODES = enDocsModes;
 export const EN_DOCS_RUNTIME_API = enDocsRuntimeApi;
 export const EN_DOCS_SANDBOX = enDocsSandbox;
+export const EN_DOCS_SUBAGENTS = enDocsSubagents;
 export const EN_DOCS_WEB = enDocsWeb;
 
 /** Interpolate `{name}` tokens in a dictionary template. Unknown tokens are

--- a/web/lib/i18n/dictionaries/types.ts
+++ b/web/lib/i18n/dictionaries/types.ts
@@ -423,6 +423,27 @@ export interface DocsFleetDict {
   sourceNote: string;
 }
 
+/** `app/[locale]/docs/mcp/page.tsx`. */
+export interface DocsMcpDict {
+  metaTitle: string;
+  metaDescription: string;
+  /** Body-copy typography for this locale (CJK needs looser leading). */
+  bodyClassName: string;
+  overviewLead: string;
+  overviewConfig: string;
+  setupTitle: string;
+  setupLead: string;
+  setupReload: string;
+  authTitle: string;
+  authLead: string;
+  toolsTitle: string;
+  toolsLead: string;
+  toolsTrust: string;
+  serverTitle: string;
+  serverLead: string;
+  sourceNote: string;
+}
+
 /** `app/[locale]/docs/modes/page.tsx`. */
 export interface DocsModesDict {
   metaTitle: string;
@@ -477,6 +498,26 @@ export interface DocsSandboxDict {
   diagnosticsTitle: string;
   diagnosticsLead: string;
   diagnosticsLimits: string;
+  sourceNote: string;
+}
+
+/** `app/[locale]/docs/subagents/page.tsx`. */
+export interface DocsSubagentsDict {
+  metaTitle: string;
+  metaDescription: string;
+  /** Body-copy typography for this locale (CJK needs looser leading). */
+  bodyClassName: string;
+  overviewTitle: string;
+  overviewLead: string;
+  overviewFleetNote: string;
+  /** Eight `[key, detail]` rows; the key names the page's role literal. */
+  roles: [string, string][];
+  forkTitle: string;
+  forkLead: string;
+  worktreeTitle: string;
+  worktreeLead: string;
+  capacityTitle: string;
+  capacityLead: string;
   sourceNote: string;
 }
 

--- a/web/lib/i18n/dictionaries/zh/docs-mcp.ts
+++ b/web/lib/i18n/dictionaries/zh/docs-mcp.ts
@@ -1,0 +1,30 @@
+import type { DocsMcpDict } from "../types";
+
+/** 中文对照见 `en/docs-mcp.ts`,文案自页面的 `isZh` 三元逐字迁入。 */
+export const docsMcp: DocsMcpDict = {
+  metaTitle: "MCP · Codewhale 文档",
+  metaDescription:
+    "通过 Model Context Protocol 消费外部工具服务器，或把 Codewhale 作为 MCP 服务器暴露。",
+  bodyClassName: "text-ink-soft leading-[1.9] tracking-wide",
+  overviewLead:
+    "Codewhale 可以通过 MCP（Model Context Protocol）加载额外的工具。MCP 服务器可以是由 TUI 启动的本地 stdio 进程，也可以是远程 URL 服务器（Streamable HTTP，带旧版 SSE 回退）。连接成功的服务器会把工具注册进模型目录；失败或被禁用的服务器不会作为可用工具呈现给模型。",
+  overviewConfig:
+    "配置文件默认在 {configPath}（新文件缺失时仍读取旧版 {legacyConfigPath}），可用 {configPathOption} 或 {configEnvVar} 覆盖。也兼容其他客户端使用的 {serversKey} 键名。",
+  setupTitle: "配置与管理",
+  setupLead:
+    "用 {initCommand} 生成初始配置；TUI 内的 {mcpCommand} 打开紧凑管理器，显示每个服务器的启用状态、传输方式、命令或 URL、超时和连接错误。常用命令：",
+  setupReload:
+    "在 TUI 里做的配置编辑会立即写盘，但模型可见的 MCP 工具池不会热加载——管理器会把它标记为需要重启。/mcp validate 和 /mcp reload 会重新连接以刷新界面快照。",
+  authTitle: "远程认证",
+  authLead:
+    "URL 服务器可以使用静态 headers、从环境变量派生的 env_headers、bearer_token_env_var 或 OAuth。优先级是保守的：先应用 headers 和 env_headers；bearer_token_env_var 只在尚未设置 Authorization 时添加；OAuth 登录获取的令牌同样不会覆盖已有的显式 header。应避免提交字面量 Authorization header——优先用 env_headers、bearer_token_env_var 或 OAuth 登录，让秘密留在 MCP 文件之外。",
+  toolsTitle: "工具命名与安全",
+  toolsLead:
+    "发现的 MCP 工具以 {toolNamePattern} 的形式暴露给模型——例如名为 {gitServer} 的服务器的 {statusTool} 工具会变成 {gitStatusTool}。MCP 工具和内置工具走同一套审批框架：只读的 MCP 辅助工具在策略允许时可免提示运行，有副作用的 MCP 工具需要审批，Full Access 也不会绕过硬策略拦截。",
+  toolsTrust:
+    "只配置你信任的 MCP 服务器，并把 MCP 服务器配置视为等同于在本机运行代码。经过审查的本地插件包也可以贡献 MCP 服务器：它们复用同一个 MCP 管理器、审批和网络策略路径，以 <plugin>-<server> 的命名空间身份出现，边界比手写的 mcp.json 更严格。",
+  serverTitle: "把 Codewhale 作为 MCP 服务器",
+  serverLead:
+    "{serveMcp} 会把 Codewhale 作为 stdio MCP 服务器运行，让其他会话（或任何 MCP 客户端）调用它的工具；{mcpServerCommand} 是 dispatcher 暴露的等价入口。{addSelfCommand} 会自动解析当前二进制路径并把服务器写进你的 MCP 配置。注意区分：{serveHttp} 是运行时 HTTP/SSE API，是另一种模式。",
+  sourceNote: "来源文档：docs/MCP.md · 更新时请同步修改 docs-map.ts。",
+};

--- a/web/lib/i18n/dictionaries/zh/docs-subagents.ts
+++ b/web/lib/i18n/dictionaries/zh/docs-subagents.ts
@@ -1,0 +1,36 @@
+import type { DocsSubagentsDict } from "../types";
+
+/** 中文对照见 `en/docs-subagents.ts`,文案自页面的 `isZh` 三元逐字迁入。 */
+export const docsSubagents: DocsSubagentsDict = {
+  metaTitle: "子 Agent · Codewhale 文档",
+  metaDescription: "agent 工具、Fleet 角色、上下文分叉、worktree 隔离和并发上限。",
+  bodyClassName: "text-ink-soft leading-[1.9] tracking-wide",
+  overviewTitle: "子 Agent",
+  overviewLead:
+    "父会话通过 agent 工具启动一个有明确职责的子 Agent，并立即拿回 agent_id、compact 收据和 transcript 句柄；子 Agent 在后台运行。子 Agent 默认继承父级的工具注册表，但它们是叶子 worker：不会再拿到 agent 或嵌套生命周期工具。agent 启动的是分离的后台工作——取消父回合会停止父级的等待路径，但不会杀死已经启动的子运行。",
+  overviewFleetNote:
+    "对于必须跨进程重启、睡眠或远程执行存活的工作，优先选择 Fleet 或 Workflow 支撑的 Fleet 运行，而不是会话内的短寿命 agent 调用。",
+  roles: [
+    ["worker", "灵活执行父级交代的多步任务；可写、可用 shell。默认角色。"],
+    ["scout", "只读，快速摸清相关代码——例如“找出 Foo 的所有调用点”。"],
+    ["planner", "分析并产出策略，不执行——“设计迁移方案，不要动手”。"],
+    ["reviewer", "只读审查并按严重度打分——“审一遍这个 PR 的 bug”。"],
+    ["builder", "以最小改动落地一个明确的变更；可写、可用 shell。"],
+    ["verifier", "运行测试和校验并汇报结果，不写代码。"],
+    ["consultant", "只读的高推理力度顾问，用于判断类问题和设计评审。"],
+    ["custom", "手工指定狭窄的工具白名单，用于锁定的派发。"],
+  ],
+  forkTitle: "上下文分叉",
+  forkLead:
+    "{agentTool} 默认开启全新会话：子 Agent 只拿到角色提示词和你给的任务。当任务依赖父 transcript 里已有的决定、文件、待办或计划状态时，用 {forkContext}——运行时在可用时保持父级前缀逐字节一致（保留前缀缓存复用），追加一份结构化状态快照，再把子 Agent 的角色说明和任务放在末尾。独立探索用新会话，延续、审查、总结或压缩类工作用分叉会话。",
+  worktreeTitle: "Worktree 隔离",
+  // No space before 值: the old JSX put a line break after the
+  // `coordination_contracts` span, and JSX drops leading whitespace that
+  // carries a newline. Reproduced so this stays a move, not a copy edit.
+  worktreeLead:
+    "并行编辑通道用 {worktreeFlag} 启动：Codewhale 为子 Agent 创建新的 git worktree 和分支（默认 {branchPattern}，检出在父仓库旁的 {worktreeDir} 下），父检出保持干净。隔离不等于写权限：只带 prompt 的 worker 从只读开始；要写代码的子 Agent 还需声明 {writeAuthority} 和至少一个规范化的 {writeRoots}、{exactFiles} 或 {coordinationContracts}值；重叠的共享写声明会在任何改动之前失败。",
+  capacityTitle: "并发上限",
+  capacityLead:
+    "子 Agent 容量的权威来源是 crates/tui/src/config/subagent_limits.rs：默认配置并发 64，最大配置并发 128，运行加排队的最大准入 1024。这些是容量上限，不是建议把每个槽位都派出去——管理者应使用最小的有效扇出，保持单一汇总负责人，并在汇报整体完成前验证 worker 收据。",
+  sourceNote: "来源文档：docs/SUBAGENTS.md · 更新时请同步修改 docs-map.ts。",
+};

--- a/web/scripts/check-locales.mjs
+++ b/web/scripts/check-locales.mjs
@@ -33,9 +33,11 @@ const OPTIONAL_FILES = [
   "docs-configuration.ts",
   "docs-constitution.ts",
   "docs-fleet.ts",
+  "docs-mcp.ts",
   "docs-modes.ts",
   "docs-runtime-api.ts",
   "docs-sandbox.ts",
+  "docs-subagents.ts",
   "docs-web.ts",
 ];
 


### PR DESCRIPTION
Next group in the #5337 series, after #5520. `docs/subagents` and `docs/mcp` carried 16 and 18 `isZh` branches; both are now zero. Same shape as the earlier groups: two dictionaries per page, `types.ts` and `index.ts` wired, and both files added to `check-locales.mjs`'s `OPTIONAL_FILES` so zh is held to key and token parity while the other sixteen locales fall back to English exactly as the ternaries did.

Two things here are new.

The eight sub-agent roles are identifiers rather than copy — `worker`, `scout`, `planner` and the rest read the same in both branches today. So the page keeps the list and its order in a `ROLE_ORDER` const and the dictionary keys each row by role name, carrying only the prose. That is the `docs/VOICE.md` code-owned rule applied to a list instead of a code span, and it lets the test compare row keys across locales rather than only the count, which is all the sandbox platform rows allow.

`docs/mcp`'s h1 is the literal `MCP` in every locale, so it stays in the page and there is no `overviewTitle` to translate. The shared key-parity test asserted `get("zh").overviewTitle` differs from the reference, which for this dictionary would have compared `undefined` against `undefined` and passed while checking nothing. It now takes the probe key per entry, `metaTitle` for this one.

The 36-page comparison caught one difference before this landed, the same class as the one in #5517. The old JSX wrapped a line right after the `coordination_contracts` span:

```
或 <code className="inline">coordination_contracts</code>
值；重叠的共享写声明会在任何改动之前失败。
```

JSX drops leading whitespace that carries a newline, so the live page has no space before `值`. The dictionary reproduces that, with a comment saying where it comes from — a move that also fixes typography is no longer a move.

Rendered output is otherwise unchanged. All 36 pages (18 locales x 2) compared against a clean worktree at the same base, keeping the inline tags with their `class` attributes rather than flattening them, and dropping React's `<!-- -->` text-node separators so a sentence built from one interpolated array compares equal to the same sentence built from several JSX children. The difference is empty. As a control, three one-word edits do get reported: one in a token sentence and one in an array row hit 17 pages each, and one in a zh string hits 1 — which is the fallback semantics, seventeen locales reading English and zh reading its own.

`npm run lint`, `npm test` (313 passing) and `npm run check:locales` are clean.

Remaining after this group: `docs/work`, `docs/vocabulary`, `docs/tools`. `docs/modes`, `docs/configuration` and `docs/fleet` moved in c07794747.

No-Issue: one page group of the #5337 series. The tracker was closed on 08-20 — happy to reopen it, or to keep carrying the remaining groups in the PR descriptions, whichever you prefer.
