### PR TITLE
fix(release): close pre-tag v0.9.11 truthfulness and tool-output gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,32 @@ item-level change record is retained below the categorized release highlights.
   credential keys. Project and global bundle operations now load and validate
   the document for their actual scope in both directions, including a
   workspace whose document still lives under the legacy app directory.
+- `codewhale login` now means Codewhale account sign-in (the same browser
+  device flow as `codewhale account login`, with `--no-open` and
+  `--timeout-seconds`); provider API keys are configured exclusively through
+  `codewhale auth set --provider <provider>`, and the hidden legacy
+  `--api-key`/`--provider` flags redirect loudly instead of silently writing
+  a key.
+- Account sessions prefer the OS credential manager and now fall back
+  automatically to the private `0600` Codewhale secrets file on headless
+  hosts, SSH boxes, and containers; the `CODEWHALE_CLOUD_ALLOW_FILE_SESSION_STORE`
+  opt-in is deprecated and ignored.
+- `/update` gained a `Ctrl+Shift+U` install chord (catalogued in
+  `docs/KEYBINDINGS.md`, localized in all 15 packs) and a startup hint that
+  names the previous and current version on the first launch of a newer
+  build, pointing at `/change`.
+- Fleet product-model copy pass: the TUI, docs, and locale packs now use
+  Fleet / Member / Role / Model / Access / Saved consistently so a user can
+  say "scout", "DeepSeek V4 Flash", or the member name and mean the same
+  thing.
+- Model-bound tool results now use a credential-shaped redaction policy:
+  only values that look like secrets (known prefixes, JWTs, bearer tokens,
+  PEM private-key blocks, long opaque strings) are masked before a `read` or
+  shell result reaches the model, so code such as `password:
+  credentials?.password` or `"password-validator": "^5.3.0"` stays byte-exact
+  for edits and read-back. Exact configured credential values are still always
+  replaced, and logs/previews/exports keep the broad key-based scrubber. (#5546,
+  reported by @ronohara)
 - Terminal input shutdown no longer waits forever on a wedged TTY read,
   Windows launch receipts can atomically replace an existing record, and the
   complete `/status` report now follows the active locale without rewriting

--- a/crates/cli/src/config_bundles.rs
+++ b/crates/cli/src/config_bundles.rs
@@ -113,10 +113,12 @@ pub fn parse_bundle_bytes(raw: &[u8], source: &str) -> Result<PortableBundle> {
 /// `.json` or the document starts with `{`.
 pub fn parse_bundle_str(text: &str, source: &str) -> Result<PortableBundle> {
     let trimmed = text.trim_start();
-    let bundle = if trimmed.starts_with('{') {
-        serde_json::from_str::<PortableBundle>(text)
-            .with_context(|| format!("bundle at {source} is not valid JSON"))?
-    } else if source.ends_with(".json") {
+    let bundle = if trimmed.starts_with('{') || source.ends_with(".json") {
+        // serde_json keeps the last of two identical object keys. A bundle is
+        // a reviewed plan, so a repeated key must fail before anything is
+        // planned or written, exactly as TOML already refuses duplicates.
+        reject_duplicate_json_keys(text)
+            .with_context(|| format!("bundle at {source} is not valid JSON"))?;
         serde_json::from_str::<PortableBundle>(text)
             .with_context(|| format!("bundle at {source} is not valid JSON"))?
     } else {
@@ -125,6 +127,103 @@ pub fn parse_bundle_str(text: &str, source: &str) -> Result<PortableBundle> {
     };
     validate_bundle(&bundle, source)?;
     Ok(bundle)
+}
+
+/// Fail closed on a JSON document that repeats an object key at any depth.
+///
+/// The document is walked with a deserializer seed that never materializes
+/// values, so the check costs one pass and reports the first offending key
+/// path without echoing any value.
+fn reject_duplicate_json_keys(text: &str) -> Result<()> {
+    use serde::de::{DeserializeSeed, Error as _, MapAccess, SeqAccess, Visitor};
+    use std::fmt;
+
+    struct NoDuplicates<'a> {
+        path: &'a mut Vec<String>,
+    }
+
+    impl<'de> DeserializeSeed<'de> for NoDuplicates<'_> {
+        type Value = ();
+
+        fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(self)
+        }
+    }
+
+    impl<'de> Visitor<'de> for NoDuplicates<'_> {
+        type Value = ();
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a JSON value without duplicate object keys")
+        }
+
+        fn visit_bool<E: serde::de::Error>(self, _: bool) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_i64<E: serde::de::Error>(self, _: i64) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_u64<E: serde::de::Error>(self, _: u64) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_f64<E: serde::de::Error>(self, _: f64) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_str<E: serde::de::Error>(self, _: &str) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_unit<E: serde::de::Error>(self) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_none<E: serde::de::Error>(self) -> Result<(), E> {
+            Ok(())
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
+            let mut index = 0usize;
+            loop {
+                self.path.push(format!("[{index}]"));
+                let next = seq.next_element_seed(NoDuplicates { path: self.path });
+                self.path.pop();
+                if next?.is_none() {
+                    return Ok(());
+                }
+                index += 1;
+            }
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
+            let mut seen = std::collections::BTreeSet::new();
+            while let Some(key) = map.next_key::<String>()? {
+                if !seen.insert(key.clone()) {
+                    let mut path = self.path.clone();
+                    path.push(key);
+                    return Err(A::Error::custom(format!(
+                        "duplicate key {:?}",
+                        path.join(".")
+                    )));
+                }
+                self.path.push(key);
+                let nested = map.next_value_seed(NoDuplicates { path: self.path });
+                self.path.pop();
+                nested?;
+            }
+            Ok(())
+        }
+    }
+
+    let mut deserializer = serde_json::Deserializer::from_str(text);
+    let mut path = Vec::new();
+    NoDuplicates { path: &mut path }
+        .deserialize(&mut deserializer)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    deserializer
+        .end()
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    Ok(())
 }
 
 fn validate_bundle(bundle: &PortableBundle, source: &str) -> Result<()> {
@@ -1540,6 +1639,27 @@ note = "{shaped_value}"
         let rendered = format!("{rejected:?}");
         assert!(!rendered.contains("nested-password-must-not-leak"));
         assert!(!rendered.contains("nested-token-must-not-leak"));
+    }
+
+    #[test]
+    fn json_bundles_with_duplicate_keys_fail_before_parse() {
+        let duplicate = r#"{"schema_version":1,"kind":"codewhale.portable-config","preferences":{"verbosity":"quiet","verbosity":"loud"}}"#;
+        let error = parse_bundle_str(duplicate, "dup.json").expect_err("duplicate key must fail");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("duplicate key"), "{rendered}");
+        assert!(rendered.contains("preferences.verbosity"), "{rendered}");
+        assert!(!rendered.contains("loud"), "{rendered}");
+
+        let nested_array = r#"{"schema_version":1,"kind":"codewhale.portable-config","preferences":{"list":[{"a":1,"a":2}]}}"#;
+        let error = parse_bundle_str(nested_array, "dup-array.json")
+            .expect_err("nested duplicate must fail");
+        assert!(
+            format!("{error:#}").contains("preferences.list.[0].a"),
+            "{error:#}"
+        );
+
+        let clean = r#"{"schema_version":1,"kind":"codewhale.portable-config","preferences":{"verbosity":"quiet","profiles":{"verbosity":"loud"}}}"#;
+        parse_bundle_str(clean, "clean.json").expect("same key under different parents is fine");
     }
 
     #[test]

--- a/crates/config/src/persistence.rs
+++ b/crates/config/src/persistence.rs
@@ -314,28 +314,78 @@ pub fn redact_json_secrets(value: &serde_json::Value) -> serde_json::Value {
 /// backstop for anything that echoes raw config text.
 #[must_use]
 pub fn redact_secrets(input: &str) -> String {
+    redact_secrets_with(input, RedactionPolicy::KeyBased)
+}
+
+/// How aggressively [`redact_secrets_with`] treats a sensitive-looking key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedactionPolicy {
+    /// Mask the value of every sensitive-looking key, whatever the value is.
+    /// Right for logs, previews, exports, and diagnostics: a false positive
+    /// costs nothing there and a miss leaks a credential.
+    KeyBased,
+    /// Mask a keyed value only when the value itself looks like a credential
+    /// (known prefix, JWT, bearer token, PEM block, long opaque string).
+    /// Right for text the model must be able to quote back byte-for-byte,
+    /// such as tool results that feed exact-match edits: `password:
+    /// credentials?.password`, `"password-validator": "^5.3.0"`, or
+    /// `token = make_token()` are code, not secrets (#5546).
+    CredentialShaped,
+}
+
+/// Redact model-bound tool output: exact configured credential values are the
+/// caller's job; this masks only values that look like credentials so the
+/// model keeps seeing the real bytes of ordinary code and config.
+#[must_use]
+pub fn redact_model_bound_secrets(input: &str) -> String {
+    redact_secrets_with(input, RedactionPolicy::CredentialShaped)
+}
+
+/// [`redact_secrets`] with an explicit [`RedactionPolicy`].
+#[must_use]
+pub fn redact_secrets_with(input: &str, policy: RedactionPolicy) -> String {
     let mut out = String::with_capacity(input.len());
-    let mut first = true;
+    let mut in_private_key_block = false;
     for line in input.split_inclusive('\n') {
-        if !first {
-            // split_inclusive keeps the newline on the previous chunk, so we do
-            // not need to re-add separators here.
+        // split_inclusive keeps the newline on the previous chunk, so we do
+        // not need to re-add separators here.
+        let body = line.strip_suffix('\n').unwrap_or(line);
+        let trimmed = body.trim();
+        if in_private_key_block {
+            if trimmed.starts_with("-----END") {
+                in_private_key_block = false;
+                out.push_str(line);
+            } else {
+                out.push_str(REDACTED);
+                if line.ends_with('\n') {
+                    out.push('\n');
+                }
+            }
+            continue;
         }
-        first = false;
-        out.push_str(&redact_line(line));
+        if is_private_key_block_start(trimmed) {
+            in_private_key_block = true;
+            out.push_str(line);
+            continue;
+        }
+        out.push_str(&redact_line(line, policy));
     }
     out
 }
 
+fn is_private_key_block_start(trimmed: &str) -> bool {
+    trimmed.starts_with("-----BEGIN") && trimmed.contains("PRIVATE KEY")
+}
+
 /// Redact a single line (which may include a trailing newline).
-fn redact_line(line: &str) -> String {
+fn redact_line(line: &str, policy: RedactionPolicy) -> String {
     // Preserve any trailing newline so callers keep their line structure.
     let (body, newline) = match line.strip_suffix('\n') {
         Some(rest) => (rest, "\n"),
         None => (line, ""),
     };
 
-    if let Some(redacted) = redact_keyed_assignment(body) {
+    if let Some(redacted) = redact_keyed_assignment(body, policy) {
         return format!("{redacted}{newline}");
     }
 
@@ -349,13 +399,35 @@ fn redact_line(line: &str) -> String {
     for word in body.split(' ') {
         let trimmed = trim_word_punctuation(word);
         if spaced == SpacedAssignment::AwaitingValue && !trimmed.is_empty() {
-            // The value may run to the end of the line, so drop the remainder
-            // rather than masking one word and leaking the rest.
-            masked.push(REDACTED.to_string());
-            changed = true;
-            break;
+            match policy {
+                RedactionPolicy::KeyBased => {
+                    // The value may run to the end of the line, so drop the
+                    // remainder rather than masking one word and leaking the
+                    // rest.
+                    masked.push(REDACTED.to_string());
+                    changed = true;
+                    break;
+                }
+                RedactionPolicy::CredentialShaped => {
+                    // Only a credential-shaped value is hidden, and only that
+                    // word: the rest of the line stays quotable. An auth scheme
+                    // word (`Bearer`) keeps the assignment open for its token.
+                    if is_auth_scheme_word(trimmed) {
+                        masked.push(word.to_string());
+                        continue;
+                    }
+                    if value_looks_like_credential(trimmed) {
+                        masked.push(word.replace(trimmed, REDACTED));
+                        changed = true;
+                    } else {
+                        masked.push(word.to_string());
+                    }
+                    spaced = SpacedAssignment::None;
+                    continue;
+                }
+            }
         }
-        if let Some(redacted) = redact_inline_keyed_assignment(trimmed) {
+        if let Some(redacted) = redact_inline_keyed_assignment(trimmed, policy) {
             changed = true;
             masked.push(word.replace(trimmed, &redacted));
             spaced = SpacedAssignment::None;
@@ -522,7 +594,7 @@ fn key_matches_sensitive_hint(key_norm: &str, hint: &str) -> bool {
     key_norm.split(['_', '-']).any(|segment| segment == hint)
 }
 
-fn redact_inline_keyed_assignment(word: &str) -> Option<String> {
+fn redact_inline_keyed_assignment(word: &str, policy: RedactionPolicy) -> Option<String> {
     let sep_idx = word.find(['=', ':'])?;
     let (raw_key, rest) = word.split_at(sep_idx);
     let raw_value = &rest[1..];
@@ -532,12 +604,158 @@ fn redact_inline_keyed_assignment(word: &str) -> Option<String> {
     if !key_is_sensitive(raw_key) {
         return None;
     }
-    Some(format!("{}{}{}", raw_key, &rest[..1], REDACTED))
+    match policy {
+        RedactionPolicy::KeyBased => Some(format!("{}{}{}", raw_key, &rest[..1], REDACTED)),
+        RedactionPolicy::CredentialShaped => {
+            let (core, quote) = strip_value_quotes(raw_value);
+            if !value_looks_like_credential(core) {
+                return None;
+            }
+            Some(format!("{}{}{quote}{REDACTED}{quote}", raw_key, &rest[..1]))
+        }
+    }
+}
+
+/// Whether a word announces an HTTP auth scheme whose credential follows.
+fn is_auth_scheme_word(word: &str) -> bool {
+    matches!(
+        word,
+        "Bearer" | "bearer" | "Basic" | "basic" | "Token" | "token"
+    )
+}
+
+/// Split a matching pair of surrounding quotes off a value, returning the
+/// inner text and the quote to restore (empty when unquoted or unbalanced).
+fn strip_value_quotes(value: &str) -> (&str, &str) {
+    for quote in ['"', '\''] {
+        if value.len() >= 2 && value.starts_with(quote) && value.ends_with(quote) {
+            return (&value[1..value.len() - 1], &value[..1]);
+        }
+    }
+    // A leading quote without its partner (the word pass strips the outer
+    // punctuation of `"x",` to `"x`): treat the remainder as the value.
+    if let Some(inner) = value.strip_prefix(['"', '\'']) {
+        return (inner, "");
+    }
+    (value, "")
+}
+
+/// Extra bare prefixes that mark a value as a credential even though they are
+/// too product-specific to mask as standalone words in prose.
+const CREDENTIAL_VALUE_PREFIXES: &[&str] = &[
+    "sk-ant-",
+    "AKIA",
+    "ASIA",
+    "AIza",
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "github_pat_",
+    "glpat-",
+    "xoxa-",
+    "xoxb-",
+    "xoxp-",
+    "xoxr-",
+    "xoxs-",
+    "npm_",
+    "ya29.",
+];
+
+/// Whether a keyed value looks like credential material rather than code,
+/// configuration, or prose.
+///
+/// True for known provider prefixes, JWTs, `Bearer`/`Basic` tokens, PEM
+/// headers, and long opaque alphanumeric runs. False for short literals,
+/// version strings, identifiers, property/call/env references, and the
+/// redaction placeholder itself.
+pub(crate) fn value_looks_like_credential(value: &str) -> bool {
+    let value = value
+        .trim()
+        .trim_matches(|c| matches!(c, '"' | '\'' | ',' | ';'));
+    if value.is_empty() || value == REDACTED {
+        return false;
+    }
+    if looks_like_secret_token(value)
+        || CREDENTIAL_VALUE_PREFIXES
+            .iter()
+            .any(|prefix| value.len() > prefix.len() + 6 && value.starts_with(prefix))
+    {
+        return true;
+    }
+    if value.starts_with("-----BEGIN") {
+        return true;
+    }
+    if let Some((scheme, rest)) = value.split_once(' ')
+        && is_auth_scheme_word(scheme)
+    {
+        return value_looks_like_credential(rest);
+    }
+    if is_jwt_shaped(value) {
+        return true;
+    }
+    if value.len() < 16 {
+        return false;
+    }
+    if is_version_like(value) || is_reference_like(value) {
+        return false;
+    }
+    is_opaque_run(value)
+}
+
+fn is_jwt_shaped(value: &str) -> bool {
+    let mut parts = value.split('.');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some(header), Some(payload), Some(signature), None) => {
+            header.starts_with("eyJ")
+                && payload.starts_with("eyJ")
+                && !signature.is_empty()
+                && [header, payload, signature].iter().all(|part| {
+                    part.chars()
+                        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+                })
+        }
+        _ => false,
+    }
+}
+
+fn is_version_like(value: &str) -> bool {
+    let digits = value.trim_start_matches(['^', '~', '>', '<', '=', 'v', 'V', ' ']);
+    !digits.is_empty()
+        && digits
+            .chars()
+            .all(|c| c.is_ascii_digit() || c == '.' || c == '-' || c == '+')
+        && digits.chars().next().is_some_and(|c| c.is_ascii_digit())
+}
+
+fn is_reference_like(value: &str) -> bool {
+    // Property access, calls, template/env lookups, and plain identifiers are
+    // code, not credential material.
+    value.contains("?.")
+        || value.contains('(')
+        || value.contains("${")
+        || value.contains("process.env")
+        || value.contains("os.environ")
+        || value.contains("getenv")
+        || value.contains("://")
+        || value
+            .chars()
+            .all(|c| c.is_ascii_alphabetic() || c == '_' || c == '.')
+}
+
+fn is_opaque_run(value: &str) -> bool {
+    value.len() >= 20
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '/' | '=' | '_' | '-' | '.'))
+        && value.chars().any(|c| c.is_ascii_alphabetic())
+        && value.chars().any(|c| c.is_ascii_digit())
 }
 
 /// If `body` is a `key <sep> value` assignment with a sensitive key, return the
 /// line with the value redacted; otherwise `None`.
-fn redact_keyed_assignment(body: &str) -> Option<String> {
+fn redact_keyed_assignment(body: &str, policy: RedactionPolicy) -> Option<String> {
     // Find the first `=` or `:` that separates a key from a value.
     let sep_idx = body.find(['=', ':'])?;
     let (raw_key, rest) = body.split_at(sep_idx);
@@ -549,6 +767,28 @@ fn redact_keyed_assignment(body: &str) -> Option<String> {
         .trim_matches(|c| matches!(c, '"' | '\'' | '[' | ']'));
     if !key_is_sensitive(key_norm) {
         return None;
+    }
+
+    if policy == RedactionPolicy::CredentialShaped {
+        // Replace only the value span, keep the key bytes, separator spacing,
+        // quote style, and trailing punctuation, and only when the value is
+        // credential-shaped: the model must still be able to quote the line.
+        let value_lead_ws: String = raw_value
+            .chars()
+            .take_while(|c| c.is_whitespace())
+            .collect();
+        let value_rest = raw_value.trim_start();
+        let value_core = value_rest.trim_end();
+        let trailing_ws = &value_rest[value_core.len()..];
+        let literal = value_core.trim_end_matches([',', ';']);
+        let trailer = &value_core[literal.len()..];
+        let (core, quote) = strip_value_quotes(literal);
+        if core.is_empty() || !value_looks_like_credential(core) {
+            return None;
+        }
+        return Some(format!(
+            "{raw_key}{sep}{value_lead_ws}{quote}{REDACTED}{quote}{trailer}{trailing_ws}"
+        ));
     }
 
     // Keep leading whitespace of the key and the original separator spacing so
@@ -703,6 +943,114 @@ mod tests {
         assert!(tx.commit().is_err());
         // The newly created file must be removed on rollback, not left behind.
         assert!(!fresh.exists());
+    }
+
+    #[test]
+    fn model_bound_redaction_keeps_code_and_config_byte_exact() {
+        // Every line here is code or configuration that a model must be able
+        // to quote back for an exact-match edit (#5546).
+        let lines = [
+            "    \"jsonwebtoken\": \"^9.0.2\",",
+            "    \"@types/jsonwebtoken\": \"^9.0.5\",",
+            "    \"password-validator\": \"^5.3.0\",",
+            "    \"authorization\": \"1.0.0\",",
+            "      password: credentials?.password,",
+            "    token = generate_verification_token()",
+            "  secret: process.env.NEXTAUTH_SECRET!,",
+            "  password?: string;",
+            "  token: string;",
+            "    \"tokenizer\": \"gpt2\",",
+            "max tokens = 8192",
+            "export const AUTH_TOKEN_HEADER = 'x-auth-token';",
+            "{\"id\":1, \"password\": \"x\", \"language\": \"en\"}",
+            "{\"id\":1, \"password\":\"x\", \"language\":\"en\"}",
+            "password = hunter2",
+            "api_key = os.environ[\"OPENAI_API_KEY\"]",
+            "let token = ${TOKEN_FROM_ENV}",
+            "auth_url = https://example.test/oauth/token",
+        ];
+        for line in lines {
+            assert_eq!(
+                redact_model_bound_secrets(line),
+                line,
+                "line changed: {line}"
+            );
+        }
+        let file = lines.join("\n");
+        assert_eq!(redact_model_bound_secrets(&file), file);
+    }
+
+    #[test]
+    fn model_bound_redaction_masks_credential_shaped_values() {
+        let hex40 = ["0123456789abcdef", "0123456789abcdef", "01234567"].concat();
+        let sk = ["sk-", "abcdef1234567890abcdef"].concat();
+        let jwt = [
+            "eyJhbGciOiJIUzI1NiJ9",
+            ".",
+            "eyJzdWIiOiIxMjM0NTY3ODkwIn0",
+            ".",
+            "c2lnbmF0dXJlLXNpZ25hdHVyZQ",
+        ]
+        .concat();
+        let ya = ["ya29.", "a0AfH6SMBx1234567890abcdefghij"].concat();
+        let cases = [
+            (
+                format!("NEXTAUTH_SECRET={hex40}"),
+                "NEXTAUTH_SECRET=[redacted]".to_string(),
+            ),
+            (
+                format!("api_key = \"{sk}\""),
+                "api_key = \"[redacted]\"".to_string(),
+            ),
+            (
+                format!("  \"access_token\": \"{ya}\","),
+                "  \"access_token\": \"[redacted]\",".to_string(),
+            ),
+            (
+                format!("Authorization: Bearer {jwt}"),
+                "Authorization: [redacted]".to_string(),
+            ),
+            (
+                format!("curl -H \"Authorization: Bearer {jwt}\" https://api.test"),
+                "curl -H \"Authorization: Bearer [redacted]\" https://api.test".to_string(),
+            ),
+            (
+                format!("password = {hex40}, retries = 3"),
+                "password = [redacted], retries = 3".to_string(),
+            ),
+            (
+                format!("found key {sk} in the log"),
+                "found key [redacted] in the log".to_string(),
+            ),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                redact_model_bound_secrets(&input),
+                expected,
+                "input: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn private_key_blocks_are_masked_between_pem_markers() {
+        let pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn\nabcdefghijklmnopqrstuvwxyz012345\n-----END RSA PRIVATE KEY-----\nnext_line = ok\n";
+        let expected = "-----BEGIN RSA PRIVATE KEY-----\n[redacted]\n[redacted]\n-----END RSA PRIVATE KEY-----\nnext_line = ok\n";
+        assert_eq!(redact_model_bound_secrets(pem), expected);
+        assert_eq!(redact_secrets(pem), expected);
+    }
+
+    #[test]
+    fn key_based_policy_is_unchanged_by_the_model_bound_mode() {
+        // The broad scrubber for logs/previews keeps masking key-only hits.
+        assert_eq!(
+            redact_secrets("      password: credentials?.password,"),
+            "      password: [redacted]"
+        );
+        assert_eq!(
+            redact_secrets("    \"password-validator\": \"^5.3.0\","),
+            "    \"password-validator\": \"[redacted]\""
+        );
     }
 
     #[test]

--- a/crates/secrets/src/account.rs
+++ b/crates/secrets/src/account.rs
@@ -274,8 +274,9 @@ impl AccountSessionStore {
 
 /// Select the approved account-session backend shared by CLI, TUI, and Runtime.
 ///
-/// The native credential manager is required unless the user explicitly opts
-/// into the private `0600` file store for a headless environment.
+/// The native credential manager is preferred; when it is unavailable the
+/// private `0600` Codewhale secrets file is used automatically, so headless
+/// hosts can sign in without any opt-in.
 pub fn secure_account_session_secrets() -> Result<Secrets, AccountSessionError> {
     // Codex-style storage contract: prefer the OS credential manager, fall
     // back to the private 0600 file store when it is unavailable. Account

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -92,6 +92,32 @@ item-level change record is retained below the categorized release highlights.
   credential keys. Project and global bundle operations now load and validate
   the document for their actual scope in both directions, including a
   workspace whose document still lives under the legacy app directory.
+- `codewhale login` now means Codewhale account sign-in (the same browser
+  device flow as `codewhale account login`, with `--no-open` and
+  `--timeout-seconds`); provider API keys are configured exclusively through
+  `codewhale auth set --provider <provider>`, and the hidden legacy
+  `--api-key`/`--provider` flags redirect loudly instead of silently writing
+  a key.
+- Account sessions prefer the OS credential manager and now fall back
+  automatically to the private `0600` Codewhale secrets file on headless
+  hosts, SSH boxes, and containers; the `CODEWHALE_CLOUD_ALLOW_FILE_SESSION_STORE`
+  opt-in is deprecated and ignored.
+- `/update` gained a `Ctrl+Shift+U` install chord (catalogued in
+  `docs/KEYBINDINGS.md`, localized in all 15 packs) and a startup hint that
+  names the previous and current version on the first launch of a newer
+  build, pointing at `/change`.
+- Fleet product-model copy pass: the TUI, docs, and locale packs now use
+  Fleet / Member / Role / Model / Access / Saved consistently so a user can
+  say "scout", "DeepSeek V4 Flash", or the member name and mean the same
+  thing.
+- Model-bound tool results now use a credential-shaped redaction policy:
+  only values that look like secrets (known prefixes, JWTs, bearer tokens,
+  PEM private-key blocks, long opaque strings) are masked before a `read` or
+  shell result reaches the model, so code such as `password:
+  credentials?.password` or `"password-validator": "^5.3.0"` stays byte-exact
+  for edits and read-back. Exact configured credential values are still always
+  replaced, and logs/previews/exports keep the broad key-based scrubber. (#5546,
+  reported by @ronohara)
 - Terminal input shutdown no longer waits forever on a wedged TTY read,
   Windows launch receipts can atomically replace an existing record, and the
   complete `/status` report now follows the active locale without rewriting

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -638,7 +638,10 @@ fn redact_model_bound_text(text: &str, exact_secret_values: &[String]) -> String
     for secret in exact_secret_values {
         redacted = redacted.replace(secret, codewhale_config::persistence::REDACTED);
     }
-    codewhale_config::persistence::redact_secrets(&redacted)
+    // Tool results feed exact-match edits, so only credential-shaped values
+    // are masked here; key-only hits (`password: credentials?.password`) stay
+    // byte-exact. Logs and previews keep the broad key-based scrubber.
+    codewhale_config::persistence::redact_model_bound_secrets(&redacted)
 }
 
 // === Helpers ===
@@ -6233,6 +6236,40 @@ mod tests {
                 )
             })
         }));
+    }
+
+    #[test]
+    fn model_bound_tool_results_keep_ordinary_code_byte_exact() {
+        // #5546: key-only hits in source files must reach the model unchanged
+        // so exact-match edits and read-back verification keep working.
+        let client = client_with_config_secret_sentinels();
+        let source = "\
+    \"jsonwebtoken\": \"^9.0.2\",
+      password: credentials?.password,
+    token = generate_verification_token()
+  secret: process.env.NEXTAUTH_SECRET!,
+{\"id\":1, \"password\": \"x\", \"language\": \"en\"}
+";
+        let prepared =
+            client.prepare_model_bound_request(request_with_tool_result(source.to_string()));
+        assert_eq!(tool_result_content(&prepared), source);
+
+        // A configured credential and a credential-shaped value are still hidden.
+        let leaking = format!(
+            "api_key = \"{}\"\nsession = \"{}\"\n",
+            CONFIG_SECRET_SENTINELS[0],
+            ["sk-", "abcdef1234567890abcdef"].concat()
+        );
+        let prepared = client.prepare_model_bound_request(request_with_tool_result(leaking));
+        let content = tool_result_content(&prepared);
+        assert!(!content.contains(CONFIG_SECRET_SENTINELS[0]));
+        assert!(!content.contains("abcdef1234567890abcdef"));
+        assert_eq!(
+            content
+                .matches(codewhale_config::persistence::REDACTED)
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/crates/tui/src/fleet/manager.rs
+++ b/crates/tui/src/fleet/manager.rs
@@ -4644,11 +4644,12 @@ esac
                         !permissions.write,
                         "scout receipt {key} must stay read-only"
                     );
-                    // Scout/reviewer lanes now carry the read-only inspection posture:
-                    // network reach + bounded verification surface, so the
-                    // receipt records full shell authority (raw shell still
-                    // requires write and stays denied by the clamp).
-                    assert_eq!(permissions.shell, "full");
+                    // Scout/reviewer/planner lanes are narrowed to a read-only
+                    // shell at spawn (network reach + bounded verification
+                    // surface, never a mutating shell). The receipt records
+                    // that effective posture rather than the requested
+                    // profile, so headers and ledgers cannot overclaim.
+                    assert_eq!(permissions.shell, "read_only");
                 }
                 Some("verifier") => {
                     assert!(

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -1433,7 +1433,35 @@ pub fn apply_exec_hardening(
 pub(crate) fn fleet_effective_permissions_from_worker_spec(
     spec: &AgentWorkerSpec,
 ) -> FleetEffectivePermissions {
-    fleet_effective_permissions_from_runtime_profile(&spec.runtime_profile, None)
+    fleet_effective_permissions_from_runtime_profile(
+        &effective_runtime_profile_for_role(&spec.agent_type, &spec.runtime_profile),
+        None,
+    )
+}
+
+/// Whether a Fleet role is never allowed a mutating shell, whatever its
+/// requested runtime profile says. Spawn narrows the child to a read-only
+/// shell for these roles, and every receipt must report that same posture.
+pub(crate) fn role_requires_read_only_shell(role: &crate::tools::subagent::FleetRole) -> bool {
+    use crate::tools::subagent::FleetRole;
+    matches!(
+        role,
+        FleetRole::Scout | FleetRole::Reviewer | FleetRole::Planner
+    )
+}
+
+/// The runtime profile a worker of `role` actually runs under: the requested
+/// profile with the shell narrowed for read-only roles. Receipts and headers
+/// derive from this, never from the requested profile alone (#5542 review).
+pub(crate) fn effective_runtime_profile_for_role(
+    role: &crate::tools::subagent::FleetRole,
+    requested: &WorkerRuntimeProfile,
+) -> WorkerRuntimeProfile {
+    let mut effective = requested.clone();
+    if role_requires_read_only_shell(role) && effective.shell.allows_shell() {
+        effective.shell = crate::worker_profile::ShellPolicy::ReadOnly;
+    }
+    effective
 }
 
 pub(crate) fn fleet_effective_permissions_for_task(
@@ -1445,7 +1473,7 @@ pub(crate) fn fleet_effective_permissions_for_task(
         .ok()
         .flatten();
     fleet_effective_permissions_from_runtime_profile(
-        &spec.runtime_profile,
+        &effective_runtime_profile_for_role(&spec.agent_type, &spec.runtime_profile),
         agent_profile.as_deref(),
     )
 }
@@ -1600,6 +1628,35 @@ mod tests {
     use super::*;
     use codewhale_protocol::fleet::{FleetHostSpec, FleetTaskBudget, FleetWorkspaceRequirements};
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn read_only_roles_report_the_narrowed_shell_they_actually_run_under() {
+        use crate::tools::subagent::FleetRole;
+        use crate::worker_profile::ShellPolicy;
+        let mut requested = WorkerRuntimeProfile {
+            shell: ShellPolicy::Full,
+            ..WorkerRuntimeProfile::default()
+        };
+
+        for role in [FleetRole::Scout, FleetRole::Reviewer, FleetRole::Planner] {
+            let effective = effective_runtime_profile_for_role(&role, &requested);
+            assert_eq!(effective.shell, ShellPolicy::ReadOnly, "{role:?}");
+            assert_eq!(
+                fleet_effective_permissions_from_runtime_profile(&effective, None).shell,
+                "read_only",
+                "{role:?}"
+            );
+        }
+        let worker = effective_runtime_profile_for_role(&FleetRole::Worker, &requested);
+        assert_eq!(worker.shell, ShellPolicy::Full);
+
+        // A role that was already narrower than read-only keeps its posture.
+        requested.shell = ShellPolicy::None;
+        assert_eq!(
+            effective_runtime_profile_for_role(&FleetRole::Scout, &requested).shell,
+            ShellPolicy::None
+        );
+    }
 
     #[test]
     fn worker_workspace_isolation_requires_linked_worktree_outside_manager() {

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -6851,9 +6851,8 @@ impl SubAgentManager {
         if let Some(record) = self.worker_records.get(&agent.id) {
             snap.worker_status = Some(record.status);
             snap.runtime_permissions = Some(
-                crate::fleet::worker_runtime::fleet_effective_permissions_from_runtime_profile(
-                    &record.spec.runtime_profile,
-                    None,
+                crate::fleet::worker_runtime::fleet_effective_permissions_from_worker_spec(
+                    &record.spec,
                 ),
             );
             snap.parent_run_id = record
@@ -14069,10 +14068,8 @@ impl SubAgentToolRegistry {
         // has a full shell.
         let parent_shell = ShellPolicy::from_legacy_allow_shell(runtime.allow_shell);
         let mut child_shell = runtime.worker_profile.shell.min_with(parent_shell);
-        if matches!(
-            &agent_type,
-            FleetRole::Scout | FleetRole::Reviewer | FleetRole::Planner
-        ) && child_shell.allows_shell()
+        if crate::fleet::worker_runtime::role_requires_read_only_shell(&agent_type)
+            && child_shell.allows_shell()
         {
             child_shell = ShellPolicy::ReadOnly;
         }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -312,9 +312,12 @@ credentials are configured exclusively through `codewhale auth set
 That provider credential is distinct from the optional managed-product
 account. `codewhale account login` starts the Codewhale browser device flow;
 `codewhale account status` and `codewhale account logout` inspect or remove the
-session for the selected `--profile`. Account sessions are stored in the OS
-credential manager. A file-backed session store exists only as an explicit
-development fallback. `codewhale account keys list|set|remove` manages the
+session for the selected `--profile`. Account sessions prefer the OS
+credential manager and fall back automatically to the private `0600`
+Codewhale secrets file when no credential manager is available (headless
+hosts, SSH, containers); the former
+`CODEWHALE_CLOUD_ALLOW_FILE_SESSION_STORE` opt-in is deprecated and ignored.
+`codewhale account keys list|set|remove` manages the
 signed-in account's BYOK vault without displaying secret values. The older
 `codewhale cloud ...` spelling remains a command alias.
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,6 +1,6 @@
 # Codewhale product telemetry
 
-**Status for 0.9.10: anonymous usage counting is on by default and can be
+**Status for 0.9.11: anonymous usage counting is on by default and can be
 disabled immediately.** The first interactive launch shows one localized,
 nonblocking notice after the terminal is ready. It says what is never collected,
 points to this field-by-field schema, and links the ordinary `/settings` toggle.


### PR DESCRIPTION
## Summary

Same-version follow-up to #5542, to land on `main` before the `v0.9.11` tag (the tag is the release anchor; the version surface is unchanged).

- **Model-bound tool output redaction (#5546, @ronohara):** `read`/shell results reaching the model now use a credential-shaped policy (`redact_model_bound_secrets`): only values that look like secrets (known prefixes, JWTs, bearer tokens, PEM private-key blocks, long opaque strings) are masked; `password: credentials?.password`, `"password-validator": "^5.3.0"`, `token = make_token()` and short JSON literals stay byte-exact so exact-match edits and read-back work. Exact configured credential values are still always replaced; logs/previews/exports keep the broad key-based `redact_secrets` unchanged. Tests: `model_bound_redaction_keeps_code_and_config_byte_exact`, `model_bound_redaction_masks_credential_shaped_values`, `private_key_blocks_are_masked_between_pem_markers`, `key_based_policy_is_unchanged_by_the_model_bound_mode`, `model_bound_tool_results_keep_ordinary_code_byte_exact` (end-to-end through `prepare_model_bound_request`).
- **Sub-agent permission receipts are truthful:** Scout/Reviewer/Planner snapshots report the read-only shell they actually run under; one `role_requires_read_only_shell` predicate is shared by the spawn path and every snapshot producer. Test: `read_only_roles_report_the_narrowed_shell_they_actually_run_under`.
- **JSON portable bundles reject duplicate object keys at any depth** before parse (TOML already did; cross-section duplicates were already rejected). Test: `json_bundles_with_duplicate_keys_fail_before_parse`.
- **Docs/CHANGELOG truth:** four shipped 0.9.11 changes were missing from the CHANGELOG (`login` = account sign-in, automatic 0600 file-store session fallback, Ctrl+Shift+U `/update` chord + startup version hint, Fleet copy pass); `docs/CONFIGURATION.md`, the account-session doc comment, and `docs/TELEMETRY.md` now match shipped behaviour.

Found by the fresh issue report and the v0.9.11 ops-potential audit (34-agent verification of 188 commitments against the merged tree).

## Validation (local, final tree)

`cargo fmt --check`, `git diff --check`, changelog sync, `cargo check --workspace --all-targets --locked`, `cargo clippy --workspace --all-targets --all-features --locked -D warnings`, `cargo test --workspace --all-features --locked`, 21-crate publish dry-run — results recorded in the PR comment on the final head.

No benchmark-lane change. Signed-off.


Closes #5546
