### PR TITLE
ci(release): fail when the release-note receipt check cannot run

### DIFF
--- a/scripts/release/check-versions.sh
+++ b/scripts/release/check-versions.sh
@@ -215,6 +215,18 @@ if [[ -n "${previous_tag}" ]]; then
       git diff "${previous_tag}..HEAD" -- README.md \
         | grep -E '^\+[-*] \*\*\[[^]]+\]\(https://github.com/[^)]+\)\*\*' || true
     )
+  else
+    # A gate that silently no-ops is worse than no gate: it reports success and
+    # is read as evidence. If the tag cannot be resolved -- the fetch above is
+    # `|| true` and a network blip is enough -- then the feature release-note
+    # receipt check and the contributor-credit check did not run at all, and
+    # this script must not imply that they passed.
+    echo "::error::Cannot resolve refs/tags/${previous_tag}, so the feature release-note receipt and contributor-credit checks did not run. Fetch the tag and re-run; do not treat this as a pass." >&2
+    if [[ "${CWC_ALLOW_MISSING_PREVIOUS_TAG:-}" == "1" ]]; then
+      echo "::warning::CWC_ALLOW_MISSING_PREVIOUS_TAG=1 set, continuing with those two checks UNRUN." >&2
+    else
+      fail=1
+    fi
   fi
 fi
 


### PR DESCRIPTION
`scripts/release/check-versions.sh` resolves the previous release tag, fetching it if absent with `|| true`, then runs the feature release-note receipt check and the contributor-credit check **only if that tag resolves**. If the fetch failed — a network blip is enough — both checks were skipped in silence and the script still exited `0`.

A gate that silently no-ops is worse than no gate: it reports success and then gets read as evidence that the thing it guards was verified. This is the same failure shape as a probe hardcoding a capability to `true`.

It now names the checks that did not run and fails. `CWC_ALLOW_MISSING_PREVIOUS_TAG=1` preserves the old behaviour for a genuinely tagless history, but says out loud that the two checks are UNRUN.

**Verified non-vacuous**, in a throwaway `--no-tags` clone with `origin` pointed at a nonexistent path so the fetch really fails:

```
::error::Cannot resolve refs/tags/v0.9.10, so the feature release-note receipt
and contributor-credit checks did not run. Fetch the tag and re-run; do not
treat this as a pass.
exit WITHOUT hatch = 1
::warning::CWC_ALLOW_MISSING_PREVIOUS_TAG=1 set, continuing with those two checks UNRUN.
exit WITH hatch = 0
```

And unchanged on a normal checkout:

```
Feature release-note receipts OK: 21 linked issue reference(s) checked in v0.9.10..HEAD.
Version state OK: workspace=0.9.11, npm=0.9.11, npm-binary=0.9.11, lockfile in sync.
```

No-Issue: CI hardening found while diagnosing why every open PR was red on `Version drift`.