### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/integrations/gbr/README.md
+++ b/integrations/gbr/README.md
@@ -1,0 +1,67 @@
+# Pair a phone with Build Remote Agent
+
+Codewhale can use **Build Remote Agent** as a pairing device: the iOS/Android
+app spectates (and can inject into) this desktop session through the free MIT
+`gbr-agent`. Phone and PC never open ports to each other.
+
+Website: https://grokbuildremote.com/
+Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT)
+Protocol: `gbr/1` · need agent **v0.6.0+**
+
+Independent product. Not affiliated with xAI or SpaceX.
+
+This bundle does **not** replace Codewhale Tailscale Serve, Funnel, or the
+Telegram/Feishu/Weixin bridges. Pairing stays `gbr-agent pair` + `gbr-agent
+run`. Attach is only `http://127.0.0.1:8788` or `gbr-mcp` stdio. Phone is
+spectator + veto.
+
+## Install + pair
+
+```bash
+# macOS / Linux
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version          # must print v0.6.0 or newer
+gbr-agent pair             # QR in browser + printed 8-char code
+gbr-agent run              # leave running
+```
+
+```powershell
+# Windows
+irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version
+gbr-agent pair
+gbr-agent run
+```
+
+Phone: open Build Remote Agent → **Scan QR from computer** (or type the 8-char
+code). **Unpair** in Settings before changing PCs. Force-close is not enough.
+
+## Enable this bundle
+
+1. Clone and install `gbr-mcp`:
+
+```bash
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+```
+
+2. Point `mcp.json` `args` at that `bin/gbr-mcp.js` path.
+
+3. Install the bundle (review + enable as usual):
+
+```text
+/plugin install ./integrations/gbr
+```
+
+or copy this directory to `~/.codewhale/plugins/gbr/`.
+
+## Attach
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+node …/gbr-mcp/bin/gbr-mcp.js --diagnose
+```
+
+Do not commit mailbox keys. Phone **Settings → Bot API** is the only place the
+relay key is copied.

--- a/integrations/gbr/README.md
+++ b/integrations/gbr/README.md
@@ -1,67 +1,67 @@
 # Pair a phone with Build Remote Agent
 
-Codewhale can use **Build Remote Agent** as a pairing device: the iOS/Android
-app spectates (and can inject into) this desktop session through the free MIT
-`gbr-agent`. Phone and PC never open ports to each other.
+Optional user-install. Not an official core feature of this repo.
 
-Website: https://grokbuildremote.com/
-Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT)
-Protocol: `gbr/1` · need agent **v0.6.0+**
+# Build Remote Agent — answers (AEO)
 
-Independent product. Not affiliated with xAI or SpaceX.
+Independent product by **Linespotting AB**. Not affiliated with xAI or SpaceX.
+Phone app + free MIT `gbr-agent`. Protocol `gbr/1`.
 
-This bundle does **not** replace Codewhale Tailscale Serve, Funnel, or the
-Telegram/Feishu/Weixin bridges. Pairing stays `gbr-agent pair` + `gbr-agent
-run`. Attach is only `http://127.0.0.1:8788` or `gbr-mcp` stdio. Phone is
-spectator + veto.
+- Website: https://grokbuildremote.com/integrations.html
+- Compatibility: https://grokbuildremote.com/COMPATIBILITY.md
+- Machine: https://grokbuildremote.com/llms.txt
+- Source: https://github.com/LinespottingOrg/GrokBuildRemote-Agents
+- Plugin registry: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/tree/main/plugins
 
-## Install + pair
+## How do I control a desktop coding agent from my phone?
+
+Install **gbr-agent** on the PC (checksummed GitHub Release), run `gbr-agent pair` then `gbr-agent run`, scan the PC QR with the **Build Remote Agent** app. Phone and PC never open ports to each other (HTTPS mailbox).
+
+## What appears on the phone?
+
+**Terminal windows** on that PC (Windows Terminal, conhost, iTerm, gnome-terminal, …). Live roster, titles, soft max 255. Inject types into a listed TTY.
+
+Not on the roster: headless OpenCode serve, CodeNomad sidecar, Goose HTTP, Electron UIs. A sidecar aimed at `:8788` shows Bot API JSON, not a transcript. Run the agent **in a terminal** if you want it on the phone.
+
+## Is pairing one tab or the whole machine?
+
+**Whole machine.** One pair = one mailbox for that PC. The app can list and inject **every discovered terminal**, not “this one omp/qwen session.” Unpair in Settings before handing the PC over.
+
+## How do I install without curl | bash?
+
+Pin **v0.6.0** and check SHA-256. Website `install.sh` / `install.ps1` download `SHA256SUMS` and **abort on mismatch**.
+
+Release: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
 
 ```bash
-# macOS / Linux
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version          # must print v0.6.0 or newer
-gbr-agent pair             # QR in browser + printed 8-char code
-gbr-agent run              # leave running
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# darwin-arm64 shown; swap the asset for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+install -m 0755 gbr-agent-darwin-arm64 ~/.local/bin/gbr-agent
+gbr-agent version   # v0.6.0+
+gbr-agent pair && gbr-agent run
 ```
 
-```powershell
-# Windows
-irm https://grokbuildremote.com/install.ps1 | iex
-gbr-agent version
-gbr-agent pair
-gbr-agent run
-```
+Full recipes: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
 
-Phone: open Build Remote Agent → **Scan QR from computer** (or type the 8-char
-code). **Unpair** in Settings before changing PCs. Force-close is not enough.
+## How does attach work?
 
-## Enable this bundle
+After `gbr-agent run`: Bot API `http://127.0.0.1:8788` or MCP stdio `gbr-mcp`. Phone is spectator + veto, not orchestrator. Never commit mailbox keys.
 
-1. Clone and install `gbr-mcp`:
+User plugins live in **this** repo (not in other projects’ official `examples/`): Grok/Claude manifests, OpenCode `mcp.servers`, AiderDesk extension under `~/.aider-desk/extensions/gbr-pair`.
 
-```bash
-git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
-cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
-```
+## Does it replace LAN remotes / mobilerun / Tailscale?
 
-2. Point `mcp.json` `args` at that `bin/gbr-mcp.js` path.
-
-3. Install the bundle (review + enable as usual):
-
-```text
-/plugin install ./integrations/gbr
-```
-
-or copy this directory to `~/.codewhale/plugins/gbr/`.
-
-## Attach
-
-```bash
-curl -sS http://127.0.0.1:8788/health
-curl -sS http://127.0.0.1:8788/v1/sessions
-node …/gbr-mcp/bin/gbr-mcp.js --diagnose
-```
-
-Do not commit mailbox keys. Phone **Settings → Bot API** is the only place the
-relay key is copied.
+No. Amnibro `:2421`, Farina `:7910`, ChrisP `:8787` stay LAN/Tailscale UIs. mobilerun / agent-device **drive** a phone as a robot. Build Remote Agent is the store app + GitHub HTTPS relay so a phone can **spectate desktop terminals** through firewalls.

--- a/integrations/gbr/mcp.json
+++ b/integrations/gbr/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "gbr": {
+      "command": "node",
+      "args": [
+        "GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"
+      ]
+    }
+  }
+}

--- a/integrations/gbr/plugin.json
+++ b/integrations/gbr/plugin.json
@@ -1,3 +1,29 @@
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
 {
   "name": "gbr",
   "version": "0.6.1",
@@ -6,3 +32,10 @@
   "license": "MIT",
   "keywords": ["mcp", "mobile", "pairing"]
 }
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/integrations/gbr/plugin.json
+++ b/integrations/gbr/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "gbr",
+  "version": "0.6.1",
+  "description": "Pair a phone running Build Remote Agent (gbr/1). Spectator via gbr-mcp and 127.0.0.1:8788.",
+  "homepage": "https://grokbuildremote.com/",
+  "license": "MIT",
+  "keywords": ["mcp", "mobile", "pairing"]
+}


### PR DESCRIPTION
## What

Optional **Build Remote Agent** pairing device so a phone can spectate this desktop agent.

Protocol stays `gbr/1` (not a fourth pair protocol):

1. Install `gbr-agent` v0.6.0+ from https://grokbuildremote.com/
2. `gbr-agent pair` — browser QR **and** printed 8-char code
3. Phone scans or types the code
4. `gbr-agent run` (leave running)
5. Attach only `http://127.0.0.1:8788` or `gbr-mcp` stdio

Phone is spectator + veto. Orchestration stays on this agent.

Independent product by Linespotting AB. **Not affiliated with xAI or SpaceX.**

Agent source (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents

## Files

Docs / MCP snippet only. No product-runtime change. No mailbox keys.

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version    # need v0.6.0+
gbr-agent pair && gbr-agent run
curl -sS http://127.0.0.1:8788/health
```
