### PR TITLE
fix(subagents): persist child approval receipts

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -4105,6 +4105,7 @@ impl Engine {
                 .with_parent_completion_tx(self.tx_subagent_completion.clone())
                 .with_runtime_cost_owner(self.config.compaction.runtime_cost_owner.as_deref())
                 .with_parent_mode(input_policy.mode)
+                .with_approval_receipt_store(self.approval_receipt_store.clone())
                 .with_permission_posture(
                     self.session.approval_mode,
                     Arc::clone(&self.shared_auto_review_policy),
@@ -5456,6 +5457,7 @@ impl Engine {
         .with_parent_completion_tx(self.tx_subagent_completion.clone())
         .with_runtime_cost_owner(self.config.compaction.runtime_cost_owner.as_deref())
         .with_parent_mode(mode)
+        .with_approval_receipt_store(self.approval_receipt_store.clone())
         .with_permission_posture(
             self.session.approval_mode,
             Arc::clone(&self.shared_auto_review_policy),

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -2464,6 +2464,9 @@ pub struct SubAgentRuntime {
     /// Whether the host can answer an approval prompt for a child (an
     /// interactive TUI). Headless hosts keep the fail-closed denial.
     pub parent_can_prompt: bool,
+    /// Durable approval evidence inherited from the parent session. Legacy
+    /// runtimes that do not install a store cannot open child approval prompts.
+    approval_receipt_store: Option<Result<crate::approval_log::ApprovalReceiptStore, String>>,
 }
 
 impl SubAgentRuntime {
@@ -2521,6 +2524,7 @@ impl SubAgentRuntime {
                 crate::tui::auto_review::AutoReviewPolicy::default(),
             ),
             parent_can_prompt: false,
+            approval_receipt_store: None,
         }
     }
 
@@ -2544,6 +2548,16 @@ impl SubAgentRuntime {
         self.approval_mode = approval_mode;
         self.auto_review_policy = auto_review_policy;
         self.parent_can_prompt = parent_can_prompt;
+        self
+    }
+
+    /// Install the parent session's append-only approval receipt store.
+    #[must_use]
+    pub(crate) fn with_approval_receipt_store(
+        mut self,
+        store: Result<crate::approval_log::ApprovalReceiptStore, String>,
+    ) -> Self {
+        self.approval_receipt_store = Some(store);
         self
     }
 
@@ -2846,6 +2860,7 @@ impl SubAgentRuntime {
             approval_mode: self.approval_mode,
             auto_review_policy: Arc::clone(&self.auto_review_policy),
             parent_can_prompt: self.parent_can_prompt,
+            approval_receipt_store: self.approval_receipt_store.clone(),
         }
     }
 
@@ -14391,6 +14406,61 @@ impl SubAgentToolRegistry {
         }
     }
 
+    async fn commit_child_approval_receipt(
+        &self,
+        receipt: crate::approval_log::ApprovalReceipt,
+    ) -> Result<(), ToolError> {
+        let store = self
+            .gate_runtime
+            .approval_receipt_store
+            .clone()
+            .ok_or_else(|| {
+                tracing::warn!(
+                    target: "approval",
+                    "child approval receipt store was not installed"
+                );
+                ToolError::execution_failed(
+                    "Approval evidence could not be committed; tool execution was blocked."
+                        .to_string(),
+                )
+            })?
+            .map_err(|error| {
+                tracing::warn!(
+                    target: "approval",
+                    %error,
+                    "child approval receipt store is unavailable"
+                );
+                ToolError::execution_failed(
+                    "Approval evidence could not be committed; tool execution was blocked."
+                        .to_string(),
+                )
+            })?;
+        let session_id = self.gate_runtime.context.state_namespace.clone();
+        let write = tokio::task::spawn_blocking(move || store.append(&session_id, &receipt))
+            .await
+            .map_err(|error| {
+                tracing::warn!(
+                    target: "approval",
+                    %error,
+                    "child approval receipt writer did not complete"
+                );
+                ToolError::execution_failed(
+                    "Approval evidence could not be committed; tool execution was blocked."
+                        .to_string(),
+                )
+            })?;
+        write.map_err(|error| {
+            tracing::warn!(
+                target: "approval",
+                error_kind = ?error.kind(),
+                "child approval receipt write failed"
+            );
+            ToolError::execution_failed(
+                "Approval evidence could not be committed; tool execution was blocked.".to_string(),
+            )
+        })
+    }
+
     /// Ask: raise the held call as an approval prompt in the parent's UI and
     /// wait for the person, visibly (`waiting for user`). Hosts that cannot
     /// prompt keep the fail-closed denial with the reason.
@@ -14418,6 +14488,20 @@ impl SubAgentToolRegistry {
             .write()
             .await
             .register_child_approval(agent_id);
+        if let Err(error) = self
+            .commit_child_approval_receipt(crate::approval_log::ApprovalReceipt::asked(
+                approval_id.clone(),
+                name,
+            ))
+            .await
+        {
+            self.gate_runtime
+                .manager
+                .write()
+                .await
+                .cancel_child_approval(&approval_id);
+            return ChildGateVerdict::Deny(error.to_string());
+        }
         let description = format!(
             "{} (worker {}) wants to run '{name}': {reason}",
             self.owner_agent_name,
@@ -14443,6 +14527,15 @@ impl SubAgentToolRegistry {
                 .write()
                 .await
                 .cancel_child_approval(&approval_id);
+            if let Err(error) = self
+                .commit_child_approval_receipt(crate::approval_log::ApprovalReceipt::decided(
+                    approval_id,
+                    crate::approval_log::ApprovalOutcome::Unavailable,
+                ))
+                .await
+            {
+                return ChildGateVerdict::Deny(error.to_string());
+            }
             return ChildGateVerdict::Deny(format!(
                 "{reason} (the session could not be asked; the call was denied)"
             ));
@@ -14454,34 +14547,77 @@ impl SubAgentToolRegistry {
                 .with_tool(name.to_string()),
             format!("waiting for your decision on '{name}'"),
         );
+        #[derive(Clone, Copy)]
+        enum WaitOutcome {
+            Answer(ChildApprovalOutcome),
+            Cancelled,
+            Unavailable,
+        }
         let outcome = tokio::select! {
-            () = self.gate_runtime.cancel_token.cancelled() => None,
-            answer = receiver => answer.ok(),
+            () = self.gate_runtime.cancel_token.cancelled() => WaitOutcome::Cancelled,
+            answer = receiver => match answer {
+                Ok(answer) => WaitOutcome::Answer(answer),
+                Err(_) => WaitOutcome::Unavailable,
+            },
         };
-        if outcome.is_none() {
+        if !matches!(outcome, WaitOutcome::Answer(_)) {
             self.gate_runtime
                 .manager
                 .write()
                 .await
                 .cancel_child_approval(&approval_id);
         }
+        let receipt_outcome = match outcome {
+            WaitOutcome::Answer(ChildApprovalOutcome::Approved) => {
+                crate::approval_log::ApprovalOutcome::ApprovedOnce
+            }
+            WaitOutcome::Answer(ChildApprovalOutcome::Denied) => {
+                crate::approval_log::ApprovalOutcome::Denied
+            }
+            WaitOutcome::Cancelled => crate::approval_log::ApprovalOutcome::Cancelled,
+            WaitOutcome::Unavailable => crate::approval_log::ApprovalOutcome::Unavailable,
+        };
+        if let Err(error) = self
+            .commit_child_approval_receipt(crate::approval_log::ApprovalReceipt::decided(
+                approval_id,
+                receipt_outcome,
+            ))
+            .await
+        {
+            record_agent_progress(
+                &self.gate_runtime,
+                agent_id,
+                AgentProgressEventMeta::new(AgentWorkerStatus::RunningTool)
+                    .with_tool(name.to_string()),
+                format!("blocked '{name}': approval evidence could not be committed"),
+            );
+            return ChildGateVerdict::Deny(error.to_string());
+        }
         record_agent_progress(
             &self.gate_runtime,
             agent_id,
             AgentProgressEventMeta::new(AgentWorkerStatus::RunningTool).with_tool(name.to_string()),
             match outcome {
-                Some(ChildApprovalOutcome::Approved) => format!("approved '{name}'"),
-                Some(ChildApprovalOutcome::Denied) => format!("denied '{name}'"),
-                None => format!("stopped waiting on '{name}'"),
+                WaitOutcome::Answer(ChildApprovalOutcome::Approved) => {
+                    format!("approved '{name}'")
+                }
+                WaitOutcome::Answer(ChildApprovalOutcome::Denied) => {
+                    format!("denied '{name}'")
+                }
+                WaitOutcome::Cancelled => format!("stopped waiting on '{name}'"),
+                WaitOutcome::Unavailable => format!("lost approval channel for '{name}'"),
             },
         );
         match outcome {
-            Some(ChildApprovalOutcome::Approved) => ChildGateVerdict::Proceed,
-            Some(ChildApprovalOutcome::Denied) => {
+            WaitOutcome::Answer(ChildApprovalOutcome::Approved) => ChildGateVerdict::Proceed,
+            WaitOutcome::Answer(ChildApprovalOutcome::Denied) => {
                 ChildGateVerdict::Deny(format!("Tool {name} was denied by the user"))
             }
-            None => ChildGateVerdict::Deny(format!(
+            WaitOutcome::Cancelled => ChildGateVerdict::Deny(format!(
                 "Tool {name} was cancelled while awaiting the user's decision"
+            )),
+            WaitOutcome::Unavailable => ChildGateVerdict::Deny(format!(
+                "Tool {name} approval could no longer reach the worker; tool execution was blocked"
             )),
         }
     }

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -12223,6 +12223,7 @@ pub(crate) fn stub_runtime() -> SubAgentRuntime {
             crate::tui::auto_review::AutoReviewPolicy::default(),
         ),
         parent_can_prompt: false,
+        approval_receipt_store: None,
         mcp_pool: None,
         step_api_timeout: DEFAULT_STEP_API_TIMEOUT,
         api_timeout_retry_base_backoff: SUBAGENT_API_TIMEOUT_INITIAL_BACKOFF,
@@ -19585,6 +19586,7 @@ fn user_follow_up_to_completed_child_requires_a_runtime_to_resume() {
 
 mod child_permission_gate {
     use super::*;
+    use crate::approval_log::{ApprovalOutcome, ApprovalReceipt, ApprovalReceiptStore};
     use crate::core::events::{Event, ToolGate, ToolGateVerdict};
     use crate::tui::approval::ApprovalMode;
 
@@ -19606,10 +19608,15 @@ mod child_permission_gate {
         if let Some(client) = client {
             runtime.client = client;
         }
-        runtime.context = ToolContext::new(tmp.path().to_path_buf());
+        let session_id = format!("child_gate_{}", uuid::Uuid::new_v4().simple());
+        runtime.context =
+            ToolContext::new(tmp.path().to_path_buf()).with_state_namespace(session_id);
         runtime.context.auto_approve = auto_approve;
         runtime.allow_shell = true;
         runtime.event_tx = Some(tx);
+        runtime = runtime.with_approval_receipt_store(Ok(
+            crate::approval_log::ApprovalReceiptStore::new(tmp.path().join("sessions")),
+        ));
         runtime = runtime.with_permission_posture(
             approval_mode,
             std::sync::Arc::new(crate::tui::auto_review::AutoReviewPolicy::default()),
@@ -19648,6 +19655,44 @@ mod child_permission_gate {
             }
         }
         out
+    }
+
+    fn receipt_context(registry: &SubAgentToolRegistry) -> (ApprovalReceiptStore, String) {
+        let store = registry
+            .gate_runtime
+            .approval_receipt_store
+            .as_ref()
+            .expect("test runtime installs a receipt store")
+            .as_ref()
+            .expect("test receipt store is available")
+            .clone();
+        (store, registry.gate_runtime.context.state_namespace.clone())
+    }
+
+    async fn next_child_approval_id(rx: &mut tokio::sync::mpsc::Receiver<Event>) -> String {
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while let Some(event) = rx.recv().await {
+                if let Event::ApprovalRequired { id, .. } = event {
+                    return id;
+                }
+            }
+            panic!("approval event channel closed before the child prompt arrived");
+        })
+        .await
+        .expect("child approval prompt arrives")
+    }
+
+    fn assert_completed_receipt(
+        store: &ApprovalReceiptStore,
+        session_id: &str,
+        expected: ApprovalOutcome,
+    ) {
+        let replay = store
+            .replay(session_id)
+            .expect("the completed child approval replays");
+        assert_eq!(replay.completed.len(), 1);
+        assert_eq!(replay.completed[0].outcome, expected);
+        assert!(replay.unmatched_asks.is_empty());
     }
 
     /// A chat-completions mock that answers every request with `content`.
@@ -19710,6 +19755,29 @@ mod child_permission_gate {
     }
 
     #[tokio::test]
+    async fn ask_without_a_durable_receipt_store_fails_closed_before_prompting() {
+        let (mut registry, mut rx, _) = worker_registry(ApprovalMode::Suggest, false, true, None);
+        registry.gate_runtime.approval_receipt_store = None;
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            registry.execute("agent_gate", "bash", json!({"command": "echo gated"})),
+        )
+        .await
+        .expect("a missing receipt store must fail closed without waiting for a decision");
+        let err = result.expect_err("the call must not run without durable approval evidence");
+        assert!(
+            err.to_string()
+                .contains("Approval evidence could not be committed"),
+            "{err}"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "the host must not see an approval prompt that cannot be persisted"
+        );
+    }
+
+    #[tokio::test]
     async fn ask_with_a_prompting_host_raises_the_prompt_and_honours_the_answer() {
         for (answer, expect_ok) in [
             (ChildApprovalOutcome::Approved, true),
@@ -19717,6 +19785,9 @@ mod child_permission_gate {
         ] {
             let (registry, mut rx, manager) =
                 worker_registry(ApprovalMode::Suggest, false, true, None);
+            let (receipt_store, session_id) = receipt_context(&registry);
+            let receipt_store_for_answer = receipt_store.clone();
+            let session_id_for_answer = session_id.clone();
             let manager_for_answer = Arc::clone(&manager);
             let answerer = tokio::spawn(async move {
                 // Wait for the prompt, then answer it exactly like the engine
@@ -19740,6 +19811,9 @@ mod child_permission_gate {
                     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                 }
                 let approval_id = approval_id.expect("child prompt must reach the host");
+                let replay_before_decision = receipt_store_for_answer
+                    .replay(&session_id_for_answer)
+                    .expect("the durable ask replays before the prompt is answered");
                 assert_eq!(manager_for_answer.read().await.pending_child_approvals(), 1);
                 assert!(
                     manager_for_answer
@@ -19754,11 +19828,14 @@ mod child_permission_gate {
                         .await
                         .resolve_child_approval(&approval_id, answer)
                 );
+                replay_before_decision
             });
             let result = registry
                 .execute("agent_gate", "bash", json!({"command": "echo gated"}))
                 .await;
-            answerer.await.expect("answerer task");
+            let replay_before_decision = answerer.await.expect("answerer task");
+            assert_eq!(replay_before_decision.unmatched_asks.len(), 1);
+            assert!(replay_before_decision.completed.is_empty());
             match (expect_ok, result) {
                 (true, Ok(output)) => assert!(output.contains("gated"), "{output}"),
                 (false, Err(err)) => {
@@ -19767,8 +19844,125 @@ mod child_permission_gate {
                 (true, Err(err)) => panic!("approved call must run: {err}"),
                 (false, Ok(output)) => panic!("denied call must not run: {output}"),
             }
+            let replay = receipt_store
+                .replay(&session_id)
+                .expect("the completed child approval replays");
+            assert!(replay.unmatched_asks.is_empty());
+            assert_eq!(replay.completed.len(), 1);
+            let expected_outcome = if expect_ok {
+                ApprovalOutcome::ApprovedOnce
+            } else {
+                ApprovalOutcome::Denied
+            };
+            assert_eq!(replay.completed[0].outcome, expected_outcome);
+            assert!(matches!(
+                &replay.completed[0].ask,
+                ApprovalReceipt::Asked { tool_name, .. } if tool_name == "bash"
+            ));
             assert_eq!(manager.read().await.pending_child_approvals(), 0);
         }
+    }
+
+    #[tokio::test]
+    async fn closed_child_approval_waiter_persists_unavailable_not_cancelled() {
+        let (registry, mut rx, manager) = worker_registry(ApprovalMode::Suggest, false, true, None);
+        let (receipt_store, session_id) = receipt_context(&registry);
+        let manager_for_close = Arc::clone(&manager);
+        let closer = tokio::spawn(async move {
+            let id = next_child_approval_id(&mut rx).await;
+            manager_for_close.write().await.cancel_child_approval(&id);
+        });
+
+        let err = registry
+            .execute("agent_gate", "bash", json!({"command": "echo gated"}))
+            .await
+            .expect_err("a closed decision channel must fail closed");
+        closer.await.expect("closer task");
+        assert!(err.to_string().contains("could no longer reach"), "{err}");
+        assert_completed_receipt(&receipt_store, &session_id, ApprovalOutcome::Unavailable);
+        assert_eq!(manager.read().await.pending_child_approvals(), 0);
+    }
+
+    #[tokio::test]
+    async fn cancelled_child_approval_persists_cancelled() {
+        let (registry, mut rx, manager) = worker_registry(ApprovalMode::Suggest, false, true, None);
+        let (receipt_store, session_id) = receipt_context(&registry);
+        let cancel_token = registry.gate_runtime.cancel_token.clone();
+        let canceller = tokio::spawn(async move {
+            let _ = next_child_approval_id(&mut rx).await;
+            cancel_token.cancel();
+        });
+
+        let err = registry
+            .execute("agent_gate", "bash", json!({"command": "echo gated"}))
+            .await
+            .expect_err("runtime cancellation must fail the held call closed");
+        canceller.await.expect("canceller task");
+        assert!(err.to_string().contains("was cancelled"), "{err}");
+        assert_completed_receipt(&receipt_store, &session_id, ApprovalOutcome::Cancelled);
+        assert_eq!(manager.read().await.pending_child_approvals(), 0);
+    }
+
+    #[tokio::test]
+    async fn unavailable_prompt_host_persists_unavailable() {
+        let (registry, rx, manager) = worker_registry(ApprovalMode::Suggest, false, true, None);
+        let (receipt_store, session_id) = receipt_context(&registry);
+        drop(rx);
+
+        let err = registry
+            .execute("agent_gate", "bash", json!({"command": "echo gated"}))
+            .await
+            .expect_err("an unavailable prompt host must fail closed");
+        assert!(err.to_string().contains("could not be asked"), "{err}");
+        assert_completed_receipt(&receipt_store, &session_id, ApprovalOutcome::Unavailable);
+        assert_eq!(manager.read().await.pending_child_approvals(), 0);
+    }
+
+    #[tokio::test]
+    async fn terminal_receipt_failure_blocks_an_approved_child_call() {
+        let (registry, mut rx, manager) = worker_registry(ApprovalMode::Suggest, false, true, None);
+        let (receipt_store, session_id) = receipt_context(&registry);
+        let marker = registry
+            .gate_runtime
+            .context
+            .workspace
+            .join("approved-child-command-ran");
+        let log_path = receipt_store
+            .sessions_dir()
+            .join(session_id)
+            .join("approval_receipts.jsonl");
+        let manager_for_answer = Arc::clone(&manager);
+        let answerer = tokio::spawn(async move {
+            let approval_id = next_child_approval_id(&mut rx).await;
+            std::fs::remove_file(&log_path).expect("remove log after durable ask");
+            std::fs::create_dir(&log_path).expect("replace log with unwritable directory");
+            assert!(
+                manager_for_answer
+                    .write()
+                    .await
+                    .resolve_child_approval(&approval_id, ChildApprovalOutcome::Approved)
+            );
+        });
+
+        let err = registry
+            .execute(
+                "agent_gate",
+                "bash",
+                json!({"command": "touch approved-child-command-ran"}),
+            )
+            .await
+            .expect_err("an uncommitted terminal approval must not grant execution");
+        answerer.await.expect("answerer task");
+        assert!(
+            err.to_string()
+                .contains("Approval evidence could not be committed"),
+            "{err}"
+        );
+        assert!(
+            !marker.exists(),
+            "the approved command must not have executed"
+        );
+        assert_eq!(manager.read().await.pending_child_approvals(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #5543

## Problem

Child approval prompts could grant a tool call from an in-memory decision without durable Asked or
terminal evidence.

## Change

- inherit the session approval receipt store in child runtimes
- commit Asked before exposing the prompt and terminal outcomes before closing the gate
- distinguish cancellation from unavailable decision channels and fail closed on write errors

## Verification

- `cargo test -p codewhale-tui --lib --locked child_permission_gate` (13 passed)
- `cargo test -p codewhale-tui --lib --locked core::engine::approval::tests` (4 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
