### PR TITLE
fix(tui): move git_status/git_diff off the async executor thread

### DIFF
--- a/crates/tui/src/tools/git.rs
+++ b/crates/tui/src/tools/git.rs
@@ -80,7 +80,7 @@ impl ToolSpec for GitStatusTool {
         }
 
         let command_str = format_command(&git_ctx.working_dir, &args);
-        let output = run_git_command(&git_ctx.working_dir, &args)?;
+        let output = run_git_command_async(git_ctx.working_dir.clone(), args).await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -182,7 +182,7 @@ impl ToolSpec for GitDiffTool {
         }
 
         let command_str = format_command(&git_ctx.working_dir, &args);
-        let output = run_git_command(&git_ctx.working_dir, &args)?;
+        let output = run_git_command_async(git_ctx.working_dir.clone(), args).await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -283,6 +283,17 @@ fn run_git_command(working_dir: &Path, args: &[String]) -> Result<std::process::
             ToolError::execution_failed(format!("Failed to run git: {e}"))
         }
     })
+}
+
+/// Async wrapper that offloads the blocking `git` invocation onto a
+/// blocking-capable thread so the tokio worker is not stalled.
+async fn run_git_command_async(
+    working_dir: PathBuf,
+    args: Vec<String>,
+) -> Result<std::process::Output, ToolError> {
+    tokio::task::spawn_blocking(move || run_git_command(&working_dir, &args))
+        .await
+        .map_err(|e| ToolError::execution_failed(format!("git task panicked: {e}")))?
 }
 
 fn format_command(working_dir: &Path, args: &[String]) -> String {


### PR DESCRIPTION
## Summary
- `GitStatusTool`/`GitDiffTool` in `crates/tui/src/tools/git.rs` called the blocking `std::process::Command::output()` directly inside async `execute()`, which can stall the tokio worker pool and hang the whole session with no error, timeout, or approval prompt (both tools are `ApprovalRequirement::Auto` and `supports_parallel() == true`, so several read-only tool calls firing concurrently can exhaust the worker pool at once).
- `crates/tui/src/tools/git_history.rs` (`log`/`show`/`blame` actions) already has the correct fix, wrapping the same kind of call in `tokio::task::spawn_blocking` (added in 346bfe3b6, scoped only to `git_history.rs`/`review.rs`).
- This PR mirrors that fix in `git.rs`: adds a `run_git_command_async` wrapper around the existing `run_git_command`, and switches `GitStatusTool::execute`/`GitDiffTool::execute` to call it instead of the blocking function directly.

## Test plan
- [x] `cargo check -p codewhale-tui --lib` — compiles cleanly
- [x] `cargo test -p codewhale-tui --lib tools::git::` — 6 passed