### PR TITLE
feat(tui): report post-compaction input tokens

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1074,6 +1074,9 @@ impl Engine {
         messages_after: Option<usize>,
     ) {
         let summary_prompt = self.rendered_compaction_summary();
+        // Every call site runs after message replacement and checkpoint
+        // commit. Reuse the same complete estimate as context pressure.
+        let post_input_tokens = Some(self.estimated_input_tokens() as u64);
         let _ = self
             .tx_event
             .send(Event::CompactionCompleted {
@@ -1083,6 +1086,7 @@ impl Engine {
                 messages_before,
                 messages_after,
                 summary_prompt,
+                post_input_tokens,
             })
             .await;
     }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -14000,6 +14000,57 @@ async fn compaction_keeps_todos_out_of_the_prefix() {
     assert!(!checkpoint.contains("### Todos"), "{checkpoint}");
 }
 
+#[tokio::test]
+async fn compaction_completed_reports_complete_post_input_tokens() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, handle) = Engine::new(config, &Config::default());
+    engine.session.system_prompt = Some(SystemPrompt::Text("stable system context ".repeat(400)));
+    engine.session.replace_messages(vec![Message {
+        role: Role::User,
+        content: vec![ContentBlock::Text {
+            text: "post-compaction message".to_string(),
+            cache_control: None,
+        }],
+    }]);
+    engine.commit_compaction_checkpoint(Some(SystemPrompt::Text(format!(
+        "{COMPACTION_SUMMARY_MARKER}\npost-compaction summary"
+    ))));
+
+    let messages_only =
+        crate::compaction::estimate_input_tokens_conservative(&engine.session.messages, None);
+    let expected = engine.estimated_input_tokens();
+    assert!(expected > messages_only);
+
+    engine
+        .emit_compaction_completed(
+            "compact_test".to_string(),
+            false,
+            "Compaction complete".to_string(),
+            Some(4),
+            Some(1),
+        )
+        .await;
+
+    let event = handle
+        .rx_event
+        .write()
+        .await
+        .recv()
+        .await
+        .expect("compaction completed event");
+    let Event::CompactionCompleted {
+        post_input_tokens, ..
+    } = event
+    else {
+        panic!("expected CompactionCompleted, got {event:?}");
+    };
+    assert_eq!(post_input_tokens, Some(expected as u64));
+}
+
 /// `fork_context` is captured once at turn start, so a `work_update` followed
 /// by an `agent` spawn *in the same turn* must still hand the child the
 /// current snapshot. Only the To-do portion is refreshed; the inherited

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -294,6 +294,10 @@ pub enum Event {
         /// summary lives only in engine memory and is lost on LRU eviction
         /// or restart (SyncSession re-extracts it from the record prompt).
         summary_prompt: Option<String>,
+        /// Conservative input-token estimate for the complete post-compaction
+        /// request, including its system prompt. Hosts can use this until the
+        /// next provider-reported usage arrives.
+        post_input_tokens: Option<u64>,
     },
 
     /// Context compaction was canceled before it could commit a checkpoint.

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -8219,6 +8219,7 @@ impl RuntimeThreadManager {
                     messages_before,
                     messages_after,
                     summary_prompt,
+                    post_input_tokens: _,
                 } => {
                     // Persist the summary in the legacy thread-record carrier
                     // so reloads survive LRU eviction/restart. SyncSession

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -1919,6 +1919,7 @@ async fn compact_lifecycle_outlives_caller_and_preserves_concurrent_thread_updat
             messages_before: Some(4),
             messages_after: Some(2),
             summary_prompt: None,
+            post_input_tokens: None,
         })
         .await?;
     harness
@@ -9982,6 +9983,7 @@ async fn compaction_lifecycle_emits_item_events_with_compaction_counts() -> Resu
                             messages_before: Some(7),
                             messages_after: Some(3),
                             summary_prompt: None,
+                            post_input_tokens: None,
                         })
                         .await;
                     let _ = tx_event
@@ -10018,6 +10020,7 @@ async fn compaction_lifecycle_emits_item_events_with_compaction_counts() -> Resu
                                 "## 📋 Conversation Summary (Auto-Generated)\n\nkey facts."
                                     .to_string(),
                             ),
+                            post_input_tokens: None,
                         })
                         .await;
                     let _ = tx_event


### PR DESCRIPTION
## Summary

- add `post_input_tokens` to `CompactionCompleted`
- compute it once in the shared completion-event emitter, after message replacement and compaction-checkpoint commit
- reuse the engine canonical input estimate so the value includes messages, stable system context, and accumulated compaction summary
- keep runtime-thread persistence behavior unchanged
- port and adapt the compaction-event portion of Pinvou/CodeWhale pull request 19

Embedded hosts currently receive compaction message counts and the summary prompt, but no post-compaction token value. They therefore keep showing stale provider usage until another model response arrives. This event field lets them refresh immediately from the same conservative estimate the engine uses for context pressure.

No existing issue tracks this exact host-usage gap.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [ ] `cargo test --workspace --all-features --locked`
- [x] `cargo clippy -p codewhale-tui --lib --locked -- -D warnings`
- [x] `cargo test -p codewhale-tui --lib --locked compaction_completed_reports_complete_post_input_tokens`
- [x] `cargo test -p codewhale-tui --lib --locked compaction_lifecycle_emits_item_events_with_compaction_counts`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (not applicable; engine event only)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

## Risk

The new value is optional for compatibility with synthetic event producers. Every real engine completion emits `Some(...)`; all three compaction paths share the same emitter, so manual, automatic, and emergency compaction cannot drift.

No-Issue: This focused upstream port fixes a verified foundation gap with no existing tracker.