### PR TITLE
feat(web): add Register and Sign in header links to the app

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -528,6 +528,43 @@ mark.search-highlight {
   color: var(--paper);
 }
 
+.paper-auth {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.paper-auth-signin,
+.paper-auth-register {
+  align-items: center;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.75rem;
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease;
+}
+
+.paper-auth-signin {
+  color: var(--ink);
+}
+
+.paper-auth-signin:hover {
+  color: var(--indigo);
+}
+
+.paper-auth-register {
+  color: var(--indigo);
+  border: 1px solid var(--indigo);
+}
+
+.paper-auth-register:hover {
+  background: var(--indigo);
+  color: var(--paper);
+}
+
 .site-nav-actions {
   display: flex;
   flex-shrink: 0;

--- a/web/components/mobile-menu.tsx
+++ b/web/components/mobile-menu.tsx
@@ -10,6 +10,10 @@ export function MobileMenu({
   links,
   installHref,
   installLabel,
+  signInHref,
+  signInLabel,
+  registerHref,
+  registerLabel,
   openLabel,
   closeLabel,
   navAria,
@@ -17,6 +21,10 @@ export function MobileMenu({
   links: ChromeLink[];
   installHref: string;
   installLabel: string;
+  signInHref: string;
+  signInLabel: string;
+  registerHref: string;
+  registerLabel: string;
   openLabel: string;
   closeLabel: string;
   /** Accessible name for the dialog's navigation landmark. */
@@ -222,6 +230,22 @@ export function MobileMenu({
             >
               {installLabel}
             </Link>
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              <Link
+                href={signInHref}
+                onClick={() => setOpen(false)}
+                className="block text-center px-5 py-3 hairline-t hairline-b hairline-l hairline-r font-mono text-sm uppercase tracking-wider hover:bg-paper-deep transition-colors"
+              >
+                {signInLabel}
+              </Link>
+              <Link
+                href={registerHref}
+                onClick={() => setOpen(false)}
+                className="block text-center px-5 py-3 hairline-t hairline-b hairline-l hairline-r font-mono text-sm uppercase tracking-wider text-indigo hover:bg-paper-deep transition-colors"
+              >
+                {registerLabel}
+              </Link>
+            </div>
           </nav>
         </div>, document.body)}
     </>

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Locale } from "@/lib/i18n/config";
 import { FACTS } from "@/lib/facts.generated";
 import { fill, getChrome } from "@/lib/i18n/dictionaries";
-import { navLinks, REPO_URL, DISCORD_URL } from "@/lib/i18n/links";
+import { navLinks, REPO_URL, DISCORD_URL, APP_LOGIN_URL, APP_SIGNUP_URL } from "@/lib/i18n/links";
 import { fetchRepoStats, formatStars } from "@/lib/github";
 import { getEnv } from "@/lib/kv";
 import { LocaleSwitcher } from "./locale-switcher";
@@ -101,6 +101,14 @@ export async function Nav({ locale = "en" }: { locale?: Locale }) {
           >
             <svg viewBox="0 0 71 55" aria-hidden fill="currentColor" className="brand-mark"><path d="M60.1 4.9C55.6 2.8 50.7 1.3 45.6.4c-.6 1.1-1.3 2.6-1.8 3.8-5.4-.8-10.8-.8-16.1 0-.5-1.2-1.2-2.7-1.8-3.8-5.1.9-10 2.4-14.5 4.5C2.6 18.2-.4 31.2 1 44c6.1 4.6 12.1 7.4 17.9 9.3 1.4-1.9 2.7-4 3.8-6.2-2.1-.8-4.1-1.8-6-3 .5-.4 1-.8 1.5-1.2 11.5 5.4 24 5.4 35.4 0 .5.4 1 .8 1.5 1.2-1.9 1.2-3.9 2.2-6 3 1.1 2.2 2.4 4.3 3.8 6.2 5.8-1.9 11.8-4.7 17.9-9.3 1.7-15-2.9-27.9-10.7-39.1zM23.7 36.3c-3.5 0-6.4-3.2-6.4-7.2s2.8-7.2 6.4-7.2 6.5 3.2 6.4 7.2c0 4-2.9 7.2-6.4 7.2zm23.4 0c-3.5 0-6.4-3.2-6.4-7.2s2.8-7.2 6.4-7.2c3.5 0 6.5 3.2 6.4 7.2 0 4-2.9 7.2-6.4 7.2z"/></svg>
           </Link>
+          <span className="paper-auth" role="group" aria-label={chrome.authGroupAria}>
+            <Link href={APP_LOGIN_URL} className="paper-auth-signin hidden lg:inline-flex">
+              {chrome.authSignIn}
+            </Link>
+            <Link href={APP_SIGNUP_URL} className="paper-auth-register hidden lg:inline-flex">
+              {chrome.authRegister}
+            </Link>
+          </span>
           <Link
             href={`/${locale}/install`}
             className="paper-install-cta hidden xl:inline-flex"
@@ -110,6 +118,10 @@ export async function Nav({ locale = "en" }: { locale?: Locale }) {
           <MobileMenu
             installHref={`/${locale}/install`}
             installLabel={chrome.installCta}
+            signInHref={APP_LOGIN_URL}
+            signInLabel={chrome.authSignIn}
+            registerHref={APP_SIGNUP_URL}
+            registerLabel={chrome.authRegister}
             links={links}
             openLabel={chrome.menuOpen}
             closeLabel={chrome.menuClose}

--- a/web/lib/i18n/dictionaries/ar/chrome.ts
+++ b/web/lib/i18n/dictionaries/ar/chrome.ts
@@ -34,6 +34,10 @@ export const chrome: ChromeDict = {
 
   installCta: "ثبّت ←",
 
+  authSignIn: "تسجيل الدخول",
+  authRegister: "إنشاء حساب",
+  authGroupAria: "الحساب",
+
   wordmarkSeal: "深",
   wordmarkTag: "أي نموذج، على جهازك",
 

--- a/web/lib/i18n/dictionaries/ca/chrome.ts
+++ b/web/lib/i18n/dictionaries/ca/chrome.ts
@@ -39,6 +39,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Instal·la →",
 
+  authSignIn: "Inicia la sessió",
+  authRegister: "Registra't",
+  authGroupAria: "Compte",
+
   wordmarkSeal: "深",
   wordmarkTag: "qualsevol model, a la teva màquina",
 

--- a/web/lib/i18n/dictionaries/de/chrome.ts
+++ b/web/lib/i18n/dictionaries/de/chrome.ts
@@ -39,6 +39,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Installieren →",
 
+  authSignIn: "Anmelden",
+  authRegister: "Registrieren",
+  authGroupAria: "Konto",
+
   wordmarkSeal: "深",
   wordmarkTag: "jedes Modell, auf deiner Maschine",
 

--- a/web/lib/i18n/dictionaries/en/chrome.ts
+++ b/web/lib/i18n/dictionaries/en/chrome.ts
@@ -32,6 +32,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Install →",
 
+  authSignIn: "Sign in",
+  authRegister: "Register",
+  authGroupAria: "Account",
+
   wordmarkSeal: "深",
   wordmarkTag: "any model, on your machine",
 

--- a/web/lib/i18n/dictionaries/es/chrome.ts
+++ b/web/lib/i18n/dictionaries/es/chrome.ts
@@ -40,6 +40,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Instalar →",
 
+  authSignIn: "Iniciar sesión",
+  authRegister: "Crear cuenta",
+  authGroupAria: "Cuenta",
+
   wordmarkSeal: "深",
   wordmarkTag: "cualquier modelo, en tu máquina",
 

--- a/web/lib/i18n/dictionaries/fr/chrome.ts
+++ b/web/lib/i18n/dictionaries/fr/chrome.ts
@@ -39,6 +39,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Installer →",
 
+  authSignIn: "Se connecter",
+  authRegister: "Créer un compte",
+  authGroupAria: "Compte",
+
   wordmarkSeal: "深",
   wordmarkTag: "n’importe quel modèle, sur votre machine",
 

--- a/web/lib/i18n/dictionaries/hi/chrome.ts
+++ b/web/lib/i18n/dictionaries/hi/chrome.ts
@@ -37,6 +37,10 @@ export const chrome: ChromeDict = {
 
   installCta: "इंस्टॉल करें →",
 
+  authSignIn: "साइन इन करें",
+  authRegister: "रजिस्टर करें",
+  authGroupAria: "खाता",
+
   wordmarkSeal: "深",
   wordmarkTag: "कोई भी मॉडल, आपकी मशीन पर",
 

--- a/web/lib/i18n/dictionaries/id/chrome.ts
+++ b/web/lib/i18n/dictionaries/id/chrome.ts
@@ -38,6 +38,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Instal →",
 
+  authSignIn: "Masuk",
+  authRegister: "Daftar",
+  authGroupAria: "Akun",
+
   wordmarkSeal: "深",
   wordmarkTag: "model apa pun, di mesin Anda",
 

--- a/web/lib/i18n/dictionaries/it/chrome.ts
+++ b/web/lib/i18n/dictionaries/it/chrome.ts
@@ -37,6 +37,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Installa →",
 
+  authSignIn: "Accedi",
+  authRegister: "Registrati",
+  authGroupAria: "Account",
+
   wordmarkSeal: "深",
   wordmarkTag: "qualsiasi modello, sulla tua macchina",
 

--- a/web/lib/i18n/dictionaries/ja/chrome.ts
+++ b/web/lib/i18n/dictionaries/ja/chrome.ts
@@ -39,6 +39,10 @@ export const chrome: ChromeDict = {
 
   installCta: "インストール →",
 
+  authSignIn: "ログイン",
+  authRegister: "新規登録",
+  authGroupAria: "アカウント",
+
   wordmarkSeal: "深",
   wordmarkTag: "どんなモデルでも、あなたのマシンで",
 

--- a/web/lib/i18n/dictionaries/ko/chrome.ts
+++ b/web/lib/i18n/dictionaries/ko/chrome.ts
@@ -42,6 +42,10 @@ export const chrome: ChromeDict = {
 
   installCta: "설치 →",
 
+  authSignIn: "로그인",
+  authRegister: "회원가입",
+  authGroupAria: "계정",
+
   wordmarkSeal: "深",
   wordmarkTag: "어떤 모델이든, 당신의 머신에서",
 

--- a/web/lib/i18n/dictionaries/pl/chrome.ts
+++ b/web/lib/i18n/dictionaries/pl/chrome.ts
@@ -36,6 +36,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Instaluj →",
 
+  authSignIn: "Zaloguj się",
+  authRegister: "Zarejestruj się",
+  authGroupAria: "Konto",
+
   wordmarkSeal: "深",
   wordmarkTag: "dowolny model, na twojej maszynie",
 

--- a/web/lib/i18n/dictionaries/pt-BR/chrome.ts
+++ b/web/lib/i18n/dictionaries/pt-BR/chrome.ts
@@ -29,6 +29,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Instalar →",
 
+  authSignIn: "Entrar",
+  authRegister: "Criar conta",
+  authGroupAria: "Conta",
+
   wordmarkSeal: "深",
   wordmarkTag: "qualquer modelo, na sua máquina",
 

--- a/web/lib/i18n/dictionaries/ru/chrome.ts
+++ b/web/lib/i18n/dictionaries/ru/chrome.ts
@@ -35,6 +35,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Установить →",
 
+  authSignIn: "Войти",
+  authRegister: "Регистрация",
+  authGroupAria: "Аккаунт",
+
   wordmarkSeal: "深",
   wordmarkTag: "любая модель, на вашей машине",
 

--- a/web/lib/i18n/dictionaries/tr/chrome.ts
+++ b/web/lib/i18n/dictionaries/tr/chrome.ts
@@ -36,6 +36,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Kur →",
 
+  authSignIn: "Giriş yap",
+  authRegister: "Kayıt ol",
+  authGroupAria: "Hesap",
+
   wordmarkSeal: "深",
   wordmarkTag: "istediğin model, senin makinen",
 

--- a/web/lib/i18n/dictionaries/types.ts
+++ b/web/lib/i18n/dictionaries/types.ts
@@ -62,6 +62,12 @@ export interface ChromeDict {
   /** Mobile-menu and masthead call to action, e.g. "Install →". */
   installCta: string;
 
+  /** Header account links to the Codewhale app (app.codewhale.net). */
+  authSignIn: string;
+  authRegister: string;
+  /** aria-label for the header account link group. */
+  authGroupAria: string;
+
   /** Wordmark seal glyph beside the masthead brand (components/seal.tsx). */
   wordmarkSeal: string;
   /** Wordmark strapline under the brand, e.g. "any model, on your machine". */

--- a/web/lib/i18n/dictionaries/uk/chrome.ts
+++ b/web/lib/i18n/dictionaries/uk/chrome.ts
@@ -34,6 +34,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Встановити →",
 
+  authSignIn: "Увійти",
+  authRegister: "Реєстрація",
+  authGroupAria: "Обліковий запис",
+
   wordmarkSeal: "深",
   wordmarkTag: "будь-яка модель, на вашій машині",
 

--- a/web/lib/i18n/dictionaries/vi/chrome.ts
+++ b/web/lib/i18n/dictionaries/vi/chrome.ts
@@ -39,6 +39,10 @@ export const chrome: ChromeDict = {
 
   installCta: "Cài đặt →",
 
+  authSignIn: "Đăng nhập",
+  authRegister: "Đăng ký",
+  authGroupAria: "Tài khoản",
+
   wordmarkSeal: "深",
   wordmarkTag: "mọi mô hình, trên máy của bạn",
 

--- a/web/lib/i18n/dictionaries/zh/chrome.ts
+++ b/web/lib/i18n/dictionaries/zh/chrome.ts
@@ -30,6 +30,10 @@ export const chrome: ChromeDict = {
 
   installCta: "安装 →",
 
+  authSignIn: "登录",
+  authRegister: "注册",
+  authGroupAria: "账户",
+
   wordmarkSeal: "深",
   wordmarkTag: "任意模型，本机运行",
 

--- a/web/lib/i18n/links.ts
+++ b/web/lib/i18n/links.ts
@@ -17,6 +17,11 @@ export const REPO_LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`;
 /** Community chat. A brand name, so it is not a dictionary string. */
 export const DISCORD_URL = "https://discord.gg/37gfS3ksug";
 
+/** The hosted Codewhale app (account sign-in / sign-up). */
+export const APP_URL = "https://app.codewhale.net";
+export const APP_LOGIN_URL = `${APP_URL}/login`;
+export const APP_SIGNUP_URL = `${APP_URL}/signup`;
+
 /** A chrome link. `secondary` is the small bilingual companion label. */
 export interface ChromeLink {
   href: string;


### PR DESCRIPTION
## Summary

Adds account entry points to the marketing-site header that link to the hosted Codewhale app.

- **Desktop header:** a `Sign in` ghost link + an outlined `Register` button in the nav actions (shown at `lg`+), styled to match the paper masthead.
- **Mobile menu:** a two-up `Sign in` / `Register` row under the existing Install CTA.
- **Targets:** `https://app.codewhale.net/login` and `https://app.codewhale.net/signup` (the app's real routes), added as `APP_URL`/`APP_LOGIN_URL`/`APP_SIGNUP_URL` in `lib/i18n/links.ts`.
- **Localized:** `authSignIn` / `authRegister` / `authGroupAria` added to the typed `ChromeDict` and translated in all 18 locale chrome dictionaries, so `check:locales` and `dictionaries.test.ts` key-parity stay green.

## Validation

`npm run lint`, `npm run check:locales` (PASS), `npm run check:facts` / `check:docs` (PASS), `npm run test` (38 files / 331 tests pass), `npm run build` (513 pages, compiled successfully).

No new binary, no server/API change; header-only. Deploys with the next web release.

No-Issue: connect the website header to the hosted app sign-in/sign-up.
