### PR TITLE
fix(tui): make edit-last-turn boundaries authoritative

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -28,7 +28,7 @@ use crate::client::DeepSeekClient;
 use crate::compaction::{CompactionConfig, PreparedCompactionEnvelope, compact_messages_safe};
 use crate::config::{ApiProvider, Config, DEFAULT_MAX_SUBAGENTS, DEFAULT_TEXT_MODEL};
 use crate::core::model_client::SharedModelClient;
-use crate::error_taxonomy::{ErrorCategory, ErrorEnvelope, StreamError};
+use crate::error_taxonomy::{ErrorCategory, ErrorEnvelope, ErrorSeverity, StreamError};
 use crate::features::{Feature, Features};
 use crate::mcp::{McpConfig, McpPool};
 #[cfg(test)]
@@ -2961,37 +2961,55 @@ impl Engine {
                         let route = match self.current_runtime_route() {
                             Ok(route) => route,
                             Err(err) => {
-                                let _ = self
-                                    .tx_event
-                                    .send(Event::error(ErrorEnvelope::fatal_auth(format!(
+                                self.reject_edit_last_turn(ErrorEnvelope::new(
+                                    ErrorCategory::Authentication,
+                                    ErrorSeverity::Critical,
+                                    false,
+                                    "edit_last_turn_invalid_route",
+                                    format!(
                                         "Cannot edit the last turn because its provider route is no longer valid: {err}"
-                                    ))))
-                                    .await;
-                                let outcome = SendMessageOutcome::NotStarted {
-                                    error: Some(format!(
-                                        "provider route is no longer valid: {err}"
-                                    )),
-                                };
-                                self.reconcile_non_completed_goal_turn(&outcome).await;
+                                    ),
+                                ))
+                                .await;
                                 continue;
                             }
                         };
                         // #383: /edit — remove the last user+assistant exchange
                         // from the session, then re-send with the new content.
-                        // Pop messages from the tail until we've removed the
-                        // most recent user message and everything after it.
-                        // First, find the last user message index.
-                        let mut cut = None;
-                        for (idx, msg) in self.session.messages.iter().enumerate().rev() {
-                            if msg.role == "user" {
-                                cut = Some(idx);
-                                break;
+                        // Tool results and runtime-owned internal envelopes are
+                        // also persisted with role "user", so locate the cut
+                        // point by genuine user prompt — a bare role scan would
+                        // land mid-turn on a tool_result and keep the old
+                        // prompt plus its tool round-trips in history.
+                        let idx = match crate::runtime_handoff::edit_last_turn_target(
+                            &self.session.messages,
+                        ) {
+                            crate::runtime_handoff::EditLastTurnTarget::Editable(idx) => idx,
+                            crate::runtime_handoff::EditLastTurnTarget::Unsupported => {
+                                self.reject_edit_last_turn(ErrorEnvelope::new(
+                                    ErrorCategory::InvalidInput,
+                                    ErrorSeverity::Error,
+                                    false,
+                                    "edit_last_turn_unsupported_user_content",
+                                    "Cannot edit the last turn because the latest user message has no editable text content.",
+                                ))
+                                .await;
+                                continue;
                             }
-                        }
-                        if let Some(idx) = cut {
-                            self.session.messages.truncate_to(idx);
-                            self.session.bump_messages_revision();
-                        }
+                            crate::runtime_handoff::EditLastTurnTarget::Missing => {
+                                self.reject_edit_last_turn(ErrorEnvelope::new(
+                                    ErrorCategory::State,
+                                    ErrorSeverity::Error,
+                                    false,
+                                    "edit_last_turn_no_user_prompt",
+                                    "Cannot edit the last turn because the session history has no user message to replace.",
+                                ))
+                                .await;
+                                continue;
+                            }
+                        };
+                        self.session.messages.truncate_to(idx);
+                        self.session.bump_messages_revision();
                         // Now dispatch the new message as a normal send,
                         // reusing the engine's stored mode/model config.
                         let mode = self.current_mode;
@@ -3718,6 +3736,29 @@ impl Engine {
                 }
             }
         }
+    }
+
+    /// Reject an edit operation before model dispatch while still completing
+    /// the submitted host lifecycle. `Event::Error` is advisory to embedded
+    /// hosts; `TurnComplete(Failed)` is the authoritative terminal signal that
+    /// releases their busy state and closes the admitted operation.
+    async fn reject_edit_last_turn(&mut self, envelope: ErrorEnvelope) {
+        let message = envelope.message.clone();
+        let _ = self.tx_event.send(Event::error(envelope)).await;
+        let _ = self
+            .tx_event
+            .send(Event::TurnComplete {
+                usage: Usage::default(),
+                status: TurnOutcomeStatus::Failed,
+                error: Some(message.clone()),
+                tool_catalog: None,
+                base_url: None,
+            })
+            .await;
+        let outcome = SendMessageOutcome::NotStarted {
+            error: Some(message),
+        };
+        self.reconcile_non_completed_goal_turn(&outcome).await;
     }
 
     /// Reconcile a turn that did not complete with the autonomous goal loop.

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -14752,6 +14752,376 @@ async fn edit_last_turn_preserves_current_mode() {
 }
 
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn edit_last_turn_cuts_at_user_prompt_before_tool_results() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // Tool results persist with role "user"; the edit cut must land on the
+    // last genuine user prompt, not on the trailing tool_result of the
+    // previous turn.
+    let _lock = lock_test_env();
+    let tmp = tempdir().expect("tempdir");
+    let server = MockServer::start().await;
+    let done_sse = concat!(
+        "data: {\"id\":\"chatcmpl-edit-cut\",\"choices\":[{\"index\":0,",
+        "\"delta\":{\"content\":\"Revised answer.\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"chatcmpl-edit-cut\",\"choices\":[{\"index\":0,",
+        "\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(done_sse),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let api_config = Config {
+        api_key: Some("test-key".to_string()),
+        base_url: Some(server.uri()),
+        ..Config::default()
+    };
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        model: "deepseek-v4-pro".to_string(),
+        snapshots_enabled: false,
+        subagents_enabled: false,
+        ..Default::default()
+    };
+    let (engine, handle) = Engine::new(config, &api_config);
+
+    let run = tokio::spawn(engine.run());
+    let seeded_messages = vec![
+        Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: "original prompt".to_string(),
+                cache_control: None,
+            }],
+        },
+        Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: "call_1".to_string(),
+                name: "Bash".to_string(),
+                input: serde_json::json!({"command": "printf hi"}),
+                caller: None,
+                thought_signature: None,
+            }],
+        },
+        Message {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: "call_1".to_string(),
+                content: "unique-tool-output-marker".to_string(),
+                is_error: None,
+                content_blocks: None,
+            }],
+        },
+        Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text {
+                text: "final answer".to_string(),
+                cache_control: None,
+            }],
+        },
+    ];
+    handle
+        .send(Op::SyncSession {
+            session_id: Some("edit-cut-test".to_string()),
+            messages: seeded_messages,
+            system_prompt: None,
+            system_prompt_override: false,
+            model: "deepseek-v4-pro".to_string(),
+            workspace: tmp.path().to_path_buf(),
+            mode: AppMode::Agent,
+        })
+        .await
+        .expect("sync session");
+    handle
+        .send(Op::EditLastTurn {
+            new_message: "edited prompt".to_string(),
+        })
+        .await
+        .expect("send edit");
+
+    // Ops are processed in order: once the snapshot arrives, the replacement
+    // turn has completed.
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    handle
+        .send(Op::GetSessionSnapshot {
+            tx: std::sync::Arc::new(std::sync::Mutex::new(Some(tx))),
+        })
+        .await
+        .expect("request snapshot");
+    let snapshot = tokio::time::timeout(model_turn_event_timeout(), rx)
+        .await
+        .expect("snapshot response")
+        .expect("snapshot");
+
+    assert_eq!(
+        snapshot.messages.len(),
+        2,
+        "the whole previous turn (prompt, tool_use, tool_result, answer) must be cut: {:?}",
+        snapshot.messages
+    );
+    assert!(
+        snapshot.messages.iter().all(|message| !message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::ToolResult { .. }))),
+        "no tool_result may survive the cut: {:?}",
+        snapshot.messages
+    );
+    let replacement_text = message_text_of(&snapshot.messages[0]);
+    assert!(
+        replacement_text.contains("edited prompt"),
+        "first surviving message is the edited prompt: {replacement_text}"
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("recorded replacement request");
+    assert_eq!(requests.len(), 1);
+    let body = String::from_utf8(requests[0].body.clone()).expect("request body utf8");
+    assert!(body.contains("edited prompt"));
+    assert!(
+        !body.contains("original prompt"),
+        "old prompt must not leak into the replacement turn: {body}"
+    );
+    assert!(
+        !body.contains("unique-tool-output-marker"),
+        "tool round-trip must not leak into the replacement turn: {body}"
+    );
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run.await.expect("engine task");
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn edit_last_turn_without_user_prompt_errors_and_sends_nothing() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let _lock = lock_test_env();
+    let tmp = tempdir().expect("tempdir");
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let api_config = Config {
+        api_key: Some("test-key".to_string()),
+        base_url: Some(server.uri()),
+        ..Config::default()
+    };
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        model: "deepseek-v4-pro".to_string(),
+        snapshots_enabled: false,
+        subagents_enabled: false,
+        ..Default::default()
+    };
+    let (engine, handle) = Engine::new(config, &api_config);
+
+    let run = tokio::spawn(engine.run());
+    // History without any genuine user prompt: nothing to edit. The engine
+    // must surface an error instead of silently appending the message.
+    handle
+        .send(Op::SyncSession {
+            session_id: Some("edit-no-user-test".to_string()),
+            messages: vec![Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "assistant only".to_string(),
+                    cache_control: None,
+                }],
+            }],
+            system_prompt: None,
+            system_prompt_override: false,
+            model: "deepseek-v4-pro".to_string(),
+            workspace: tmp.path().to_path_buf(),
+            mode: AppMode::Agent,
+        })
+        .await
+        .expect("sync session");
+    handle
+        .send(Op::EditLastTurn {
+            new_message: "edited prompt".to_string(),
+        })
+        .await
+        .expect("send edit");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut saw_edit_error = false;
+    let mut saw_failed_terminal = false;
+    {
+        let mut events = handle.rx_event.write().await;
+        while let Ok(Some(event)) = tokio::time::timeout_at(deadline, events.recv()).await {
+            match event {
+                Event::Error { envelope, .. } => {
+                    assert_eq!(envelope.code, "edit_last_turn_no_user_prompt");
+                    assert!(!envelope.recoverable);
+                    assert!(
+                        envelope.message.contains("no user message"),
+                        "unexpected error: {}",
+                        envelope.message
+                    );
+                    saw_edit_error = true;
+                }
+                Event::TurnComplete { status, error, .. } => {
+                    assert_eq!(status, TurnOutcomeStatus::Failed);
+                    assert!(
+                        error
+                            .as_deref()
+                            .is_some_and(|message| message.contains("no user message")),
+                        "failed edit terminal must carry the rejection: {error:?}"
+                    );
+                    saw_failed_terminal = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+    }
+    assert!(saw_edit_error, "edit without a user prompt must error out");
+    assert!(
+        saw_failed_terminal,
+        "edit rejection must complete the submitted host lifecycle"
+    );
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    handle
+        .send(Op::GetSessionSnapshot {
+            tx: std::sync::Arc::new(std::sync::Mutex::new(Some(tx))),
+        })
+        .await
+        .expect("request snapshot");
+    let snapshot = tokio::time::timeout(Duration::from_secs(2), rx)
+        .await
+        .expect("snapshot response")
+        .expect("snapshot");
+    assert_eq!(
+        snapshot.messages.len(),
+        1,
+        "failed edit must not append the new message: {:?}",
+        snapshot.messages
+    );
+
+    // An unsupported latest user turn is still a history boundary. It must
+    // fail in place rather than falling through to the older text prompt and
+    // deleting a larger portion of the conversation.
+    let image_only_history = vec![
+        Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: "older editable prompt".to_string(),
+                cache_control: None,
+            }],
+        },
+        Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text {
+                text: "older response".to_string(),
+                cache_control: None,
+            }],
+        },
+        Message {
+            role: Role::User,
+            content: vec![ContentBlock::ImageUrl {
+                image_url: crate::models::ImageUrlContent {
+                    url: "data:image/png;base64,AAAA".to_string(),
+                },
+            }],
+        },
+    ];
+    handle
+        .send(Op::SyncSession {
+            session_id: Some("edit-unsupported-user-test".to_string()),
+            messages: image_only_history.clone(),
+            system_prompt: None,
+            system_prompt_override: false,
+            model: "deepseek-v4-pro".to_string(),
+            workspace: tmp.path().to_path_buf(),
+            mode: AppMode::Agent,
+        })
+        .await
+        .expect("sync unsupported user session");
+    handle
+        .send(Op::EditLastTurn {
+            new_message: "must not replace the older prompt".to_string(),
+        })
+        .await
+        .expect("send unsupported edit");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut saw_unsupported_error = false;
+    let mut saw_unsupported_terminal = false;
+    {
+        let mut events = handle.rx_event.write().await;
+        while let Ok(Some(event)) = tokio::time::timeout_at(deadline, events.recv()).await {
+            match event {
+                Event::Error { envelope, .. } => {
+                    assert_eq!(envelope.code, "edit_last_turn_unsupported_user_content");
+                    assert!(!envelope.recoverable);
+                    saw_unsupported_error = true;
+                }
+                Event::TurnComplete { status, error, .. } => {
+                    assert_eq!(status, TurnOutcomeStatus::Failed);
+                    assert!(
+                        error
+                            .as_deref()
+                            .is_some_and(|message| message
+                                .contains("latest user message has no editable text")),
+                        "unsupported edit terminal must carry the rejection: {error:?}"
+                    );
+                    saw_unsupported_terminal = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+    }
+    assert!(saw_unsupported_error);
+    assert!(saw_unsupported_terminal);
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    handle
+        .send(Op::GetSessionSnapshot {
+            tx: std::sync::Arc::new(std::sync::Mutex::new(Some(tx))),
+        })
+        .await
+        .expect("request unsupported snapshot");
+    let unsupported_snapshot = tokio::time::timeout(Duration::from_secs(2), rx)
+        .await
+        .expect("unsupported snapshot response")
+        .expect("unsupported snapshot");
+    assert_eq!(
+        unsupported_snapshot.messages, image_only_history,
+        "unsupported latest user content must leave the entire history unchanged"
+    );
+
+    let requests = server.received_requests().await.expect("recorded requests");
+    assert!(
+        requests.is_empty(),
+        "failed edit must not dispatch a provider turn"
+    );
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run.await.expect("engine task");
+}
+
+#[tokio::test]
 async fn provider_runtime_status_reports_configured_zai_cap_without_client() {
     let (engine, handle) = {
         let _lock = lock_test_env();

--- a/crates/tui/src/prompt_zones.rs
+++ b/crates/tui/src/prompt_zones.rs
@@ -218,9 +218,9 @@ impl AppendLog {
         self.messages.extend(batch);
     }
 
-    /// Truncate to keep only the most recent `new_len` messages.
-    /// Discards older messages (and their prefix-cache contribution)
-    /// from the front.
+    /// Truncate to keep only the first `new_len` messages.
+    /// Discards newer messages (and their prefix-cache contribution)
+    /// from the tail.
     pub fn truncate_to(&mut self, new_len: usize) {
         self.messages.truncate(new_len);
     }

--- a/crates/tui/src/runtime_handoff.rs
+++ b/crates/tui/src/runtime_handoff.rs
@@ -898,6 +898,149 @@ pub(crate) fn restored_subagent_checkpoint_display(message: &Message) -> Option<
     Some(text)
 }
 
+/// Classification used when locating a user-authored turn in the session log.
+///
+/// Runtime and tool messages are skipped because their provider-compatible
+/// `role = "user"` is not user authority. Unsupported user content is a real
+/// turn boundary, however, so callers must not skip it and edit an older turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UserTurnPromptKind {
+    /// Assistant messages, tool results, and runtime-owned control messages.
+    NotPrompt,
+    /// A genuine user turn containing editable text.
+    Editable,
+    /// A genuine user turn without editable text, such as an image-only turn.
+    Unsupported,
+}
+
+/// Authoritative target selection for edit-last-turn operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EditLastTurnTarget {
+    /// Index of the latest editable user-authored turn.
+    Editable(usize),
+    /// The latest real user turn exists but has no editable text.
+    Unsupported,
+    /// The history contains no user-authored turn.
+    Missing,
+}
+
+/// Classify `message` for edit-last-turn and admitted-display handling.
+#[must_use]
+pub(crate) fn classify_user_turn_prompt(message: &Message) -> UserTurnPromptKind {
+    if message.role != Role::User {
+        return UserTurnPromptKind::NotPrompt;
+    }
+    if message.content.iter().any(|block| {
+        matches!(
+            block,
+            ContentBlock::ToolResult { .. }
+                | ContentBlock::ToolSearchToolResult { .. }
+                | ContentBlock::CodeExecutionToolResult { .. }
+        )
+    }) {
+        return UserTurnPromptKind::NotPrompt;
+    }
+    if is_runtime_owned_user_message(message) {
+        return UserTurnPromptKind::NotPrompt;
+    }
+
+    let turn_metadata_index = turn_metadata_text(message).map(|(index, _)| index);
+    if message.content.iter().enumerate().any(|(index, block)| {
+        Some(index) != turn_metadata_index && matches!(block, ContentBlock::Text { .. })
+    }) {
+        UserTurnPromptKind::Editable
+    } else {
+        UserTurnPromptKind::Unsupported
+    }
+}
+
+/// Locate the latest real user boundary without skipping unsupported content.
+#[must_use]
+pub(crate) fn edit_last_turn_target(messages: &[Message]) -> EditLastTurnTarget {
+    messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(
+            |(index, message)| match classify_user_turn_prompt(message) {
+                UserTurnPromptKind::NotPrompt => None,
+                UserTurnPromptKind::Editable => Some(EditLastTurnTarget::Editable(index)),
+                UserTurnPromptKind::Unsupported => Some(EditLastTurnTarget::Unsupported),
+            },
+        )
+        .unwrap_or(EditLastTurnTarget::Missing)
+}
+
+/// True when a `role = "user"` message is runtime-owned rather than
+/// user-authored. Runtime authority is accepted only from the engine-owned
+/// structural `<turn_meta>` block, never from arbitrary user text that happens
+/// to resemble a runtime envelope or metadata marker.
+fn is_runtime_owned_user_message(message: &Message) -> bool {
+    restored_subagent_checkpoint_display(message).is_some()
+        || has_non_authoritative_turn_provenance(message)
+}
+
+/// Return engine-owned metadata in either the current trailing shape or the
+/// historical leading shape. Requiring a separate prompt block prevents a
+/// user who submits `<turn_meta>…</turn_meta>` as ordinary text from minting
+/// authority.
+fn turn_metadata_text(message: &Message) -> Option<(usize, &str)> {
+    if message.content.len() < 2 {
+        return None;
+    }
+    if let Some(ContentBlock::Text {
+        text,
+        cache_control: None,
+    }) = message.content.last()
+    {
+        let trimmed = text.trim();
+        if is_complete_turn_metadata(trimmed) {
+            return Some((message.content.len() - 1, trimmed));
+        }
+    }
+    // Sessions written before the metadata-tail migration used
+    // `[turn_meta, prompt, ...]`. Match the same conservative legacy shape as
+    // the transcript renderer: a metadata envelope first and ordinary text
+    // last. A single user-authored metadata example is never hidden.
+    let ContentBlock::Text {
+        text,
+        cache_control: None,
+    } = message.content.first()?
+    else {
+        return None;
+    };
+    let trimmed = text.trim();
+    let trailing_text_is_ordinary = matches!(
+        message.content.last(),
+        Some(ContentBlock::Text { text, .. }) if !is_complete_turn_metadata(text.trim())
+    );
+    (is_complete_turn_metadata(trimmed) && trailing_text_is_ordinary).then_some((0, trimmed))
+}
+
+fn is_complete_turn_metadata(text: &str) -> bool {
+    text.starts_with("<turn_meta>") && text.ends_with("</turn_meta>")
+}
+
+/// Recognize both the current condensed provenance line and the legacy
+/// provenance/authority pair. Any explicitly non-authoritative provenance is
+/// runtime-owned; this stays correct as new provenance variants are added.
+fn has_non_authoritative_turn_provenance(message: &Message) -> bool {
+    let Some((_, metadata)) = turn_metadata_text(message) else {
+        return false;
+    };
+    let mut has_provenance = false;
+    let mut condensed_non_authoritative = false;
+    let mut legacy_non_authoritative = false;
+    for line in metadata.lines().map(str::trim) {
+        if let Some(value) = line.strip_prefix("Input provenance: ") {
+            has_provenance = true;
+            condensed_non_authoritative |= value.ends_with(" (non-authoritative)");
+        }
+        legacy_non_authoritative |= line == "Input authority: non_authoritative";
+    }
+    condensed_non_authoritative || (has_provenance && legacy_non_authoritative)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1106,6 +1249,186 @@ mod tests {
     }
 
     #[test]
+    fn user_turn_prompt_separates_prompts_from_tool_results_and_envelopes() {
+        let prompt = Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: "Fix the resume regression".to_string(),
+                cache_control: None,
+            }],
+        };
+        assert_eq!(
+            classify_user_turn_prompt(&prompt),
+            UserTurnPromptKind::Editable
+        );
+
+        let tool_result = Message {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: "call_1".to_string(),
+                content: "tool output".to_string(),
+                is_error: None,
+                content_blocks: None,
+            }],
+        };
+        assert_eq!(
+            classify_user_turn_prompt(&tool_result),
+            UserTurnPromptKind::NotPrompt
+        );
+
+        let raw = subagent_completion_runtime_message(&completion_payload(
+            "agent_abc",
+            "completed",
+            "Implemented the shared restore projection.",
+        ));
+        assert_eq!(
+            classify_user_turn_prompt(&raw),
+            UserTurnPromptKind::NotPrompt
+        );
+
+        let projected = project_messages_for_restore(&[raw]);
+        assert_eq!(
+            classify_user_turn_prompt(&projected[0]),
+            UserTurnPromptKind::NotPrompt
+        );
+
+        for provenance in [
+            "runtime",
+            "subagent_handoff",
+            "shell_completion",
+            "imported_transcript",
+            "memory_recall",
+            "assistant_generated",
+            "future_runtime_origin",
+        ] {
+            let runtime_provenance = Message {
+                role: Role::User,
+                content: vec![
+                    ContentBlock::Text {
+                        text: "diagnostic text".to_string(),
+                        cache_control: None,
+                    },
+                    ContentBlock::Text {
+                        text: format!(
+                            "<turn_meta>\nInput provenance: {provenance} (non-authoritative)\n</turn_meta>"
+                        ),
+                        cache_control: None,
+                    },
+                ],
+            };
+            assert_eq!(
+                classify_user_turn_prompt(&runtime_provenance),
+                UserTurnPromptKind::NotPrompt,
+                "non-authoritative provenance {provenance} must never become a user prompt"
+            );
+        }
+
+        let legacy_non_authoritative = Message {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text {
+                    text: "legacy recalled text".to_string(),
+                    cache_control: None,
+                },
+                ContentBlock::Text {
+                    text: concat!(
+                        "<turn_meta>\n",
+                        "Input provenance: memory_recall\n",
+                        "Input authority: non_authoritative\n",
+                        "</turn_meta>"
+                    )
+                    .to_string(),
+                    cache_control: None,
+                },
+            ],
+        };
+        assert_eq!(
+            classify_user_turn_prompt(&legacy_non_authoritative),
+            UserTurnPromptKind::NotPrompt
+        );
+
+        let legacy_leading_non_authoritative = Message {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text {
+                    text: concat!(
+                        "<turn_meta>\n",
+                        "Input provenance: memory_recall\n",
+                        "Input authority: non_authoritative\n",
+                        "</turn_meta>"
+                    )
+                    .to_string(),
+                    cache_control: None,
+                },
+                ContentBlock::Text {
+                    text: "legacy recalled text".to_string(),
+                    cache_control: None,
+                },
+            ],
+        };
+        assert_eq!(
+            classify_user_turn_prompt(&legacy_leading_non_authoritative),
+            UserTurnPromptKind::NotPrompt
+        );
+
+        let legacy_leading_external = Message {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text {
+                    text: "<turn_meta>\nCurrent local date: 2026-08-25\n</turn_meta>".to_string(),
+                    cache_control: None,
+                },
+                ContentBlock::Text {
+                    text: "legacy external prompt".to_string(),
+                    cache_control: None,
+                },
+            ],
+        };
+        assert_eq!(
+            classify_user_turn_prompt(&legacy_leading_external),
+            UserTurnPromptKind::Editable
+        );
+
+        let image_only = Message {
+            role: Role::User,
+            content: vec![ContentBlock::ImageUrl {
+                image_url: crate::models::ImageUrlContent {
+                    url: "data:image/png;base64,AAAA".to_string(),
+                },
+            }],
+        };
+        assert_eq!(
+            classify_user_turn_prompt(&image_only),
+            UserTurnPromptKind::Unsupported
+        );
+        assert_eq!(
+            edit_last_turn_target(&[
+                prompt.clone(),
+                Message {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::Text {
+                        text: "older response".to_string(),
+                        cache_control: None,
+                    }],
+                },
+                image_only,
+            ]),
+            EditLastTurnTarget::Unsupported,
+            "an unsupported latest user turn must stop the backward scan"
+        );
+        assert_eq!(
+            edit_last_turn_target(&[Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "assistant only".to_string(),
+                    cache_control: None,
+                }],
+            }]),
+            EditLastTurnTarget::Missing
+        );
+    }
+
+    #[test]
     fn restore_projection_accepts_failed_error_location_sentinel() {
         let raw = subagent_completion_runtime_message(concat!(
             "Failed: child tool timed out\n",
@@ -1244,7 +1567,17 @@ mod tests {
         };
 
         let projected = project_messages_for_restore(&[lookalike.clone(), wrong_authority.clone()]);
-        assert_eq!(projected, vec![lookalike, wrong_authority]);
+        assert_eq!(projected, vec![lookalike.clone(), wrong_authority.clone()]);
+        assert_eq!(
+            classify_user_turn_prompt(&lookalike),
+            UserTurnPromptKind::Editable,
+            "runtime-looking user text without trusted metadata stays editable"
+        );
+        assert_eq!(
+            classify_user_turn_prompt(&wrong_authority),
+            UserTurnPromptKind::Editable,
+            "explicit external-user authority must not be hidden by text lookalikes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make edit-last-turn locate the latest genuine user-authored prompt instead of any persisted `role = "user"` message
- treat unsupported user content as an authoritative boundary instead of deleting an older turn
- emit both the typed error and a failed terminal outcome when an edit cannot start, so embedded hosts release their busy lifecycle
- correct the `AppendLog::truncate_to` documentation
- port and adapt the reusable fix from Pinvou/CodeWhale pull request 17

This fixes sessions where a tool result or runtime handoff is persisted with the provider-compatible user role: the previous implementation could truncate in the middle of a turn and resend stale prompt/tool state.

No existing issue tracks this exact boundary bug.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [ ] `cargo test --workspace --all-features --locked`
- [x] `cargo clippy -p codewhale-tui --lib --locked -- -D warnings`
- [x] `cargo test -p codewhale-tui --lib --locked runtime_handoff` (14 passed)
- [x] `cargo test -p codewhale-tui --lib --locked edit_last_turn` (3 passed)

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (not applicable; engine/session behavior only)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

## Risk

The new classification deliberately trusts only structurally separated, non-authoritative turn metadata. User-authored text that merely resembles a runtime envelope remains editable.

No-Issue: This focused upstream port fixes a verified foundation gap with no existing tracker.