### PR TITLE
ci: run Linux workspace tests on pull requests

### DIFF
--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -42,6 +42,23 @@ const archiveInstaller = read("scripts/release/install.sh");
 const cliDispatcher = read("crates/cli/src/lib.rs");
 const runbook = read("docs/RELEASE_RUNBOOK.md");
 
+const ciTestJob = ci.slice(ci.indexOf("\n  test:\n"));
+assert.match(
+  ciTestJob,
+  /matrix\.os == 'ubuntu-latest'.*github\.event_name == 'pull_request'/,
+  "heavy pull requests must select the real Ubuntu test lane",
+);
+assert.match(
+  ciTestJob,
+  /cargo nextest run --workspace --all-features --locked --profile ci/,
+  "the Ubuntu pull-request lane must run workspace nextest",
+);
+assert.match(
+  ciTestJob,
+  /name: Linux test location \(CNB\)/,
+  "the non-PR CNB fallback must be named explicitly",
+);
+
 assert.match(ci, /^  workflow_dispatch:\n    inputs:\n      expected_sha:/m);
 const manualForceBlock = ci.match(
   /if \[\[ "\$\{EVENT_NAME\}" == "workflow_dispatch" \]\]; then([\s\S]*?)\n\s+if \[\[ "\$\{EVENT_NAME\}" == "schedule" \]\]; then/,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,7 +464,8 @@ jobs:
     # "Test (windows-latest)" derive from job name + matrix.os and are
     # independent of runs-on. For light changes the macOS/Windows legs only
     # echo a skip line, so run them on ubuntu instead of queueing for scarce
-    # macOS/Windows runners. Heavy changes use the real matrix OS as before.
+    # macOS/Windows runners. Heavy pull requests run the Linux lane directly;
+    # non-PR release/main pushes use CNB for Linux.
     # The ternary is safe: matrix.os is always a non-empty literal, so
     # runs-on can never evaluate to empty.
     timeout-minutes: 90
@@ -474,15 +475,15 @@ jobs:
       # other one. We need both conclusions to diagnose and release safely.
       fail-fast: false
       matrix:
-        # Linux workspace tests moved to CNB; GitHub keeps the platform
-        # coverage CNB cannot provide.
+        # Linux workspace tests run directly for pull requests. CNB remains
+        # the Linux lane for non-PR release/main pushes.
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Skip tests for light change
         if: needs.changes.outputs.heavy != 'true'
         run: echo "No executable Rust changes detected; preserving required Test context."
       - uses: actions/checkout@v7
-        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
       - name: Test Windows installer PATH helper
         if: needs.changes.outputs.heavy == 'true' && matrix.os == 'windows-latest'
         shell: pwsh
@@ -519,20 +520,20 @@ jobs:
         shell: pwsh
         run: ./scripts/installer/installer-path-regression.tests.ps1 -AllowUserPathMutation
       - uses: dtolnay/rust-toolchain@stable
-        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
       - uses: mozilla-actions/sccache-action@v0.0.11
         id: sccache
         continue-on-error: true
-        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
       - name: Enable sccache
-        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch') && steps.sccache.outcome == 'success'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && steps.sccache.outcome == 'success'
         shell: bash
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
           echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
           echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> "${GITHUB_ENV}"
       - name: Install Linux system dependencies
-        if: needs.changes.outputs.heavy == 'true' && matrix.os == 'ubuntu-latest' && github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.heavy == 'true' && matrix.os == 'ubuntu-latest' && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
         run: |
           for i in 1 2 3 4 5; do
             sudo apt-get update && break
@@ -541,12 +542,12 @@ jobs:
           done
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
-        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
         with:
           cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
-        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
       - name: Run tests
         # Same test binaries as `cargo test`, run by cargo-nextest: one
         # process per test, all runner cores busy, slow tests named instead
@@ -554,7 +555,7 @@ jobs:
         # binary and bounds the integration binary that spawns the real
         # executable; retries are off, so a flake is a red run, not a hidden
         # one. nextest does not run doctests — the next step keeps them.
-        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
         run: cargo nextest run --workspace --all-features --locked --profile ci
         env:
           # Give test threads the stack the product gives itself. main.rs runs
@@ -571,7 +572,7 @@ jobs:
           # both libtest's per-test threads and tokio's workers.
           RUST_MIN_STACK: '16777216'
       - name: Run doctests
-        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
         run: cargo test --workspace --all-features --locked --doc
         env:
           RUST_MIN_STACK: '16777216'
@@ -582,7 +583,7 @@ jobs:
         if: needs.changes.outputs.heavy == 'true' && matrix.os == 'macos-latest'
         run: python3 scripts/check-persistence-backlog-budget.py
       - name: Lockfile drift guard
-        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
         run: git diff --exit-code -- Cargo.lock
       - name: Run Offline Eval Harness
         # The eval harness is OS-independent prompt/composition checking;
@@ -592,13 +593,13 @@ jobs:
         if: needs.changes.outputs.heavy == 'true' && matrix.os == 'macos-latest'
         run: cargo run -p codewhale-tui --all-features -- eval
       - name: sccache stats
-        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch') && steps.sccache.outcome == 'success'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && steps.sccache.outcome == 'success'
         continue-on-error: true
         shell: bash
         run: sccache --show-stats
-      - name: Linux test location
-        if: needs.changes.outputs.heavy == 'true' && matrix.os == 'ubuntu-latest' && github.event_name != 'workflow_dispatch'
-        run: echo "Linux workspace tests run on CNB for mirrored first-party branches."
+      - name: Linux test location (CNB)
+        if: needs.changes.outputs.heavy == 'true' && matrix.os == 'ubuntu-latest' && github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request'
+        run: echo "Linux workspace tests run on CNB for non-PR release/main pushes; pull requests run directly on Ubuntu."
 
   npm-wrapper-smoke:
     name: npm wrapper smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Heavy pull requests now run the real Linux workspace nextest, doctest, and
+  lockfile lanes directly on GitHub Actions instead of reporting a green
+  placeholder while waiting for a branch-specific CNB mirror (#5547).
+
 ## [0.9.11] - 2026-08-22
 
 Codewhale v0.9.11 tightens the long-running agent loop, makes workflow

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Heavy pull requests now run the real Linux workspace nextest, doctest, and
+  lockfile lanes directly on GitHub Actions instead of reporting a green
+  placeholder while waiting for a branch-specific CNB mirror (#5547).
+
 ## [0.9.11] - 2026-08-22
 
 Codewhale v0.9.11 tightens the long-running agent loop, makes workflow


### PR DESCRIPTION
## Summary

Addresses the approved CI coverage slice of #5547.

Heavy pull requests now run the existing Linux workspace gates directly on the GitHub Ubuntu matrix leg regardless of branch prefix:

- `cargo nextest run --workspace --all-features --locked --profile ci`;
- workspace doctests;
- lockfile drift guard;
- Linux dependency/toolchain/cache setup.

The non-PR CNB path remains unchanged for release/main pushes. The previous Ubuntu placeholder is now explicitly named as the CNB fallback and no longer runs for pull requests.

## Workflow contract coverage

`release-workflows.test.js` asserts that:

- heavy pull requests select the real Ubuntu test lane;
- the Ubuntu lane runs workspace nextest;
- the CNB fallback remains explicitly named.

## Known baseline note

The coordination note on #5547 identifies three existing `tui::ui` stack-overflow tests under nextest's default stack behavior (#5585):

- `setup_confirm_toast_names_secret_store_and_global_scope`;
- `provider_switch_to_openrouter_canonicalizes_deepseek_default_model`;
- `successful_custom_provider_activation_completes_onboarding`.

If the new Ubuntu leg reports those failures, they are pre-existing main/0.9.12 breakage and not caused by this workflow change.

## Verification

- `node .github/scripts/release-workflows.test.js`
- `git diff --check`
- `cargo fmt --all -- --check`

No provider credentials or network access are required locally.

No-Issue: This PR addresses the approved #5547 CI coverage slice without automatically closing the broader issue.
