### PR TITLE
docs(release): add unpublished-tag re-cut recovery + external publish gates

### DIFF
--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -409,6 +409,45 @@ If the workflow failed for the release tag, use the exact-tag rerun or
 
 ## Recovery and Rollback
 
+### Re-tagging an UNPUBLISHED release (pulled before npm/crates)
+
+If `vX.Y.Z` was tagged and a GitHub Release was created, but **no package was
+published** (npm still on the prior version, `check-published.sh` shows the
+crates unpublished), the tag is still recoverable — a bug found after tagging
+can be fixed and the same version recut. Confirm first that nothing consumed it:
+`npm view codewhale version` and crates.io both show the PRIOR version, no
+Homebrew/Winget/mirror points at it, and the GitHub Release download counts are
+only the release pipeline's own verification passes. Then, with explicit
+maintainer approval:
+
+```bash
+# 1. land the fix on main (normal PR + required CI)
+# 2. delete the premature Release + tag
+gh release delete vX.Y.Z --repo Hmbown/CodeWhale --yes --cleanup-tag
+git push origin :refs/tags/vX.Y.Z    # belt-and-suspenders
+git tag -d vX.Y.Z                    # local
+# 3. recut at the fixed HEAD (workspace version unchanged)
+gh workflow run auto-tag.yml --repo Hmbown/CodeWhale --ref main
+# 4. release.yml rebuilds assets; rebuild + reinstall locally from the new tag
+```
+
+This is the sanctioned path from "do not delete/move/recreate a release tag
+implicitly": it is explicit, approved, and only for a tag no registry consumer
+has treated as public. Never do it once a crate or the npm wrapper is published
+for that version — bump to the next patch instead.
+
+### External publish gates (not code defects)
+
+- **crates.io:** publishing needs a valid `cargo login` token on the operator
+  machine (`curl -H "Authorization: <token>" https://crates.io/api/v1/me`
+  returning 200). A 403 means the token is missing/expired — `cargo login`,
+  then `./scripts/release/publish-crates.sh publish`.
+- **npm:** the OIDC job publishes only if the npmjs.com Trusted Publisher for
+  `Hmbown` / `CodeWhale` / workflow `release.yml` / blank environment is
+  configured. Missing config → the `npm` job fails `E404 No match found`. Fix
+  the binding (or use the manual WebAuthn recovery below), then re-run the
+  failed `npm` job: `gh run rerun <release-run-id> --failed`.
+
 - User-facing rollback:
   - npm: `npm install -g codewhale@X.Y.Z`
   - Cargo: `cargo install codewhale-cli --version X.Y.Z --locked --force`;

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -445,7 +445,7 @@ for that version — bump to the next patch instead.
 - **npm:** the OIDC job publishes only if the npmjs.com Trusted Publisher for
   `Hmbown` / `CodeWhale` / workflow `release.yml` / blank environment is
   configured. Missing config → the `npm` job fails `E404 No match found`. Fix
-  the binding (or use the manual WebAuthn recovery below), then re-run the
+  the binding (or use the manual WebAuthn recovery above), then re-run the
   failed `npm` job: `gh run rerun <release-run-id> --failed`.
 
 - User-facing rollback:


### PR DESCRIPTION
Documents the recovery flow used for v0.9.11 tonight: pull an **unpublished** tag/Release (nothing on npm/crates) and recut at a fixed HEAD after a post-tag fix, plus the crates.io token (403) and npm Trusted Publisher (E404) external gates. Docs-only.

No-Issue: release runbook recovery guidance from the v0.9.11 re-cut.