### PR TITLE
feat(tui): show live session token totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Session token totals now include display-only per-model-call deltas while a
+  turn is running, including input/output and cache-class counters; the
+  authoritative `TurnComplete` totals still reconcile exactly once (#5581).
 - Provider neutrality (#5588): model resolution of omitted/aliased models is
   now provider-relative, OpenAI-native defaults no longer route through
   another provider's table, CLI credentials stay provider-scoped, and NVIDIA

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -65,6 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Session token totals now include display-only per-model-call deltas while a
+  turn is running, including input/output and cache-class counters; the
+  authoritative `TurnComplete` totals still reconcile exactly once (#5581).
 - Provider neutrality (#5588): model resolution of omitted/aliased models is
   now provider-relative, OpenAI-native defaults no longer route through
   another provider's table, CLI credentials stay provider-scoped, and NVIDIA

--- a/crates/tui/src/commands/groups/config/status.rs
+++ b/crates/tui/src/commands/groups/config/status.rs
@@ -230,26 +230,39 @@ fn session_summary(app: &App) -> String {
 /// The session input/output split and the cumulative cache totals live only
 /// here; the per-turn figures they used to sit beside are `/tokens`.
 fn session_tokens(app: &App) -> String {
-    let cache =
-        if app.session.total_cache_hit_tokens == 0 && app.session.total_cache_miss_tokens == 0 {
-            tr(app.ui_locale, MessageId::StatusCacheNotReported).into_owned()
-        } else {
-            localized(
-                app.ui_locale,
-                MessageId::StatusCacheSummary,
-                &[
-                    ("{hit}", &app.session.total_cache_hit_tokens.to_string()),
-                    ("{miss}", &app.session.total_cache_miss_tokens.to_string()),
-                ],
-            )
-        };
+    let cache = if app.session.displayed_total_cache_hit_tokens() == 0
+        && app.session.displayed_total_cache_miss_tokens() == 0
+    {
+        tr(app.ui_locale, MessageId::StatusCacheNotReported).into_owned()
+    } else {
+        localized(
+            app.ui_locale,
+            MessageId::StatusCacheSummary,
+            &[
+                (
+                    "{hit}",
+                    &app.session.displayed_total_cache_hit_tokens().to_string(),
+                ),
+                (
+                    "{miss}",
+                    &app.session.displayed_total_cache_miss_tokens().to_string(),
+                ),
+            ],
+        )
+    };
     localized(
         app.ui_locale,
         MessageId::StatusSessionTokensSummary,
         &[
-            ("{input}", &app.session.total_input_tokens.to_string()),
-            ("{output}", &app.session.total_output_tokens.to_string()),
-            ("{total}", &app.session.total_tokens.to_string()),
+            (
+                "{input}",
+                &app.session.displayed_total_input_tokens().to_string(),
+            ),
+            (
+                "{output}",
+                &app.session.displayed_total_output_tokens().to_string(),
+            ),
+            ("{total}", &app.session.displayed_total_tokens().to_string()),
             ("{cache}", &cache),
         ],
     )

--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -611,7 +611,7 @@ pub fn home_dashboard(app: &mut App) -> CommandResult {
 
     // Session stats
     let history_count = app.history.len();
-    let total_tokens = app.session.total_conversation_tokens;
+    let total_tokens = app.session.displayed_total_conversation_tokens();
     let queued_messages = app.queued_messages.len();
     let _ = writeln!(
         stats,

--- a/crates/tui/src/commands/groups/debug/tokens.rs
+++ b/crates/tui/src/commands/groups/debug/tokens.rs
@@ -65,7 +65,7 @@ pub fn tokens(app: &mut App) -> CommandResult {
             &token_count(app.session.last_completion_tokens, locale),
         )
         .replace("{cache}", &cache_summary(app, locale))
-        .replace("{total}", &app.session.total_tokens.to_string())
+        .replace("{total}", &app.session.displayed_total_tokens().to_string())
         .replace("{cost}", &cost_report_amount(app, locale))
         .replace("{api_messages}", &message_count.to_string())
         .replace("{chat_messages}", &chat_count.to_string())
@@ -85,7 +85,7 @@ pub fn tokens(app: &mut App) -> CommandResult {
 /// is neither folded into input nor hidden: `/tokens` shows the total and says
 /// where the detail lives.
 fn cache_write_summary(app: &App, locale: Locale) -> String {
-    let write = app.session.total_cache_write_tokens;
+    let write = app.session.displayed_total_cache_write_tokens();
     let mut out = String::from("\n");
     out.push_str(&tr(locale, MessageId::CmdTokensCacheWriteTotal).replace(
         "{write}",

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -24,7 +24,7 @@ use crate::core::authority::{ModeSessionPrefs, base_policy_for_mode};
 use crate::core::events::TurnRoute;
 use crate::hooks::{HookContext, HookEvent, HookExecutor, HookResult};
 use crate::localization::{Locale, MessageId, resolve_locale, tr};
-use crate::models::{Message, SystemPrompt, Tool};
+use crate::models::{Message, SystemPrompt, Tool, Usage};
 use crate::palette::{self, UiTheme};
 use crate::pricing::{CostCurrency, CostEstimate};
 use crate::resource_telemetry::TokenThroughput;
@@ -783,6 +783,14 @@ pub struct SessionState {
     /// `session_cost`. Never persisted.
     pub pending_turn_cost: f64,
     pub pending_turn_cost_cny: f64,
+    /// Display-only per-step token deltas for the active turn. These are
+    /// cleared at `TurnComplete` before authoritative cumulative totals land.
+    pub pending_turn_total_tokens: u32,
+    pub pending_turn_input_tokens: u32,
+    pub pending_turn_output_tokens: u32,
+    pub pending_turn_cache_hit_tokens: u32,
+    pub pending_turn_cache_miss_tokens: u32,
+    pub pending_turn_cache_write_tokens: u32,
     pub subagent_cost: f64,
     pub subagent_cost_cny: f64,
     /// Redacted provider-response identities already accrued. The same
@@ -968,6 +976,12 @@ impl Default for SessionState {
             session_cost_cny: 0.0,
             pending_turn_cost: 0.0,
             pending_turn_cost_cny: 0.0,
+            pending_turn_total_tokens: 0,
+            pending_turn_input_tokens: 0,
+            pending_turn_output_tokens: 0,
+            pending_turn_cache_hit_tokens: 0,
+            pending_turn_cache_miss_tokens: 0,
+            pending_turn_cache_write_tokens: 0,
             subagent_cost: 0.0,
             subagent_cost_cny: 0.0,
             subagent_usage_sources: HashSet::new(),
@@ -1016,7 +1030,84 @@ impl SessionState {
         self.total_cache_miss_tokens = 0;
         self.total_cache_write_tokens = 0;
         self.total_output_tokens = 0;
+        self.clear_pending_turn_usage();
         self.last_output_throughput = None;
+    }
+
+    /// Add one provider-reported model-call receipt to the display-only
+    /// in-flight ledger. The cache split mirrors the authoritative
+    /// `TurnComplete` accounting path.
+    pub fn accrue_pending_turn_usage(&mut self, usage: &Usage) {
+        self.pending_turn_total_tokens = self
+            .pending_turn_total_tokens
+            .saturating_add(usage.input_tokens.saturating_add(usage.output_tokens));
+        self.pending_turn_input_tokens = self
+            .pending_turn_input_tokens
+            .saturating_add(usage.input_tokens);
+        self.pending_turn_output_tokens = self
+            .pending_turn_output_tokens
+            .saturating_add(usage.output_tokens);
+        if usage.prompt_cache_hit_tokens.is_some()
+            || usage.prompt_cache_miss_tokens.is_some()
+            || usage.prompt_cache_write_tokens.is_some()
+        {
+            let classes = crate::pricing::token_usage_for_pricing(usage);
+            self.pending_turn_cache_hit_tokens = self
+                .pending_turn_cache_hit_tokens
+                .saturating_add(u32::try_from(classes.cache_read).unwrap_or(u32::MAX));
+            self.pending_turn_cache_miss_tokens = self
+                .pending_turn_cache_miss_tokens
+                .saturating_add(u32::try_from(classes.input).unwrap_or(u32::MAX));
+            self.pending_turn_cache_write_tokens = self
+                .pending_turn_cache_write_tokens
+                .saturating_add(u32::try_from(classes.cache_write).unwrap_or(u32::MAX));
+        }
+    }
+
+    /// Clear the active turn's display-only token deltas before the
+    /// authoritative cumulative usage is reconciled.
+    pub fn clear_pending_turn_usage(&mut self) {
+        self.pending_turn_total_tokens = 0;
+        self.pending_turn_input_tokens = 0;
+        self.pending_turn_output_tokens = 0;
+        self.pending_turn_cache_hit_tokens = 0;
+        self.pending_turn_cache_miss_tokens = 0;
+        self.pending_turn_cache_write_tokens = 0;
+    }
+
+    pub fn displayed_total_tokens(&self) -> u32 {
+        self.total_tokens
+            .saturating_add(self.pending_turn_total_tokens)
+    }
+
+    pub fn displayed_total_conversation_tokens(&self) -> u32 {
+        self.total_conversation_tokens
+            .saturating_add(self.pending_turn_total_tokens)
+    }
+
+    pub fn displayed_total_input_tokens(&self) -> u32 {
+        self.total_input_tokens
+            .saturating_add(self.pending_turn_input_tokens)
+    }
+
+    pub fn displayed_total_output_tokens(&self) -> u32 {
+        self.total_output_tokens
+            .saturating_add(self.pending_turn_output_tokens)
+    }
+
+    pub fn displayed_total_cache_hit_tokens(&self) -> u32 {
+        self.total_cache_hit_tokens
+            .saturating_add(self.pending_turn_cache_hit_tokens)
+    }
+
+    pub fn displayed_total_cache_miss_tokens(&self) -> u32 {
+        self.total_cache_miss_tokens
+            .saturating_add(self.pending_turn_cache_miss_tokens)
+    }
+
+    pub fn displayed_total_cache_write_tokens(&self) -> u32 {
+        self.total_cache_write_tokens
+            .saturating_add(self.pending_turn_cache_write_tokens)
     }
 }
 

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::config::{ApiProvider, Config, ProviderConfig, ProvidersConfig};
+use crate::models::Usage;
 use crate::settings::Settings;
 use crate::test_support::{EnvVarGuard, lock_test_env};
 use crate::tools::plan::{PlanItemArg, StepStatus, UpdatePlanArgs};
@@ -1886,6 +1887,37 @@ fn pending_turn_cost_moves_displayed_total_mid_turn() {
         app.displayed_session_cost_for_currency(CostCurrency::Usd),
         0.1
     );
+}
+
+#[test]
+fn pending_turn_usage_moves_token_surfaces_without_double_counting() {
+    let mut app = App::new(test_options(false), &Config::default());
+    let usage = Usage {
+        input_tokens: 100,
+        output_tokens: 20,
+        prompt_cache_hit_tokens: Some(60),
+        prompt_cache_miss_tokens: Some(40),
+        prompt_cache_write_tokens: Some(5),
+        ..Usage::default()
+    };
+
+    app.session.accrue_pending_turn_usage(&usage);
+    assert_eq!(app.session.displayed_total_tokens(), 120);
+    assert_eq!(app.session.displayed_total_input_tokens(), 100);
+    assert_eq!(app.session.displayed_total_output_tokens(), 20);
+    assert_eq!(app.session.displayed_total_cache_hit_tokens(), 60);
+    assert_eq!(app.session.displayed_total_cache_miss_tokens(), 35);
+    assert_eq!(app.session.displayed_total_cache_write_tokens(), 5);
+
+    app.session.clear_pending_turn_usage();
+    app.session.total_tokens = 120;
+    app.session.total_input_tokens = 100;
+    app.session.total_output_tokens = 20;
+    app.session.total_cache_hit_tokens = 60;
+    app.session.total_cache_miss_tokens = 35;
+    app.session.total_cache_write_tokens = 5;
+    assert_eq!(app.session.displayed_total_tokens(), 120);
+    assert_eq!(app.session.displayed_total_cache_write_tokens(), 5);
 }
 
 #[test]

--- a/crates/tui/src/tui/phase_strip.rs
+++ b/crates/tui/src/tui/phase_strip.rs
@@ -71,8 +71,8 @@ fn working_detail(app: &App, activity: LiveActivity) -> Option<String> {
 }
 
 fn session_cache_hit_percentage(app: &App) -> Option<u8> {
-    let hit = u64::from(app.session.total_cache_hit_tokens);
-    let miss = u64::from(app.session.total_cache_miss_tokens);
+    let hit = u64::from(app.session.displayed_total_cache_hit_tokens());
+    let miss = u64::from(app.session.displayed_total_cache_miss_tokens());
     let total = hit + miss;
     if total == 0 {
         return None;

--- a/crates/tui/src/tui/session_metrics.rs
+++ b/crates/tui/src/tui/session_metrics.rs
@@ -491,8 +491,8 @@ pub fn fit_to_width(
 /// Snapshot the live app state into the strip's inputs.
 #[must_use]
 pub fn snapshot_from_app(app: &crate::tui::app::App) -> MetricsSnapshot {
-    let hit = u64::from(app.session.total_cache_hit_tokens);
-    let miss = u64::from(app.session.total_cache_miss_tokens);
+    let hit = u64::from(app.session.displayed_total_cache_hit_tokens());
+    let miss = u64::from(app.session.displayed_total_cache_miss_tokens());
     let cache_hit_percent = (hit + miss > 0).then(|| {
         // Widen before adding so saturated counters never exceed 100%.
         u8::try_from((hit * 100 + (hit + miss) / 2) / (hit + miss)).unwrap_or(100)
@@ -505,7 +505,7 @@ pub fn snapshot_from_app(app: &crate::tui::app::App) -> MetricsSnapshot {
         ttft_avg: app.session_metrics.ttft_average(),
         tokens_per_second: app.session_metrics.tokens_per_second(),
         cache_hit_percent,
-        input_tokens: u64::from(app.session.total_input_tokens),
+        input_tokens: u64::from(app.session.displayed_total_input_tokens()),
     }
 }
 

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1136,7 +1136,7 @@ pub(crate) fn context_panel_lines(app: &App, content_width: usize) -> Vec<Line<'
     // ── Token usage ──────────────────────────────────────────────
     // Context % is disclosed in the header; the sidebar keeps the raw token
     // counts for at-a-glance reference without duplicating the bar.
-    let total_tokens = app.session.total_conversation_tokens;
+    let total_tokens = app.session.displayed_total_conversation_tokens();
     let window = crate::route_budget::route_context_window_tokens(
         app.api_provider,
         app.effective_model_for_budget(),

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -1485,6 +1485,7 @@ pub(crate) async fn run_event_loop(
                         app.turn_started_at = Some(now);
                         app.turn_last_activity_at = Some(now);
                         app.session.last_output_throughput = None;
+                        app.session.clear_pending_turn_usage();
                         app.streaming_output_token_estimate = 0;
                         app.provider_wait_incident_logged = false;
                         // Discoverability hint for users who don't know how
@@ -1528,6 +1529,7 @@ pub(crate) async fn run_event_loop(
                         // high-water mark keeps the displayed total monotonic
                         // through the swap (#244).
                         app.clear_pending_turn_cost();
+                        app.session.clear_pending_turn_usage();
                         app.session.last_tool_catalog = tool_catalog;
                         // The endpoint this turn's client actually used. Kept
                         // separately from the mutable session/config surfaces
@@ -3000,6 +3002,7 @@ pub(crate) async fn run_event_loop(
                         if let Some(cost) = step_cost {
                             app.accrue_pending_turn_cost_estimate(cost);
                         }
+                        app.session.accrue_pending_turn_usage(&usage);
                     }
                     EngineEvent::AdvisoryNote { note, .. } => {
                         // Advisor background watcher note. Display as a

--- a/crates/tui/src/tui/underwater.rs
+++ b/crates/tui/src/tui/underwater.rs
@@ -1131,9 +1131,11 @@ fn session_token_breakdown(app: &App) -> Option<Span<'static>> {
         Span::styled(
             format!(
                 "{} in · {} cch · {} out",
-                format_token_count_compact(u64::from(app.session.total_input_tokens)),
-                format_token_count_compact(u64::from(app.session.total_cache_hit_tokens)),
-                format_token_count_compact(u64::from(app.session.total_output_tokens)),
+                format_token_count_compact(u64::from(app.session.displayed_total_input_tokens())),
+                format_token_count_compact(u64::from(
+                    app.session.displayed_total_cache_hit_tokens(),
+                )),
+                format_token_count_compact(u64::from(app.session.displayed_total_output_tokens())),
             ),
             header_fg(app, ChromeInk::Info),
         )


### PR DESCRIPTION
## Summary

Addresses the approved first slice of #5581: live session token totals.

Per-model-call `TurnUsage` receipts now feed a display-only pending ledger while a turn is running:

- input tokens;
- output tokens;
- total tokens;
- cache-hit tokens;
- cache-miss tokens;
- cache-write tokens.

The existing authoritative `TurnComplete` accounting remains unchanged. Pending values are cleared immediately before cumulative totals reconcile, so no usage is double-counted and no new persistence or billing contract is introduced.

The pending deltas are reflected in the existing token surfaces: sidebar/context total, header token breakdown, phase/session metrics, `/status`, `/tokens`, and the dashboard token summary. Cache-write totals use the same canonical mutually-exclusive pricing split as the existing completion path.

## Tests

Passed locally:

- `cargo fmt --all -- --check`
- `git diff --check`
- focused pending ledger test
- full `tui::app::tests`
- config status tests
- underwater/header tests
- phase strip tests
- session metrics tests
- strict all-target TUI Clippy with `-D warnings`

The regression covers multiple receipt fields, cache-class splitting, turn reconciliation, saturation-safe displayed totals, and no-double-counting.

No provider credentials or network access are required.

No-Issue: This PR addresses the approved #5581 live-token-observability slice without automatically closing the broader audit issue.
