### PR TITLE
feat(tui): add capability-gated cursor accent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variables (the route-budget test removes the overrides; the prompts test
   points `HOME`/`USERPROFILE` at a scratch dir). Assertions unchanged.
 
+- TUI sessions now apply a subtle OSC 12 cursor accent only on explicitly
+  supported terminals and restore the terminal default through normal, panic,
+  and signal cleanup paths (#5554).
+
 ## [0.9.11] - 2026-08-22
 
 Codewhale v0.9.11 tightens the long-running agent loop, makes workflow

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variables (the route-budget test removes the overrides; the prompts test
   points `HOME`/`USERPROFILE` at a scratch dir). Assertions unchanged.
 
+- TUI sessions now apply a subtle OSC 12 cursor accent only on explicitly
+  supported terminals and restore the terminal default through normal, panic,
+  and signal cleanup paths (#5554).
+
 ## [0.9.11] - 2026-08-22
 
 Codewhale v0.9.11 tightens the long-running agent loop, makes workflow

--- a/crates/tui/src/prompt_zones.rs
+++ b/crates/tui/src/prompt_zones.rs
@@ -286,14 +286,14 @@ impl std::ops::Deref for AppendLog {
 /// Per-turn ephemeral data. Cleared at every turn boundary.
 ///
 /// **Phase 1 scaffolding** — not yet wired into the engine request path.
-#[cfg_attr(not(test), expect(dead_code))]
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, Default)]
 pub struct TurnScratch {
     pub working_set: Vec<String>,
     pub user_message: Option<Message>,
 }
 
-#[cfg_attr(not(test), expect(dead_code))]
+#[cfg_attr(not(test), allow(dead_code))]
 impl TurnScratch {
     pub fn new() -> Self {
         Self::default()

--- a/crates/tui/src/tui/cursor_accent.rs
+++ b/crates/tui/src/tui/cursor_accent.rs
@@ -1,0 +1,189 @@
+//! Capability-gated OSC 12 cursor accent support.
+//!
+//! OSC 12 changes the terminal cursor color and OSC 112 restores the terminal
+//! default. The guard is deliberately conservative: an explicit supported
+//! terminal marker is required, while `TERM=dumb` and reduced-motion policy
+//! suppress the decorative escape entirely.
+
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::palette::WHALE_ACCENT_PRIMARY_RGB;
+use ratatui::style::Color;
+
+const OSC12_RESET: &[u8] = b"\x1b]112\x07";
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// RAII handle for one process-wide cursor accent installation.
+pub(crate) struct CursorAccentGuard {
+    active: bool,
+}
+
+impl CursorAccentGuard {
+    /// Install the accent only when the resolved settings and environment make
+    /// decorative terminal control safe and explicit.
+    pub(crate) fn install(reduced_motion: bool, accent: Color) -> Self {
+        if reduced_motion || !environment_allows_cursor_accent() {
+            return Self { active: false };
+        }
+
+        let mut stdout = io::stdout();
+        if write_cursor_accent(&mut stdout, color_rgb(accent)).is_ok() {
+            ACTIVE.store(true, Ordering::SeqCst);
+            Self { active: true }
+        } else {
+            Self { active: false }
+        }
+    }
+}
+
+fn color_rgb(color: Color) -> (u8, u8, u8) {
+    match color {
+        Color::Rgb(red, green, blue) => (red, green, blue),
+        _ => WHALE_ACCENT_PRIMARY_RGB,
+    }
+}
+
+impl Drop for CursorAccentGuard {
+    fn drop(&mut self) {
+        if self.active {
+            restore_cursor_accent();
+        }
+    }
+}
+
+/// Restore the terminal's default cursor color once. Safe from normal,
+/// panic, and signal cleanup paths; repeated calls are no-ops.
+pub(crate) fn restore_cursor_accent() {
+    if !ACTIVE.swap(false, Ordering::SeqCst) {
+        return;
+    }
+    let mut stdout = io::stdout();
+    let _ = stdout.write_all(OSC12_RESET).and_then(|()| stdout.flush());
+}
+
+fn write_cursor_accent<W: Write>(
+    writer: &mut W,
+    (red, green, blue): (u8, u8, u8),
+) -> io::Result<()> {
+    write!(writer, "\x1b]12;#{red:02X}{green:02X}{blue:02X}\x07")?;
+    writer.flush()
+}
+
+fn environment_allows_cursor_accent() -> bool {
+    let term = std::env::var("TERM").unwrap_or_default();
+    let term_program = std::env::var("TERM_PROGRAM").unwrap_or_default();
+    let color_term = std::env::var("COLORTERM").unwrap_or_default();
+    let reduced_motion = std::env::var("NO_ANIMATIONS")
+        .ok()
+        .is_some_and(|value| env_truthy(&value));
+    cursor_accent_supported(
+        Some(&term_program),
+        Some(&term),
+        Some(&color_term),
+        reduced_motion,
+    )
+}
+
+fn cursor_accent_supported(
+    term_program: Option<&str>,
+    term: Option<&str>,
+    color_term: Option<&str>,
+    reduced_motion: bool,
+) -> bool {
+    if reduced_motion || term == Some("dumb") {
+        return false;
+    }
+
+    let program = term_program.unwrap_or_default().to_ascii_lowercase();
+    let known_terminal = matches!(
+        program.as_str(),
+        "alacritty"
+            | "apple_terminal"
+            | "contour"
+            | "ghostty"
+            | "iterm.app"
+            | "kitty"
+            | "konsole"
+            | "rio"
+            | "vscode"
+            | "wezterm"
+            | "windows_terminal"
+    );
+    known_terminal && (color_term.is_some_and(|value| !value.is_empty()) || term.is_some())
+}
+
+fn env_truthy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_terminals_are_explicitly_allowlisted() {
+        assert!(cursor_accent_supported(
+            Some("Ghostty"),
+            Some("xterm-256color"),
+            Some("truecolor"),
+            false
+        ));
+        assert!(cursor_accent_supported(
+            Some("kitty"),
+            Some("xterm-kitty"),
+            Some("truecolor"),
+            false
+        ));
+        assert!(!cursor_accent_supported(
+            Some("unknown-terminal"),
+            Some("xterm-256color"),
+            Some("truecolor"),
+            false
+        ));
+    }
+
+    #[test]
+    fn plain_and_reduced_motion_terminals_are_suppressed() {
+        assert!(!cursor_accent_supported(
+            Some("Ghostty"),
+            Some("dumb"),
+            Some("truecolor"),
+            false
+        ));
+        assert!(!cursor_accent_supported(
+            Some("Ghostty"),
+            Some("xterm-256color"),
+            Some("truecolor"),
+            true
+        ));
+    }
+
+    #[test]
+    fn cursor_sequences_set_and_restore_the_default() {
+        let mut output = Vec::new();
+        write_cursor_accent(&mut output, (0x12, 0xab, 0xf0)).unwrap();
+        assert_eq!(
+            output, b"\x1b]12;#12ABF0\x07",
+            "OSC 12 must use the existing accent as an RGB cursor color"
+        );
+        assert_eq!(OSC12_RESET, b"\x1b]112\x07");
+    }
+
+    #[test]
+    fn non_rgb_themes_fall_back_to_the_existing_accent() {
+        assert_eq!(color_rgb(Color::Blue), WHALE_ACCENT_PRIMARY_RGB);
+        assert_eq!(color_rgb(Color::Rgb(1, 2, 3)), (1, 2, 3));
+    }
+
+    #[test]
+    fn truthy_environment_values_are_conservative() {
+        assert!(env_truthy("1"));
+        assert!(env_truthy(" TRUE "));
+        assert!(!env_truthy("0"));
+        assert!(!env_truthy("false"));
+    }
+}

--- a/crates/tui/src/tui/mod.rs
+++ b/crates/tui/src/tui/mod.rs
@@ -32,6 +32,7 @@ pub mod composer_ui;
 pub mod context_inspector;
 pub mod context_menu;
 pub(crate) mod coordination_detail;
+pub(crate) mod cursor_accent;
 pub mod diff_render;
 pub mod display_refresh;
 pub mod event_broker;

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -308,6 +308,10 @@ pub async fn run_tui(
     let mut config = config.clone();
     let config = &mut config;
     let mut app = App::new_with_plugin_registry(options.clone(), config, plugin_registry);
+    let _cursor_accent_guard = crate::tui::cursor_accent::CursorAccentGuard::install(
+        app.low_motion || !app.fancy_animations,
+        app.ui_theme.accent_primary,
+    );
     crate::startup_trace::mark("app_constructed");
     sync_config_provider_from_app(config, &app);
     surface_prompt_override_notices(&mut app);
@@ -622,6 +626,7 @@ pub async fn run_tui(
     }
 
     cleanup_guard.defused = true;
+    crate::tui::cursor_accent::restore_cursor_accent();
     pop_keyboard_enhancement_flags(terminal.backend_mut());
     disable_alternate_scroll_mode(terminal.backend_mut());
     execute!(terminal.backend_mut(), DisableFocusChange)?;

--- a/crates/tui/src/tui/ui/terminal.rs
+++ b/crates/tui/src/tui/ui/terminal.rs
@@ -387,6 +387,7 @@ pub(crate) fn disable_alternate_scroll_mode<W: Write>(writer: &mut W) {
 /// `^[[>5u` shell pollution reported in #1583.
 pub fn emergency_restore_terminal() {
     let mut stdout = std::io::stdout();
+    crate::tui::cursor_accent::restore_cursor_accent();
     pop_keyboard_enhancement_flags(&mut stdout);
     disable_alternate_scroll_mode(&mut stdout);
     let _ = execute!(stdout, DisableFocusChange);


### PR DESCRIPTION
## Summary

Addresses the approved scope of #5554.

TUI sessions now apply a subtle OSC 12 cursor accent only when the terminal is explicitly recognized as capable and the session is not in reduced-motion/plain-terminal mode. The selected UI theme's accent color is used when it is RGB, with the existing whale accent as a safe fallback.

OSC 112 restoration is wired into:

- normal TUI teardown;
- the existing panic emergency restore path;
- the existing SIGTERM/SIGHUP cleanup path.

Restoration is process-wide, best-effort, and idempotent, so repeated cleanup cannot emit conflicting state.

## Capability and accessibility behavior

Supported terminal identifiers are explicitly allowlisted (`Ghostty`, Kitty, WezTerm, iTerm2, Terminal.app, Alacritty, VS Code, Windows Terminal, and other known modern terminals). Unknown terminals, `TERM=dumb`, and `NO_ANIMATIONS`/resolved reduced-motion sessions do not receive OSC 12.

## Tests and verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --lib 'cursor_accent' --locked` (5 passed)
- Full TUI library suite rerun: 11,023 passed, 13 ignored
- `CARGO_INCREMENTAL=0 cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings` (passed)
- Workflow/resource note: a later test invocation was killed by the local OS with SIGKILL during compilation; no test assertion failed in that invocation.

The second commit changes an existing stale `expect(dead_code)` to `allow(dead_code)` so Rust 1.98 Clippy does not reject the intentionally staged `TurnScratch` scaffolding. It is behavior-neutral and unrelated to cursor output.

No-Issue: This PR addresses the approved #5554 cursor-accent slice without automatically closing the broader issue.
