### PR TITLE
fix(tui): persist context pressure warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Context-pressure warnings and critical alerts now remain visible in sticky UI
+  status until compaction or explicit dismissal, instead of disappearing into
+  scrolling turn metadata (#5620).
 - Session token totals now include display-only per-model-call deltas while a
   turn is running, including input/output and cache-class counters; the
   authoritative `TurnComplete` totals still reconcile exactly once (#5581).

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -65,6 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Context-pressure warnings and critical alerts now remain visible in sticky UI
+  status until compaction or explicit dismissal, instead of disappearing into
+  scrolling turn metadata (#5620).
 - Session token totals now include display-only per-model-call deltas while a
   turn is running, including input/output and cache-class counters; the
   authoritative `TurnComplete` totals still reconcile exactly once (#5581).

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -61,6 +61,7 @@ pub(crate) use composer::{InputHistoryDraft, char_count};
 pub(crate) use composer::{
     MAX_SUBMITTED_INPUT_CHARS, next_grapheme_boundary, prev_grapheme_boundary,
 };
+pub(crate) use status::is_context_pressure_status;
 pub use status::{StatusToast, StatusToastLevel};
 pub use types::{
     AppAction, AppMode, AppModeUi, AutomationAction, ComposerDensity, ComposerSubmitAction,
@@ -1285,6 +1286,10 @@ pub struct App {
     pub sticky_status: Option<StatusToast>,
     /// Last status text already promoted from `status_message` into toast state.
     pub last_status_message_seen: Option<String>,
+    /// Prevents the same pressure condition from immediately re-arming after
+    /// the operator explicitly dismisses its sticky warning. Reset when the
+    /// pressure falls below the warning threshold or compaction starts.
+    pub context_pressure_warning_dismissed: bool,
     pub model: String,
     /// Persisted model selections by provider name. Loaded from settings so
     /// `/model` and the picker can surface saved provider-specific choices.

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -61,7 +61,7 @@ pub(crate) use composer::{InputHistoryDraft, char_count};
 pub(crate) use composer::{
     MAX_SUBMITTED_INPUT_CHARS, next_grapheme_boundary, prev_grapheme_boundary,
 };
-pub(crate) use status::is_context_pressure_status;
+pub(crate) use status::StatusToastKind;
 pub use status::{StatusToast, StatusToastLevel};
 pub use types::{
     AppAction, AppMode, AppModeUi, AutomationAction, ComposerDensity, ComposerSubmitAction,
@@ -1289,7 +1289,7 @@ pub struct App {
     /// Prevents the same pressure condition from immediately re-arming after
     /// the operator explicitly dismisses its sticky warning. Reset when the
     /// pressure falls below the warning threshold or compaction starts.
-    pub context_pressure_warning_dismissed: bool,
+    pub context_pressure_warning_dismissed: Option<crate::context_budget::PressureLevel>,
     pub model: String,
     /// Persisted model selections by provider name. Loaded from settings so
     /// `/model` and the picker can surface saved provider-specific choices.

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -739,6 +739,7 @@ impl App {
             update_available: None,
             sticky_status: None,
             last_status_message_seen: None,
+            context_pressure_warning_dismissed: false,
             model,
             provider_models,
             enabled_provider_models,

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -739,7 +739,7 @@ impl App {
             update_available: None,
             sticky_status: None,
             last_status_message_seen: None,
-            context_pressure_warning_dismissed: false,
+            context_pressure_warning_dismissed: None,
             model,
             provider_models,
             enabled_provider_models,

--- a/crates/tui/src/tui/app/status.rs
+++ b/crates/tui/src/tui/app/status.rs
@@ -22,6 +22,13 @@ pub struct StatusToast {
     pub level: StatusToastLevel,
     pub created_at: Instant,
     pub ttl_ms: Option<u64>,
+    pub(crate) kind: StatusToastKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StatusToastKind {
+    Ordinary,
+    ContextPressure(crate::context_budget::PressureLevel),
 }
 
 impl StatusToast {
@@ -32,6 +39,21 @@ impl StatusToast {
             level,
             created_at: Instant::now(),
             ttl_ms,
+            kind: StatusToastKind::Ordinary,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn context_pressure(
+        text: impl Into<String>,
+        level: crate::context_budget::PressureLevel,
+    ) -> Self {
+        Self {
+            text: text.into(),
+            level: StatusToastLevel::Warning,
+            created_at: Instant::now(),
+            ttl_ms: None,
+            kind: StatusToastKind::ContextPressure(level),
         }
     }
 
@@ -40,15 +62,6 @@ impl StatusToast {
         self.ttl_ms
             .is_some_and(|ttl| now.duration_since(self.created_at).as_millis() >= u128::from(ttl))
     }
-}
-
-/// Whether a status message is one of the context-pressure messages emitted
-/// by the compaction flow. Keeping this predicate here lets dismissal,
-/// replacement, and compaction clearing share one identity check.
-pub(crate) fn is_context_pressure_status(text: &str) -> bool {
-    text.starts_with("Context building:")
-        || text.starts_with("Context high:")
-        || text.starts_with("Context critical:")
 }
 
 impl App {
@@ -102,10 +115,14 @@ impl App {
         let is_context_pressure = self
             .sticky_status
             .as_ref()
-            .is_some_and(|status| is_context_pressure_status(&status.text));
+            .is_some_and(|status| matches!(status.kind, StatusToastKind::ContextPressure(_)));
         if is_context_pressure {
+            if let Some(StatusToastKind::ContextPressure(level)) =
+                self.sticky_status.as_ref().map(|status| status.kind)
+            {
+                self.context_pressure_warning_dismissed = Some(level);
+            }
             self.clear_sticky_status();
-            self.context_pressure_warning_dismissed = true;
             return true;
         }
         false
@@ -232,7 +249,15 @@ impl App {
         let sticky = self.sticky_status.clone();
         let latest = self.status_toasts.back().cloned();
         match (sticky, latest) {
-            (Some(sticky), Some(latest)) if is_context_pressure_status(&sticky.text) => {
+            (Some(sticky), Some(latest))
+                if matches!(
+                    sticky.kind,
+                    StatusToastKind::ContextPressure(crate::context_budget::PressureLevel::High)
+                        | StatusToastKind::ContextPressure(
+                            crate::context_budget::PressureLevel::Medium
+                        )
+                ) =>
+            {
                 Some(latest)
             }
             (Some(sticky), _) => Some(sticky),

--- a/crates/tui/src/tui/app/status.rs
+++ b/crates/tui/src/tui/app/status.rs
@@ -87,6 +87,21 @@ impl App {
         }
     }
 
+    /// Dismiss the persistent context-pressure warning without dismissing
+    /// unrelated error/status chrome. Returns whether anything was cleared.
+    pub fn dismiss_context_pressure_warning(&mut self) -> bool {
+        let is_context_pressure = self.sticky_status.as_ref().is_some_and(|status| {
+            status.text.starts_with("Context building:")
+                || status.text.starts_with("Context high:")
+                || status.text.starts_with("Context critical:")
+        });
+        if is_context_pressure {
+            self.clear_sticky_status();
+            return true;
+        }
+        false
+    }
+
     /// Drop sticky error chrome when the user resumes typing so a prior
     /// workflow/provider failure does not linger over the next draft.
     pub fn acknowledge_sticky_on_composer_activity(&mut self) {

--- a/crates/tui/src/tui/app/status.rs
+++ b/crates/tui/src/tui/app/status.rs
@@ -42,6 +42,15 @@ impl StatusToast {
     }
 }
 
+/// Whether a status message is one of the context-pressure messages emitted
+/// by the compaction flow. Keeping this predicate here lets dismissal,
+/// replacement, and compaction clearing share one identity check.
+pub(crate) fn is_context_pressure_status(text: &str) -> bool {
+    text.starts_with("Context building:")
+        || text.starts_with("Context high:")
+        || text.starts_with("Context critical:")
+}
+
 impl App {
     pub fn push_status_toast(
         &mut self,
@@ -90,13 +99,13 @@ impl App {
     /// Dismiss the persistent context-pressure warning without dismissing
     /// unrelated error/status chrome. Returns whether anything was cleared.
     pub fn dismiss_context_pressure_warning(&mut self) -> bool {
-        let is_context_pressure = self.sticky_status.as_ref().is_some_and(|status| {
-            status.text.starts_with("Context building:")
-                || status.text.starts_with("Context high:")
-                || status.text.starts_with("Context critical:")
-        });
+        let is_context_pressure = self
+            .sticky_status
+            .as_ref()
+            .is_some_and(|status| is_context_pressure_status(&status.text));
         if is_context_pressure {
             self.clear_sticky_status();
+            self.context_pressure_warning_dismissed = true;
             return true;
         }
         false
@@ -220,8 +229,14 @@ impl App {
         let now = Instant::now();
         self.prune_expired_status_toasts(now);
 
-        self.sticky_status
-            .clone()
-            .or_else(|| self.status_toasts.back().cloned())
+        let sticky = self.sticky_status.clone();
+        let latest = self.status_toasts.back().cloned();
+        match (sticky, latest) {
+            (Some(sticky), Some(latest)) if is_context_pressure_status(&sticky.text) => {
+                Some(latest)
+            }
+            (Some(sticky), _) => Some(sticky),
+            (None, latest) => latest,
+        }
     }
 }

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -1921,6 +1921,40 @@ fn pending_turn_usage_moves_token_surfaces_without_double_counting() {
 }
 
 #[test]
+fn context_pressure_toast_kind_is_not_inferred_from_display_text() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.sticky_status = Some(StatusToast::new(
+        "Context high: 90%",
+        StatusToastLevel::Warning,
+        None,
+    ));
+    assert!(!app.dismiss_context_pressure_warning());
+    assert!(app.sticky_status.is_some());
+
+    app.sticky_status = Some(StatusToast::context_pressure(
+        "localized pressure warning",
+        crate::context_budget::PressureLevel::High,
+    ));
+    assert!(app.dismiss_context_pressure_warning());
+    assert!(app.sticky_status.is_none());
+}
+
+#[test]
+fn critical_context_pressure_remains_visible_over_transient_info_toasts() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.sticky_status = Some(StatusToast::context_pressure(
+        "Context critical: 95%",
+        crate::context_budget::PressureLevel::Critical,
+    ));
+    app.push_status_toast("Saved", StatusToastLevel::Info, None);
+
+    assert_eq!(
+        app.active_status_toast().map(|toast| toast.text),
+        Some("Context critical: 95%".to_string())
+    );
+}
+
+#[test]
 fn cny_display_falls_back_to_usd_for_usd_only_costs() {
     let mut app = App::new(test_options(false), &Config::default());
     app.cost_currency = CostCurrency::Cny;

--- a/crates/tui/src/tui/ui/compaction_flow.rs
+++ b/crates/tui/src/tui/ui/compaction_flow.rs
@@ -201,6 +201,13 @@ pub(crate) fn flush_deferred_manual_compaction(
 }
 
 pub(crate) fn apply_compaction_started(app: &mut App, id: String, auto: bool) {
+    if app
+        .sticky_status
+        .as_ref()
+        .is_some_and(|status| is_context_pressure_status(&status.text))
+    {
+        app.clear_sticky_status();
+    }
     if !auto {
         app.manual_compaction_queued = false;
         if app.manual_compaction_id.as_deref() == Some(id.as_str()) {
@@ -386,22 +393,47 @@ pub(crate) fn maybe_warn_context_pressure_for_config(
     };
 
     if percent >= CONTEXT_CRITICAL_THRESHOLD_PERCENT {
-        app.status_message = Some(format!(
-            "Context critical: {percent:.0}% ({used}/{max} tokens{window_note}). {recommendation}"
-        ));
+        set_context_pressure_status(
+            app,
+            format!(
+                "Context critical: {percent:.0}% ({used}/{max} tokens{window_note}). {recommendation}"
+            ),
+        );
         return;
     }
 
-    if app.status_message.is_none() {
-        let status_prefix = if percent >= CONTEXT_WARNING_THRESHOLD_PERCENT {
-            "Context high"
-        } else {
-            "Context building"
-        };
-        app.status_message = Some(format!(
+    let status_prefix = if percent >= CONTEXT_WARNING_THRESHOLD_PERCENT {
+        "Context high"
+    } else {
+        "Context building"
+    };
+    set_context_pressure_status(
+        app,
+        format!(
             "{status_prefix}: {percent:.0}% ({used}/{max} tokens{window_note}). {recommendation}"
-        ));
+        ),
+    );
+}
+
+fn is_context_pressure_status(text: &str) -> bool {
+    text.starts_with("Context building:")
+        || text.starts_with("Context high:")
+        || text.starts_with("Context critical:")
+}
+
+fn set_context_pressure_status(app: &mut App, text: String) {
+    let can_replace = app
+        .sticky_status
+        .as_ref()
+        .is_none_or(|status| is_context_pressure_status(&status.text));
+    if !can_replace {
+        return;
     }
+    app.status_message = Some(text.clone());
+    app.last_status_message_seen = Some(text.clone());
+    // No TTL: this warning stays visible until compaction or explicit Esc
+    // dismissal instead of being pushed out by later transcript activity.
+    app.set_sticky_status(text, StatusToastLevel::Warning, None);
 }
 
 #[cfg(test)]

--- a/crates/tui/src/tui/ui/compaction_flow.rs
+++ b/crates/tui/src/tui/ui/compaction_flow.rs
@@ -201,14 +201,15 @@ pub(crate) fn flush_deferred_manual_compaction(
 }
 
 pub(crate) fn apply_compaction_started(app: &mut App, id: String, auto: bool) {
-    if app
-        .sticky_status
-        .as_ref()
-        .is_some_and(|status| crate::tui::app::is_context_pressure_status(&status.text))
-    {
+    if app.sticky_status.as_ref().is_some_and(|status| {
+        matches!(
+            status.kind,
+            crate::tui::app::StatusToastKind::ContextPressure(_)
+        )
+    }) {
         app.clear_sticky_status();
     }
-    app.context_pressure_warning_dismissed = false;
+    app.context_pressure_warning_dismissed = None;
     if !auto {
         app.manual_compaction_queued = false;
         if app.manual_compaction_id.as_deref() == Some(id.as_str()) {
@@ -374,17 +375,29 @@ pub(crate) fn maybe_warn_context_pressure_for_config(
     let warning_threshold = CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT.min(configured_threshold);
     let will_auto_compact = config.enabled && used.max(0) as usize >= config.token_threshold;
     if percent < warning_threshold && !will_auto_compact {
-        app.context_pressure_warning_dismissed = false;
-        if app
-            .sticky_status
-            .as_ref()
-            .is_some_and(|status| crate::tui::app::is_context_pressure_status(&status.text))
-        {
+        app.context_pressure_warning_dismissed = None;
+        if app.sticky_status.as_ref().is_some_and(|status| {
+            matches!(
+                status.kind,
+                crate::tui::app::StatusToastKind::ContextPressure(_)
+            )
+        }) {
             app.clear_sticky_status();
         }
+        app.context_pressure_warning_dismissed = None;
         return;
     }
-    if app.context_pressure_warning_dismissed {
+    let pressure_level = if percent >= CONTEXT_CRITICAL_THRESHOLD_PERCENT {
+        crate::context_budget::PressureLevel::Critical
+    } else if percent >= CONTEXT_WARNING_THRESHOLD_PERCENT {
+        crate::context_budget::PressureLevel::High
+    } else {
+        crate::context_budget::PressureLevel::Medium
+    };
+    if app
+        .context_pressure_warning_dismissed
+        .is_some_and(|dismissed| pressure_level <= dismissed)
+    {
         return;
     }
 
@@ -410,6 +423,7 @@ pub(crate) fn maybe_warn_context_pressure_for_config(
             format!(
                 "Context critical: {percent:.0}% ({used}/{max} tokens{window_note}). {recommendation}"
             ),
+            pressure_level,
         );
         return;
     }
@@ -424,14 +438,21 @@ pub(crate) fn maybe_warn_context_pressure_for_config(
         format!(
             "{status_prefix}: {percent:.0}% ({used}/{max} tokens{window_note}). {recommendation}"
         ),
+        pressure_level,
     );
 }
 
-fn set_context_pressure_status(app: &mut App, text: String) {
-    let can_replace = app
-        .sticky_status
-        .as_ref()
-        .is_none_or(|status| crate::tui::app::is_context_pressure_status(&status.text));
+fn set_context_pressure_status(
+    app: &mut App,
+    text: String,
+    pressure_level: crate::context_budget::PressureLevel,
+) {
+    let can_replace = app.sticky_status.as_ref().is_none_or(|status| {
+        matches!(
+            status.kind,
+            crate::tui::app::StatusToastKind::ContextPressure(_)
+        )
+    });
     if !can_replace {
         return;
     }
@@ -439,7 +460,11 @@ fn set_context_pressure_status(app: &mut App, text: String) {
     app.last_status_message_seen = Some(text.clone());
     // No TTL: this warning stays visible until compaction or explicit Esc
     // dismissal instead of being pushed out by later transcript activity.
-    app.set_sticky_status(text, StatusToastLevel::Warning, None);
+    app.sticky_status = Some(crate::tui::app::StatusToast::context_pressure(
+        text,
+        pressure_level,
+    ));
+    app.needs_redraw = true;
 }
 
 #[cfg(test)]

--- a/crates/tui/src/tui/ui/compaction_flow.rs
+++ b/crates/tui/src/tui/ui/compaction_flow.rs
@@ -204,10 +204,11 @@ pub(crate) fn apply_compaction_started(app: &mut App, id: String, auto: bool) {
     if app
         .sticky_status
         .as_ref()
-        .is_some_and(|status| is_context_pressure_status(&status.text))
+        .is_some_and(|status| crate::tui::app::is_context_pressure_status(&status.text))
     {
         app.clear_sticky_status();
     }
+    app.context_pressure_warning_dismissed = false;
     if !auto {
         app.manual_compaction_queued = false;
         if app.manual_compaction_id.as_deref() == Some(id.as_str()) {
@@ -373,6 +374,17 @@ pub(crate) fn maybe_warn_context_pressure_for_config(
     let warning_threshold = CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT.min(configured_threshold);
     let will_auto_compact = config.enabled && used.max(0) as usize >= config.token_threshold;
     if percent < warning_threshold && !will_auto_compact {
+        app.context_pressure_warning_dismissed = false;
+        if app
+            .sticky_status
+            .as_ref()
+            .is_some_and(|status| crate::tui::app::is_context_pressure_status(&status.text))
+        {
+            app.clear_sticky_status();
+        }
+        return;
+    }
+    if app.context_pressure_warning_dismissed {
         return;
     }
 
@@ -415,17 +427,11 @@ pub(crate) fn maybe_warn_context_pressure_for_config(
     );
 }
 
-fn is_context_pressure_status(text: &str) -> bool {
-    text.starts_with("Context building:")
-        || text.starts_with("Context high:")
-        || text.starts_with("Context critical:")
-}
-
 fn set_context_pressure_status(app: &mut App, text: String) {
     let can_replace = app
         .sticky_status
         .as_ref()
-        .is_none_or(|status| is_context_pressure_status(&status.text));
+        .is_none_or(|status| crate::tui::app::is_context_pressure_status(&status.text));
     if !can_replace {
         return;
     }

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -4787,18 +4787,6 @@ pub(crate) async fn run_event_loop(
                     crate::tui::agent_focus::exit_focus(app);
                     continue;
                 }
-                // An idle operator can dismiss the persistent context warning
-                // without affecting unrelated error/status chrome. While a
-                // turn is active Esc retains its cancellation meaning.
-                KeyCode::Esc
-                    if !app.is_loading
-                        && app.input.is_empty()
-                        && !slash_menu_open
-                        && !mention_menu_open
-                        && app.dismiss_context_pressure_warning() =>
-                {
-                    continue;
-                }
                 // Vim composer mode: Esc from Insert/Visual → Normal.
                 // This arm runs before the generic Esc handler so Insert mode
                 // Esc doesn't accidentally cancel an in-flight request.
@@ -4810,6 +4798,18 @@ pub(crate) async fn run_event_loop(
                     continue;
                 }
                 KeyCode::Esc if app.clear_composer_attachment_selection() => {
+                    continue;
+                }
+                // An idle operator can dismiss the persistent context warning
+                // without affecting vim or attachment handling. While a turn
+                // is active Esc retains its cancellation meaning.
+                KeyCode::Esc
+                    if !app.is_loading
+                        && app.input.is_empty()
+                        && !slash_menu_open
+                        && !mention_menu_open
+                        && app.dismiss_context_pressure_warning() =>
+                {
                     continue;
                 }
                 KeyCode::Esc if mention_menu_open => {

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -4787,6 +4787,18 @@ pub(crate) async fn run_event_loop(
                     crate::tui::agent_focus::exit_focus(app);
                     continue;
                 }
+                // An idle operator can dismiss the persistent context warning
+                // without affecting unrelated error/status chrome. While a
+                // turn is active Esc retains its cancellation meaning.
+                KeyCode::Esc
+                    if !app.is_loading
+                        && app.input.is_empty()
+                        && !slash_menu_open
+                        && !mention_menu_open
+                        && app.dismiss_context_pressure_warning() =>
+                {
+                    continue;
+                }
                 // Vim composer mode: Esc from Insert/Visual → Normal.
                 // This arm runs before the generic Esc handler so Insert mode
                 // Esc doesn't accidentally cancel an in-flight request.

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -12837,10 +12837,21 @@ fn context_pressure_warning_survives_later_status_and_can_be_dismissed() {
     app.status_message = Some("A later transcript status".to_string());
     let visible = app
         .active_status_toast()
-        .expect("sticky warning remains active");
-    assert_eq!(visible.text, warning);
+        .expect("a later transient status is visible");
+    assert_eq!(visible.text, "A later transcript status");
+    assert_eq!(
+        app.sticky_status.as_ref().map(|toast| toast.text.as_str()),
+        Some(warning.as_str()),
+        "the persistent pressure warning remains behind the transient status"
+    );
     assert!(app.dismiss_context_pressure_warning());
     assert!(app.sticky_status.is_none());
+    app.status_message = None;
+    maybe_warn_context_pressure(&mut app);
+    assert!(
+        app.sticky_status.is_none(),
+        "explicit dismissal must not re-arm on the next pressure check"
+    );
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1,6 +1,6 @@
 use super::activity_detail::*;
 use super::compaction_flow::{
-    maybe_warn_context_pressure, should_auto_compact_before_send,
+    apply_compaction_started, maybe_warn_context_pressure, should_auto_compact_before_send,
     should_auto_compact_before_send_with_config,
 };
 use super::observer_hooks::{
@@ -12799,10 +12799,93 @@ fn context_pressure_warning_reflects_auto_compact_threshold_state() {
 
     maybe_warn_context_pressure(&mut app);
 
-    let status = app.status_message.expect("context warning");
+    let status = app.status_message.as_deref().expect("context warning");
     assert!(
         status.contains("Auto-compaction will run before the next send."),
         "unexpected status: {status}"
+    );
+    assert!(
+        app.sticky_status
+            .as_ref()
+            .is_some_and(|toast| toast.text == status),
+        "context pressure must remain visible in sticky status: {status}"
+    );
+}
+
+#[test]
+fn context_pressure_warning_survives_later_status_and_can_be_dismissed() {
+    let mut app = create_test_app();
+    app.api_messages = vec![Message {
+        role: Role::User,
+        content: vec![ContentBlock::Text {
+            text: "context ".repeat(240_000),
+            cache_control: None,
+        }],
+    }];
+    app.auto_compact = true;
+    app.auto_compact_threshold_percent = 100.0;
+    let (used, _, _) = context_usage_snapshot(&app).expect("context snapshot");
+    app.compact_threshold = usize::try_from(used).expect("non-negative context estimate");
+    maybe_warn_context_pressure(&mut app);
+    let warning = app
+        .sticky_status
+        .as_ref()
+        .expect("sticky context warning")
+        .text
+        .clone();
+
+    app.status_message = Some("A later transcript status".to_string());
+    let visible = app
+        .active_status_toast()
+        .expect("sticky warning remains active");
+    assert_eq!(visible.text, warning);
+    assert!(app.dismiss_context_pressure_warning());
+    assert!(app.sticky_status.is_none());
+}
+
+#[test]
+fn context_pressure_warning_clears_when_compaction_starts() {
+    let mut app = create_test_app();
+    app.api_messages = vec![Message {
+        role: Role::User,
+        content: vec![ContentBlock::Text {
+            text: "context ".repeat(240_000),
+            cache_control: None,
+        }],
+    }];
+    app.auto_compact = true;
+    app.auto_compact_threshold_percent = 100.0;
+    let (used, _, _) = context_usage_snapshot(&app).expect("context snapshot");
+    app.compact_threshold = usize::try_from(used).expect("non-negative context estimate");
+    maybe_warn_context_pressure(&mut app);
+    assert!(
+        app.sticky_status
+            .as_ref()
+            .is_some_and(|toast| toast.text.starts_with("Context "))
+    );
+
+    apply_compaction_started(&mut app, "compaction-1".to_string(), false);
+    assert!(
+        app.sticky_status.is_none(),
+        "pressure warning should be cleared"
+    );
+    assert!(
+        app.status_message
+            .as_deref()
+            .is_some_and(|text| text.to_ascii_lowercase().contains("compacting")),
+        "compaction status should replace the pressure warning"
+    );
+}
+
+#[test]
+fn context_pressure_warning_stays_absent_below_threshold() {
+    let mut app = create_test_app();
+    maybe_warn_context_pressure(&mut app);
+
+    assert!(app.sticky_status.is_none());
+    assert!(
+        app.status_message.is_none(),
+        "low-pressure sessions should not create warning chrome"
     );
 }
 


### PR DESCRIPTION
## Summary

Addresses the approved display-only slice of #5620.

The existing context-pressure warning/critical signal is now promoted to persistent UI status:

- warning, high, and critical pressure remain visible in sticky status instead of disappearing into scrolling turn metadata;
- pressure updates can replace an earlier pressure status but do not clobber unrelated sticky error/status chrome;
- the warning clears when compaction starts or when the idle operator presses `Esc` with no composer/menu activity;
- existing turn metadata text, compaction thresholds, auto-compaction behavior, and model-facing guidance are unchanged.

## Tests

Passed locally:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --lib 'tui::ui::tests::context_pressure_warning' --locked` (4 passed)
- `cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings`

Coverage verifies persistent warning visibility across later status activity, explicit dismissal, compaction clearing, and silence below the pressure threshold.

No provider credentials or network access are required.

No-Issue: This PR addresses the approved persistent human-visible warning slice without automatically closing the broader #5620 issue.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->