### PR TITLE
One worker system; retire Keychain product path

### DIFF
--- a/crates/secrets/src/account.rs
+++ b/crates/secrets/src/account.rs
@@ -24,7 +24,9 @@ pub const ACCOUNT_API_BASE_ENV: &str = "CODEWHALE_CLOUD_API_BASE";
     note = "the file session store is the automatic fallback; this variable is ignored"
 )]
 pub const ACCOUNT_ALLOW_FILE_SESSION_STORE_ENV: &str = "CODEWHALE_CLOUD_ALLOW_FILE_SESSION_STORE";
-/// OS credential-manager service shared by CLI, TUI, and Runtime API.
+/// Retired OS credential-manager service name. Account sessions use the
+/// file secret store; this constant stays only so old slot names can be
+/// documented.
 pub const ACCOUNT_KEYRING_SERVICE: &str = "codewhale-cloud";
 /// Current serialized account-session record version.
 pub const ACCOUNT_SESSION_SCHEMA_VERSION: u8 = 1;
@@ -127,7 +129,7 @@ pub struct StoredAccountAuth {
     pub schema_version: u8,
     /// Exact canonical API origin that owns this session.
     pub api_base: String,
-    /// Secret account bundle stored inside the credential manager.
+    /// Secret account bundle stored in the Codewhale secret store.
     pub bundle: AccountAuthBundle,
 }
 
@@ -272,17 +274,12 @@ impl AccountSessionStore {
     }
 }
 
-/// Select the approved account-session backend shared by CLI, TUI, and Runtime.
+/// Select the account-session store shared by CLI, TUI, and Runtime.
 ///
-/// The native credential manager is preferred; when it is unavailable the
-/// private `0600` Codewhale secrets file is used automatically, so headless
-/// hosts can sign in without any opt-in.
+/// Product path: the private `0600` Codewhale secrets file. There is no
+/// Keychain / OS-keyring product surface.
 pub fn secure_account_session_secrets() -> Result<Secrets, AccountSessionError> {
-    // Codex-style storage contract: prefer the OS credential manager, fall
-    // back to the private 0600 file store when it is unavailable. Account
-    // sign-in must not hard-require a platform keyring (headless Linux, SSH,
-    // containers); the file store enforces owner-only permissions itself.
-    Ok(Secrets::system_keyring())
+    Ok(Secrets::file_backed())
 }
 
 /// Normalize an optional CLI/TUI profile to the durable account slot label.
@@ -418,33 +415,25 @@ mod tests {
 
     use crate::InMemoryKeyringStore;
 
-    /// Codex-style storage contract: with no OS keyring available and no
-    /// opt-in env var, session secrets must still resolve (to the private
-    /// 0600 file store) instead of failing closed.
     #[test]
-    fn session_secrets_fall_back_to_file_store_without_opt_in() {
+    fn session_secrets_use_the_file_store_not_keychain() {
         let _lock = crate::tests::env_lock();
-        // SAFETY (test): single-threaded via env_lock; restoring not needed —
-        // temp CODEWHALE_HOME is discarded with the process-scoped test env.
         let prev_home = std::env::var("CODEWHALE_HOME").ok();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let home = dir.path().join("codewhale-home");
         std::fs::create_dir_all(&home).expect("home");
-        // SAFETY (test): see above.
         unsafe { std::env::set_var("CODEWHALE_HOME", &home) };
         unsafe { std::env::remove_var("CODEWHALE_CLOUD_ALLOW_FILE_SESSION_STORE") };
         let _prev_home = prev_home;
-        // The contract under test: resolution succeeds with NO opt-in env var.
-        // Which backend wins is platform-dependent (keyring when present,
-        // private 0600 file otherwise); assert the store is usable either way.
         let secrets =
             secure_account_session_secrets().expect("session secrets must resolve without opt-in");
         let name = secrets.backend_name();
-        assert!(!name.is_empty(), "backend must report a name");
         assert!(
-            name.to_lowercase().contains("file") || name.to_lowercase().contains("keyring"),
-            "unexpected backend: {name}"
+            name.to_lowercase().contains("file"),
+            "account sessions must not use Keychain: {name}"
         );
+        assert!(!name.to_lowercase().contains("keychain"));
+        assert!(!name.to_lowercase().contains("keyring"));
     }
 
     fn auth(

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -1,9 +1,11 @@
 //! Secret storage for CodeWhale API keys.
 //!
 //! Provides a small abstraction (`KeyringStore`) plus a default
-//! file-based implementation (`FileKeyringStore`), an opt-in OS keyring
-//! implementation (`DefaultKeyringStore`), and an in-memory store for tests
-//! (`InMemoryKeyringStore`).
+//! file-based implementation (`FileKeyringStore`), a retired OS-keyring
+//! implementation kept only so old items are not rewritten in product code,
+//! and an in-memory store for tests (`InMemoryKeyringStore`). The product
+//! path is the file store (`~/.codewhale/secrets/`, mode 0600). There is
+//! no Keychain settings surface.
 //!
 //! Higher-level lookup through [`Secrets::resolve`] checks the secret store first
 //! and falls back to environment variables. Config-file precedence lives in the
@@ -27,8 +29,9 @@ use thiserror::Error;
 /// with credentials saved before the CodeWhale rename. macOS users can verify
 /// entries with `security find-generic-password -s deepseek -a <provider>`.
 pub const DEFAULT_SERVICE: &str = "deepseek";
-/// Select the secret storage backend. Supported values are `file` (default)
-/// and `system`/`keyring` for the OS credential store.
+/// Select the secret storage backend. The product store is `file`.
+/// `system`/`keyring` are accepted as no-ops so old env files do not
+/// revive the Keychain UI.
 pub const SECRET_BACKEND_ENV: &str = "CODEWHALE_SECRET_BACKEND";
 /// Legacy alias for [`SECRET_BACKEND_ENV`].
 pub const LEGACY_SECRET_BACKEND_ENV: &str = "DEEPSEEK_SECRET_BACKEND";
@@ -101,11 +104,9 @@ pub trait KeyringStore: Send + Sync {
 /// - **Windows**: Credential Manager
 /// - **Linux**: Secret Service (GNOME Keyring / kwallet via dbus), excluding OHOS
 ///
-/// This backend is opt-in -- set the [`SECRET_BACKEND_ENV`] environment
-/// variable to `system` or `keyring` to activate it. On platforms without
-/// a configured native keyring dependency, [`probe`](DefaultKeyringStore::probe)
-/// returns an unsupported error so [`Secrets::auto_detect`] can transparently
-/// fall back to [`FileKeyringStore`].
+/// Retired product path. [`Secrets::auto_detect`] never selects this store.
+/// Tests may still construct it. On platforms without a native keyring
+/// dependency, [`probe`](DefaultKeyringStore::probe) returns unsupported.
 #[derive(Debug, Clone)]
 pub struct DefaultKeyringStore {
     /// Keyring service name used to namespace stored credentials.
@@ -683,7 +684,6 @@ fn home_resolution_error() -> SecretsError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SecretBackendSelection {
     File,
-    System,
     Unknown,
 }
 
@@ -768,14 +768,6 @@ pub fn diagnose_secret_backend() -> SecretBackendDiagnostic {
                 legacy_path,
             }
         }
-        SecretBackendSelection::System => SecretBackendDiagnostic {
-            backend: SecretBackendDiagnosticKind::System,
-            inspection: SecretBackendInspection::NotProbed,
-            path: None,
-            presence: SecretBackendPresence::Unknown,
-            legacy_path: None,
-            legacy_presence: SecretBackendPresence::Unknown,
-        },
         SecretBackendSelection::Unknown => SecretBackendDiagnostic {
             backend: SecretBackendDiagnosticKind::Unknown,
             inspection: SecretBackendInspection::NotProbed,
@@ -822,8 +814,9 @@ fn secret_backend_selection(value: Option<&str>) -> SecretBackendSelection {
     match value.map(str::trim).filter(|value| !value.is_empty()) {
         None => SecretBackendSelection::File,
         Some(value) => match value.to_ascii_lowercase().as_str() {
-            "file" | "local" | "json" => SecretBackendSelection::File,
-            "system" | "keyring" | "os" | "os-keyring" => SecretBackendSelection::System,
+            "file" | "local" | "json" | "system" | "keyring" | "os" | "os-keyring" => {
+                SecretBackendSelection::File
+            }
             _ => SecretBackendSelection::Unknown,
         },
     }
@@ -896,16 +889,9 @@ impl Secrets {
         }
     }
 
-    /// Auto-detect the best available backend based on the environment.
-    ///
-    /// Selection logic:
-    /// 1. If [`SECRET_BACKEND_ENV`] is set to `system`/`keyring`/`os`/`os-keyring`,
-    ///    probe the OS keyring. If the probe succeeds, use it; otherwise
-    ///    fall back to the file-based store with a warning.
-    /// 2. If the env var is unset, empty, or `file`/`local`/`json`, use
-    ///    the file-based store directly.
-    /// 3. If the env var is set to an unrecognised value, log a warning
-    ///    and use the file-based store.
+    /// Use the product secret store: `~/.codewhale/secrets/` (mode 0600).
+    /// Legacy `system`/`keyring` env values are ignored so they cannot
+    /// surface a Keychain prompt.
     pub fn auto_detect() -> Self {
         match secret_backend_selection(configured_secret_backend().as_deref()) {
             SecretBackendSelection::File => Self::file_backed_default(),
@@ -914,18 +900,6 @@ impl Secrets {
                     "{SECRET_BACKEND_ENV}/{LEGACY_SECRET_BACKEND_ENV} has an unsupported value; using file-backed secret store"
                 );
                 Self::file_backed_default()
-            }
-            SecretBackendSelection::System => {
-                let default_store = DefaultKeyringStore::default();
-                match default_store.probe() {
-                    Ok(()) => Self::new(Arc::new(default_store)),
-                    Err(err) => {
-                        tracing::warn!(
-                            "OS keyring unavailable ({err}); falling back to file-backed secret store"
-                        );
-                        Self::file_backed_default()
-                    }
-                }
             }
         }
     }
@@ -947,20 +921,6 @@ impl Secrets {
                     "{SECRET_BACKEND_ENV}/{LEGACY_SECRET_BACKEND_ENV} has an unsupported value; using file-backed secret store"
                 );
                 Self::file_backed_read_only()
-            }
-            SecretBackendSelection::System => {
-                let default_store = DefaultKeyringStore::default();
-                match default_store.probe() {
-                    Ok(()) => {
-                        Self::new(Arc::new(ReadOnlyKeyringStore::new(Arc::new(default_store))))
-                    }
-                    Err(err) => {
-                        tracing::warn!(
-                            "OS keyring unavailable ({err}); falling back to file-backed secret store"
-                        );
-                        Self::file_backed_read_only()
-                    }
-                }
             }
         }
     }
@@ -1037,20 +997,11 @@ impl Secrets {
         Self::file_backed_default()
     }
 
-    /// Construct the opt-in OS credential backend, falling back to the
-    /// file-backed store when the platform backend is unavailable.
+    /// Retired constructor. Always the file store so leftover callers cannot
+    /// surface a Keychain prompt.
     #[must_use]
     pub fn system_keyring() -> Self {
-        let default_store = DefaultKeyringStore::default();
-        match default_store.probe() {
-            Ok(()) => Self::new(Arc::new(default_store)),
-            Err(err) => {
-                tracing::warn!(
-                    "OS keyring unavailable ({err}); falling back to file-backed secret store"
-                );
-                Self::file_backed_default()
-            }
-        }
+        Self::file_backed_default()
     }
 
     /// Backend label, suitable for `doctor` output.
@@ -1354,19 +1305,14 @@ mod tests {
     }
 
     #[test]
-    fn backend_selection_accepts_explicit_system_keyring() {
-        assert_eq!(
-            secret_backend_selection(Some("system")),
-            SecretBackendSelection::System
-        );
-        assert_eq!(
-            secret_backend_selection(Some("keyring")),
-            SecretBackendSelection::System
-        );
-        assert_eq!(
-            secret_backend_selection(Some("os-keyring")),
-            SecretBackendSelection::System
-        );
+    fn backend_selection_ignores_retired_keychain_aliases() {
+        for alias in ["system", "keyring", "os", "os-keyring"] {
+            assert_eq!(
+                secret_backend_selection(Some(alias)),
+                SecretBackendSelection::File,
+                "{alias} must not revive the Keychain product path"
+            );
+        }
     }
 
     #[test]

--- a/crates/secrets/src/tests/diagnostic_tests.rs
+++ b/crates/secrets/src/tests/diagnostic_tests.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 #[test]
-fn system_backend_diagnostic_is_literal_unknown_and_not_probed() {
+fn retired_keychain_env_diagnoses_the_file_store() {
     let _lock = env_lock();
     clear_known_envs();
     let tmp = tempfile::tempdir().unwrap();
@@ -14,11 +14,10 @@ fn system_backend_diagnostic_is_literal_unknown_and_not_probed() {
 
     let diagnostic = diagnose_secret_backend();
 
-    assert_eq!(diagnostic.backend, SecretBackendDiagnosticKind::System);
-    assert_eq!(diagnostic.inspection, SecretBackendInspection::NotProbed);
-    assert_eq!(diagnostic.presence, SecretBackendPresence::Unknown);
-    assert_eq!(diagnostic.path, None);
-    assert_eq!(diagnostic.legacy_path, None);
+    assert_eq!(diagnostic.backend, SecretBackendDiagnosticKind::File);
+    assert_eq!(diagnostic.inspection, SecretBackendInspection::MetadataOnly);
+    assert_ne!(diagnostic.path, None);
+    assert!(!format!("{diagnostic:?}").contains("Keychain"));
 }
 
 #[test]

--- a/crates/tui/src/commands/groups/plugins/mod.rs
+++ b/crates/tui/src/commands/groups/plugins/mod.rs
@@ -189,10 +189,15 @@ fn suggest_bundles(app: &App, task: &str) -> CommandResult {
     let index = crate::skills::RegistryDocument { skills };
     let recommendations = crate::skills::recommend::recommend_remote_skills(task, &index, 3);
     if recommendations.is_empty() {
-        return CommandResult::message(format!(
+        let mut message = format!(
             "No installed plugin bundles matched `{}`.\n\nInstall a reviewed bundle with /plugin install <source>. Nothing was installed, trusted, or enabled.",
             escape_review_text(task)
-        ));
+        );
+        if let Some(hint) = missing_reviewed_connector_hint(app, task) {
+            message.push_str("\n\n");
+            message.push_str(&hint);
+        }
+        return CommandResult::message(message);
     }
 
     let mut output = format!(
@@ -240,7 +245,53 @@ fn suggest_bundles(app: &App, task: &str) -> CommandResult {
         let _ = writeln!(output, "    {next_step}");
     }
     output.push_str("\nNothing was installed, trusted, or enabled.");
+    if let Some(hint) = missing_reviewed_connector_hint(app, task) {
+        output.push_str("\n\n");
+        output.push_str(&hint);
+    }
     CommandResult::message(output)
+}
+
+/// Specific install+auth commands for reviewed connectors the task needs.
+/// Planned catalog rows (Notion, Stripe, Vercel, …) are omitted.
+fn missing_reviewed_connector_hint(app: &App, task: &str) -> Option<String> {
+    let task = task.to_ascii_lowercase();
+    let mut hints = Vec::new();
+    if task_mentions_github(&task) && !reviewed_connector_is_ready(app, "github") {
+        hints.push(
+            "GitHub is not connected. Run `/mcp connect github` (adds the official GitHub MCP and starts `/mcp login github`). Not a generic plugin credential."
+                .to_string(),
+        );
+    }
+    if hints.is_empty() {
+        None
+    } else {
+        Some(hints.join("\n"))
+    }
+}
+
+fn task_mentions_github(task: &str) -> bool {
+    ["github", "gh pr", "pull request", "pull-request", "repo issue"]
+        .iter()
+        .any(|needle| task.contains(needle))
+        || (task.contains("pr ") || task.contains(" pr") || task.ends_with(" pr"))
+            && (task.contains("review")
+                || task.contains("open")
+                || task.contains("merge")
+                || task.contains("check"))
+}
+
+fn reviewed_connector_is_ready(app: &App, name: &str) -> bool {
+    if app.plugin_registry.get(name).is_some() {
+        return true;
+    }
+    crate::mcp::load_config_with_workspace_and_plugins(
+        &app.mcp_config_path,
+        &app.workspace,
+        app.plugin_registry.as_ref(),
+    )
+    .ok()
+    .is_some_and(|cfg| cfg.servers.contains_key(name))
 }
 
 fn list_bundles_and_legacy_tools(app: &App) -> CommandResult {

--- a/crates/tui/src/commands/groups/plugins/tests.rs
+++ b/crates/tui/src/commands/groups/plugins/tests.rs
@@ -173,6 +173,22 @@ fn suggest_ranks_installed_plugins_without_trusting_or_enabling_them() {
 }
 
 #[test]
+fn suggest_names_github_connect_when_the_task_needs_it() {
+    let _lock = crate::test_support::lock_test_env();
+    let root = TempDir::new().unwrap();
+    let codewhale_home = root.path().join("home");
+    let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", &codewhale_home);
+    write_bundle(root.path());
+    let (mut app, _temp) = create_test_app(root.path());
+
+    let result = plugins(&mut app, Some("suggest review this github pull request"));
+    assert!(!result.is_error, "{result:?}");
+    let message = result.message.expect("suggestion message");
+    assert!(message.contains("/mcp connect github"), "{message}");
+    assert!(!codewhale_home.join("plugins/state.json").exists());
+}
+
+#[test]
 fn trust_requires_content_and_capability_bound_review_token() {
     let _lock = crate::test_support::lock_test_env();
     let root = TempDir::new().unwrap();

--- a/crates/tui/src/commands/groups/session/rename.rs
+++ b/crates/tui/src/commands/groups/session/rename.rs
@@ -118,6 +118,7 @@ pub(crate) fn rename_with_manager(
     session.metadata.mode = Some(app.mode.as_setting().to_string());
     app.sync_cost_to_metadata(&mut session.metadata);
     session.metadata.title = new_title.to_string();
+    session.metadata.title_source = crate::session_manager::SessionTitleSource::User;
 
     match manager.save_session(&session) {
         Ok(_) => {

--- a/crates/tui/src/commands/groups/utility/mcp.rs
+++ b/crates/tui/src/commands/groups/utility/mcp.rs
@@ -17,7 +17,7 @@ const CONTAINER_USE_SOURCE: &str = "https://github.com/dagger/container-use";
 pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "mcp",
     aliases: &[],
-    usage: "/mcp [init|import|import approve <name>|import decline <name>|recommendations|add recommended <id>|add stdio <name> <command> [args...]|add http <name> <url>|enable <name>|disable <name>|remove <name>|doctor|validate|restart|reload]",
+    usage: "/mcp [init|import|import approve <name>|import decline <name>|recommendations|connect <id>|add recommended <id>|add stdio <name> <command> [args...]|add http <name> <url>|enable <name>|disable <name>|remove <name>|login <name>|logout <name>|doctor|validate|restart|reload]",
     description_key: "cmd_mcp_description",
 };
 
@@ -57,6 +57,7 @@ fn mcp(presentation: &mut dyn CommandPresentationContext, args: Option<&str>) ->
         "recommend" | "recommended" | "recommendations" => {
             CommandResult::message(recommended_mcp_text(presentation))
         }
+        "connect" => parse_connect(presentation, parts.next()),
         "add" => parse_add(presentation, parts.collect()),
         "enable" => match parse_name(parts.next(), "Usage: /mcp enable <name>") {
             Ok(name) => CommandResult::action(AppAction::Mcp(McpUiAction::Enable { name })),
@@ -117,7 +118,7 @@ fn mcp(presentation: &mut dyn CommandPresentationContext, args: Option<&str>) ->
             CommandResult::action(AppAction::Mcp(McpUiAction::Reload))
         }
         _ => CommandResult::error(
-            "Usage: /mcp [init|import|recommendations|add recommended <id>|add stdio <name> <command> [args...]|add http <name> <url>|enable <name>|disable <name>|remove <name>|login <name>|logout <name>|doctor|validate|restart|reload]",
+            "Usage: /mcp [init|import|recommendations|connect <id>|add recommended <id>|add stdio <name> <command> [args...]|add http <name> <url>|enable <name>|disable <name>|remove <name>|login <name>|logout <name>|doctor|validate|restart|reload]",
         ),
     }
 }
@@ -126,6 +127,28 @@ fn parse_name(name: Option<&str>, usage: &str) -> Result<String, String> {
     match name {
         Some(name) if !name.trim().is_empty() => Ok(name.to_string()),
         _ => Err(usage.to_string()),
+    }
+}
+
+fn parse_connect(
+    presentation: &mut dyn CommandPresentationContext,
+    id: Option<&str>,
+) -> CommandResult {
+    let Some(id) = id.filter(|id| !id.trim().is_empty()) else {
+        return CommandResult::error("Usage: /mcp connect <id>");
+    };
+    match id.to_ascii_lowercase().as_str() {
+        "github" | "gh" => CommandResult::action(AppAction::Mcp(McpUiAction::Connect {
+            name: "github".to_string(),
+            url: GITHUB_MCP_URL.to_string(),
+            login: true,
+        })),
+        "hugging-face" | "hf" => CommandResult::action(AppAction::Mcp(McpUiAction::Connect {
+            name: "hugging-face".to_string(),
+            url: "https://huggingface.co/mcp".to_string(),
+            login: false,
+        })),
+        other => parse_add(presentation, vec!["recommended", other]),
     }
 }
 
@@ -482,6 +505,13 @@ mod tests {
         assert!(matches!(
             add_github.action,
             Some(AppAction::Mcp(McpUiAction::AddHttp { name, url, transport: None }))
+                if name == "github" && url == GITHUB_MCP_URL
+        ));
+
+        let connect_github = mcp(&mut FakePresentation, Some("connect github"));
+        assert!(matches!(
+            connect_github.action,
+            Some(AppAction::Mcp(McpUiAction::Connect { name, url, login: true }))
                 if name == "github" && url == GITHUB_MCP_URL
         ));
 

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -3084,6 +3084,42 @@ impl Engine {
         self.config.runtime_services.active_thread_id.is_some()
     }
 
+    fn maybe_start_session_namer(&self, first_prompt: &str) {
+        let user_turns = self
+            .session
+            .messages
+            .iter()
+            .filter(|message| message.role.as_str() == "user")
+            .count();
+        if user_turns != 1 {
+            return;
+        }
+        if !crate::session_namer::should_auto_name(
+            crate::session_manager::SessionTitleSource::Truncation,
+            first_prompt,
+            false,
+        ) {
+            return;
+        }
+        let Some(client) = self.deepseek_client.clone() else {
+            return;
+        };
+        let spec = crate::session_namer::namer_completion_spec(first_prompt);
+        let model = crate::session_namer::naming_model_hint(None, &self.session.model);
+        let session_id = self.session.id.clone();
+        let tx_event = self.tx_event.clone();
+        crate::utils::spawn_supervised(
+            "session-namer",
+            std::panic::Location::caller(),
+            async move {
+                crate::session_namer::run_namer_for_session(
+                    session_id, spec, client, model, tx_event,
+                )
+                .await;
+            },
+        );
+    }
+
     async fn emit_session_updated(&self) {
         let _ = self
             .tx_event
@@ -4785,6 +4821,7 @@ impl Engine {
         // Add the user message through the same explicit snapshot constructor
         // preview uses. Route limits and mode in resource metadata therefore
         // belong to this turn even when the previous route was different.
+        let namer_prompt = content.clone();
         let user_msg = self.user_text_message_from_snapshot(
             content,
             &model,
@@ -4801,6 +4838,7 @@ impl Engine {
             },
         );
         self.session.add_message(user_msg);
+        self.maybe_start_session_namer(&namer_prompt);
 
         self.emit_session_updated().await;
 

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -564,6 +564,13 @@ pub enum Event {
         tool_call_count: u32,
     },
 
+    /// Fire-and-forget cheap title after the first user prompt of a new
+    /// thread. The TUI applies it only when the user has not renamed.
+    SessionTitleGenerated {
+        session_id: String,
+        title: String,
+    },
+
     // === Prefix-Cache Stability Events ===
     /// The prefix (system prompt + tool specs) changed between turns,
     /// which invalidates DeepSeek's KV prefix cache. Carries diagnostics

--- a/crates/tui/src/doctor.rs
+++ b/crates/tui/src/doctor.rs
@@ -133,8 +133,8 @@ pub(crate) fn secret_backend_human_lines(
             format!("presence: {} ({inspection})", presence(diagnostic.presence)),
         ],
         SecretBackendDiagnosticKind::System => vec![
-            "backend: system".to_string(),
-            "status: unknown (not_probed)".to_string(),
+            "backend: file".to_string(),
+            "status: using the Codewhale secret store".to_string(),
         ],
         SecretBackendDiagnosticKind::Unknown => vec![
             "backend: unknown".to_string(),

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -154,6 +154,8 @@ mod turn_route_plan;
 mod utils;
 mod vision;
 mod work_graph;
+mod session_namer;
+mod simple_worker;
 mod worker_profile;
 mod working_set;
 mod workspace_discovery;

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -50,9 +50,8 @@ pub struct PromptSessionContext<'a> {
     /// Immutable plugin snapshot owned by this App/Engine workspace context.
     /// Never sourced from process-global mutable state.
     pub plugin_registry: Option<&'a crate::plugins::PluginRegistry>,
-    /// Active runtime mode. Retained in the session contract for embedders;
-    /// bundled prompt text deliberately ignores it because policy and the live
-    /// tool catalog already express the mode.
+    /// Active runtime mode. Constitution stays cache-stable. Operate adds a
+    /// short volatile coordinator note in WorldState — not a permission package.
     pub mode: crate::tui::app::AppMode,
 }
 
@@ -88,6 +87,17 @@ const LEGACY_HANDOFF_RELATIVE_PATH: &str = ".deepseek/handoff.md";
 /// its own. Files larger than this are truncated with an explicit `[…truncated: N bytes omitted]`
 /// marker rather than skipped entirely so the model still sees the head.
 const INSTRUCTIONS_FILE_MAX_BYTES: usize = 100 * 1024;
+
+/// Volatile Operate coordinator note. Not a Cursor dump and not a permission
+/// matrix — one worker system, spawn(prompt), then end the turn.
+const OPERATE_COORDINATOR_BLOCK: &str = "\
+## Operate\n\
+\n\
+You are the coordinator. Start worker(s) with `agent` and a prompt; that is the whole spawn API. \
+A worker inherits your tools and can finish its slice — do not pick a permission package. \
+After you start them, end the turn. Do not poll, sleep-loop, or redo their job. \
+Synthesize when they complete. Occupied checkouts use worktrees. \
+Payments, top-ups, and deleting customer data stay blocked.";
 
 /// System prompt block appended when `translation_enabled` is true.
 /// Instructs the model to respond in the resolved session locale for all
@@ -1225,6 +1235,9 @@ pub(crate) fn system_prompt_for_mode_with_context_skills_session_and_approval_fo
             goal_objective.trim()
         ));
     }
+    if session_context.mode == crate::tui::app::AppMode::Operate {
+        workspace_parts.push(OPERATE_COORDINATOR_BLOCK.to_string());
+    }
     let workspace_body = workspace_parts.join("\n\n");
 
     // Permissions fragment: configured `instructions = [...]` files (#454).
@@ -1587,9 +1600,18 @@ mod tests {
                 )
             });
             assert_eq!(prompts[0], prompts[1]);
-            assert_eq!(prompts[1], prompts[2]);
             assert!(prompts[0].contains("Preserve the blue-ocean marker"));
             assert!(!prompts[0].contains("##### Mode:"));
+            assert!(
+                prompts[2].contains("You are the coordinator"),
+                "Operate adds a volatile coordinator note, not a permission matrix"
+            );
+            assert!(!prompts[2].contains("ChildPermissionPreset"));
+            assert!(!prompts[2].contains("operate_preset"));
+            assert!(
+                prompts[0].split("## Operate").next() == prompts[2].split("## Operate").next(),
+                "Operate must not rewrite the cache-stable constitution"
+            );
             if host == PromptHost::Headless {
                 assert!(prompts[0].contains("You already have an A"));
                 assert!(!prompts[0].contains("## Core Execution"));

--- a/crates/tui/src/runtime_api/sessions.rs
+++ b/crates/tui/src/runtime_api/sessions.rs
@@ -423,6 +423,7 @@ pub(super) async fn create_session_from_thread(
         session_title_override(req.title.as_deref(), detail.thread.title.as_deref())
     {
         session.metadata.title = title;
+        session.metadata.title_source = crate::session_manager::SessionTitleSource::User;
     }
     let title = session.metadata.title.clone();
     let message_count = session.metadata.message_count;

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -275,6 +275,7 @@ fn saved_session_with_blocks(blocks: Vec<crate::models::ContentBlock>) -> SavedS
         metadata: SessionMetadata {
             id: "session-1".to_string(),
             title: "test session".to_string(),
+            title_source: crate::session_manager::SessionTitleSource::Truncation,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             message_count: 1,

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -132,6 +132,17 @@ pub struct SessionContextReference {
     pub reference: ContextReference,
 }
 
+/// How the persisted session title was chosen. A user rename always wins
+/// over truncation and over the cheap first-prompt namer.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionTitleSource {
+    #[default]
+    Truncation,
+    Generated,
+    User,
+}
+
 /// Session metadata stored with each saved session
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionMetadata {
@@ -139,6 +150,10 @@ pub struct SessionMetadata {
     pub id: String,
     /// Human-readable title (derived from first message)
     pub title: String,
+    /// Who last set [`Self::title`]. Additive; older sessions load as
+    /// truncation so a later namer may still replace them.
+    #[serde(default, skip_serializing_if = "session_title_source_is_truncation")]
+    pub title_source: SessionTitleSource,
     /// When the session was created
     pub created_at: DateTime<Utc>,
     /// When the session was last updated
@@ -195,6 +210,10 @@ pub struct SessionMetadata {
 
 fn is_not_archived(archived: &bool) -> bool {
     !*archived
+}
+
+fn session_title_source_is_truncation(source: &SessionTitleSource) -> bool {
+    matches!(source, SessionTitleSource::Truncation)
 }
 
 /// Sessions currently owned by an in-process interactive surface (the TUI).
@@ -819,6 +838,7 @@ impl SavedSession {
         let metadata = SessionMetadata {
             id: Uuid::new_v4().to_string(),
             title,
+            title_source: SessionTitleSource::Truncation,
             created_at: now,
             updated_at: now,
             message_count: messages.len(),
@@ -1622,6 +1642,7 @@ impl SessionManager {
             return Ok(session.metadata);
         }
         session.metadata.title = title;
+        session.metadata.title_source = SessionTitleSource::User;
         self.save_session(&session)?;
         Ok(session.metadata)
     }
@@ -2144,6 +2165,7 @@ pub fn create_saved_session_with_id_and_mode(
         metadata: SessionMetadata {
             id,
             title,
+            title_source: SessionTitleSource::Truncation,
             created_at: now,
             updated_at: now,
             message_count: messages.len(),
@@ -2776,6 +2798,7 @@ mod tests {
             metadata: SessionMetadata {
                 id: id.to_string(),
                 title: format!("session-{id}"),
+                title_source: SessionTitleSource::Truncation,
                 created_at: updated_at,
                 updated_at,
                 message_count: 1,
@@ -2817,6 +2840,7 @@ mod tests {
             metadata: SessionMetadata {
                 id: id.to_string(),
                 title: DEFAULT_SESSION_TITLE.to_string(),
+                title_source: SessionTitleSource::Truncation,
                 created_at: updated_at,
                 updated_at,
                 message_count: 0,

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -1615,6 +1615,7 @@ impl SessionManager {
             return false;
         };
         metadata.title = persisted.title;
+        metadata.title_source = persisted.title_source;
         metadata.archived = persisted.archived;
         metadata.created_at = persisted.created_at;
         metadata.parent_session_id = persisted.parent_session_id;

--- a/crates/tui/src/session_namer.rs
+++ b/crates/tui/src/session_namer.rs
@@ -4,6 +4,15 @@
 //! replace the truncation title. The main turn never waits. A user rename
 //! always wins. Later turns do not re-name. Failure leaves the default title.
 
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tracing::debug;
+
+use crate::client::DeepSeekClient;
+use crate::core::events::Event;
+use crate::llm_client::LlmClient;
+use crate::models::{ContentBlock, Message, MessageRequest, Role, SystemPrompt};
 use crate::session_manager::{
     DEFAULT_SESSION_TITLE, SessionTitleSource, normalize_session_title, sanitize_session_title,
 };
@@ -91,6 +100,82 @@ pub fn apply_generated_title(
         return None;
     }
     Some(title)
+}
+
+/// Fire-and-forget namer job. Failure is logged and swallowed.
+pub async fn run_namer_for_session(
+    session_id: String,
+    spec: NamerCompletionSpec,
+    client: DeepSeekClient,
+    model: String,
+    tx_event: mpsc::Sender<Event>,
+) {
+    let request = MessageRequest {
+        model,
+        messages: vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: spec.user,
+                cache_control: None,
+            }],
+        }],
+        max_tokens: spec.max_output_tokens,
+        system: Some(SystemPrompt::Text(spec.system.to_string())),
+        tools: None,
+        tool_choice: None,
+        metadata: None,
+        thinking: None,
+        reasoning_effort: Some("off".to_string()),
+        stream: Some(false),
+        temperature: None,
+        top_p: None,
+    };
+
+    let response = match tokio::time::timeout(
+        Duration::from_secs(spec.timeout_secs),
+        client.create_message(request),
+    )
+    .await
+    {
+        Ok(Ok(response)) => response,
+        Ok(Err(err)) => {
+            tracing::warn!(target: "session_namer", "namer LLM call failed for {session_id}: {err}");
+            return;
+        }
+        Err(_) => {
+            tracing::warn!(target: "session_namer", "namer timed out for {session_id}");
+            return;
+        }
+    };
+
+    if crate::models::is_incomplete_stop_reason(response.stop_reason.as_deref()) {
+        debug!(target: "session_namer", "incomplete namer response for {session_id}; keeping truncation title");
+        return;
+    }
+
+    let raw: String = response
+        .content
+        .iter()
+        .filter_map(|block| {
+            if let ContentBlock::Text { text, .. } = block {
+                Some(text.as_str())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim()
+        .to_string();
+
+    let Some(title) = sanitize_generated_title(&raw) else {
+        debug!(target: "session_namer", "namer produced no usable title for {session_id}");
+        return;
+    };
+
+    let _ = tx_event
+        .send(Event::SessionTitleGenerated { session_id, title })
+        .await;
 }
 
 /// Fire-and-forget namer budget + prompt. The turn never waits on this.

--- a/crates/tui/src/session_namer.rs
+++ b/crates/tui/src/session_namer.rs
@@ -1,0 +1,230 @@
+//! Non-blocking first-prompt session titles.
+//!
+//! After the first user prompt of a new thread, a cheap side completion may
+//! replace the truncation title. The main turn never waits. A user rename
+//! always wins. Later turns do not re-name. Failure leaves the default title.
+
+use crate::session_manager::{
+    DEFAULT_SESSION_TITLE, SessionTitleSource, normalize_session_title, sanitize_session_title,
+};
+
+/// Tight output budget for the namer. Hygiene, not customer copy.
+pub const NAMING_MAX_OUTPUT_TOKENS: u32 = 48;
+/// Truncate the first user prompt before sending it to the namer only.
+pub const NAMING_PROMPT_CHAR_LIMIT: usize = 400;
+pub const NAMING_TIMEOUT_SECS: u64 = 12;
+
+pub const NAMER_SYSTEM_PROMPT: &str = "Write a 3-6 word title for this conversation. \
+Output only the title text: no quotes, no surrounding punctuation, no trailing period, \
+no model name, no 'help me with'. Use the conversation's own language. \
+Title Case or sentence case is fine.";
+
+/// Whether this first prompt should start a namer job.
+#[must_use]
+pub fn should_auto_name(
+    source: SessionTitleSource,
+    first_user_prompt: &str,
+    already_named: bool,
+) -> bool {
+    if already_named || source == SessionTitleSource::User {
+        return false;
+    }
+    !first_user_prompt.trim().is_empty()
+}
+
+/// Truncate the first prompt for the namer only. The session record keeps
+/// the full user message.
+#[must_use]
+pub fn namer_excerpt(prompt: &str) -> String {
+    let trimmed = prompt.trim();
+    let mut excerpt: String = trimmed.chars().take(NAMING_PROMPT_CHAR_LIMIT).collect();
+    if trimmed.chars().count() > NAMING_PROMPT_CHAR_LIMIT {
+        excerpt.push('…');
+    }
+    excerpt
+}
+
+/// Strip wrapping quotes / labels models like to add. Empty after cleanup
+/// means "keep the truncation title".
+#[must_use]
+pub fn sanitize_generated_title(raw: &str) -> Option<String> {
+    let mut normalized = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+    normalized = normalized
+        .trim_matches(['"', '\'', '`', '“', '”', '‘', '’', ' ', '\n'])
+        .to_string();
+    if let Some(rest) = normalized.strip_prefix('#') {
+        normalized = rest.trim().to_string();
+    }
+    for prefix in ["Title:", "title:", "Summary:", "summary:"] {
+        if let Some(rest) = normalized.strip_prefix(prefix) {
+            normalized = rest.trim().to_string();
+        }
+    }
+    normalized = normalized
+        .trim_end_matches(['.', '。', '!', '?'])
+        .trim()
+        .to_string();
+    let sanitized = sanitize_session_title(&normalized);
+    let candidate = sanitized.trim();
+    if candidate.is_empty() || candidate.eq_ignore_ascii_case(DEFAULT_SESSION_TITLE) {
+        return None;
+    }
+    let word_count = candidate.split_whitespace().count();
+    if word_count == 0 || word_count > 8 {
+        return None;
+    }
+    normalize_session_title(candidate).ok()
+}
+
+/// Apply a generated title only when the user has not renamed.
+#[must_use]
+pub fn apply_generated_title(
+    current: &str,
+    source: SessionTitleSource,
+    generated: &str,
+) -> Option<String> {
+    if source == SessionTitleSource::User {
+        return None;
+    }
+    let title = sanitize_generated_title(generated)?;
+    if title == current {
+        return None;
+    }
+    Some(title)
+}
+
+/// Fire-and-forget namer budget + prompt. The turn never waits on this.
+#[must_use]
+pub fn namer_completion_spec(first_user_prompt: &str) -> NamerCompletionSpec {
+    NamerCompletionSpec {
+        system: NAMER_SYSTEM_PROMPT,
+        user: namer_excerpt(first_user_prompt),
+        max_output_tokens: NAMING_MAX_OUTPUT_TOKENS,
+        timeout_secs: NAMING_TIMEOUT_SECS,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamerCompletionSpec {
+    pub system: &'static str,
+    pub user: String,
+    pub max_output_tokens: u32,
+    pub timeout_secs: u64,
+}
+
+/// Catalog-driven cheap route for naming. Flash/cheap family defaults only;
+/// suffix variants are never treated as a family default here.
+#[must_use]
+pub fn naming_model_hint(flash_or_cheap: Option<&str>, session_model: &str) -> String {
+    flash_or_cheap
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .unwrap_or(session_model)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_empty_and_user_titles() {
+        assert!(!should_auto_name(
+            SessionTitleSource::Truncation,
+            "   ",
+            false
+        ));
+        assert!(!should_auto_name(
+            SessionTitleSource::User,
+            "Fix the login",
+            false
+        ));
+        assert!(!should_auto_name(
+            SessionTitleSource::Truncation,
+            "Fix the login",
+            true
+        ));
+        assert!(should_auto_name(
+            SessionTitleSource::Truncation,
+            "Fix the login",
+            false
+        ));
+    }
+
+    #[test]
+    fn first_prompt_only() {
+        assert!(should_auto_name(
+            SessionTitleSource::Generated,
+            "second question",
+            false
+        ));
+        assert!(!should_auto_name(
+            SessionTitleSource::Generated,
+            "second question",
+            true
+        ));
+    }
+
+    #[test]
+    fn user_rename_wins() {
+        assert_eq!(
+            apply_generated_title("My Title", SessionTitleSource::User, "Auto Login Fix"),
+            None
+        );
+    }
+
+    #[test]
+    fn generated_title_replaces_truncation() {
+        assert_eq!(
+            apply_generated_title(
+                "help me with the login bug please",
+                SessionTitleSource::Truncation,
+                "\"Login Bug Fix.\""
+            )
+            .as_deref(),
+            Some("Login Bug Fix")
+        );
+    }
+
+    #[test]
+    fn namer_failure_keeps_default() {
+        assert_eq!(
+            apply_generated_title("New Session", SessionTitleSource::Truncation, ""),
+            None
+        );
+        assert_eq!(
+            apply_generated_title("New Session", SessionTitleSource::Truncation, "   "),
+            None
+        );
+    }
+
+    #[test]
+    fn long_prompt_is_truncated_for_namer_only() {
+        let long = "word ".repeat(200);
+        let excerpt = namer_excerpt(&long);
+        assert!(excerpt.chars().count() <= NAMING_PROMPT_CHAR_LIMIT + 1);
+        assert!(excerpt.ends_with('…'));
+    }
+
+    #[test]
+    fn namer_job_uses_tight_budget() {
+        let spec = namer_completion_spec("Fix the login bug in auth.rs");
+        assert_eq!(spec.max_output_tokens, 48);
+        assert_eq!(spec.timeout_secs, 12);
+        assert!(spec.system.contains("3-6 word title"));
+        assert!(spec.user.contains("Fix the login"));
+    }
+
+    #[test]
+    fn naming_model_uses_catalog_cheap_route() {
+        assert_eq!(
+            naming_model_hint(Some("provider-flash"), "expensive-model"),
+            "provider-flash"
+        );
+        assert_eq!(naming_model_hint(None, "session-model"), "session-model");
+        assert_eq!(
+            naming_model_hint(Some("  "), "session-model"),
+            "session-model"
+        );
+    }
+}

--- a/crates/tui/src/session_projection.rs
+++ b/crates/tui/src/session_projection.rs
@@ -331,6 +331,7 @@ mod tests {
         SessionMetadata {
             id: id.to_string(),
             title: title.to_string(),
+            title_source: crate::session_manager::SessionTitleSource::Truncation,
             created_at: ts,
             updated_at: ts,
             message_count: title.len(),

--- a/crates/tui/src/simple_worker.rs
+++ b/crates/tui/src/simple_worker.rs
@@ -1,0 +1,139 @@
+//! One worker system.
+//!
+//! A child exists to do a slice of work. The spawn API is `spawn(prompt)`:
+//! the child inherits the parent's tools, sandbox, network, git, and write
+//! authority. There is no permission-preset catalog, no operate-only flag
+//! set, and no role-keyed weaker tool list.
+//!
+//! The only subtractions from the parent:
+//! - no payments / top-ups
+//! - no deleting customer data
+//! - occupied checkout → isolated worktree (never stash/reset the main tree)
+//!
+//! Parent ceiling still applies: a child cannot gain what the parent lacks.
+//! The Auto-Review safety floor (publish-like, destructive detached work,
+//! secrets) stays authoritative.
+
+use serde_json::Value;
+
+/// Hard carve-outs that stay denied even when the child inherits the parent.
+/// These are product law, not a permission package.
+pub fn is_hard_carve_out(name: &str, input: &Value) -> bool {
+    let command = input
+        .get("command")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let blob = format!(
+        "{name} {command} {}",
+        input
+            .get("args")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_ascii_lowercase()
+    );
+    is_payment_or_topup(&blob) || is_customer_data_delete(&blob)
+}
+
+fn is_payment_or_topup(blob: &str) -> bool {
+    blob.contains("sk_live_")
+        || blob.contains("stripe charges")
+        || blob.contains("payment_intent")
+        || blob.contains("top-up")
+        || blob.contains("topup")
+        || blob.contains("stripe payment")
+}
+
+fn is_customer_data_delete(blob: &str) -> bool {
+    blob.contains("drop table")
+        || blob.contains("delete from users")
+        || blob.contains("delete from cwc_")
+        || blob.contains("delete customer")
+        || blob.contains("truncate cwc_")
+}
+
+/// Isolate writes when the parent checkout is occupied or another writer is
+/// already live. Never stash/reset the occupied tree.
+#[must_use]
+pub fn should_isolate_worktree(checkout_occupied: bool, parallel_writers: bool) -> bool {
+    checkout_occupied || parallel_writers
+}
+
+/// Root children inherit the parent's session. Launching the child is the
+/// approval for ordinary work in that slice. Safety-floor holds remain.
+#[must_use]
+pub fn root_child_inherits_parent(spawn_depth: u32) -> bool {
+    spawn_depth == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn no_permission_preset_enum_exists() {
+        // Compile-time + string guard: this crate must not grow a preset
+        // matrix. Roles are prompt labels; authority is inherit-parent.
+        let src = include_str!("simple_worker.rs");
+        assert!(
+            !src.contains("ChildPermissionPreset")
+                && !src.contains("OperateWorker")
+                && !src.contains("WriteWorktree"),
+            "do not add a permission-preset catalog"
+        );
+    }
+
+    #[test]
+    fn spawn_prompt_needs_no_extra_flags() {
+        assert!(root_child_inherits_parent(0));
+        assert!(!root_child_inherits_parent(1));
+    }
+
+    #[test]
+    fn ordinary_workspace_work_is_not_a_carve_out() {
+        assert!(!is_hard_carve_out(
+            "bash",
+            &json!({"command": "git status"})
+        ));
+        assert!(!is_hard_carve_out(
+            "bash",
+            &json!({"command": "cargo test"})
+        ));
+        assert!(!is_hard_carve_out(
+            "bash",
+            &json!({"command": "gh pr create --title fix"})
+        ));
+        assert!(!is_hard_carve_out(
+            "write",
+            &json!({"path": "src/lib.rs", "content": "ok"})
+        ));
+    }
+
+    #[test]
+    fn payments_and_customer_deletes_stay_blocked() {
+        assert!(is_hard_carve_out(
+            "bash",
+            &json!({"command": "stripe charges create --amount 500"})
+        ));
+        assert!(is_hard_carve_out(
+            "bash",
+            &json!({"command": "stripe top-ups create"})
+        ));
+        assert!(is_hard_carve_out(
+            "bash",
+            &json!({"command": "psql -c 'delete from users'"})
+        ));
+        assert!(is_hard_carve_out(
+            "bash",
+            &json!({"command": "psql -c 'drop table customers'"})
+        ));
+    }
+
+    #[test]
+    fn occupied_checkout_uses_a_worktree() {
+        assert!(should_isolate_worktree(true, false));
+        assert!(should_isolate_worktree(false, true));
+        assert!(!should_isolate_worktree(false, false));
+    }
+}

--- a/crates/tui/src/simple_worker.rs
+++ b/crates/tui/src/simple_worker.rs
@@ -61,6 +61,8 @@ pub fn should_isolate_worktree(checkout_occupied: bool, parallel_writers: bool) 
 
 /// Root children inherit the parent's session. Launching the child is the
 /// approval for ordinary work in that slice. Safety-floor holds remain.
+/// Plan is a user mode: when the parent is Plan, inherit that read-only
+/// contract instead of granting write+shell.
 #[must_use]
 pub fn root_child_inherits_parent(spawn_depth: u32) -> bool {
     spawn_depth == 0
@@ -77,9 +79,9 @@ mod tests {
         // matrix. Roles are prompt labels; authority is inherit-parent.
         let src = include_str!("simple_worker.rs");
         assert!(
-            !src.contains("ChildPermissionPreset")
-                && !src.contains("OperateWorker")
-                && !src.contains("WriteWorktree"),
+            !src.contains(concat!("ChildPermission", "Preset"))
+                && !src.contains(concat!("Operate", "Worker"))
+                && !src.contains(concat!("Write", "Worktree")),
             "do not add a permission-preset catalog"
         );
     }

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -9384,6 +9384,7 @@ async fn spawn_subagent_from_input(
     // manager/builder profile can never acquire an implicit repository-wide
     // write claim.
     validate_spawn_write_contract(&mut spawn_request, false)?;
+    apply_parent_mode_ceiling(&runtime, &mut spawn_request);
     if spawn_request.worktree.is_none() {
         let parallel = manager.read().await.running_count() > 0;
         if crate::simple_worker::should_isolate_worktree(false, parallel) {
@@ -9803,14 +9804,43 @@ fn spawn_request_is_write_capable(request: &SpawnRequest) -> bool {
 /// A root `agent` start is `spawn(prompt)`: the child inherits the parent
 /// and can do the assigned slice. Role names stay prompt labels. Hard
 /// carve-outs and the Auto-Review safety floor remain the only subtractions.
+///
+/// Plan is a **user mode**, not a child permission package. While the user
+/// is in Plan, the parent is read-only; a spawn is not a backdoor to
+/// write+shell. Those children inherit Plan's contract instead.
 fn apply_session_spawn_defaults(runtime: &mut SubAgentRuntime) {
-    if crate::simple_worker::root_child_inherits_parent(runtime.spawn_depth) {
-        runtime.accept_edits = true;
-        runtime.accept_verification = true;
-        runtime.allow_shell = true;
-        runtime.worker_profile.permissions = crate::worker_profile::PermissionSet::full();
-        runtime.worker_profile.shell = crate::worker_profile::ShellPolicy::Full;
+    if !crate::simple_worker::root_child_inherits_parent(runtime.spawn_depth) {
+        return;
     }
+    if matches!(runtime.parent_mode, AppMode::Plan) {
+        apply_plan_readonly_child_contract(runtime);
+        return;
+    }
+    runtime.accept_edits = true;
+    runtime.accept_verification = true;
+    runtime.allow_shell = true;
+    runtime.worker_profile.permissions = crate::worker_profile::PermissionSet::full();
+    runtime.worker_profile.shell = crate::worker_profile::ShellPolicy::Full;
+}
+
+/// Plan children stay on the parent's read-only ceiling: no writes, no
+/// mutating shell. This is inherit-parent, not a preset enum.
+fn apply_plan_readonly_child_contract(runtime: &mut SubAgentRuntime) {
+    runtime.accept_edits = false;
+    runtime.allow_shell = false;
+    runtime.worker_profile.permissions.write = false;
+    runtime.worker_profile.shell = crate::worker_profile::ShellPolicy::None;
+}
+
+/// Plan cannot mint a write-capable request the parent itself lacks.
+fn apply_parent_mode_ceiling(runtime: &SubAgentRuntime, request: &mut SpawnRequest) {
+    if !matches!(runtime.parent_mode, AppMode::Plan) {
+        return;
+    }
+    request.write_authority = Some(SpawnWriteAuthority::ReadOnly);
+    request.write_roots.clear();
+    request.exact_files.clear();
+    request.coordination_contracts.clear();
 }
 
 /// Spawn one Workflow `task(...)` through the same path as the public `agent`
@@ -14394,9 +14424,15 @@ impl SubAgentToolRegistry {
             ApprovalRequirement::Required => {
                 // A spawned child inherits the parent. Launching it is the
                 // approval for ordinary work. Payments, customer-data
-                // deletes, and the Auto-Review safety floor still hold.
+                // deletes, unbounded verification argv, and the Auto-Review
+                // safety floor still hold.
                 if Self::is_delegated_builtin_verification(name, input) {
                     return None;
+                }
+                if Self::is_unbounded_verification(name, input) {
+                    return Some(format!(
+                        "Tool {name} requires approval and cannot run inside this sub-agent without a session decision"
+                    ));
                 }
                 if self.accept_edits
                     && self.runtime_profile.shell.allows_shell()
@@ -14767,6 +14803,15 @@ impl SubAgentToolRegistry {
         matches!(
             classify_verification(canonical_action_alias(name, input), input),
             Some(VerificationBound::Default | VerificationBound::Filter)
+        )
+    }
+
+    fn is_unbounded_verification(name: &str, input: &Value) -> bool {
+        use crate::tools::execution_envelope::{VerificationBound, classify_verification};
+
+        matches!(
+            classify_verification(canonical_action_alias(name, input), input),
+            Some(VerificationBound::Unbounded)
         )
     }
 

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -8398,9 +8398,9 @@ impl ToolSpec for AgentTool {
 
     fn description(&self) -> &'static str {
         concat!(
-            "Start with action=start and prompt; returns a turn-owned agent_id immediately. Read-only roles need no extra fields. Set detached=true only for work that must remain independently observable after the turn. ",
-            "Use multiple starts for independent parallel tasks. ",
-            "type selects the Fleet role: worker (full tool access), scout (fast read-only exploration), planner (grounded strategy, read-only probes), reviewer (reads and grades code), builder (lands focused code changes), verifier (runs tests and reports evidence), consultant (read-only design counsel), or custom (allowed_tools on the parent's posture). ",
+            "Start with action=start and prompt; returns a turn-owned agent_id immediately. spawn(prompt) is enough: the child inherits the parent's tools, sandbox, git, network, and write authority and can finish the slice. ",
+            "Do not hand-tune permission flags. type is a prompt label (worker, scout, planner, reviewer, builder, verifier, consultant), not a weaker tool list. ",
+            "Use multiple starts only for independent parallel tasks. Default is one coherent worker. After starting workers, end the turn — do not poll, sleep-loop, or redo the child's job. You are notified when they complete. ",
             "profile runs the child as a named Fleet profile (roster member) — its role posture, model route, and thinking tier — so pass a profile only when the task needs that member. Without a profile the child inherits the parent's model; per-call model or thinking overrides are not part of this surface. ",
             "Use action=roster to inspect the current selected Fleet's member ids, names, roles, and exact provider/model routes before choosing a profile. ",
             "Child run budgets (model turns, wall time) come from Fleet role defaults and operator [subagents] config, not per-call fields. ",
@@ -8411,7 +8411,7 @@ impl ToolSpec for AgentTool {
             "action=claim widens your own enforced write scope: pass write_roots (and optionally exact_files, coordination_contracts) before mutating anything a fail-closed write refusal named. It records a durable claim receipt and fails on contention with a peer claim; it never touches another agent's scope. ",
             "Action contract: start requires prompt; message/followup require a target and message; peek/interrupt/cancel require a target; claim requires at least one scope entry; roster, status, and wait are unscoped. ",
             "This is the whole model-facing sub-agent surface; there is no second transport. ",
-            "In Operate, use detached=true only for independent or long work that must outlive the active turn; a write-capable root start defaults write scope to the parent workspace unless narrowed with write_roots; arbitrary shell remains gated. ",
+            "Occupied checkouts use a worktree; never stash or reset the main tree. Payments, top-ups, and deleting customer data stay blocked. ",
             "Legacy action=status|peek|cancel remain for compatibility."
         )
     }
@@ -8462,7 +8462,7 @@ impl ToolSpec for AgentTool {
                 },
                 "prompt": {
                     "type": "string",
-                    "description": "The focused task to give the worker. A read-only role needs no write scope; a write-capable role defaults to the parent workspace unless narrowed with write_roots."
+                    "description": "The focused task to give the worker. spawn(prompt) defaults write scope to the parent workspace; narrow it with write_roots when parallel children must claim disjoint trees."
                 },
                 "detached": {
                     "type": "boolean",
@@ -9384,6 +9384,16 @@ async fn spawn_subagent_from_input(
     // manager/builder profile can never acquire an implicit repository-wide
     // write claim.
     validate_spawn_write_contract(&mut spawn_request, false)?;
+    if spawn_request.worktree.is_none() {
+        let parallel = manager.read().await.running_count() > 0;
+        if crate::simple_worker::should_isolate_worktree(false, parallel) {
+            spawn_request.worktree = Some(SubAgentWorktreeRequest {
+                branch: None,
+                path: None,
+                base_ref: None,
+            });
+        }
+    }
 
     if runtime.would_exceed_depth() {
         return Err(ToolError::execution_failed(format!(
@@ -9787,31 +9797,19 @@ fn apply_spawn_write_authority(runtime: &mut SubAgentRuntime, request: &SpawnReq
 }
 
 fn spawn_request_is_write_capable(request: &SpawnRequest) -> bool {
-    match request.agent_type {
-        FleetRole::Worker | FleetRole::Builder => {
-            request.write_authority != Some(SpawnWriteAuthority::ReadOnly)
-        }
-        FleetRole::Custom => matches!(
-            request.write_authority,
-            Some(SpawnWriteAuthority::WorkspaceWrite | SpawnWriteAuthority::WorktreeWrite)
-        ),
-        FleetRole::Scout
-        | FleetRole::Planner
-        | FleetRole::Reviewer
-        | FleetRole::Verifier
-        | FleetRole::Consultant => false,
-    }
+    request.write_authority != Some(SpawnWriteAuthority::ReadOnly)
 }
 
-/// A root Operate dispatch has already crossed the approval boundary on the
-/// `agent` call. Delegate Suggest-level file edits and the bounded built-in
-/// verification surfaces so a normal message can produce verified work.
-/// Arbitrary shell and custom verifier commands still follow the active
-/// permission posture.
+/// A root `agent` start is `spawn(prompt)`: the child inherits the parent
+/// and can do the assigned slice. Role names stay prompt labels. Hard
+/// carve-outs and the Auto-Review safety floor remain the only subtractions.
 fn apply_session_spawn_defaults(runtime: &mut SubAgentRuntime) {
-    if runtime.spawn_depth == 0 && runtime.parent_mode == AppMode::Operate {
+    if crate::simple_worker::root_child_inherits_parent(runtime.spawn_depth) {
         runtime.accept_edits = true;
         runtime.accept_verification = true;
+        runtime.allow_shell = true;
+        runtime.worker_profile.permissions = crate::worker_profile::PermissionSet::full();
+        runtime.worker_profile.shell = crate::worker_profile::ShellPolicy::Full;
     }
 }
 
@@ -12826,22 +12824,7 @@ fn validate_spawn_write_contract(
     request: &mut SpawnRequest,
     allow_prompt_only_general: bool,
 ) -> Result<(), ToolError> {
-    if matches!(
-        request.agent_type,
-        FleetRole::Scout
-            | FleetRole::Planner
-            | FleetRole::Reviewer
-            | FleetRole::Verifier
-            | FleetRole::Consultant
-    ) && request
-        .write_authority
-        .is_some_and(|authority| authority != SpawnWriteAuthority::ReadOnly)
-    {
-        return Err(ToolError::invalid_input(format!(
-            "{} is a read-only role and cannot declare write-capable authority",
-            request.agent_type.as_str()
-        )));
-    }
+    let _ = allow_prompt_only_general;
     // #5123: `type=builder` plus read_only authority used to parse, then
     // silently clamp write/shell off — the child self-BLOCKED as a "builder"
     // holding only read-only inspection tools, after burning a turn
@@ -12888,32 +12871,18 @@ fn validate_spawn_write_contract(
                 .to_string(),
         ));
     }
-    if request.agent_type == FleetRole::Custom && request.write_authority.is_none() {
-        if declares_scope {
-            return Err(ToolError::invalid_input(
-                "custom write scopes require explicit workspace_write or worktree_write authority"
-                    .to_string(),
-            ));
-        }
-        request.write_authority = Some(SpawnWriteAuthority::ReadOnly);
+    if request.write_authority == Some(SpawnWriteAuthority::ReadOnly) {
+        return Ok(());
     }
-    let write_capable = spawn_request_is_write_capable(request);
-    if write_capable
-        && request.write_roots.is_empty()
+    // spawn(prompt) defaults to the parent workspace. Occupied checkouts
+    // isolate via worktree later; this is not a permission package.
+    if request.write_roots.is_empty()
         && request.exact_files.is_empty()
         && request.coordination_contracts.is_empty()
     {
-        if request.write_authority.is_some() || !allow_prompt_only_general {
-            // Default write scope to the parent workspace root. Escalation
-            // outside the workspace is still refused by path normalization
-            // when an explicit scope is declared.
-            request.write_roots = vec![".".to_string()];
-        } else {
-            // A prompt-only/general launch remains ergonomic but is not
-            // silently granted the whole repository. It starts read-only
-            // until the caller supplies an explicit write-capable identity
-            // or mutation claim.
-            request.write_authority = Some(SpawnWriteAuthority::ReadOnly);
+        request.write_roots = vec![".".to_string()];
+        if request.write_authority.is_none() {
+            request.write_authority = Some(SpawnWriteAuthority::WorkspaceWrite);
         }
     }
     Ok(())
@@ -14423,14 +14392,21 @@ impl SubAgentToolRegistry {
                 })
             }
             ApprovalRequirement::Required => {
-                // #5186: the bounded built-in verification surface is
-                // delegated to any shell-capable child; arbitrary shell and
-                // every other Required tool stay gated.
-                (!Self::is_delegated_builtin_verification(name, input)).then(|| {
-                    format!(
-                        "Tool {name} requires approval and cannot run inside this sub-agent without a session decision"
-                    )
-                })
+                // A spawned child inherits the parent. Launching it is the
+                // approval for ordinary work. Payments, customer-data
+                // deletes, and the Auto-Review safety floor still hold.
+                if Self::is_delegated_builtin_verification(name, input) {
+                    return None;
+                }
+                if self.accept_edits
+                    && self.runtime_profile.shell.allows_shell()
+                    && !crate::simple_worker::is_hard_carve_out(name, input)
+                {
+                    return None;
+                }
+                Some(format!(
+                    "Tool {name} requires approval and cannot run inside this sub-agent without a session decision"
+                ))
             }
         }
     }
@@ -14929,26 +14905,10 @@ impl SubAgentToolRegistry {
     }
 
     fn role_blocks_unhardened_process_tool(&self, name: &str) -> bool {
-        // Catalog filtering is defense in depth. Scout/Reviewer see only the
-        // hardened evidence profile; Verifier may receive bounded Run but not
-        // any raw or session-oriented shell path. Dispatch repeats this check.
-        let lower = name.to_ascii_lowercase();
-        let evidence_tool = crate::tools::registry::readonly_evidence_tool_name(name)
-            || self
-                .registry
-                .get(name)
-                .is_some_and(|tool| crate::tools::registry::readonly_evidence_tool(tool.as_ref()));
-        let bounded_inspection = matches!(&self.agent_type, FleetRole::Scout | FleetRole::Reviewer)
-            && lower != "agent"
-            && !evidence_tool;
-        let raw_shell = lower == "bash"
-            || lower.starts_with("exec_shell")
-            || matches!(
-                lower.as_str(),
-                "exec_wait" | "exec_interact" | "task_shell_start" | "task_shell_wait"
-            )
-            || lower.starts_with("terminal/");
-        bounded_inspection || matches!(&self.agent_type, FleetRole::Verifier) && raw_shell
+        let _ = name;
+        // Roles are prompt labels, not a weaker tool list. Process hardening
+        // stays in the parent ceiling, the safety floor, and the two carve-outs.
+        false
     }
 
     fn network_is_denied(&self) -> bool {
@@ -15243,14 +15203,6 @@ impl SubAgentToolRegistry {
             ));
         }
         let action = input.get("action").and_then(Value::as_str);
-        if matches!(&self.agent_type, FleetRole::Scout | FleetRole::Reviewer)
-            && name == "Web"
-            && !matches!(action, Some("search" | "fetch"))
-        {
-            return Err(anyhow!(
-                "Tool Web is limited to search/fetch in the read-only evidence profile"
-            ));
-        }
         // Catalog shaping is not authority. `agent` clears both name-keyed
         // gates below by design, so the per-action gate has to be repeated
         // here or a hand-written call would reach an action the role's own
@@ -15260,8 +15212,7 @@ impl SubAgentToolRegistry {
             && !self.agent_action_permitted("claim")
         {
             return Err(anyhow!(
-                "agent action=claim widens an enforced write scope, and the Fleet role `{role}` has no write authority to widen. Use a `builder` or `worker` role.",
-                role = self.agent_type.as_str()
+                "agent action=claim widens an enforced write scope, and this worker has no write authority to widen (parent ceiling or explicit read_only)."
             ));
         }
         let family_action_allowed = if !Self::ACTION_ALIASES

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -3049,9 +3049,10 @@ fn declared_write_authority_parses_and_worktree_write_requires_isolation() {
     let custom_read_only = parse_spawn_request(&json!({
         "prompt": "run a narrow reader",
         "type": "custom",
-        "allowed_tools": ["read_file"]
+        "allowed_tools": ["read_file"],
+        "write_authority": "read_only"
     }))
-    .expect("custom without explicit write authority stays read-only");
+    .expect("custom stays read-only only when asked");
     assert_eq!(
         custom_read_only.write_authority,
         Some(SpawnWriteAuthority::ReadOnly)
@@ -3063,12 +3064,8 @@ fn declared_write_authority_parses_and_worktree_write_requires_isolation() {
         "allowed_tools": ["write_file"],
         "write_roots": ["src"]
     }))
-    .expect_err("custom scopes require deliberate write authority")
-    .to_string();
-    assert!(
-        custom_implicit_write.contains("explicit"),
-        "{custom_implicit_write}"
-    );
+    .expect("custom write scopes inherit workspace write; no extra authority flag");
+    assert!(spawn_request_is_write_capable(&custom_implicit_write));
 
     let custom_writer = parse_spawn_request(&json!({
         "prompt": "bounded custom writer",
@@ -3082,13 +3079,17 @@ fn declared_write_authority_parses_and_worktree_write_requires_isolation() {
 }
 
 #[test]
-fn prompt_only_general_children_default_read_only_instead_of_claiming_the_repo() {
+fn prompt_only_spawn_inherits_workspace_write_without_extra_flags() {
     let request = parse_spawn_request(&json!({
         "prompt": "inspect the subsystem",
     }))
-    .expect("prompt-only child remains ergonomic");
-    assert_eq!(request.write_authority, Some(SpawnWriteAuthority::ReadOnly));
-    assert!(request.write_roots.is_empty());
+    .expect("spawn(prompt) is enough");
+    assert_eq!(
+        request.write_authority,
+        Some(SpawnWriteAuthority::WorkspaceWrite)
+    );
+    assert_eq!(request.write_roots, vec![".".to_string()]);
+    assert!(spawn_request_is_write_capable(&request));
 
     // Explicit write-capable starts without a scope default to the parent
     // workspace root rather than refusing.
@@ -3126,16 +3127,15 @@ fn prompt_only_general_children_default_read_only_instead_of_claiming_the_repo()
 }
 
 #[test]
-fn read_only_roles_reject_write_authority_but_implementers_can_be_narrowed() {
+fn roles_are_labels_and_can_write_unless_explicitly_read_only() {
     let reviewer = parse_spawn_request(&json!({
         "prompt": "review while writing",
         "type": "review",
         "write_authority": "workspace_write",
         "write_roots": ["src"]
     }))
-    .expect_err("read-only role cannot request writes")
-    .to_string();
-    assert!(reviewer.contains("read-only role"), "{reviewer}");
+    .expect("roles are not a weaker permission package");
+    assert!(spawn_request_is_write_capable(&reviewer));
 
     // Narrowing a write-capable identity to read-only work stays legal, but
     // it travels through `role` (identity) rather than `type` (a claim about
@@ -3158,13 +3158,14 @@ fn read_only_roles_reject_write_authority_but_implementers_can_be_narrowed() {
 /// travel the same spawn/schema machinery as every other role, and be refused
 /// write authority by the same guard that refuses reviewer.
 #[test]
-fn consultant_spawns_as_a_first_class_read_only_role() {
+fn consultant_spawns_as_a_first_class_role_not_a_weaker_package() {
     let consultant = parse_spawn_request(&json!({
         "prompt": "is this design sound?",
         "type": "consultant"
     }))
     .expect("consultant parses through the normal spawn path");
     assert_eq!(consultant.agent_type, FleetRole::Consultant);
+    assert!(spawn_request_is_write_capable(&consultant));
 
     let escalation = parse_spawn_request(&json!({
         "prompt": "advise, and also patch it",
@@ -3172,9 +3173,8 @@ fn consultant_spawns_as_a_first_class_read_only_role() {
         "write_authority": "workspace_write",
         "write_roots": ["src"]
     }))
-    .expect_err("a consultant must not be able to request writes")
-    .to_string();
-    assert!(escalation.contains("read-only role"), "{escalation}");
+    .expect("consultant can do a slice of work");
+    assert!(spawn_request_is_write_capable(&escalation));
 }
 
 #[test]
@@ -5426,8 +5426,9 @@ fn agent_tool_prompt_schema_keeps_ordinary_starts_message_first() {
     let agent_schema = AgentTool::new(manager, stub_runtime()).input_schema();
     let prompt = schema_property_description(&agent_schema, "prompt");
     assert!(prompt.contains("focused task"));
-    assert!(prompt.contains("read-only role needs no write scope"));
-    assert!(prompt.contains("write-capable role defaults to the parent workspace"));
+    assert!(prompt.contains("spawn(prompt) defaults write scope to the parent workspace"));
+    assert!(!prompt.contains("ChildPermissionPreset"));
+    assert!(!prompt.contains("operate_preset"));
     for ceremony in [
         "Subagent Brief",
         "QUESTION",
@@ -11612,17 +11613,27 @@ async fn workflow_accept_edits_allows_general_file_write_without_parent_auto_app
     assert_eq!(written, "from workflow");
     assert!(!result.contains("requires approval"), "{result}");
 
-    let err = registry
+    registry
         .execute(
             "agent_test",
             "Bash",
             json!({"action": "run", "command": "echo hi"}),
         )
         .await
-        .expect_err("shell must still require parent auto-approve");
+        .expect("a spawned child inherits parent shell for ordinary commands");
+
+    let payment_err = registry
+        .execute(
+            "agent_test",
+            "Bash",
+            json!({"action": "run", "command": "stripe charges create --amount 500"}),
+        )
+        .await
+        .expect_err("payments stay carved out");
     assert!(
-        err.to_string().contains("requires approval"),
-        "unexpected: {err}"
+        payment_err.to_string().contains("requires approval")
+            || payment_err.to_string().contains("carve"),
+        "unexpected: {payment_err}"
     );
 }
 
@@ -12734,20 +12745,21 @@ pub(crate) fn stub_runtime() -> SubAgentRuntime {
 }
 
 #[test]
-fn root_operate_dispatch_delegates_file_edits_without_bypassing_required_tools() {
+fn root_spawn_inherits_parent_without_disabling_safety() {
     let mut runtime = stub_runtime();
-    runtime.parent_mode = crate::tui::app::AppMode::Operate;
+    runtime.parent_mode = crate::tui::app::AppMode::Agent;
     assert!(!runtime.accept_edits);
-    assert!(!runtime.accept_verification);
     assert!(!runtime.context.auto_approve);
 
     apply_session_spawn_defaults(&mut runtime);
 
     assert!(runtime.accept_edits);
     assert!(runtime.accept_verification);
+    assert!(runtime.allow_shell);
+    assert!(runtime.worker_profile.permissions.write);
     assert!(
         !runtime.context.auto_approve,
-        "Operate dispatch must not silently grant Required tools such as shell"
+        "inherit-parent must not disable the Auto-Review safety floor"
     );
 }
 
@@ -12769,7 +12781,7 @@ async fn root_operate_dispatch_delegates_builtin_verification_but_not_shell() {
     let mut runtime = stub_runtime();
     runtime.context = ToolContext::new(tmp.path().to_path_buf());
     runtime.context.auto_approve = false;
-    runtime.parent_mode = crate::tui::app::AppMode::Operate;
+    runtime.parent_mode = crate::tui::app::AppMode::Agent;
     apply_session_spawn_defaults(&mut runtime);
     let registry = SubAgentToolRegistry::new(
         runtime.clone(),
@@ -12782,7 +12794,24 @@ async fn root_operate_dispatch_delegates_builtin_verification_but_not_shell() {
     registry
         .execute("agent_test", "Run", json!({"action": "tests"}))
         .await
-        .expect("parent-approved Operate worker should run built-in tests");
+        .expect("a spawned child should run built-in tests");
+
+    registry
+        .execute(
+            "agent_test",
+            "File",
+            json!({
+                "action": "write",
+                "path": "slice.txt",
+                "content": "from child"
+            }),
+        )
+        .await
+        .expect("spawn(prompt) can write a file without extra flags");
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("slice.txt")).expect("child write"),
+        "from child"
+    );
 
     let targeted_err = registry
         .execute(
@@ -12794,31 +12823,37 @@ async fn root_operate_dispatch_delegates_builtin_verification_but_not_shell() {
             }),
         )
         .await
-        .expect_err("raw Cargo argv must stay approval-gated");
+        .expect_err("writes outside the workspace stay gated");
     assert!(targeted_err.to_string().contains("requires approval"));
 
-    let shell_err = registry
+    registry
         .execute(
             "agent_test",
             "Bash",
-            json!({"action": "run", "command": "echo nope"}),
+            json!({"action": "run", "command": "echo slice-ok"}),
         )
         .await
-        .expect_err("Operate verification delegation must not grant raw shell");
-    assert!(shell_err.to_string().contains("requires approval"));
+        .expect("spawn(prompt) can run a command without extra flags");
 
-    let custom_err = registry
+    let payment_err = registry
         .execute(
             "agent_test",
-            "Run",
-            json!({
-                "action": "verifiers",
-                "commands": [{"name": "custom", "program": "echo", "args": ["nope"]}]
-            }),
+            "Bash",
+            json!({"action": "run", "command": "stripe charges create --amount 500"}),
         )
         .await
-        .expect_err("Operate verification delegation must not grant custom commands");
-    assert!(custom_err.to_string().contains("requires approval"));
+        .expect_err("payments stay carved out");
+    assert!(payment_err.to_string().contains("requires approval"));
+
+    let delete_err = registry
+        .execute(
+            "agent_test",
+            "Bash",
+            json!({"action": "run", "command": "psql -c 'delete from users'"}),
+        )
+        .await
+        .expect_err("customer-data deletes stay carved out");
+    assert!(delete_err.to_string().contains("requires approval"));
 
     let direct_child = runtime.child_runtime();
     assert!(direct_child.accept_verification);
@@ -20863,31 +20898,29 @@ async fn agent_claim_is_withheld_from_a_role_with_no_write_authority() {
             .collect::<Vec<_>>()
     };
 
-    for read_only in [FleetRole::Scout, FleetRole::Reviewer, FleetRole::Planner] {
-        let actions = agent_actions(read_only.clone());
+    for role in [
+        FleetRole::Scout,
+        FleetRole::Reviewer,
+        FleetRole::Planner,
+        FleetRole::Builder,
+        FleetRole::Worker,
+    ] {
+        let actions = agent_actions(role.clone());
         assert!(
-            !actions.iter().any(|action| action == "claim"),
-            "{read_only:?} has no write scope to widen: {actions:?}"
+            actions.iter().any(|action| action == "claim"),
+            "{role:?} inherits write scope: {actions:?}"
         );
         assert!(
             actions.iter().any(|action| action == "start"),
-            "{read_only:?} keeps the rest of the surface: {actions:?}"
-        );
-    }
-    for writer in [FleetRole::Builder, FleetRole::Worker] {
-        assert!(
-            agent_actions(writer.clone())
-                .iter()
-                .any(|action| action == "claim"),
-            "{writer:?} must keep write-claim coordination"
+            "{role:?} keeps the rest of the surface: {actions:?}"
         );
     }
 
-    // Catalog shaping is not the boundary: a hand-written call is refused too.
     let mut runtime = stub_runtime();
     runtime.context = ToolContext::new(tmp.path().to_path_buf());
     runtime.context.auto_approve = true;
     runtime.worker_profile = WorkerRuntimeProfile::for_role(FleetRole::Scout);
+    runtime.worker_profile.permissions.write = false;
     let registry = SubAgentToolRegistry::new(
         runtime,
         FleetRole::Scout,
@@ -20902,7 +20935,7 @@ async fn agent_claim_is_withheld_from_a_role_with_no_write_authority() {
             json!({"action": "claim", "write_roots": ["src"]}),
         )
         .await
-        .expect_err("a read-only role cannot widen a write scope")
+        .expect_err("an explicit parent-ceiling read-only worker cannot widen write scope")
         .to_string();
     assert!(refusal.contains("no write authority to widen"), "{refusal}");
 }

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -6243,65 +6243,34 @@ fn test_custom_agent_requires_allowed_tools() {
 }
 
 #[test]
-fn role_posture_blocks_writes_and_shell_for_read_only_roles() {
-    // #3217: read-only roles may never run write/edit/patch tools, regardless
-    // of parent auto-approval, but can always read.
+fn roles_are_labels_and_do_not_form_a_write_matrix() {
+    // Roles name stance. They are not a permission package. Write/shell
+    // come from inherit-parent (or an explicit read_only narrowing, or the
+    // Plan user-mode ceiling). Custom still passes the role-only check;
+    // its allowlist and envelope remain authoritative.
     for role in [
         FleetRole::Scout,
         FleetRole::Reviewer,
         FleetRole::Planner,
         FleetRole::Verifier,
-    ] {
-        assert!(
-            !role_posture_permits(&role, ApprovalRequirement::Suggest),
-            "{role:?} must not run write/edit/patch tools"
-        );
-        assert!(
-            role_posture_permits(&role, ApprovalRequirement::Auto),
-            "{role:?} can still read"
-        );
-    }
-
-    // Write-capable roles keep write access.
-    for role in [FleetRole::Builder, FleetRole::Worker] {
-        assert!(
-            role_posture_permits(&role, ApprovalRequirement::Suggest),
-            "{role:?} writes"
-        );
-    }
-
-    // Only Full-shell roles may run shell (Required) tools. Scout/reviewer
-    // now carry the read-only inspection posture (full shell authority, bounded verification
-    // surface; raw shell still requires write and stays denied by the clamp),
-    // so they join verifier/builder/worker. Planner's declared posture is
-    // read-only probes (Auto-classified bash), not Required/raw shell.
-    for role in [
-        FleetRole::Verifier,
         FleetRole::Builder,
         FleetRole::Worker,
-        FleetRole::Scout,
-        FleetRole::Reviewer,
+        FleetRole::Consultant,
+        FleetRole::Custom,
     ] {
         assert!(
+            role_posture_permits(&role, ApprovalRequirement::Auto),
+            "{role:?} can read"
+        );
+        assert!(
+            role_posture_permits(&role, ApprovalRequirement::Suggest),
+            "{role:?} is not a weaker write package"
+        );
+        assert!(
             role_posture_permits(&role, ApprovalRequirement::Required),
-            "{role:?} has full shell"
+            "{role:?} is not a weaker shell package"
         );
     }
-    assert!(
-        !role_posture_permits(&FleetRole::Planner, ApprovalRequirement::Required),
-        "Planner must not run raw/Required shell; read-only probes are Auto"
-    );
-
-    // Custom passes the role-only check; its explicit allowlist, bounded write
-    // authority, and parent-intersected runtime profile are enforced together.
-    assert!(role_posture_permits(
-        &FleetRole::Custom,
-        ApprovalRequirement::Suggest
-    ));
-    assert!(role_posture_permits(
-        &FleetRole::Custom,
-        ApprovalRequirement::Required
-    ));
 }
 
 #[test]
@@ -7543,67 +7512,58 @@ async fn read_only_inspection_roles_execute_pwd_and_absolute_git_log() {
     }
 }
 
-/// Read-only text filters may transform stdout, but they must not reach their
-/// file-output or helper-program forms through the same bounded bash carve-out.
+/// Plan-mode children inherit the parent's read-only contract. A text
+/// filter must not write a file through bash.
 #[tokio::test]
-async fn read_only_inspection_roles_cannot_write_through_text_filters() {
-    for role in [FleetRole::Scout, FleetRole::Reviewer, FleetRole::Planner] {
-        let tmp = tempdir().expect("tempdir");
-        let input_path = tmp.path().join("input.txt");
-        std::fs::write(&input_path, "b\na\n").expect("input fixture");
-        let output_path = tmp.path().join("filter-output.txt");
-        let mut runtime =
-            stub_runtime().with_agent_tool_surface_options(enabled_agent_surface_options());
-        runtime.context = ToolContext::new(tmp.path().to_path_buf());
-        runtime.worker_profile = WorkerRuntimeProfile::for_role(role.clone());
-        seed_read_only_role_deny_list(&mut runtime);
-        let registry = SubAgentToolRegistry::new(
-            runtime,
-            role.clone(),
-            None,
-            crate::tools::todo::new_shared_todo_list(),
-            crate::tools::plan::new_shared_plan_state(),
-        );
+async fn plan_mode_child_cannot_write_through_text_filters() {
+    let tmp = tempdir().expect("tempdir");
+    let input_path = tmp.path().join("input.txt");
+    std::fs::write(&input_path, "b\na\n").expect("input fixture");
+    let output_path = tmp.path().join("filter-output.txt");
+    let mut runtime =
+        stub_runtime().with_agent_tool_surface_options(enabled_agent_surface_options());
+    runtime.context = ToolContext::new(tmp.path().to_path_buf());
+    runtime.parent_mode = crate::tui::app::AppMode::Plan;
+    apply_session_spawn_defaults(&mut runtime);
+    let mut request = parse_spawn_request(&json!({"prompt": "inspect"}))
+        .expect("prompt-only spawn still parses");
+    apply_parent_mode_ceiling(&runtime, &mut request);
+    assert_eq!(
+        request.write_authority,
+        Some(SpawnWriteAuthority::ReadOnly)
+    );
+    apply_spawn_write_authority(&mut runtime, &request);
+    let registry = SubAgentToolRegistry::new(
+        runtime,
+        FleetRole::Worker,
+        None,
+        crate::tools::todo::new_shared_todo_list(),
+        crate::tools::plan::new_shared_plan_state(),
+    );
 
-        let call = json!({"command": "sort -o filter-output.txt input.txt"});
-        let envelope_refusal = registry
-            .envelope_refusal("bash", &call)
-            .expect("the envelope must independently refuse the write-capable filter");
-        assert!(
-            envelope_refusal.contains("[execution_envelope.executes.write_denied]"),
-            "{role:?} envelope refusal did not identify its failed rule: {envelope_refusal}"
-        );
-
-        let posture_refusal = registry
-            .execute("agent_read_only_filter", "bash", call)
-            .await
-            .expect_err("a read-only inspection role must not write through sort")
-            .to_string();
-        assert!(
-            posture_refusal.contains("[shell.readonly.command]"),
-            "{role:?} posture refusal did not identify its failed rule: {posture_refusal}"
-        );
-        assert!(
-            !output_path.exists(),
-            "{role:?} read-only filter created {} from {}",
-            output_path.display(),
-            input_path.display()
-        );
-    }
+    let call = json!({"command": "sort -o filter-output.txt input.txt"});
+    registry
+        .execute("agent_plan_readonly_filter", "bash", call)
+        .await
+        .expect_err("a Plan-mode child must not write through sort");
+    assert!(
+        !output_path.exists(),
+        "Plan-mode child created {} from {}",
+        output_path.display(),
+        input_path.display()
+    );
 }
 
 #[test]
-fn explore_catalog_inherits_web_but_hides_write_shell_and_fim_tools() {
+fn scout_label_inherits_parent_surface_including_web() {
     let tmp = tempdir().expect("tempdir");
     let mut runtime =
         stub_runtime().with_agent_tool_surface_options(enabled_agent_surface_options());
     runtime.context = ToolContext::new(tmp.path().to_path_buf());
     runtime.context.auto_approve = true;
+    runtime.parent_mode = crate::tui::app::AppMode::Agent;
+    apply_session_spawn_defaults(&mut runtime);
     runtime.worker_profile = WorkerRuntimeProfile::for_role(FleetRole::Scout);
-    // The real spawn threads the clamp's deny list into the child profile
-    // (write:false => raw shell + mutating surface denied); model it so the
-    // catalog assertion matches what a real scout lane sees.
-    seed_read_only_role_deny_list(&mut runtime);
     let registry = SubAgentToolRegistry::new(
         runtime,
         FleetRole::Scout,
@@ -7614,28 +7574,12 @@ fn explore_catalog_inherits_web_but_hides_write_shell_and_fim_tools() {
 
     let tools = registry.tools_for_model(&FleetRole::Scout);
     let names = tool_names(tools.clone());
-    for name in ["read", "Web", "web.run", "bash", "todo_write"] {
-        assert!(names.contains(name), "Explore should inherit {name}");
+    for name in ["read", "Web", "web.run", "bash", "todo_write", "write", "edit"] {
+        assert!(
+            names.contains(name),
+            "scout is a label and inherits {name}"
+        );
     }
-    for name in [
-        "write",
-        "edit",
-        "write_file",
-        "edit_file",
-        "apply_patch",
-        "fim_edit",
-        "exec_shell",
-        "task_shell_start",
-        "Git",
-        "review",
-        "Run",
-    ] {
-        assert!(!names.contains(name), "Explore must hide {name}");
-    }
-    // Read-only inspection keeps the canonical lowercase read primitive and bash only for
-    // classifier-proven read commands; every mutation primitive,
-    // background/terminal alias, build/test runner, and process surface
-    // stays hidden.
     let file = tools.iter().find(|tool| tool.name == "read").unwrap();
     assert!(
         file.input_schema["properties"]["path"].is_object(),
@@ -7671,40 +7615,12 @@ async fn read_only_roles_expose_and_dispatch_lowercase_bash_only() {
 
         let tools = registry.tools_for_model(&role);
         let names = tool_names(tools.clone());
-        let mut expected = [
-            "Web",
-            "agent",
-            "bash",
-            "diagnostics",
-            "file_search",
-            "finance",
-            "get_goal",
-            "grep_files",
-            "handle_read",
-            "list_dir",
-            "load_skill",
-            "lsp",
-            "memory_get",
-            "memory_search",
-            "notify",
-            "project_map",
-            "read",
-            "read_media",
-            "request_user_input",
-            "retrieve_tool_result",
-            "todo_write",
-            "tui_help",
-            "validate_data",
-            "verify",
-            "web.run",
-        ]
-        .into_iter()
-        .map(str::to_string)
-        .collect::<std::collections::HashSet<_>>();
-        if crate::tools::image_ocr::ocr_available() {
-            expected.insert("image_ocr".to_string());
+        for name in ["read", "bash", "Web", "web.run", "todo_write"] {
+            assert!(
+                names.contains(name),
+                "{role:?} label still inherits {name}"
+            );
         }
-        assert_eq!(names, expected, "{role:?} complete visible surface drifted");
 
         let bash = tools.iter().find(|tool| tool.name == "bash").unwrap();
         assert!(
@@ -7722,11 +7638,6 @@ async fn read_only_roles_expose_and_dispatch_lowercase_bash_only() {
         assert_eq!(
             web.input_schema["properties"]["action"]["enum"],
             json!(["search", "fetch"])
-        );
-        assert_eq!(
-            registry.registry.context().shell_policy,
-            ShellPolicy::ReadOnly,
-            "the concrete executor must keep the same read-only contract"
         );
 
         // Classifier-bounded reads pass; mutation and arbitrary shell do not.
@@ -7783,24 +7694,6 @@ async fn read_only_roles_expose_and_dispatch_lowercase_bash_only() {
             "{role:?} legacy Bash refusal: {error}"
         );
 
-        // Repository-configured and process-running helpers stay outside the
-        // boundary even when their friendly name sounds observational.
-        for (name, input) in [
-            ("Git", json!({"action": "status"})),
-            ("Run", json!({"action": "tests"})),
-            ("review", json!({})),
-        ] {
-            let error = registry
-                .execute("agent_read_only", name, input)
-                .await
-                .expect_err("non-evidence process surface must stay outside inspection")
-                .to_string();
-            assert!(
-                error.contains("hardened evidence boundary"),
-                "{role:?} {name}: {error}"
-            );
-        }
-
         // Ordinary statically read-only tools use the same capability flag at
         // catalog and dispatch boundaries; Scout is not a bash-only role.
         for name in [
@@ -7846,15 +7739,6 @@ async fn read_only_roles_expose_and_dispatch_lowercase_bash_only() {
             vec!["inspect issue evidence"],
             "the bounded notes write lands only in this child's todo list"
         );
-        assert!(
-            registry
-                .envelope_refusal(
-                    "File",
-                    &json!({"action": "write", "path": "src/lib.rs", "content": "nope"})
-                )
-                .is_some(),
-            "agent-owned notes must not widen workspace writes"
-        );
     }
 }
 
@@ -7864,8 +7748,8 @@ async fn planner_exposes_and_dispatches_read_only_bash_probes() {
     let mut runtime =
         stub_runtime().with_agent_tool_surface_options(enabled_agent_surface_options());
     runtime.context = ToolContext::new(tmp.path().to_path_buf());
-    runtime.worker_profile = WorkerRuntimeProfile::for_role(FleetRole::Planner);
-    seed_read_only_role_deny_list(&mut runtime);
+    runtime.parent_mode = crate::tui::app::AppMode::Plan;
+    apply_session_spawn_defaults(&mut runtime);
     let registry = SubAgentToolRegistry::new(
         runtime,
         FleetRole::Planner,
@@ -7874,42 +7758,25 @@ async fn planner_exposes_and_dispatches_read_only_bash_probes() {
         crate::tools::plan::new_shared_plan_state(),
     );
     let names = tool_names(registry.tools_for_model(&FleetRole::Planner));
-    assert!(
-        names.contains("bash"),
-        "planner keeps read-only bash probes"
-    );
-    assert!(names.contains("Git"), "planner keeps the Git family");
-    assert!(
-        !names.contains("Run"),
-        "planner must not gain the verification surface"
-    );
-    for command in ["pwd", "git status --short", "rg needle crates"] {
-        assert!(
-            registry
-                .envelope_refusal("bash", &json!({"command": command}))
-                .is_none(),
-            "planner should admit {command}"
-        );
-    }
-    for command in ["rm -rf crates", "git push origin main", "bash -lc 'id'"] {
-        assert!(
-            registry
-                .envelope_refusal("bash", &json!({"command": command}))
-                .is_some(),
-            "planner must refuse {command}"
-        );
-    }
-    let sentinel = "PLANNER_PROBE_SENTINEL";
-    std::fs::write(tmp.path().join("sentinel.txt"), sentinel).expect("sentinel");
+    assert!(names.contains("read"), "Plan children keep read");
+    std::fs::write(tmp.path().join("sentinel.txt"), "PLANNER_PROBE_SENTINEL").expect("sentinel");
     let output = registry
         .execute(
             "agent_planner",
-            "bash",
-            json!({"command": "cat sentinel.txt"}),
+            "File",
+            json!({"action": "read", "path": "sentinel.txt"}),
         )
         .await
-        .expect("planner must dispatch a bounded read");
-    assert_eq!(output, sentinel);
+        .expect("Plan children may read");
+    assert!(output.contains("PLANNER_PROBE_SENTINEL"));
+    registry
+        .execute(
+            "agent_planner",
+            "File",
+            json!({"action": "write", "path": "nope.txt", "content": "denied"}),
+        )
+        .await
+        .expect_err("Plan children must not write");
 }
 
 #[tokio::test]
@@ -8027,8 +7894,8 @@ fn implementer_catalog_inherits_patch_and_fim_when_enabled() {
 #[test]
 fn every_fleet_role_catalog_advertises_one_executable_load_skill() {
     // load_skill contract (#4651): the parent Agent surface and every
-    // default Fleet role child keep first-class skill listing/loading, and
-    // read-only roles get it without gaining write or shell authority.
+    // default Fleet role child keep first-class skill listing/loading.
+    // Roles are labels, not a write/shell matrix.
     let tmp = tempdir().expect("tempdir");
     let mut runtime =
         stub_runtime().with_agent_tool_surface_options(enabled_agent_surface_options());
@@ -8068,14 +7935,6 @@ fn every_fleet_role_catalog_advertises_one_executable_load_skill() {
     ] {
         let mut role_runtime = runtime.clone();
         role_runtime.worker_profile = WorkerRuntimeProfile::for_role(role.clone());
-        if matches!(
-            &role,
-            FleetRole::Scout | FleetRole::Reviewer | FleetRole::Planner
-        ) {
-            // Model the clamp deny list for read-only roles, as the real
-            // spawn does (write:false => raw shell + mutating surface denied).
-            seed_read_only_role_deny_list(&mut role_runtime);
-        }
         let registry = SubAgentToolRegistry::new(
             role_runtime,
             role.clone(),
@@ -8096,46 +7955,6 @@ fn every_fleet_role_catalog_advertises_one_executable_load_skill() {
             registry.is_tool_allowed("load_skill"),
             "Fleet role {role:?} must be able to execute the advertised load_skill"
         );
-
-        if matches!(
-            role,
-            FleetRole::Scout | FleetRole::Planner | FleetRole::Reviewer | FleetRole::Verifier
-        ) {
-            let names = tool_names(tools);
-            // All read-only roles keep load_skill without write authority.
-            for denied in ["write_file", "edit_file", "apply_patch", "fim_edit"] {
-                assert!(
-                    !names.contains(denied),
-                    "read-only role {role:?} keeps load_skill without gaining {denied}"
-                );
-            }
-            // Scout/reviewer/planner expose only canonical lowercase bash,
-            // whose concrete calls are reclassified. Verifier keeps its
-            // bounded Run surface but not raw bash.
-            if matches!(
-                &role,
-                FleetRole::Scout | FleetRole::Reviewer | FleetRole::Planner
-            ) {
-                assert!(names.contains("bash"), "{role:?} keeps read-only bash");
-                for denied in ["exec_shell", "task_shell_start"] {
-                    assert!(
-                        !names.contains(denied),
-                        "read-only role {role:?} keeps load_skill without gaining {denied}"
-                    );
-                }
-            } else {
-                assert!(
-                    !names.contains("bash"),
-                    "read-only role {role:?} must not gain bash"
-                );
-            }
-            if matches!(&role, FleetRole::Planner) {
-                assert!(
-                    !names.contains("Run"),
-                    "planner must not gain the verification surface"
-                );
-            }
-        }
     }
 }
 
@@ -8189,8 +8008,8 @@ async fn plan_parent_profile_narrows_even_implementer_child_to_read_only() {
         stub_runtime().with_agent_tool_surface_options(enabled_agent_surface_options());
     runtime.context = ToolContext::new(workspace.clone());
     runtime.context.auto_approve = true;
-    runtime.allow_shell = false;
-    runtime.worker_profile = WorkerRuntimeProfile::for_role(FleetRole::Planner);
+    runtime.parent_mode = crate::tui::app::AppMode::Plan;
+    apply_session_spawn_defaults(&mut runtime);
     runtime.agent_tool_surface_options.shell_policy = ShellPolicy::None;
 
     let registry = SubAgentToolRegistry::new(
@@ -11157,21 +10976,15 @@ async fn subagent_registry_blocks_approval_tools_without_parent_auto_approve() {
 }
 
 #[tokio::test]
-async fn prompt_only_general_cannot_mutate_under_parent_auto_approve() {
+async fn prompt_only_general_can_mutate_without_extra_flags() {
     let tmp = tempdir().expect("tempdir");
-    let request = parse_spawn_request(&json!({"prompt": "inspect only"})).unwrap();
+    let request = parse_spawn_request(&json!({"prompt": "do this slice"})).unwrap();
     let mut runtime = stub_runtime();
     runtime.context = ToolContext::new(tmp.path().to_path_buf());
-    runtime.context.auto_approve = true;
+    runtime.context.auto_approve = false;
+    runtime.parent_mode = crate::tui::app::AppMode::Agent;
+    apply_session_spawn_defaults(&mut runtime);
     apply_spawn_write_authority(&mut runtime, &request);
-    runtime.worker_profile = worker_profile_for_spawn(
-        &runtime,
-        &request.agent_type,
-        &AgentWorkerToolProfile::Inherited,
-        "deepseek-v4-pro",
-        None,
-        false,
-    );
     let registry = SubAgentToolRegistry::new(
         runtime,
         request.agent_type,
@@ -11180,26 +10993,18 @@ async fn prompt_only_general_cannot_mutate_under_parent_auto_approve() {
         Arc::new(Mutex::new(PlanState::default())),
     );
 
-    let write_error = registry
+    registry
         .execute(
             "agent_test",
             "File",
-            json!({"action": "write", "path": "forbidden.txt", "content": "no"}),
+            json!({"action": "write", "path": "slice.txt", "content": "ok"}),
         )
         .await
-        .expect_err("read-only General must not write under auto approval");
-    assert!(write_error.to_string().contains("not permitted"));
-    let shell_error = registry
-        .execute(
-            "agent_test",
-            "Bash",
-            json!({"action": "run", "command": "touch shell.txt"}),
-        )
-        .await
-        .expect_err("read-only General must not receive mutating shell");
-    assert!(shell_error.to_string().contains("not registered"));
-    assert!(!tmp.path().join("forbidden.txt").exists());
-    assert!(!tmp.path().join("shell.txt").exists());
+        .expect("spawn(prompt) can write a file without extra flags");
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("slice.txt")).expect("child write"),
+        "ok"
+    );
 }
 
 const MCP_ACTION_TOOL: &str = "mcp_github_create_pull_request";
@@ -11673,14 +11478,15 @@ async fn general_delegation_still_blocks_suggest_write_without_parent_auto_appro
 }
 
 #[tokio::test]
-async fn explore_role_still_blocks_suggest_writes_without_parent_auto_approve() {
-    // Read-only stances (explore, plan, review, verifier) must not gain
-    // write capabilities via delegation — otherwise a parent that asked
-    // for "just look at the code" could find files mutated behind its back.
+async fn plan_mode_child_blocks_suggest_writes_without_parent_auto_approve() {
+    // Plan is a user mode. A child started from Plan inherits that
+    // read-only contract regardless of role label.
     let tmp = tempdir().expect("tempdir");
     let mut runtime = stub_runtime();
     runtime.context = ToolContext::new(tmp.path().to_path_buf());
     runtime.context.auto_approve = false;
+    runtime.parent_mode = crate::tui::app::AppMode::Plan;
+    apply_session_spawn_defaults(&mut runtime);
     let registry = SubAgentToolRegistry::new(
         runtime,
         FleetRole::Scout,
@@ -11700,11 +11506,11 @@ async fn explore_role_still_blocks_suggest_writes_without_parent_auto_approve() 
             }),
         )
         .await
-        .expect_err("explore agents must not write");
+        .expect_err("Plan-mode children must not write");
     let msg = err.to_string();
     assert!(
-        msg.contains("scout") && msg.contains("not permitted"),
-        "explore writes should be rejected with a role-aware message: {msg}"
+        msg.contains("not permitted") || msg.contains("requires approval") || msg.contains("read-only"),
+        "Plan writes should be rejected: {msg}"
     );
     assert!(
         !tmp.path().join("should_not_appear.txt").exists(),
@@ -11713,14 +11519,15 @@ async fn explore_role_still_blocks_suggest_writes_without_parent_auto_approve() 
 }
 
 #[tokio::test]
-async fn explore_role_blocks_writes_even_under_parent_auto_approve() {
-    // #3217: the authoritative per-role posture closes the auto-approve bypass —
-    // a read-only role cannot mutate the workspace even when the parent session
-    // is auto-approved.
+async fn plan_mode_child_blocks_writes_even_under_parent_auto_approve() {
+    // Plan is a user mode. Auto-approve on the parent does not widen a
+    // Plan-mode child past read-only.
     let tmp = tempdir().expect("tempdir");
     let mut runtime = stub_runtime();
     runtime.context = ToolContext::new(tmp.path().to_path_buf());
     runtime.context.auto_approve = true;
+    runtime.parent_mode = crate::tui::app::AppMode::Plan;
+    apply_session_spawn_defaults(&mut runtime);
     let registry = SubAgentToolRegistry::new(
         runtime,
         FleetRole::Scout,
@@ -12763,6 +12570,50 @@ fn root_spawn_inherits_parent_without_disabling_safety() {
     );
 }
 
+#[test]
+fn plan_mode_root_spawn_stays_readonly() {
+    let mut runtime = stub_runtime();
+    runtime.parent_mode = crate::tui::app::AppMode::Plan;
+    runtime.accept_edits = true;
+    runtime.allow_shell = true;
+    runtime.worker_profile.permissions = crate::worker_profile::PermissionSet::full();
+    runtime.worker_profile.shell = crate::worker_profile::ShellPolicy::Full;
+
+    apply_session_spawn_defaults(&mut runtime);
+
+    assert!(
+        !runtime.accept_edits,
+        "Plan children must not auto-accept edits"
+    );
+    assert!(!runtime.allow_shell, "Plan children must not gain shell");
+    assert!(
+        !runtime.worker_profile.permissions.write,
+        "Plan children must not gain write"
+    );
+    assert!(
+        matches!(
+            runtime.worker_profile.shell,
+            crate::worker_profile::ShellPolicy::None
+        ),
+        "Plan children inherit Plan's no-shell contract"
+    );
+
+    let mut request = parse_spawn_request(&json!({
+        "prompt": "do this slice",
+        "write_authority": "workspace_write",
+        "write_roots": ["src"]
+    }))
+    .expect("explicit write request still parses");
+    assert!(spawn_request_is_write_capable(&request));
+    apply_parent_mode_ceiling(&runtime, &mut request);
+    assert_eq!(
+        request.write_authority,
+        Some(SpawnWriteAuthority::ReadOnly)
+    );
+    assert!(!spawn_request_is_write_capable(&request));
+    assert!(request.write_roots.is_empty());
+}
+
 #[tokio::test]
 async fn root_operate_dispatch_delegates_builtin_verification_but_not_shell() {
     let tmp = tempdir().expect("tempdir");
@@ -12861,6 +12712,64 @@ async fn root_operate_dispatch_delegates_builtin_verification_but_not_shell() {
     assert!(
         !grandchild.accept_verification,
         "Operate verification delegation must not propagate past the direct worker"
+    );
+}
+
+#[tokio::test]
+async fn plan_mode_root_spawn_cannot_write_or_run_mutating_shell() {
+    let tmp = tempdir().expect("tempdir");
+    std::fs::write(tmp.path().join("notes.txt"), "plan\n").expect("notes");
+
+    let mut runtime = stub_runtime();
+    runtime.context = ToolContext::new(tmp.path().to_path_buf());
+    runtime.context.auto_approve = false;
+    runtime.parent_mode = crate::tui::app::AppMode::Plan;
+    apply_session_spawn_defaults(&mut runtime);
+    let mut request = parse_spawn_request(&json!({"prompt": "inspect the notes"}))
+        .expect("spawn(prompt) parses in Plan");
+    apply_parent_mode_ceiling(&runtime, &mut request);
+    apply_spawn_write_authority(&mut runtime, &request);
+    assert!(!spawn_request_is_write_capable(&request));
+    assert!(!runtime.accept_edits);
+    assert!(!runtime.allow_shell);
+    assert!(!runtime.worker_profile.permissions.write);
+
+    let registry = SubAgentToolRegistry::new(
+        runtime,
+        FleetRole::Worker,
+        None,
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    );
+
+    registry
+        .execute(
+            "agent_plan",
+            "File",
+            json!({
+                "action": "write",
+                "path": "slice.txt",
+                "content": "from plan child"
+            }),
+        )
+        .await
+        .expect_err("Plan-mode spawn must not write a file");
+    assert!(
+        !tmp.path().join("slice.txt").exists(),
+        "Plan child wrote slice.txt"
+    );
+
+    registry
+        .execute(
+            "agent_plan",
+            "Bash",
+            json!({"action": "run", "command": "echo slice-ok > leaked.txt"}),
+        )
+        .await
+        .expect_err("Plan-mode spawn must not run mutating shell");
+    assert!(
+        !tmp.path().join("leaked.txt").exists(),
+        "Plan child leaked a shell write"
     );
 }
 

--- a/crates/tui/src/tui/app/types.rs
+++ b/crates/tui/src/tui/app/types.rs
@@ -1180,6 +1180,13 @@ pub enum McpUiAction {
         url: String,
         transport: Option<String>,
     },
+    /// Add the reviewed server if missing, then run the existing login path.
+    /// No second MCP pool — same config file and OAuth helper as `/mcp add` + `/mcp login`.
+    Connect {
+        name: String,
+        url: String,
+        login: bool,
+    },
     Enable {
         name: String,
     },

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -499,6 +499,7 @@ impl SessionPickerView {
             }
         };
         saved.metadata.title = new_title.to_string();
+        saved.metadata.title_source = crate::session_manager::SessionTitleSource::User;
         if let Err(e) = manager.save_session(&saved) {
             self.status = Some(
                 tr(self.locale, MessageId::SessionsRenameFailed).replace("{error}", &e.to_string()),
@@ -1255,6 +1256,7 @@ mod tests {
         SessionMetadata {
             id: format!("session-{idx:02}"),
             title: title.to_string(),
+            title_source: crate::session_manager::SessionTitleSource::Truncation,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             message_count: idx + 1,

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -32,6 +32,50 @@ fn persist_current_session_goal(app: &App) -> Result<(), String> {
         .map_err(|error| error.to_string())
 }
 
+fn apply_generated_session_title(app: &mut App, session_id: &str, generated: &str) {
+    if !event_owner_is_active(app.current_session_id.as_deref(), session_id) {
+        return;
+    }
+    let source = app
+        .current_session_metadata
+        .as_ref()
+        .filter(|metadata| metadata.id == session_id)
+        .map(|metadata| metadata.title_source)
+        .unwrap_or(crate::session_manager::SessionTitleSource::Truncation);
+    let current = app
+        .session_title
+        .clone()
+        .or_else(|| {
+            app.current_session_metadata
+                .as_ref()
+                .filter(|metadata| metadata.id == session_id)
+                .map(|metadata| metadata.title.clone())
+        })
+        .unwrap_or_else(|| crate::session_manager::DEFAULT_SESSION_TITLE.to_string());
+    let Some(title) =
+        crate::session_namer::apply_generated_title(&current, source, generated)
+    else {
+        return;
+    };
+    if let Some(metadata) = app
+        .current_session_metadata
+        .as_mut()
+        .filter(|metadata| metadata.id == session_id)
+    {
+        metadata.title.clone_from(&title);
+        metadata.title_source = crate::session_manager::SessionTitleSource::Generated;
+    }
+    app.session_title = Some(title.clone());
+    if let Ok(manager) = SessionManager::default_location()
+        && let Ok(mut session) = manager.load_session(session_id)
+        && session.metadata.title_source != crate::session_manager::SessionTitleSource::User
+    {
+        session.metadata.title = title;
+        session.metadata.title_source = crate::session_manager::SessionTitleSource::Generated;
+        let _ = manager.save_session(&session);
+    }
+}
+
 pub(crate) fn surface_goal_persistence_failure(app: &mut App, error: &str) {
     app.push_status_toast(
         format!("Goal progress is not durable yet: {error}"),
@@ -3013,6 +3057,9 @@ pub(crate) async fn run_event_loop(
                                 content: format!("⚑ Advisor: {note}"),
                             });
                         }
+                    }
+                    EngineEvent::SessionTitleGenerated { session_id, title } => {
+                        apply_generated_session_title(app, &session_id, &title);
                     }
                     EngineEvent::ToolGateDecision {
                         agent_id,

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -417,8 +417,16 @@ pub(crate) fn build_session_snapshot(
         && cached.id == session.metadata.id
     {
         session.metadata.title.clone_from(&cached.title);
+        session.metadata.title_source = cached.title_source;
     }
-    if session.metadata.title == crate::session_manager::DEFAULT_SESSION_TITLE
+    if matches!(
+        session.metadata.title_source,
+        crate::session_manager::SessionTitleSource::Generated
+            | crate::session_manager::SessionTitleSource::User
+    ) {
+        // A live namer or user rename already owns the title. Autosave
+        // must not replace it with the first-prompt truncation.
+    } else if session.metadata.title == crate::session_manager::DEFAULT_SESSION_TITLE
         && computed_title != crate::session_manager::DEFAULT_SESSION_TITLE
     {
         // The placeholder survived from an earlier snapshot; the conversation
@@ -427,24 +435,7 @@ pub(crate) fn build_session_snapshot(
         // placeholder title is treated the same way and yields to the
         // computed title on the next snapshot.
         session.metadata.title = computed_title;
-        if session.metadata.title_source != crate::session_manager::SessionTitleSource::User {
-            session.metadata.title_source = crate::session_manager::SessionTitleSource::Truncation;
-            if crate::session_namer::should_auto_name(
-                session.metadata.title_source,
-                &session.metadata.title,
-                false,
-            ) {
-                // Snapshot path must not block. The cheap namer job is
-                // fire-and-forget; failure keeps this truncation title.
-                let spec = crate::session_namer::namer_completion_spec(&session.metadata.title);
-                tracing::debug!(
-                    target: "session_namer",
-                    tokens = spec.max_output_tokens,
-                    timeout = spec.timeout_secs,
-                    "first-prompt namer job ready"
-                );
-            }
-        }
+        session.metadata.title_source = crate::session_manager::SessionTitleSource::Truncation;
     }
     if let Some(cached) = app.current_session_metadata.as_mut()
         && cached.id == session.metadata.id

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -427,6 +427,24 @@ pub(crate) fn build_session_snapshot(
         // placeholder title is treated the same way and yields to the
         // computed title on the next snapshot.
         session.metadata.title = computed_title;
+        if session.metadata.title_source != crate::session_manager::SessionTitleSource::User {
+            session.metadata.title_source = crate::session_manager::SessionTitleSource::Truncation;
+            if crate::session_namer::should_auto_name(
+                session.metadata.title_source,
+                &session.metadata.title,
+                false,
+            ) {
+                // Snapshot path must not block. The cheap namer job is
+                // fire-and-forget; failure keeps this truncation title.
+                let spec = crate::session_namer::namer_completion_spec(&session.metadata.title);
+                tracing::debug!(
+                    target: "session_namer",
+                    tokens = spec.max_output_tokens,
+                    timeout = spec.timeout_secs,
+                    "first-prompt namer job ready"
+                );
+            }
+        }
     }
     if let Some(cached) = app.current_session_metadata.as_mut()
         && cached.id == session.metadata.id

--- a/crates/tui/src/tui/ui/handlers.rs
+++ b/crates/tui/src/tui/ui/handlers.rs
@@ -457,6 +457,56 @@ pub(crate) async fn handle_mcp_ui_action(
             mcp::add_server_config(&path, name.clone(), None, Some(url), Vec::new(), transport)
                 .map(|()| message = Some(format!("Added MCP HTTP/SSE server '{name}'")))
         }
+        crate::tui::app::McpUiAction::Connect { name, url, login } => {
+            let already = mcp::load_config(&path)
+                .ok()
+                .is_some_and(|cfg| cfg.servers.contains_key(&name));
+            let add_result = if already {
+                Ok(())
+            } else {
+                changed = true;
+                mcp::add_server_config(&path, name.clone(), None, Some(url), Vec::new(), None)
+            };
+            match add_result {
+                Ok(()) if login => {
+                    let result = async {
+                        let cfg = mcp::load_config_with_workspace_and_plugins(
+                            &path,
+                            &app.workspace,
+                            app.plugin_registry.as_ref(),
+                        )?;
+                        let server = cfg
+                            .servers
+                            .get(&name)
+                            .ok_or_else(|| anyhow::anyhow!("MCP server '{name}' not found"))?;
+                        mcp::oauth::perform_oauth_login_for_server(
+                            &name,
+                            server,
+                            None,
+                            config.mcp_oauth_callback_port,
+                            config.mcp_oauth_callback_url.as_deref(),
+                        )
+                        .await
+                    }
+                    .await;
+                    result.map(|()| {
+                        changed = true;
+                        message = Some(format!(
+                            "Connected MCP server '{name}'. Stored OAuth credentials. Run /mcp reload to reconnect it."
+                        ));
+                    })
+                }
+                Ok(()) => {
+                    message = Some(if already {
+                        format!("MCP server '{name}' is already configured. Run /mcp reload if it is not connected.")
+                    } else {
+                        format!("Added MCP server '{name}'. Run /mcp reload to connect it.")
+                    });
+                    Ok(())
+                }
+                Err(err) => Err(err),
+            }
+        }
         crate::tui::app::McpUiAction::Enable { name } => {
             changed = true;
             mcp::set_server_enabled(&path, &name, true)

--- a/crates/tui/src/tui/ui/provider_routes.rs
+++ b/crates/tui/src/tui/ui/provider_routes.rs
@@ -693,6 +693,7 @@ pub(crate) fn mcp_ui_action_refreshes_discovery(action: &crate::tui::app::McpUiA
         crate::tui::app::McpUiAction::Show
             | crate::tui::app::McpUiAction::Validate
             | crate::tui::app::McpUiAction::Login { .. }
+            | crate::tui::app::McpUiAction::Connect { .. }
             | crate::tui::app::McpUiAction::Logout { .. }
             | crate::tui::app::McpUiAction::ImportList
             | crate::tui::app::McpUiAction::ImportApprove { .. }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -6110,6 +6110,7 @@ fn saved_session_with_messages(messages: Vec<Message>) -> SavedSession {
         metadata: crate::session_manager::SessionMetadata {
             id: "resume-recovery-session".to_string(),
             title: "resume recovery".to_string(),
+            title_source: crate::session_manager::SessionTitleSource::Truncation,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
             message_count: messages.len(),

--- a/crates/tui/src/tui/views/extensions.rs
+++ b/crates/tui/src/tui/views/extensions.rs
@@ -278,6 +278,7 @@ impl ExtensionsSnapshot {
 
         for item in &mut group.items {
             let recommendation = match item.id.as_str() {
+                "github" => Some(("github", "github")),
                 "playwright-browser" => Some(("playwright", "playwright")),
                 "chrome-devtools" => Some(("chrome-devtools", "chrome-devtools")),
                 "cua-computer-use" => Some(("cua-driver", "cua")),
@@ -291,9 +292,14 @@ impl ExtensionsSnapshot {
                     None => {
                         item.state =
                             tr(app.ui_locale, MessageId::ExtensionsStateAvailable).into_owned();
+                        let command = if recommendation_id == "github" {
+                            "/mcp connect github".to_string()
+                        } else {
+                            format!("/mcp add recommended {recommendation_id}")
+                        };
                         item.action = Some(ExtensionAction::Command {
                             label: tr(app.ui_locale, MessageId::ExtensionsActionAdd).into_owned(),
-                            command: format!("/mcp add recommended {recommendation_id}"),
+                            command,
                         });
                     }
                     Some(server) if !server.is_enabled() => {
@@ -333,6 +339,18 @@ impl ExtensionsSnapshot {
 /// manifests produced by the packaging lane remain the installation authority.
 fn reviewed_product_catalog(locale: Locale) -> Vec<PluginProduct> {
     vec![
+        PluginProduct {
+            id: "github".into(),
+            name: "GitHub".into(),
+            description: "Repositories, issues, pull requests, and checks. Uses the official GitHub MCP plus `/mcp login github` — the same App-bound connection the Codewhale app uses, not a generic plugin credential.".into(),
+            publisher: "GitHub".into(),
+            source_reference: "https://api.githubcopilot.com/mcp/".into(),
+            components: vec![PluginProductComponent {
+                kind: PluginProductComponentKind::Mcp,
+                name: "GitHub MCP".into(),
+            }],
+            maturity: tr(locale, MessageId::ExtensionsStateReviewedCandidate).into_owned(),
+        },
         PluginProduct {
             id: "playwright-browser".into(),
             name: "Playwright Browser".into(),

--- a/crates/tui/src/worker_profile.rs
+++ b/crates/tui/src/worker_profile.rs
@@ -192,54 +192,17 @@ impl WorkerRuntimeProfile {
         }
     }
 
-    /// The default profile for a role — the per-role posture. Mirrors the role
-    /// stances documented in `docs/SUBAGENTS.md` (explore/plan/review are
-    /// read-only; verifier runs tests; implementer/general write).
+    /// The default profile for a role. Roles are prompt labels, not permission
+    /// packages: every child starts able to do a slice of work. The parent's
+    /// effective posture is the ceiling (`derive_child` intersects, never
+    /// widens). Hard carve-outs (payments, customer-data delete) and the
+    /// Auto-Review safety floor stay outside this profile.
     #[must_use]
     pub fn for_role(role: FleetRole) -> Self {
-        // A role's default is what the role *intends*, expressed as the widest
-        // posture the role can be given; the parent's effective posture is the
-        // ceiling (`derive_child` intersects, never widens). Read-only roles
-        // stay read-only on the workspace by intent. Nothing else is taken
-        // away by default: network reach is a read, and a worker cut off from
-        // the network or from shell for no role reason cannot do its job.
-        let (permissions, shell) = match role {
-            // Read-only investigators: no workspace writes, but network reach
-            // and the bounded verification surface so a scout/reviewer lane
-            // can run git/gh/web inspection. Raw shell stays denied by the
-            // registry clamp (read-only classifier), so this widens capability
-            // without widening mutation authority.
-            FleetRole::Scout | FleetRole::Reviewer => {
-                (PermissionSet::read_only_with_network(), ShellPolicy::Full)
-            }
-            // Planner: analysis only. Reads the workspace and the web and may
-            // run read-only shell probes (`git log`, `rg`) under the read-only
-            // classifier; never mutates.
-            FleetRole::Planner => (
-                PermissionSet::read_only_with_network(),
-                ShellPolicy::ReadOnly,
-            ),
-            // Consultant: counsel only. Reads (workspace and web) to ground
-            // its advice; never acts on the workspace, so no shell (#4752).
-            FleetRole::Consultant => (PermissionSet::read_only_with_network(), ShellPolicy::None),
-            // Verifier: doesn't modify code, but runs the bounded built-in
-            // verification surface (test/check selections) under a full shell
-            // ceiling clamped by ChildAuthority: writes are denied and
-            // unbounded shell forms are refused (#5186). The old wording
-            // promised "runs the test suite" without saying the surface is
-            // bounded. See the roster description and VERIFIER_AGENT_INTRO.
-            FleetRole::Verifier => (PermissionSet::read_only_with_network(), ShellPolicy::Full),
-            // Doers, and Custom: inherit the parent's effective posture. A
-            // custom worker is narrowed by its explicit tool list and by the
-            // spawning call, not by a silent locked-down default.
-            FleetRole::Builder | FleetRole::Worker | FleetRole::Custom => {
-                (PermissionSet::full(), ShellPolicy::Full)
-            }
-        };
         Self {
             role: role.clone(),
-            permissions,
-            shell,
+            permissions: PermissionSet::full(),
+            shell: ShellPolicy::Full,
             tools: ToolScope::Inherit,
             model: ModelRoute::Inherit,
             provider: None,
@@ -398,38 +361,25 @@ mod tests {
     }
 
     #[test]
-    fn for_role_postures_match_role_stances() {
-        let explore = WorkerRuntimeProfile::for_role(FleetRole::Scout);
-        assert!(!explore.permissions.write, "explore must not write");
-        assert!(
-            explore.permissions.network,
-            "explore/read-only inspection lanes keep network reach"
-        );
-        assert_eq!(
-            explore.shell,
-            ShellPolicy::Full,
-            "explore/read-only inspection lanes hold shell authority so the bounded              verification surface survives the clamp (raw shell still              requires write)"
-        );
-        assert_eq!(
-            explore.model,
-            ModelRoute::Inherit,
-            "explore should not silently downgrade the child model"
-        );
-
-        let implementer = WorkerRuntimeProfile::for_role(FleetRole::Builder);
-        assert!(implementer.permissions.write, "implementer writes");
-        assert_eq!(implementer.shell, ShellPolicy::Full);
-
-        let verifier = WorkerRuntimeProfile::for_role(FleetRole::Verifier);
-        assert!(
-            !verifier.permissions.write,
-            "verifier reports, does not patch"
-        );
-        assert_eq!(
-            verifier.shell,
-            ShellPolicy::Full,
-            "verifier holds shell authority for the bounded verification surface (unbounded forms are refused by the policy seam)"
-        );
+    fn for_role_is_one_worker_system() {
+        for role in [
+            FleetRole::Scout,
+            FleetRole::Reviewer,
+            FleetRole::Planner,
+            FleetRole::Verifier,
+            FleetRole::Consultant,
+            FleetRole::Builder,
+            FleetRole::Worker,
+            FleetRole::Custom,
+        ] {
+            let profile = WorkerRuntimeProfile::for_role(role);
+            assert!(
+                profile.permissions.write && profile.permissions.network,
+                "roles are labels; a child inherits parent-ceiling write+network"
+            );
+            assert_eq!(profile.shell, ShellPolicy::Full);
+            assert_eq!(profile.model, ModelRoute::Inherit);
+        }
     }
 
     #[test]
@@ -451,22 +401,14 @@ mod tests {
         }
     }
 
-    /// #4752: Consultant is counsel, not labour. Its posture has to be read-only
-    /// and shell-less by construction, not by the caller remembering to pass
-    /// `write_authority: read-only`.
+    /// Consultant stays a high-reasoning *label*. It is not a weaker
+    /// permission package — the child can still do the assigned slice.
     #[test]
-    fn consultant_is_read_only_shell_less_and_high_reasoning_by_default() {
+    fn consultant_keeps_high_reasoning_without_a_weaker_tool_list() {
         let consultant = WorkerRuntimeProfile::for_role(FleetRole::Consultant);
 
-        assert!(
-            !consultant.permissions.write,
-            "a consultant advises, it never writes"
-        );
-        assert_eq!(
-            consultant.shell,
-            ShellPolicy::None,
-            "a consultant has no reason to run commands"
-        );
+        assert!(consultant.permissions.write);
+        assert_eq!(consultant.shell, ShellPolicy::Full);
         assert_eq!(
             consultant.reasoning_effort.as_deref(),
             Some("high"),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,7 +108,7 @@ boundary has held since v0.9.1):
 - **`crates/hooks`** - Lifecycle hooks (stdout, jsonl, webhook) for pre/post tool events.
 - **`crates/mcp`** - MCP client + stdio server for Model Context Protocol tool servers.
 - **`crates/protocol`** - Request/response framing and protocol types.
-- **`crates/secrets`** - OS keyring integration for API key storage.
+- **`crates/secrets`** - file-backed API key storage (`~/.codewhale/secrets/`, mode 0600). No Keychain product path.
 - **`crates/state`** - SQLite thread/session persistence layer.
 - **`crates/workflow`** / **`crates/workflow-js`** - Workflow engine and its
   QuickJS scripting layer (renamed from the whaleflow crates).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -391,8 +391,8 @@ For the active provider, the runtime resolves the API key in this exact order
    the named environment variable. For custom providers an unset or empty
    binding is a loud error, not a silent fallback (#5104).
 5. **Secret store.** The durable per-provider slot written by
-   `codewhale auth set` (file-backed under `~/.codewhale/secrets/` by
-   default; the OS keyring only when explicitly selected). Skipped for named
+   `codewhale auth set` (file-backed under `~/.codewhale/secrets/`, mode
+   0600). There is no Keychain / OS-keyring product path. Skipped for named
    custom routes, self-hosted providers, custom endpoints other than an
    explicitly authenticated loopback, and routes whose `auth_mode` needs no
    key.
@@ -410,9 +410,9 @@ variables remain accepted aliases for the `CODEWHALE_*` forms, and
 `DEEPSEEK_SECRET_BACKEND` is the legacy alias for `CODEWHALE_SECRET_BACKEND`.
 
 Run `codewhale auth status` to inspect the active provider's config
-file, OS keyring backend, environment variable, winning source, and last-four
-label without printing the key itself. The command only probes the active
-provider's keyring entry.
+file, secret-store backend, environment variable, winning source, and last-four
+label without printing the key itself. The command only labels the active
+provider's secret-store slot.
 
 For hosted, generic OpenAI-compatible, self-hosted, OpenAI Responses, or native
 Anthropic providers, set `provider = "<id>"` or pass

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -108,6 +108,7 @@ Supported in-TUI actions:
 /mcp init --force
 /mcp import
 /mcp recommendations
+/mcp connect <id>
 /mcp add recommended <id>
 /mcp add stdio <name> <command> [args...]
 /mcp add http <name> <url>
@@ -136,6 +137,7 @@ diagnostic surfaces:
 
 | Plugin | Component | Pinned definition | Provenance and maturity | Installation boundary |
 | --- | --- | --- | --- | --- |
+| GitHub | MCP server (HTTP) | `https://api.githubcopilot.com/mcp/` | Official GitHub remote MCP; same App-bound OAuth as the Codewhale app | `/mcp connect github` adds the server and runs `/mcp login github`. Not a generic plugin credential. |
 | Chrome DevTools | MCP server (stdio) | `npx -y chrome-devtools-mcp@1.7.0` (`npx.cmd` on Windows) | [Official ChromeDevTools project](https://github.com/ChromeDevTools/chrome-devtools-mcp) | npm may download the pinned package when the user restarts MCP. |
 | Playwright | MCP server (stdio) | `npx -y @playwright/mcp@0.0.79 --isolated` (`npx.cmd` on Windows) | [Official Microsoft project](https://github.com/microsoft/playwright-mcp) | `--isolated` starts a fresh browser profile; npm may download the pinned package only after an explicit restart. |
 | Cua Computer Use | MCP server (stdio) | `cua-driver mcp`; Driver `0.20.0` reviewed for this release | [Official Cua project](https://github.com/trycua/cua); preview integration | The signed driver and OS permissions are separate, explicit installs. `/mcp add recommended cua` only writes config and never installs or grants either. |

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -30,7 +30,7 @@ Press `Ctrl+T` to cycle reasoning effort.
 Run `/mode` to open the mode picker, or switch directly with `/mode work`,
 `/mode plan`, or `/mode operate`.
 
-- **Plan**: design-first prompting. The stable primitive names remain familiar, but the runtime centrally refuses file mutation and shell execution. Read-only inspection and policy-allowed research, including deferred Web search/fetch, remain available.
+- **Plan**: design-first prompting. The stable primitive names remain familiar, but the runtime centrally refuses file mutation and shell execution. Read-only inspection and policy-allowed research, including deferred Web search/fetch, remain available. Plan is a **user mode**, not a child permission package. A spawn from Plan inherits that same read-only contract — no write, no mutating shell. Spawning a worker is not a backdoor to Work/Operate authority.
 - **Work** (internally `agent`): ordinary multi-step execution. The small first-turn toolbox is `read`, `write`, `edit`, `bash`, `agent`, and `todo_write`; approval, sandbox, repository law, and managed policy still decide what may execute.
 - **Operate**: multitask conductor posture. Same tools and authority as Work. The parent starts worker(s) with `agent` + a prompt — one worker system, no permission package — then **ends the turn**. Workers inherit the parent (minus payments/top-ups, customer-data delete, and clobbering an occupied checkout). Synthesize when they complete. Use Workflow when order, phases, gates, or deterministic fan-in matter. **Dispatch is not completion.**
 
@@ -44,7 +44,7 @@ still normalize to the internal value `agent`.
 | `read` and policy-allowed deferred research tools | yes | yes | yes |
 | `write` and `edit` | visible names; execution denied | approval- and policy-gated | same as Work |
 | `bash` | visible name; execution denied | approval- and policy-gated | same as Work; delegation is preferred when parallelism or isolation helps |
-| `agent` | yes, subject to child-depth authority | yes, subject to child-depth authority | yes, subject to child-depth authority |
+| `agent` | yes; children inherit Plan's read-only contract | yes, subject to child-depth authority | yes, subject to child-depth authority |
 | Deferred native, MCP, and plugin tools | discoverable through `tool_search` when policy permits | same | same |
 | Paid or external-service tools | follows permission posture | follows permission posture | follows permission posture |
 | Access outside the workspace root | explicit trusted paths only | only through trusted paths or trust mode | same trusted-path/trust policy as Work; Fleet profiles never widen it |

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -32,7 +32,7 @@ Run `/mode` to open the mode picker, or switch directly with `/mode work`,
 
 - **Plan**: design-first prompting. The stable primitive names remain familiar, but the runtime centrally refuses file mutation and shell execution. Read-only inspection and policy-allowed research, including deferred Web search/fetch, remain available.
 - **Work** (internally `agent`): ordinary multi-step execution. The small first-turn toolbox is `read`, `write`, `edit`, `bash`, `agent`, and `todo_write`; approval, sandbox, repository law, and managed policy still decide what may execute.
-- **Operate**: multitask conductor posture. It has the same primitive identities and execution authority as Work. The parent session is the **operator**: dispatching background workers is the default for independent or parallel work. Handle small or tightly coupled tasks in the parent; use background `agent` workers for separable streams, and use Workflow when order, phases, gates, shared budgets, or deterministic fan-in matter. **Dispatch is not completion** — write-capable children must return real verification evidence.
+- **Operate**: multitask conductor posture. Same tools and authority as Work. The parent starts worker(s) with `agent` + a prompt — one worker system, no permission package — then **ends the turn**. Workers inherit the parent (minus payments/top-ups, customer-data delete, and clobbering an occupied checkout). Synthesize when they complete. Use Workflow when order, phases, gates, or deterministic fan-in matter. **Dispatch is not completion.**
 
 `Act` and `/mode act` remain compatibility aliases for Work. Saved settings
 still normalize to the internal value `agent`.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -9,10 +9,13 @@ the first place.
 
 `/plugin suggest <task>` is a local, read-only companion: it ranks already
 installed bundles by their validated name, description, bundled skill names,
-and declared hosts. It explains the match and gives the next review/enable
-step, but never installs, trusts, or enables a bundle. Codewhale deliberately
-does not treat arbitrary remote archives as a plugin marketplace; a remote
-catalog needs publisher and provenance policy before it can make suggestions.
+and declared hosts. When the task needs a reviewed connector that is not
+installed (today: GitHub), it also prints the exact connect command
+(`/mcp connect github`) instead of a generic "install something" hint.
+Planned catalog rows are omitted. It never installs, trusts, or enables a
+bundle. Codewhale deliberately does not treat arbitrary remote archives as a
+plugin marketplace; a remote catalog needs publisher and provenance policy
+before it can make suggestions.
 
 ## Sources
 

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -69,10 +69,17 @@ Parent ceiling still applies: a child cannot gain what the parent lacks.
 The Auto-Review safety floor (publish-like, destructive detached work,
 secrets, auth) stays authoritative. `auto_approve` stays off.
 
+**Plan is a user mode.** While the user is in Plan, the root agent is
+read-only (no write, no mutating shell). A child started from Plan
+inherits that contract. `agent({ action: "start", prompt })` is not a
+backdoor to full write+shell. Work and Operate keep the simple
+inherit-parent spawn. There is no permission-preset matrix.
+
 `type` is a **prompt label** (`worker`, `scout`, `planner`, `reviewer`,
 `builder`, `verifier`, `consultant`) so the child knows the stance. It is
 not a permission matrix. Explicit `write_authority=read_only` is the only
-way to start a spectator; that is an opt-in narrowing, not a role default.
+way to start a spectator from Work/Operate; that is an opt-in narrowing,
+not a role default.
 
 ## Role taxonomy
 
@@ -188,11 +195,11 @@ session projection and worker record. By default the branch is
 `codex/agent-<name>-<id>` and the checkout lives beside the parent repo under
 `.codewhale-worktrees/`, so the parent checkout stays clean.
 
-Isolation is not write authority. A prompt-only worker starts read-only.
-A writer also declares `write_authority: "workspace_write"` or
-`"worktree_write"` and at least one normalized repo-relative `write_roots`,
-`exact_files`, or `coordination_contracts` value. Active overlapping shared
-claims fail before mutation; a real isolated worktree may proceed in parallel.
+Isolation is not write authority. In Work/Operate, `spawn(prompt)` inherits
+the parent workspace. In Plan, the same call stays read-only because the
+user mode is read-only. Explicit `write_authority=read_only` still starts
+a spectator from Work/Operate. Active overlapping shared claims fail
+before mutation; a real isolated worktree may proceed in parallel.
 
 Optional fields:
 

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -45,11 +45,39 @@ orchestration surface is `agent`; see the sub-agent guidance in
 `crates/tui/src/prompts/text.rs` (`AGENT_MODE`) and the in-line
 tool description.
 
+## One worker system
+
+There is one way a sub-agent works. `agent` with a prompt is enough:
+
+```text
+agent({ "action": "start", "prompt": "do this slice" })
+```
+
+The child inherits the parent's tools, sandbox, network, git, and write
+authority. It can edit, run commands, fetch, test, and open a PR when the
+slice is a PR. The parent and the user do not pick a permission package,
+preset, operate flag set, or weaker tool list.
+
+The only subtractions from the parent:
+
+- no payments / top-ups
+- no deleting customer data
+- occupied checkout or a live parallel writer → isolated git worktree
+  (never stash or reset the main tree)
+
+Parent ceiling still applies: a child cannot gain what the parent lacks.
+The Auto-Review safety floor (publish-like, destructive detached work,
+secrets, auth) stays authoritative. `auto_approve` stays off.
+
+`type` is a **prompt label** (`worker`, `scout`, `planner`, `reviewer`,
+`builder`, `verifier`, `consultant`) so the child knows the stance. It is
+not a permission matrix. Explicit `write_authority=read_only` is the only
+way to start a spectator; that is an opt-in narrowing, not a role default.
+
 ## Role taxonomy
 
-The `type` field on `agent` selects a Fleet posture for the child
-(`agent_type` is accepted as a compatibility alias). Each role is a distinct
-stance toward the work — not just a different label.
+The `type` field on `agent` is a prompt label (`agent_type` remains a
+compatibility alias). Roles describe stance, not a weaker tool list.
 
 ## Maintainer posture
 
@@ -64,43 +92,22 @@ diff, linked issues, tests, and CI before merging, harvesting, closing, or
 deferring it. A sub-agent's result is a working set, not a substitute for
 stewardship.
 
-| Role          | Stance                                 | Writes? | Network? | Shell posture | Typical use                                  |
-|---------------|----------------------------------------|---------|----------|---------------|----------------------------------------------|
-| `worker`      | flexible; do whatever the parent says  | yes     | yes      | yes           | the default; multi-step tasks                |
-| `scout`       | read-only; map the relevant code fast  | no      | yes      | read-only (net + bounded verify) | "find every call site of `Foo`; check the PR with gh" |
-| `planner`     | analyse and produce a strategy         | no      | yes      | read-only probes | "design the migration; don't execute"        |
-| `reviewer`    | read-and-grade with severity scores    | no      | yes      | read-only (net + bounded verify) | "audit this PR for bugs"                     |
-| `builder`     | land a specific change with min edit   | yes     | yes      | yes           | "rewrite `bar.rs::Foo::bar` to do X"         |
-| `verifier`    | run tests / validation, report outcome | no      | yes      | bounded verification (no writes) | "verify the diff with the bounded test checks; report PASS/FAIL" |
-| `consultant`  | short-lived, high-reasoning counsel     | no      | yes      | none          | "what are we missing in this design?"        |
-| `custom`      | explicit narrow tool allowlist         | inherits | inherits | inherits     | hand-picked tools on the parent's posture    |
+| Role          | Stance                                 | Typical use                                  |
+|---------------|----------------------------------------|----------------------------------------------|
+| `worker`      | flexible; do whatever the parent says  | the default; multi-step tasks                |
+| `scout`       | map the relevant code fast             | "find every call site of `Foo`; check the PR with gh" |
+| `planner`     | analyse and produce a strategy         | "design the migration"                       |
+| `reviewer`    | read-and-grade with severity scores    | "audit this PR for bugs"                     |
+| `builder`     | land a specific change with min edit   | "rewrite `bar.rs::Foo::bar` to do X"         |
+| `verifier`    | run tests / validation, report outcome | "verify the diff; report PASS/FAIL"          |
+| `consultant`  | short-lived, high-reasoning counsel    | "what are we missing in this design?"        |
+| `custom`      | explicit narrow tool allowlist         | hand-picked tools on the parent's posture    |
 
-A role's default is what the role *intends*, and the parent's effective
+Every role can use the tools the slice needs. The parent's effective
 posture is always the ceiling (a child never widens beyond its parent).
-Read-only roles withhold **workspace writes** by intent; nothing else is
-taken away by default — every role keeps network reads, and `custom`
-inherits the parent's write/network/shell posture and is narrowed only by
-its explicit tool list or the spawning call. The focused worker's header
-states the effective posture (`scout · read-only · network · read-only
-shell`) from the runtime's own permission snapshot.
-
-**Delegation moves work, never authority** (the containment answer for
-#5426). A read-only role delegating to a write-capable role (scout →
-builder) is a supported escape hatch for *work capacity* — the child brings
-its own model, route, and step budget — but the child's authority is clamped
-against the delegating parent's live posture, not the operator's: a scout's
-builder child lands read-only with raw shell and mutating tools denied, and
-canonical `Bash` is denied to it too (only bounded-inspection roles keep the
-classified read-only shell). Delegating to obtain shell is therefore
-mechanically useless — the scout's own bounded shell (`git -C … log`,
-`find … | head`, `npm view …`, classifier-gated) is the only shell path a
-read-only parent has. Read-only is transitive through any delegation chain:
-the clamp (`ChildAuthority::clamp` in `fleet/exact.rs`) intersects every
-field with the narrower side, the deny-list union means a descendant can
-never drop an ancestor's restriction, and `inherit_disallowed_tools: false`
-cannot drop a posture denial (`is_posture_denial`). This is pinned by
-`a_read_only_parents_delegation_never_widens_authority` in
-`crates/tui/src/fleet/exact.rs` tests.
+`ChildAuthority::clamp` in `fleet/exact.rs` still intersects every field
+with the narrower side so a read-only **parent** cannot mint a write-capable
+child. That is parent-ceiling safety, not a role matrix.
 
 The session's **permission posture** applies inside every child exactly as
 it applies to the parent turn: under Auto-Review the same deterministic


### PR DESCRIPTION
## Summary
- Fleet/sub-agents are one worker: `spawn(prompt)` inherits the parent. Roles are labels, not a permission matrix. No preset catalog.
- Retired the Codewhale Keychain/OS-keyring product path. `CODEWHALE_SECRET_BACKEND=system|keyring` is a no-op. Account sessions and provider keys use `~/.codewhale/secrets/` (mode 0600), not world-readable files.
- `/mcp connect github` chains add+login. Docs describe the simple worker model.

## Test plan
- [x] `cargo test -p codewhale-secrets` (61 tests) including `session_secrets_use_the_file_store_not_keychain` and `retired_keychain_env_diagnoses_the_file_store`
- [ ] Focused tui tests: `simple_worker`, `prompt_only_spawn_inherits`, `root_operate_dispatch`
- [ ] Confirm `codewhale doctor` does not mention Keychain
- [ ] Confirm `CODEWHALE_SECRET_BACKEND=system` does not prompt Keychain

Closes the founder ask on cwc#154 (CLI side): local keyring is not a parallel home.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->