### PR TITLE
fix(web): keep the published-release fact current instead of after the fact

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -34,6 +34,15 @@ jobs:
         # fields by design, so it is safe to run against the committed copy that
         # exists at checkout.
         run: npm run check:facts
+      - name: Check published-release fact is current
+        # web/data/latest-published-release.json is hand-maintained and feeds
+        # facts.generated.ts. Nothing wrote it, so it drifted to v0.9.10 while
+        # v0.9.11 was live, and the post-deploy comparison below failed on
+        # latestPublishedRelease.tag AFTER the site had already shipped. Gate it
+        # here so the mismatch is caught before deploying, not after.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npm run check:latest-release
       - name: Generate derived facts
         # Regenerate after the drift gate so tsc --noEmit (TS2307 without it) and
         # the build use a current facts.generated.ts. When the gate passes this

--- a/docs/public-surface-facts.json
+++ b/docs/public-surface-facts.json
@@ -35,10 +35,10 @@
     ]
   },
   "latestPublishedRelease": {
-    "tag": "v0.9.10",
-    "version": "0.9.10",
-    "publishedAt": "2026-08-20T09:58:55Z",
-    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.10",
+    "tag": "v0.9.11",
+    "version": "0.9.11",
+    "publishedAt": "2026-08-23T17:39:46Z",
+    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.11",
     "sources": [
       "web/data/latest-published-release.json"
     ]

--- a/web/data/latest-published-release.json
+++ b/web/data/latest-published-release.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v0.9.10",
-  "version": "0.9.10",
-  "publishedAt": "2026-08-20T09:58:55Z",
-  "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.10"
+  "tag": "v0.9.11",
+  "version": "0.9.11",
+  "publishedAt": "2026-08-23T17:39:46Z",
+  "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.11"
 }

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -27,7 +27,7 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-08-24T00:45:45.791Z",
+  "generatedAt": "2026-08-25T09:50:23.220Z",
   "sourceRevision": null,
   "sourceCommittedAt": null,
   "version": "0.9.11",
@@ -290,9 +290,9 @@ export const FACTS: RepoFacts = {
   "toolCount": 74,
   "license": "MIT",
   "latestPublishedRelease": {
-    "tag": "v0.9.10",
-    "version": "0.9.10",
-    "publishedAt": "2026-08-20T09:58:55Z",
-    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.10"
+    "tag": "v0.9.11",
+    "version": "0.9.11",
+    "publishedAt": "2026-08-23T17:39:46Z",
+    "url": "https://github.com/Hmbown/CodeWhale/releases/tag/v0.9.11"
   }
 };

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "codewhale-web",
   "version": "0.1.0",
   "private": true,
-  "description": "Community site for Codewhale — codewhale.net",
+  "description": "Community site for Codewhale \u2014 codewhale.net",
   "scripts": {
     "dev": "node scripts/derive-facts.mjs && next dev",
     "prebuild": "node scripts/derive-facts.mjs",
@@ -10,6 +10,8 @@
     "start": "next start",
     "test": "vitest run",
     "check:facts": "node scripts/check-facts.mjs",
+    "sync:latest-release": "node scripts/sync-latest-release.mjs",
+    "check:latest-release": "node scripts/sync-latest-release.mjs --check",
     "check:docs": "node scripts/check-docs.mjs",
     "check:locales": "node scripts/check-locales.mjs",
     "check:deploy-env": "node scripts/check-cloudflare-deploy-env.mjs",

--- a/web/scripts/sync-latest-release.mjs
+++ b/web/scripts/sync-latest-release.mjs
@@ -1,5 +1,14 @@
 #!/usr/bin/env node
-// Refresh web/data/latest-published-release.json from the real GitHub release.
+// Refresh the checked-in "latest published release" fact from the real GitHub
+// release. The fact is mirrored in two places and BOTH must move together:
+//
+//   web/data/latest-published-release.json   (read by derive-facts.mjs)
+//   docs/public-surface-facts.json           (latestPublishedRelease, which
+//                                             names the file above as its
+//                                             `sources`)
+//
+// web/lib/public-surface-contract.test.ts asserts the two agree, so updating
+// only the first turns a stale marketing fact into a red Lint & Type Check.
 //
 // Facts must be derivable from the repo with no network (derive-facts.mjs reads
 // this file, it does not call GitHub), so the file is checked in. Nothing wrote
@@ -20,6 +29,7 @@ import { dirname, resolve } from "node:path";
 const REPO = "Hmbown/CodeWhale";
 const here = dirname(fileURLToPath(import.meta.url));
 const target = resolve(here, "..", "data", "latest-published-release.json");
+const mirror = resolve(here, "..", "..", "docs", "public-surface-facts.json");
 const checkOnly = process.argv.includes("--check");
 
 const headers = {
@@ -51,21 +61,47 @@ if (!tag || !version || tag !== `v${version}` || !Number.isFinite(Date.parse(nex
   process.exit(1);
 }
 
-const current = (() => {
-  try { return JSON.parse(readFileSync(target, "utf8")); } catch { return null; }
-})();
+const readJson = (path) => {
+  try { return JSON.parse(readFileSync(path, "utf8")); } catch { return null; }
+};
 
-const serialized = `${JSON.stringify(next, null, 2)}\n`;
-if (current && current.tag === next.tag && current.publishedAt === next.publishedAt) {
+const current = readJson(target);
+const matrix = readJson(mirror);
+const currentMirror = matrix?.latestPublishedRelease ?? null;
+
+const isCurrent = (fact) =>
+  Boolean(fact) && fact.tag === next.tag && fact.publishedAt === next.publishedAt;
+
+if (isCurrent(current) && isCurrent(currentMirror)) {
   console.log(`[sync-latest-release] already current at ${next.tag}`);
   process.exit(0);
 }
 
 if (checkOnly) {
-  console.error(`[sync-latest-release] stale: file says ${current?.tag ?? "(missing)"}, GitHub says ${next.tag}`);
+  if (!isCurrent(current)) {
+    console.error(
+      `[sync-latest-release] stale: ${target} says ${current?.tag ?? "(missing)"}, GitHub says ${next.tag}`,
+    );
+  }
+  if (!isCurrent(currentMirror)) {
+    console.error(
+      `[sync-latest-release] stale: docs/public-surface-facts.json says ${currentMirror?.tag ?? "(missing)"}, GitHub says ${next.tag}`,
+    );
+  }
   console.error("Run: npm --prefix web run sync:latest-release && npm --prefix web run build");
   process.exit(1);
 }
 
-writeFileSync(target, serialized);
-console.log(`[sync-latest-release] wrote ${next.tag} (${next.publishedAt})`);
+writeFileSync(target, `${JSON.stringify(next, null, 2)}\n`);
+
+if (!matrix) {
+  console.error(`[sync-latest-release] could not read ${mirror}; the mirror is now stale.`);
+  process.exit(1);
+}
+
+// Preserve every key the matrix carries beyond the four synced fields (notably
+// `sources`), so this stays a fact refresh and not a schema rewrite.
+matrix.latestPublishedRelease = { ...currentMirror, ...next };
+writeFileSync(mirror, `${JSON.stringify(matrix, null, 2)}\n`);
+
+console.log(`[sync-latest-release] wrote ${next.tag} (${next.publishedAt}) to both facts`);

--- a/web/scripts/sync-latest-release.mjs
+++ b/web/scripts/sync-latest-release.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Refresh web/data/latest-published-release.json from the real GitHub release.
+//
+// Facts must be derivable from the repo with no network (derive-facts.mjs reads
+// this file, it does not call GitHub), so the file is checked in. Nothing wrote
+// it, which is why it drifted: the marketing deploy's post-deploy comparison
+// failed on latestPublishedRelease.tag because this said v0.9.10 while the
+// published release was v0.9.11.
+//
+//   node web/scripts/sync-latest-release.mjs          # write if changed
+//   node web/scripts/sync-latest-release.mjs --check  # exit 1 if stale
+//
+// --check is the CI form: it makes drift a failing gate at PR time instead of a
+// surprise after a production deploy.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const REPO = "Hmbown/CodeWhale";
+const here = dirname(fileURLToPath(import.meta.url));
+const target = resolve(here, "..", "data", "latest-published-release.json");
+const checkOnly = process.argv.includes("--check");
+
+const headers = {
+  accept: "application/vnd.github+json",
+  "user-agent": "codewhale-facts-sync",
+};
+if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+
+const response = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, { headers });
+if (!response.ok) {
+  console.error(`[sync-latest-release] GitHub returned ${response.status}; leaving the file alone.`);
+  process.exit(checkOnly ? 0 : 1);
+}
+const release = await response.json();
+
+const tag = String(release.tag_name || "");
+const version = tag.startsWith("v") ? tag.slice(1) : "";
+const next = {
+  tag,
+  version,
+  publishedAt: String(release.published_at || ""),
+  url: `https://github.com/${REPO}/releases/tag/${tag}`,
+};
+
+// deriveLatestPublishedRelease() silently returns null on any shape violation,
+// which would drop the fact entirely rather than report a bad one. Fail loudly.
+if (!tag || !version || tag !== `v${version}` || !Number.isFinite(Date.parse(next.publishedAt))) {
+  console.error(`[sync-latest-release] refusing to write an unusable release fact: ${JSON.stringify(next)}`);
+  process.exit(1);
+}
+
+const current = (() => {
+  try { return JSON.parse(readFileSync(target, "utf8")); } catch { return null; }
+})();
+
+const serialized = `${JSON.stringify(next, null, 2)}\n`;
+if (current && current.tag === next.tag && current.publishedAt === next.publishedAt) {
+  console.log(`[sync-latest-release] already current at ${next.tag}`);
+  process.exit(0);
+}
+
+if (checkOnly) {
+  console.error(`[sync-latest-release] stale: file says ${current?.tag ?? "(missing)"}, GitHub says ${next.tag}`);
+  console.error("Run: npm --prefix web run sync:latest-release && npm --prefix web run build");
+  process.exit(1);
+}
+
+writeFileSync(target, serialized);
+console.log(`[sync-latest-release] wrote ${next.tag} (${next.publishedAt})`);


### PR DESCRIPTION
`web/data/latest-published-release.json` is hand-maintained and feeds `facts.generated.ts`. Nothing ever wrote it, so it sat at **v0.9.10** while **v0.9.11** had been published on 2026-08-23.

The consequence was not cosmetic: the marketing deploy on 2026-08-25 succeeded, shipped, and *then* failed its own post-deploy comparison on `latestPublishedRelease.tag`. The site was already live with a stale fact by the time anyone found out.

**What this changes**

- `web/scripts/sync-latest-release.mjs` reads the real latest release from the GitHub API and rewrites the file. `--check` turns drift into a failing gate. It refuses to write a release that `deriveLatestPublishedRelease()` would reject, because that helper returns `null` on any shape violation — it would drop the fact entirely rather than report a bad one.
- `web.yml` runs the check immediately after "Check facts drift", so a stale release fact stops the deploy *before* it ships.
- The data file and `facts.generated.ts` are refreshed to v0.9.11.

**What this deliberately does not change**

The fact stays checked in. `derive-facts.mjs` must work with no network, so the read path stays offline; this only adds the missing write path.

Verified locally: `node web/scripts/sync-latest-release.mjs` wrote v0.9.11 (2026-08-23T17:39:46Z), `npm run check:facts` → `OK — committed facts.generated.ts matches workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


No-Issue: marketing-facts staleness found while triaging the open PR queue; no filed issue.
