### PR TITLE
chore(contrib): grant @wuisabel-gif recurring PR access

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -65,3 +65,4 @@ all:AresNing
 pr:dmitri-0
 pr:sparkofspike
 pr:angel-hair
+pr:wuisabel-gif


### PR DESCRIPTION
Adds `pr:wuisabel-gif` to `.github/APPROVED_CONTRIBUTORS`.

Requested by @Hmbown in #5608.

No-Issue: contributor-gate allowlist chore, generated by the approve-contributor workflow.