### PR TITLE
fix(runtime): scope the thread store per session (#5630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Context-pressure warnings and critical alerts now remain visible in sticky UI
   status until compaction or explicit dismissal, instead of disappearing into
   scrolling turn metadata (#5620).
+- The Runtime thread store defaults to a per-session root
+  (`$CODEWHALE_HOME/sessions/<id>/runtime`) so multiple Codewhale processes on
+  one machine no longer share one owner lock (#5630). The exclusive lock is
+  unchanged; `CODEWHALE_RUNTIME_DIR` still selects a shared root when that is
+  intended.
 - Session token totals now include display-only per-model-call deltas while a
   turn is running, including input/output and cache-class counters; the
   authoritative `TurnComplete` totals still reconcile exactly once (#5581).

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -68,6 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Context-pressure warnings and critical alerts now remain visible in sticky UI
   status until compaction or explicit dismissal, instead of disappearing into
   scrolling turn metadata (#5620).
+- The Runtime thread store defaults to a per-session root
+  (`$CODEWHALE_HOME/sessions/<id>/runtime`) so multiple Codewhale processes on
+  one machine no longer share one owner lock (#5630). The exclusive lock is
+  unchanged; `CODEWHALE_RUNTIME_DIR` still selects a shared root when that is
+  intended.
 - Session token totals now include display-only per-model-call deltas while a
   turn is running, including input/output and cache-class counters; the
   authoritative `TurnComplete` totals still reconcile exactly once (#5581).

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -79,6 +79,7 @@ const EVENT_TRANSACTION_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
 const EVENT_TRANSACTION_LOCK_POLL: Duration = Duration::from_millis(5);
 const EVENT_TRANSACTION_LOCK_FILE: &str = "events.lock";
 const RUNTIME_PROCESS_OWNER_LOCK_FILE: &str = "runtime-process.owner.lock";
+const RUNTIME_PROCESS_OWNER_LOCK_HELD: &str = "This Runtime thread store is already active in another process; close the other Runtime before retrying, or set CODEWHALE_RUNTIME_DIR to a distinct store root";
 const AGENT_MAIL_OWNER_FILE: &str = "owner.json";
 const TURN_OPERATION_BINDING_SCHEMA_VERSION: u32 = 1;
 const REQUEST_USER_INPUT_TOOL_NAME: &str = "request_user_input";
@@ -2027,17 +2028,58 @@ pub struct RuntimeThreadManagerConfig {
 impl RuntimeThreadManagerConfig {
     #[must_use]
     pub fn from_task_data_dir(task_data_dir: PathBuf) -> Self {
-        let data_dir = std::env::var("CODEWHALE_RUNTIME_DIR")
-            .or_else(|_| std::env::var("DEEPSEEK_RUNTIME_DIR"))
-            .ok()
-            .filter(|override_dir| !override_dir.trim().is_empty())
-            .map_or_else(|| task_data_dir.join("runtime"), PathBuf::from);
+        Self::resolved(task_data_dir, None)
+    }
+
+    /// Scope the Runtime thread store to one interactive session.
+    ///
+    /// The process-owner lock stays exclusive; isolation comes from the path,
+    /// not from weakening the lock (#5630).
+    #[must_use]
+    pub fn for_session(task_data_dir: PathBuf, session_id: &str) -> Self {
+        Self::resolved(task_data_dir, Some(session_id))
+    }
+
+    fn resolved(task_data_dir: PathBuf, session_id: Option<&str>) -> Self {
+        let data_dir = runtime_dir_override()
+            .unwrap_or_else(|| default_runtime_store_root(&task_data_dir, session_id));
         Self {
             data_dir,
             task_data_dir,
             max_active_threads: MAX_ACTIVE_THREADS_DEFAULT,
         }
     }
+}
+
+fn runtime_dir_override() -> Option<PathBuf> {
+    std::env::var("CODEWHALE_RUNTIME_DIR")
+        .or_else(|_| std::env::var("DEEPSEEK_RUNTIME_DIR"))
+        .ok()
+        .filter(|override_dir| !override_dir.trim().is_empty())
+        .map(PathBuf::from)
+}
+
+fn default_runtime_store_root(task_data_dir: &Path, session_id: Option<&str>) -> PathBuf {
+    match session_id
+        .map(str::trim)
+        .filter(|id| is_runtime_session_scope(id))
+    {
+        Some(id) => match crate::session_manager::default_sessions_dir() {
+            Ok(sessions_dir) => sessions_dir.join(id).join("runtime"),
+            Err(_) => task_data_dir.join("runtime").join(id),
+        },
+        None => task_data_dir.join("runtime"),
+    }
+}
+
+fn is_runtime_session_scope(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 128
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && id != "checkpoints"
+        && id != "session_boot_owners"
 }
 
 /// Visibility filter for `list_threads`. Default is `ActiveOnly`. The runtime
@@ -2827,9 +2869,7 @@ impl RuntimeProcessOwnerLock {
             if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
                 let error = std::io::Error::last_os_error();
                 if error.kind() == std::io::ErrorKind::WouldBlock {
-                    bail!(
-                        "This Runtime thread store is already active in another process; close the other Runtime before retrying"
-                    );
+                    bail!("{RUNTIME_PROCESS_OWNER_LOCK_HELD}");
                 }
                 return Err(error).context("Failed to acquire Runtime process owner lock");
             }
@@ -2842,9 +2882,7 @@ impl RuntimeProcessOwnerLock {
             if unsafe { LockFile(file.as_raw_handle() as _, 0, 0, u32::MAX, u32::MAX) } == 0 {
                 let error = std::io::Error::last_os_error();
                 if matches!(error.raw_os_error(), Some(32 | 33)) {
-                    bail!(
-                        "This Runtime thread store is already active in another process; close the other Runtime before retrying"
-                    );
+                    bail!("{RUNTIME_PROCESS_OWNER_LOCK_HELD}");
                 }
                 return Err(error).context("Failed to acquire Runtime process owner lock");
             }

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -3703,6 +3703,10 @@ fn runtime_manager_store_has_one_lifetime_process_owner() -> Result<()> {
         message.contains("already active in another process"),
         "unexpected owner-lock error: {error:#}"
     );
+    assert!(
+        message.contains("CODEWHALE_RUNTIME_DIR"),
+        "owner-lock error should name the override for a shared root: {error:#}"
+    );
 
     let distinct_dir = test_runtime_dir();
     let distinct = test_manager(distinct_dir)?;
@@ -3712,6 +3716,61 @@ fn runtime_manager_store_has_one_lifetime_process_owner() -> Result<()> {
     child.wait_success("Runtime manager owner holder");
     let reopened = test_manager(dir)?;
     drop(reopened);
+    Ok(())
+}
+
+#[test]
+fn session_scoped_runtime_default_lives_under_the_session_directory() {
+    let _lock = crate::test_support::lock_test_env();
+    let temp = tempfile::tempdir().expect("temp home");
+    let home = temp.path().join("cw-home");
+    let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", &home);
+    let _runtime = crate::test_support::EnvVarGuard::remove("CODEWHALE_RUNTIME_DIR");
+    let _legacy = crate::test_support::EnvVarGuard::remove("DEEPSEEK_RUNTIME_DIR");
+
+    let cfg = RuntimeThreadManagerConfig::for_session(home.join("tasks"), "sess-1");
+    assert_eq!(
+        cfg.data_dir,
+        home.join("sessions").join("sess-1").join("runtime")
+    );
+}
+
+#[test]
+fn explicit_runtime_dir_override_beats_session_scope() {
+    let _lock = crate::test_support::lock_test_env();
+    let temp = tempfile::tempdir().expect("temp home");
+    let home = temp.path().join("cw-home");
+    let override_dir = temp.path().join("shared-runtime");
+    let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", &home);
+    let _runtime = crate::test_support::EnvVarGuard::set("CODEWHALE_RUNTIME_DIR", &override_dir);
+    let _legacy = crate::test_support::EnvVarGuard::remove("DEEPSEEK_RUNTIME_DIR");
+
+    let cfg = RuntimeThreadManagerConfig::for_session(home.join("tasks"), "sess-1");
+    assert_eq!(cfg.data_dir, override_dir);
+}
+
+#[test]
+fn session_scoped_runtime_roots_do_not_share_the_process_owner_lock() -> Result<()> {
+    let _lock = crate::test_support::lock_test_env();
+    let temp = tempfile::tempdir()?;
+    let home = temp.path().join("cw-home");
+    let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", &home);
+    let _runtime = crate::test_support::EnvVarGuard::remove("CODEWHALE_RUNTIME_DIR");
+    let _legacy = crate::test_support::EnvVarGuard::remove("DEEPSEEK_RUNTIME_DIR");
+    let tasks = home.join("tasks");
+
+    let first = RuntimeThreadManager::open(
+        Config::default(),
+        PathBuf::from("."),
+        RuntimeThreadManagerConfig::for_session(tasks.clone(), "session-a"),
+    )?;
+    let second = RuntimeThreadManager::open(
+        Config::default(),
+        PathBuf::from("."),
+        RuntimeThreadManagerConfig::for_session(tasks, "session-b"),
+    )?;
+    drop(first);
+    drop(second);
     Ok(())
 }
 

--- a/crates/tui/src/task_manager.rs
+++ b/crates/tui/src/task_manager.rs
@@ -1085,15 +1085,20 @@ struct QueueFile {
 
 impl TaskManager {
     /// Start the manager with the default DeepSeek executor.
+    ///
+    /// Interactive callers pass the session id so the Runtime store (and its
+    /// exclusive process-owner lock) is per-session rather than per-machine
+    /// (#5630).
     pub async fn start(
         cfg: TaskManagerConfig,
         api_config: Config,
         plugin_registry: Arc<crate::plugins::PluginRegistry>,
+        session_id: &str,
     ) -> Result<SharedTaskManager> {
         let runtime_threads = Arc::new(RuntimeThreadManager::open_with_plugin_registry(
             api_config.clone(),
             cfg.default_workspace.clone(),
-            RuntimeThreadManagerConfig::from_task_data_dir(cfg.data_dir.clone()),
+            RuntimeThreadManagerConfig::for_session(cfg.data_dir.clone(), session_id),
             plugin_registry,
         )?);
         Self::start_with_runtime_manager(cfg, api_config, runtime_threads).await

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -20,6 +20,24 @@ pub(super) fn event_owner_is_active(
     !owner_session_id.is_empty() && current_session_id == Some(owner_session_id)
 }
 
+/// Bind the Runtime thread store to a session before the process-owner lock
+/// is taken, so a second Codewhale on the same machine does not collide on
+/// the default root (#5630). Resume reuses the loaded id; a fresh session
+/// claims one here so first persist keeps it.
+fn ensure_runtime_session_id(app: &mut App) -> String {
+    if let Some(existing) = app
+        .current_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        return existing.to_string();
+    }
+    let session_id = uuid::Uuid::new_v4().to_string();
+    app.current_session_id = Some(session_id.clone());
+    session_id
+}
+
 fn persist_current_session_goal(app: &App) -> Result<(), String> {
     let session_id = app
         .current_session_id
@@ -409,6 +427,7 @@ pub async fn run_tui(
         }
     }
 
+    let session_id = ensure_runtime_session_id(&mut app);
     let task_manager = TaskManager::start(
         TaskManagerConfig::from_runtime(
             config,
@@ -418,6 +437,7 @@ pub async fn run_tui(
         ),
         config.clone(),
         std::sync::Arc::clone(&app.plugin_registry),
+        &session_id,
     )
     .await?;
     let automations = std::sync::Arc::new(tokio::sync::Mutex::new(

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1128,6 +1128,13 @@ the `CODEWHALE_*` value wins.
 - `CODEWHALE_TASKS_DIR` (runtime task queue/artifact storage, default
   `~/.codewhale/tasks`, with legacy `~/.deepseek/tasks` fallback when only the
   legacy directory exists)
+- `CODEWHALE_RUNTIME_DIR` (override the runtime thread store root). Interactive
+  sessions default to `$CODEWHALE_HOME/sessions/<session-id>/runtime` so each
+  Codewhale process owns its own store (#5630). The store is single-owner: a
+  second process on the **same** root fails at startup. Set this variable to
+  share one store across processes, or when the runtime API server should use a
+  stable non-session path. Unset, the API/server path remains
+  `$CODEWHALE_HOME/tasks/runtime`. Legacy alias: `DEEPSEEK_RUNTIME_DIR`.
 - `CODEWHALE_ALLOW_INSECURE_HTTP` (`1`/`true` allows non-local `http://` base URLs; default is reject)
 - `CODEWHALE_FORCE_HTTP1` (`1|true|yes|on` pins the HTTP client to HTTP/1.1, disabling HTTP/2; useful on Windows or behind proxies that mishandle long-lived H2 streams)
 - `CODEWHALE_HOME` (override the base data directory; defaults to `~/.codewhale`).


### PR DESCRIPTION
## Summary
- Closes #5630: interactive Runtime thread stores now default to `$CODEWHALE_HOME/sessions/<session-id>/runtime`, so multiple Codewhale processes on one machine no longer share `~/.codewhale/tasks/runtime`.
- The exclusive `RuntimeProcessOwnerLock` is unchanged. Two processes on the **same** session (or the same `CODEWHALE_RUNTIME_DIR`) still fail closed. The startup error names `CODEWHALE_RUNTIME_DIR` for an intentional shared root.
- The runtime API / `TaskManager::start_with_runtime_manager` path still uses `$CODEWHALE_HOME/tasks/runtime` unless overridden.

Design proposed by @M-Maciej. No PR from them existed at implementation time; authorship is preserved via `Co-authored-by`.

## Testing

- [x] focused `codewhale-tui` lib tests (see below)
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [ ] `cargo test --workspace --all-features --locked`

Focused evidence:

- `runtime_threads::tests::session_scoped_runtime_default_lives_under_the_session_directory`
- `runtime_threads::tests::session_scoped_runtime_roots_do_not_share_the_process_owner_lock`
- `runtime_threads::tests::explicit_runtime_dir_override_beats_session_scope`
- `runtime_threads::tests::runtime_manager_store_has_one_lifetime_process_owner` (lock still exclusive)
- `task_manager::tests::task_and_runtime_roots_honor_explicit_codewhale_home`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->