### PR TITLE
fix(ci): scope credit checks to PR commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,11 +410,40 @@ jobs:
       - name: Check harvested contributor credit
         if: github.event_name != 'schedule'
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_MERGE_SHA: ${{ github.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            git fetch --no-tags origin "${BASE_SHA}"
-            RANGE="${BASE_SHA}..HEAD"
+          set -euo pipefail
+          python3 scripts/test_check_coauthor_trailers.py
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            # Pull-request base.sha can lag the merge ref's actual base parent.
+            # Comparing it to the synthetic merge checkout therefore
+            # rechecks unrelated commits that landed on the base after the PR
+            # opened. Use the merge ref's immutable parents: the base snapshot
+            # used to synthesize it and the exact PR head, while excluding the
+            # synthetic merge itself.
+            if [[ "$(git rev-parse HEAD)" != "${PR_MERGE_SHA}" ]]; then
+              echo "::error::credit check is not running at the event merge SHA" >&2
+              exit 1
+            fi
+            read -r BASE_PARENT HEAD_PARENT EXTRA_PARENT < <(
+              git show -s --format='%P' "${PR_MERGE_SHA}"
+            )
+            if [[ -z "${BASE_PARENT}" || -z "${HEAD_PARENT}" || -n "${EXTRA_PARENT}" ]]; then
+              echo "::error::pull-request merge ref must have exactly two parents" >&2
+              exit 1
+            fi
+            if [[ "${HEAD_PARENT}" != "${PR_HEAD_SHA}" ]]; then
+              echo "::error::merge ref head parent does not match the event PR head" >&2
+              exit 1
+            fi
+            RANGE="${BASE_PARENT}..${HEAD_PARENT}"
+            if [[ -z "$(git rev-list -1 "${RANGE}")" ]]; then
+              echo "::error::pull-request credit range is empty" >&2
+              exit 1
+            fi
           elif [[ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
             RANGE="${{ github.event.before }}..${{ github.sha }}"
           else


### PR DESCRIPTION
## Why

The harvested-credit gate compared a pull request creation-time `base.sha` to GitHub's synthetic merge checkout. Once `main` advanced, that range rechecked unrelated merged commits and falsely blocked docs-only PR #5565 on historical contributor trailers.

## What changed

- derive the PR range from the immutable synthetic merge parents (`base snapshot..exact PR head`)
- fail closed unless the checkout, two-parent shape, and event head all agree
- exclude the synthetic merge itself
- run the existing 11 checker regressions before every live credit scan

## Evidence

- old #5565 range reproduced the Paulo/Isabel false failures
- corrected range checks exactly #5565's two commits
- a real contributor branch that merged `main` still retains its branch merge and dependency commit while excluding base history
- `actionlint` clean (including shellcheck, apart from explicitly ignored pre-existing findings)
- checker tests: 11/11
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets`: clean

No-Issue: targeted CI false-positive fix discovered while landing #5565.