### PR TITLE
fix(tui): preserve Windows verbatim-path operands through POSIX word split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   placeholder while waiting for a branch-specific CNB mirror (#5547).
 - Fleet roster members in a selected Fleet now expose a visible edit affordance
   and a direct `m` model-picker shortcut, while the coordinator row remains
-  read-only (#5589).
+  read-only (#5604, covers #5589).
 - The goal-continuation quiet period (`[goal] continuation_delay_seconds`,
   added in #5508) now applies on every dispatch path. Previously the
   within-turn dispatch hook fired the next continuation prompt immediately

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -136,7 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   placeholder while waiting for a branch-specific CNB mirror (#5547).
 - Fleet roster members in a selected Fleet now expose a visible edit affordance
   and a direct `m` model-picker shortcut, while the coordinator row remains
-  read-only (#5589).
+  read-only (#5604, covers #5589).
 - The goal-continuation quiet period (`[goal] continuation_delay_seconds`,
   added in #5508) now applies on every dispatch path. Previously the
   within-turn dispatch hook fired the next continuation prompt immediately

--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -405,10 +405,66 @@ const GITHUB_READONLY_PREFIXES: &[&str] = &[
     "gh workflow view",
 ];
 
+/// Normalize Windows absolute path spellings before any POSIX-style splitter
+/// (`shlex` / `shell_words`) or glob-charset gate in this module:
+///
+/// - `Path::canonicalize` on Windows embeds the verbatim prefix `\\?\C:\...`
+///   whose `?` trips the glob-charset gates and whose backslashes the POSIX
+///   splitters eat as escapes; strip it so the remaining spelling resolves to
+///   the same location (device `\\.\` paths are preserved verbatim);
+/// - double the backslashes of Windows-absolute-path-like words so the
+///   splitters round-trip the real path instead of `C:\Users\...` collapsing
+///   to `C:Users...`.
+///
+/// Words that do not look like Windows absolute paths are untouched, so POSIX
+/// escapes and unix hosts are unaffected.
+pub(crate) fn normalize_windows_command_paths(command: &str) -> String {
+    let stripped = command.replace(r"\\?\", "");
+    let mut out = String::with_capacity(stripped.len());
+    let mut word_start = 0;
+    let bytes = stripped.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_whitespace() {
+            let word = &stripped[word_start..i];
+            if looks_like_windows_absolute_path(word) {
+                out.push_str(&word.replace('\\', r"\\"));
+            } else {
+                out.push_str(word);
+            }
+            out.push(bytes[i] as char);
+            word_start = i + 1;
+        }
+        i += 1;
+    }
+    if word_start < bytes.len() {
+        let word = &stripped[word_start..];
+        if looks_like_windows_absolute_path(word) {
+            out.push_str(&word.replace('\\', r"\\"));
+        } else {
+            out.push_str(word);
+        }
+    }
+    out
+}
+
+/// A whitespace-delimited word is treated as a Windows absolute path when it
+/// starts (after optional quotes) with a drive letter plus colon, a verbatim
+/// (`\\?\`/`\\.\`) prefix, or a UNC (`\\`) prefix.
+fn looks_like_windows_absolute_path(word: &str) -> bool {
+    let word = word.trim_start_matches(['\'', '"']);
+    let bytes = word.as_bytes();
+    (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+        || word.starts_with(r"\\?\")
+        || word.starts_with(r"\\.\")
+        || word.starts_with("\\\\")
+}
+
 /// Return `true` when a shell command is safe to auto-approve and run in a
 /// parallel read-only chunk.
 pub fn is_parallel_readonly_command(command: &str) -> bool {
-    let trimmed = command.trim();
+    let trimmed = normalize_windows_command_paths(command);
+    let trimmed = trimmed.trim();
     if trimmed.is_empty() {
         return false;
     }
@@ -522,7 +578,8 @@ fn readonly_tokens_admitted(trimmed: &str) -> bool {
 /// redirects, backgrounding, command/parameter expansion, subshells, or
 /// env-assignment prefixes.
 pub fn is_agent_readonly_shell_command(command: &str) -> bool {
-    let trimmed = command.trim();
+    let trimmed = normalize_windows_command_paths(command);
+    let trimmed = trimmed.trim();
     if trimmed.is_empty() {
         return false;
     }
@@ -2034,6 +2091,25 @@ mod tests {
             "npm view codewhale version",
             "sort deps.txt | uniq -c",
             "ls -la *.md",
+        ] {
+            assert!(
+                is_agent_readonly_shell_command(command),
+                "{command} should be agent read-only"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_readonly_shell_admits_windows_verbatim_paths() {
+        // `Path::canonicalize` on Windows embeds `\\?\` verbatim prefixes whose
+        // `?` trips the glob-charset gate and whose backslashes POSIX splitters
+        // eat as escapes. The normalize step must admit the same commands with
+        // either spelling (the classifier is pure string logic, so this is
+        // platform-independent).
+        for command in [
+            r"git -C \\?\C:\Users\foo log --oneline -20",
+            r"git -C C:\Users\foo log --oneline -20",
+            "git -C crates/tui log --oneline -n 5",
         ] {
             assert!(
                 is_agent_readonly_shell_command(command),

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -3764,7 +3764,7 @@ fn exec_shell_input_is_parallel_readonly_shape(input: &serde_json::Value) -> boo
 }
 
 fn hardened_readonly_argv(command: &str) -> Result<(String, Vec<String>)> {
-    let mut argv = shell_words::split(command)
+    let mut argv = shell_words::split(&protect_windows_path_backslashes(command))
         .map_err(|error| anyhow!("could not parse classifier-approved read command: {error}"))?;
     if argv.is_empty() {
         return Err(anyhow!("classifier-approved read command was empty"));
@@ -3824,12 +3824,59 @@ fn hardened_readonly_argv(command: &str) -> Result<(String, Vec<String>)> {
     Ok((program, argv))
 }
 
+/// `shell_words` splits with POSIX backslash-escaping, which silently eats the
+/// separators of Windows absolute paths (`C:\Users\...` becomes `C:Users...`)
+/// and mangles the `\\?\` verbatim prefix before operand classification can
+/// see it. Double the backslashes inside Windows-absolute-path-like words so
+/// the splitter preserves them; every other word is untouched, so POSIX escape
+/// semantics and unix hosts are unaffected.
+fn protect_windows_path_backslashes(command: &str) -> String {
+    let mut out = String::with_capacity(command.len());
+    let mut word_start = 0;
+    let bytes = command.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_whitespace() {
+            let word = &command[word_start..i];
+            if looks_like_windows_absolute_path(word) {
+                out.push_str(&word.replace('\\', r"\\"));
+            } else {
+                out.push_str(word);
+            }
+            out.push(bytes[i] as char);
+            word_start = i + 1;
+        }
+        i += 1;
+    }
+    if word_start < bytes.len() {
+        let word = &command[word_start..];
+        if looks_like_windows_absolute_path(word) {
+            out.push_str(&word.replace('\\', r"\\"));
+        } else {
+            out.push_str(word);
+        }
+    }
+    out
+}
+
+/// A whitespace-delimited word is treated as a Windows absolute path when it
+/// starts (after optional quotes) with a drive letter plus colon, a verbatim
+/// (`\\?\`/`\\.\`) prefix, or a UNC (`\\`) prefix.
+fn looks_like_windows_absolute_path(word: &str) -> bool {
+    let word = word.trim_start_matches(['\'', '"']);
+    let bytes = word.as_bytes();
+    (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+        || word.starts_with(r"\\?\")
+        || word.starts_with(r"\\.\")
+        || word.starts_with("\\\\")
+}
+
 fn enforce_readonly_workspace_operands(
     command: &str,
     workspace: &std::path::Path,
     effective_cwd: &std::path::Path,
 ) -> Result<(), ToolError> {
-    let argv = shell_words::split(command).map_err(|error| {
+    let argv = shell_words::split(&protect_windows_path_backslashes(command)).map_err(|error| {
         ToolError::invalid_input(format!(
             "Could not parse read-only command arguments: {error}"
         ))

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -3356,7 +3356,7 @@ pub fn new_shared_shell_manager(workspace: PathBuf) -> SharedShellManager {
 
 use crate::command_safety::{
     SafetyLevel, analyze_command, extract_primary_command, is_agent_readonly_shell_command,
-    is_github_readonly_command, is_parallel_readonly_command,
+    is_github_readonly_command, is_parallel_readonly_command, normalize_windows_command_paths,
 };
 use crate::execpolicy::{ExecPolicyDecision, load_default_policy};
 use crate::features::Feature;
@@ -3764,7 +3764,7 @@ fn exec_shell_input_is_parallel_readonly_shape(input: &serde_json::Value) -> boo
 }
 
 fn hardened_readonly_argv(command: &str) -> Result<(String, Vec<String>)> {
-    let mut argv = shell_words::split(&protect_windows_path_backslashes(command))
+    let mut argv = shell_words::split(&normalize_windows_command_paths(command))
         .map_err(|error| anyhow!("could not parse classifier-approved read command: {error}"))?;
     if argv.is_empty() {
         return Err(anyhow!("classifier-approved read command was empty"));
@@ -3824,59 +3824,12 @@ fn hardened_readonly_argv(command: &str) -> Result<(String, Vec<String>)> {
     Ok((program, argv))
 }
 
-/// `shell_words` splits with POSIX backslash-escaping, which silently eats the
-/// separators of Windows absolute paths (`C:\Users\...` becomes `C:Users...`)
-/// and mangles the `\\?\` verbatim prefix before operand classification can
-/// see it. Double the backslashes inside Windows-absolute-path-like words so
-/// the splitter preserves them; every other word is untouched, so POSIX escape
-/// semantics and unix hosts are unaffected.
-fn protect_windows_path_backslashes(command: &str) -> String {
-    let mut out = String::with_capacity(command.len());
-    let mut word_start = 0;
-    let bytes = command.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i].is_ascii_whitespace() {
-            let word = &command[word_start..i];
-            if looks_like_windows_absolute_path(word) {
-                out.push_str(&word.replace('\\', r"\\"));
-            } else {
-                out.push_str(word);
-            }
-            out.push(bytes[i] as char);
-            word_start = i + 1;
-        }
-        i += 1;
-    }
-    if word_start < bytes.len() {
-        let word = &command[word_start..];
-        if looks_like_windows_absolute_path(word) {
-            out.push_str(&word.replace('\\', r"\\"));
-        } else {
-            out.push_str(word);
-        }
-    }
-    out
-}
-
-/// A whitespace-delimited word is treated as a Windows absolute path when it
-/// starts (after optional quotes) with a drive letter plus colon, a verbatim
-/// (`\\?\`/`\\.\`) prefix, or a UNC (`\\`) prefix.
-fn looks_like_windows_absolute_path(word: &str) -> bool {
-    let word = word.trim_start_matches(['\'', '"']);
-    let bytes = word.as_bytes();
-    (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
-        || word.starts_with(r"\\?\")
-        || word.starts_with(r"\\.\")
-        || word.starts_with("\\\\")
-}
-
 fn enforce_readonly_workspace_operands(
     command: &str,
     workspace: &std::path::Path,
     effective_cwd: &std::path::Path,
 ) -> Result<(), ToolError> {
-    let argv = shell_words::split(&protect_windows_path_backslashes(command)).map_err(|error| {
+    let argv = shell_words::split(&normalize_windows_command_paths(command)).map_err(|error| {
         ToolError::invalid_input(format!(
             "Could not parse read-only command arguments: {error}"
         ))

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -1021,6 +1021,51 @@ fn readonly_operands_are_workspace_bounded_and_symlink_aware() {
 }
 
 #[test]
+fn windows_verbatim_and_drive_operands_survive_posix_split() {
+    // `shell_words` splits with POSIX backslash-escaping, which silently eats
+    // the separators of Windows absolute paths (`C:\Users\...` becomes
+    // `C:Users...`) and mangles the `\\?\` verbatim prefix before operand
+    // classification can see it. The protection doubles those backslashes so
+    // the splitter round-trips the real path (the `\\?\` cases that the
+    // verbatim strip alone could never reach).
+    for (raw, expected) in [
+        (
+            r"\\?\C:\Users\foo\inside.txt",
+            r"\\?\C:\Users\foo\inside.txt",
+        ),
+        (r"C:\Users\foo\inside.txt", r"C:\Users\foo\inside.txt"),
+        (r"\\server\share\secret", r"\\server\share\secret"),
+        (r"\\.\device\path", r"\\.\device\path"),
+    ] {
+        let protected = protect_windows_path_backslashes(&format!("cat {raw}"));
+        let argv = shell_words::split(&protected).expect("split must succeed");
+        assert_eq!(
+            argv,
+            vec!["cat".to_string(), expected.to_string()],
+            "{raw} must survive the POSIX split"
+        );
+    }
+}
+
+#[test]
+fn windows_path_protection_leaves_other_words_untouched() {
+    // POSIX escapes, drive-relative spellings, and plain relative operands
+    // are not Windows absolute paths and must round-trip unchanged.
+    assert_eq!(
+        protect_windows_path_backslashes("echo a\\ b && cat inside.txt"),
+        "echo a\\ b && cat inside.txt"
+    );
+    assert_eq!(
+        protect_windows_path_backslashes("cat C:secret"),
+        "cat C:secret"
+    );
+    assert_eq!(
+        protect_windows_path_backslashes("cat inside.txt"),
+        "cat inside.txt"
+    );
+}
+
+#[test]
 fn readonly_github_shell_calls_obey_the_host_network_policy_before_spawn() {
     let tmp = tempdir().expect("tempdir");
     let context = |default| {

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -1029,15 +1029,12 @@ fn windows_verbatim_and_drive_operands_survive_posix_split() {
     // the splitter round-trips the real path (the `\\?\` cases that the
     // verbatim strip alone could never reach).
     for (raw, expected) in [
-        (
-            r"\\?\C:\Users\foo\inside.txt",
-            r"\\?\C:\Users\foo\inside.txt",
-        ),
+        (r"\\?\C:\Users\foo\inside.txt", r"C:\Users\foo\inside.txt"),
         (r"C:\Users\foo\inside.txt", r"C:\Users\foo\inside.txt"),
         (r"\\server\share\secret", r"\\server\share\secret"),
         (r"\\.\device\path", r"\\.\device\path"),
     ] {
-        let protected = protect_windows_path_backslashes(&format!("cat {raw}"));
+        let protected = normalize_windows_command_paths(&format!("cat {raw}"));
         let argv = shell_words::split(&protected).expect("split must succeed");
         assert_eq!(
             argv,
@@ -1052,15 +1049,15 @@ fn windows_path_protection_leaves_other_words_untouched() {
     // POSIX escapes, drive-relative spellings, and plain relative operands
     // are not Windows absolute paths and must round-trip unchanged.
     assert_eq!(
-        protect_windows_path_backslashes("echo a\\ b && cat inside.txt"),
+        normalize_windows_command_paths("echo a\\ b && cat inside.txt"),
         "echo a\\ b && cat inside.txt"
     );
     assert_eq!(
-        protect_windows_path_backslashes("cat C:secret"),
+        normalize_windows_command_paths("cat C:secret"),
         "cat C:secret"
     );
     assert_eq!(
-        protect_windows_path_backslashes("cat inside.txt"),
+        normalize_windows_command_paths("cat inside.txt"),
         "cat inside.txt"
     );
 }


### PR DESCRIPTION
## Summary

Fixes the two Windows CI failures that block FEAT-019 (PR #5609):

- `tools::shell::tests::readonly_operands_are_workspace_bounded_and_symlink_aware`
- `tools::subagent::tests::read_only_inspection_roles_execute_pwd_and_absolute_git_log`

## Root cause

`enforce_readonly_workspace_operands` (and `hardened_readonly_argv`) tokenize the read-only command with `shell_words::split`, which follows **POSIX backslash-escaping**. On Windows, `Path::canonicalize` returns verbatim device paths (`\\?\C:\...`); the POSIX splitter silently eats the separators of any backslash path (`C:\Users\...` → `C:Users...`, `\\?\C:\...` → `\?C:...`).

The previous fix (42857108f) stripped the `\\?\` prefix **after** the split and only for `key=value` operands (`token.split_once('=')`). The failing tests pass the canonical path as a **bare space-separated token** (`cat <path>`, `git -C <path> log`), so the splitter already mangled it before the strip could run — the refusal then happened on the mangled spelling.

## Fix

Normalize Windows absolute path spellings **before** any POSIX-style splitter or glob-charset gate via a shared `normalize_windows_command_paths` in `crates/tui/src/command_safety.rs`:

- strips the `\\?\` verbatim prefix (`Path::canonicalize` artifact) whose `?` trips the classifiers' glob-charset gate; `\\.\` device paths are preserved verbatim;
- doubles the backslashes of Windows-absolute-path-like words (drive letter + `:`, verbatim, or UNC prefix) so `shlex`/`shell_words` round-trip the real path instead of `C:\Users\...` collapsing to `C:Users...`.

Applied at all judging sites:

- `is_agent_readonly_shell_command` and `is_parallel_readonly_command` (command_safety.rs) — the subagent posture gate;
- both `shell_words::split` sites in shell.rs (`enforce_readonly_workspace_operands` and `hardened_readonly_argv`).

Only Windows-absolute-path-like words are touched — POSIX escapes (`echo a\ b`) and unix hosts are unaffected.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] New unit tests: verbatim/drive/UNC/device operands survive the POSIX split round-trip; the agent classifier admits verbatim-prefixed `git -C` commands; POSIX escapes and drive-relative spellings untouched
- [x] `tools::shell` module — 139 passed
- [x] `tools::subagent` module — 555 passed
- [x] Clippy `-D warnings` on `codewhale-tui` — 0 warnings

The definitive validation is the Windows CI job (Linux cannot reproduce verbatim-path canonicalization); a green `Test (windows-latest)` on this PR unblocks FEAT-019.

Paulo Aboim Pinto


No-Issue: this fix unblocks FEAT-019 (PR #5609); umbrella #5316 must remain open for the remaining decomposition FEATs.

Paulo Aboim Pinto