### PR TITLE
feat(web): embed tsnet for codewhale web --tailscale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `codewhale web --tailscale` publishes the loopback browser client on the
+  current Tailscale tailnet. Default `codewhale web` stays loopback-only. The
+  preferred path is an embedded tsnet node from the official `tailscale` 0.5.0
+  crate (`Device::tcp_listen` + `axum::Listener`, hostname `codewhale`) when
+  built with `--features tailscale` and `CODEWHALE_TSNET_AUTHKEY`/`TS_AUTHKEY`.
+  Official 0.5.0 cannot mint HTTPS certificates, so the embedded listener is
+  HTTP :80 over WireGuard (`http://codewhale.<tailnet>.ts.net`). When embed
+  cannot auth or is not compiled, the process falls back to PR #5628's
+  `tailscale serve --bg --https=443 localhost:<port>` design (browser-trusted
+  TLS on the machine MagicDNS name). Not Funnel. Stopping the process turns
+  off only HTTPS:443 for the CLI fallback (not `serve reset`).
+
 - Added the managed Chat relay: account-owned Chat commands now execute on the
   native runtime thread engine through a new `runtime_chat_relay` module
   instead of a second execution path. Each Chat thread is a dedicated,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +177,12 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "ascii"
@@ -345,6 +361,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +525,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitrs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad65ba2eda683a8486f72c13f0e1f5afbaa99ccd08029e6a72b1cf46ef0f0309"
+dependencies = [
+ "bitrs-macro",
+ "zerocopy",
+]
+
+[[package]]
+name = "bitrs-macro"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "896dc69748b78a3bc4b815084e15cb51efdedc22a6d0ef5a443f6bd5e92af89a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +599,31 @@ name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "borsh"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.2",
+]
+
+[[package]]
+name = "bounded-integer"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102dbef1187b1893e6dfe05a774e79fd52265f49f214f6879c8ff49f52c8188b"
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bstr"
@@ -608,6 +702,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex 2.0.1",
 ]
 
@@ -646,6 +742,17 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
@@ -653,6 +760,19 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -683,6 +803,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -753,6 +874,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1094,7 +1224,7 @@ dependencies = [
  "rusqlite",
  "rust-i18n",
  "rustls",
- "schemars",
+ "schemars 1.2.2",
  "schemaui",
  "semver",
  "serde",
@@ -1105,6 +1235,7 @@ dependencies = [
  "shlex 1.3.0",
  "similar",
  "syntect",
+ "tailscale",
  "tar",
  "tempfile",
  "thiserror 2.0.20",
@@ -1308,6 +1439,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1397,6 +1544,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
+dependencies = [
+ "aead",
+ "crypto_secretbox",
+ "curve25519-dalek 4.1.3",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1473,13 +1649,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1497,13 +1737,38 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
- "darling_core",
+ "darling_core 0.24.0",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if 1.0.4",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1560,6 +1825,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "defmt"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
+dependencies = [
+ "defmt 1.1.1",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1875,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "derive_more"
@@ -1686,10 +1994,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dyn-eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d035d21af5cde1a6f5c7b444a5bf963520a9f142e5d06931178433d7d5388"
+
+[[package]]
+name = "dyn-hash"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fdab65db9274e0168143841eb8f864a0a21f8b1b8d2ba6812bbe6024346e99e"
 
 [[package]]
 name = "either"
@@ -1780,6 +2112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "etherparse"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b119b9796ff800751a220394b8b3613f26dd30c48f254f6837e64c464872d1c7"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +2198,9 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+dependencies = [
+ "getrandom 0.4.3",
+]
 
 [[package]]
 name = "fax"
@@ -1883,6 +2227,18 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -1945,6 +2301,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2342,12 @@ dependencies = [
  "lazy_static",
  "num",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -2100,6 +2474,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2243,7 +2618,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2260,6 +2635,27 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2299,6 +2695,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,6 +2739,28 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "hmac-sha1"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b05da5b9e5d4720bfb691eebb2b9d42da3570745da71eac8a1f5bb7e59aab88"
+dependencies = [
+ "hmac",
+ "sha1",
+]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "hostname-validator"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "htmd"
@@ -2675,6 +3103,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -2716,7 +3155,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
- "darling",
+ "darling 0.24.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -2746,6 +3185,9 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2785,6 +3227,59 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt 1.1.1",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt 1.1.1",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -2836,6 +3331,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,6 +3385,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
 dependencies = [
  "regex-syntax",
+]
+
+[[package]]
+name = "kameo"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea00bfc3709c5b95be7c9a93289d0c3ff42cf9a3b77d532387242992705bca7"
+dependencies = [
+ "downcast-rs 2.0.2",
+ "dyn-clone",
+ "futures",
+ "kameo_macros",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "kameo_actors"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535f5db40b46b28085ddf4ba0391818e1b388548bf454e6d27a3b5cc805961fa"
+dependencies = [
+ "futures",
+ "glob",
+ "kameo",
+ "thiserror 2.0.20",
+ "tokio",
+]
+
+[[package]]
+name = "kameo_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7566055976eb86ee8e8fbafa0fbdad985c5d7c3f4eed04fc11bb495f71e3856"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3066,6 +3611,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,6 +3653,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3208,6 +3765,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b897d7bd4f0af82e68d40d0344cf37e97f9c97ddf74a098de3e4da05e96ca395"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93af8261786086024cd5e96e0a991dd65ced07bbf7c233a487bbc96b971d5539"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3236,6 +3842,30 @@ dependencies = [
  "cfg_aliases 0.2.2",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if 1.0.4",
+ "cfg_aliases 0.2.2",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if 1.0.4",
+ "cfg_aliases 0.2.2",
+ "libc",
 ]
 
 [[package]]
@@ -3512,6 +4142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3609,6 +4245,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peg"
@@ -3840,7 +4482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
- "indexmap",
+ "indexmap 2.14.0",
  "quick-xml",
  "serde",
  "time",
@@ -3874,10 +4516,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "portable-pty"
@@ -3887,7 +4549,7 @@ checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
- "downcast-rs",
+ "downcast-rs 1.2.1",
  "filedescriptor",
  "lazy_static",
  "libc",
@@ -3922,6 +4584,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "precis-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2e7b31f132e0c6f8682cfb7bf4a5340dbe925b7986618d0826a56dfe0c8e56"
+dependencies = [
+ "precis-tools",
+ "ucd-parse",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "precis-profiles"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e2768890a47af73a032af9f0cedbddce3c9d06cf8de201d5b8f2436ded7674"
+dependencies = [
+ "lazy_static",
+ "precis-core",
+ "precis-tools",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "precis-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc1eb2d5887ac7bfd2c0b745764db89edb84b856e4214e204ef48ef96d10c4a"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "ucd-parse",
 ]
 
 [[package]]
@@ -4061,6 +4757,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted-string-parser"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc75379cdb451d001f1cb667a9f74e8b355e9df84cc5193513cbe62b96fc5e9"
+dependencies = [
+ "pest",
+ "pest_derive",
+]
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4079,8 +4785,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4089,7 +4805,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -4105,12 +4821,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4308,6 +5043,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -4519,7 +5260,7 @@ dependencies = [
  "convert_case 0.11.0",
  "fnv",
  "ident_case",
- "indexmap",
+ "indexmap 2.14.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -4545,6 +5286,24 @@ checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.30.1",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -4643,6 +5402,7 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4706,6 +5466,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4724,6 +5485,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4739,6 +5509,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4776,7 +5558,7 @@ dependencies = [
  "axum",
  "crossterm",
  "include_dir",
- "indexmap",
+ "indexmap 2.14.0",
  "jsonschema",
  "percent-encoding",
  "ratatui",
@@ -4933,7 +5715,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4991,6 +5773,39 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5178,6 +5993,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "smallbox"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aca054fd9f8c2ebe8557a2433f307e038c0716124efd045daa0388afa5172189"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5201,6 +6022,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
+name = "smoltcp"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cfg-if 1.0.4",
+ "defmt 0.3.100",
+ "heapless",
+ "managed",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5208,6 +6053,15 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5284,6 +6138,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "stun-rs"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb921f10397d5669e1af6455e9e2d367bf1f9cebcd6b1dd1dc50e19f6a9ac2ac"
+dependencies = [
+ "base64 0.22.1",
+ "bounded-integer",
+ "byteorder",
+ "crc",
+ "enumflags2",
+ "fallible-iterator",
+ "hmac-sha1",
+ "hmac-sha256",
+ "hostname-validator",
+ "lazy_static",
+ "md5",
+ "paste",
+ "precis-core",
+ "precis-profiles",
+ "quoted-string-parser",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -5397,6 +6275,26 @@ dependencies = [
  "quote",
  "sealed",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tailscale"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27b4582e1de061fffac7733c893cae4ab559478462562edf13d72d83b38aece"
+dependencies = [
+ "axum",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "ts_control",
+ "ts_keys",
+ "ts_netstack_smoltcp",
+ "ts_runtime",
+ "url",
 ]
 
 [[package]]
@@ -5691,6 +6589,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -5724,6 +6623,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5762,7 +6662,7 @@ version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -5795,7 +6695,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5809,7 +6709,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -5978,6 +6878,547 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ts_array256"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f68610cca60e50dff05afb3ef4d7d183a2ac50fd2aea5c416b1946d20f0a91eb"
+dependencies = [
+ "heapless",
+ "smallvec",
+ "static_assertions",
+ "ts_bitset",
+]
+
+[[package]]
+name = "ts_bart"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9db073258ae92ea14070f5e606e4b44a81d5f6452348cae19b96935a986aac"
+dependencies = [
+ "cfg-if 1.0.4",
+ "heapless",
+ "ipnet",
+ "static_assertions",
+ "ts_array256",
+ "ts_bitset",
+]
+
+[[package]]
+name = "ts_bart_packetfilter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66e70021116d557eff0aba73ed204db118ea653ceb5e857a42bd47d60b1aa33"
+dependencies = [
+ "hashbrown 0.17.1",
+ "smallvec",
+ "ts_array256",
+ "ts_bart",
+ "ts_bitset",
+ "ts_dynbitset",
+ "ts_packetfilter",
+]
+
+[[package]]
+name = "ts_bitset"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6674d0576b769f5d6333d3121c2a03d935f478740f3a87d81e10604952e8a4d0"
+dependencies = [
+ "cfg-if 1.0.4",
+ "static_assertions",
+]
+
+[[package]]
+name = "ts_capabilityversion"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cdfc7fadb22af93860d0aad875843142ad945a829647c59ac8d3f8dd1cd307"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "ts_control"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b6a3b0fb7ced8c5db65b3cdc8adcf5e63c35f10073e67c9d399ee6f05b1293"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "gethostname",
+ "ipnet",
+ "lazy_static",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ts_bitset",
+ "ts_capabilityversion",
+ "ts_control_noise",
+ "ts_control_serde",
+ "ts_derp",
+ "ts_dynbitset",
+ "ts_http_util",
+ "ts_keys",
+ "ts_packet",
+ "ts_packetfilter",
+ "ts_packetfilter_state",
+ "ts_tls_util",
+ "url",
+ "zerocopy",
+]
+
+[[package]]
+name = "ts_control_noise"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46071c79d7454133038a317767409d03851ed945aa6367ecea62c6bebf8329cc"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chacha20poly1305",
+ "futures-util",
+ "pin-project-lite",
+ "static_assertions",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ts_capabilityversion",
+ "ts_hexdump",
+ "ts_keys",
+ "ts_noise",
+ "zerocopy",
+]
+
+[[package]]
+name = "ts_control_serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f55b206a0cc45d19e3988bbd0404847a2faabb2a738e1eabbb5f1b86f429a2"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "ipnet",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "ts_capabilityversion",
+ "ts_keys",
+ "ts_nodecapability",
+ "ts_packetfilter_serde",
+ "url",
+]
+
+[[package]]
+name = "ts_dataplane"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c0f5fe22405153f26b8756dc3b8fc7c5215bee8c7581fb2385e2742b9fcfc33"
+dependencies = [
+ "bitrs",
+ "bytes",
+ "etherparse",
+ "tokio",
+ "tracing",
+ "ts_bart",
+ "ts_disco_protocol",
+ "ts_overlay_router",
+ "ts_packet",
+ "ts_packetfilter",
+ "ts_time",
+ "ts_transport",
+ "ts_tunnel",
+ "ts_underlay_router",
+]
+
+[[package]]
+name = "ts_derp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589539f8c80460eeb3ecaaa7364388f92f80c70b7bb9c4be935f4e7f42602c6f"
+dependencies = [
+ "bytes",
+ "crypto_box",
+ "futures",
+ "hex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ts_hexdump",
+ "ts_http_util",
+ "ts_keys",
+ "ts_packet",
+ "ts_tls_util",
+ "ts_transport",
+ "url",
+ "yoke",
+ "zerocopy",
+]
+
+[[package]]
+name = "ts_disco_protocol"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e955f5bcbf02122508fb739b5eb8ef71f4e0a68addb5a2ea4335291c1753e42"
+dependencies = [
+ "aead",
+ "crypto_box",
+ "num-derive",
+ "num-traits",
+ "thiserror 2.0.20",
+ "ts_hexdump",
+ "ts_keys",
+ "zerocopy",
+]
+
+[[package]]
+name = "ts_dynbitset"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "432baa58f36d2952f6b7e68eca0dfc73bf79f5094e5a4810a89405659bff59f0"
+dependencies = [
+ "smallvec",
+ "ts_bitset",
+]
+
+[[package]]
+name = "ts_hexdump"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd23f471c3e5650af8cb867296cc032f0a44bffe082ef0e720e31a0879dd1b9"
+dependencies = [
+ "heapless",
+]
+
+[[package]]
+name = "ts_http_util"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f8f3e6af0e3b8d4936007e504c9393cdc2aa294d6dbb4f7b5df65aaf9a7b0b9"
+dependencies = [
+ "bytes",
+ "futures",
+ "http",
+ "http-body-util",
+ "httparse",
+ "hyper",
+ "hyper-util",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ts_tls_util",
+ "url",
+]
+
+[[package]]
+name = "ts_keys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374f9107b36c5d9d41cb959ae2ad929a899be50d78739a0b6ed22ea7c5e39849"
+dependencies = [
+ "crypto_box",
+ "serde",
+ "thiserror 2.0.20",
+ "x25519-dalek",
+ "zerocopy",
+ "zeroize",
+]
+
+[[package]]
+name = "ts_netcheck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9914f88d06d8fe1f57a440e6c83a8425d8d1ef8faa5e760745894a33a083425b"
+dependencies = [
+ "bytes",
+ "dashmap",
+ "stun-rs",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "ts_control",
+ "ts_derp",
+ "ts_http_util",
+ "url",
+]
+
+[[package]]
+name = "ts_netmon"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "716d439ad4af89a4c5b8368e08cc52045d5cccc6784f347a629228ef6a8b958f"
+dependencies = [
+ "cfg-if 1.0.4",
+ "flume",
+ "futures-util",
+ "ipnet",
+ "nix 0.31.3",
+ "pin-project-lite",
+ "rtnetlink",
+ "smallvec",
+ "socket2",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "ts_netstack_smoltcp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b484bf448c728ae2c3d7f5b4e1b0b1a8c88a458659ca43dc4778e58efe86d3d"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "tokio",
+ "tracing",
+ "ts_netstack_smoltcp_core",
+ "ts_netstack_smoltcp_socket",
+]
+
+[[package]]
+name = "ts_netstack_smoltcp_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eccc25ea3f18e5ed247529afa6794ec4203e4dd0783dfa54f580fbc87587ab4"
+dependencies = [
+ "bytes",
+ "flume",
+ "heapless",
+ "smoltcp",
+ "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
+name = "ts_netstack_smoltcp_socket"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afaa4deb85447ca431bbd6dd7443ec4526fb3c8c6a92461bac5d22cc5b840161"
+dependencies = [
+ "bytes",
+ "tokio",
+ "tracing",
+ "ts_netstack_smoltcp_core",
+]
+
+[[package]]
+name = "ts_nodecapability"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "564be200f8f6dd1e8d6acb865a54430c3b76dff958de7ada55f5414d542c3313"
+dependencies = [
+ "cfg-if 1.0.4",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ts_noise"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112643c4c919c3786f52af85fb3300a42b9699270c9ecd6e52aff620ebb37c9a"
+dependencies = [
+ "aead",
+ "blake2",
+ "chacha20poly1305",
+ "hkdf",
+ "itertools 0.14.0",
+ "ts_keys",
+ "x25519-dalek",
+ "zerocopy",
+ "zeroize",
+]
+
+[[package]]
+name = "ts_overlay_router"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bddee3a4d2072b2c21b2b85762c4f917c96b4ead404e60a86c93dee5ad3bb1e"
+dependencies = [
+ "itertools 0.14.0",
+ "tracing",
+ "ts_bart",
+ "ts_packet",
+ "ts_transport",
+]
+
+[[package]]
+name = "ts_packet"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765444bb1b698fbb16df5aceb036ee5859d67425ecc70f9fcc1b15ac6e612e81"
+dependencies = [
+ "bytes",
+ "crypto_box",
+ "stable_deref_trait",
+ "ts_hexdump",
+ "yoke",
+]
+
+[[package]]
+name = "ts_packetfilter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53eae69f0eb1ab1fee555669cb637a54e5086e90ec89456481d64ffeadc24634"
+dependencies = [
+ "hashbrown 0.17.1",
+ "ipnet",
+ "static_assertions",
+ "tracing",
+]
+
+[[package]]
+name = "ts_packetfilter_serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db575d1b453206bd6a391eb2c69cecb259826f9801a62657554b33f390bb91e"
+dependencies = [
+ "ipnet",
+ "nom 8.0.0",
+ "serde",
+ "serde_json",
+ "ts_nodecapability",
+ "ts_peercapability",
+]
+
+[[package]]
+name = "ts_packetfilter_state"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b694bbbcca9ada2d7293aeee51460644cf9e85ecdba8f6db6cad110d05b7ff82"
+dependencies = [
+ "ts_packetfilter",
+ "ts_packetfilter_serde",
+]
+
+[[package]]
+name = "ts_peercapability"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a10acc4f4b94891294c38cdde93f99f36639984d4890c7d2dd27969015c834d"
+dependencies = [
+ "serde",
+ "url",
+]
+
+[[package]]
+name = "ts_runtime"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f3e61236a08716aaf822e18fd4e2f1309f96ef59a36e7e69b6ba3883423977"
+dependencies = [
+ "bytes",
+ "futures",
+ "futures-util",
+ "ipnet",
+ "itertools 0.14.0",
+ "kameo",
+ "kameo_actors",
+ "rand 0.10.2",
+ "smallvec",
+ "smol_str",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "ts_bart",
+ "ts_bart_packetfilter",
+ "ts_control",
+ "ts_dataplane",
+ "ts_derp",
+ "ts_disco_protocol",
+ "ts_hexdump",
+ "ts_keys",
+ "ts_netcheck",
+ "ts_netmon",
+ "ts_netstack_smoltcp",
+ "ts_overlay_router",
+ "ts_packet",
+ "ts_packetfilter",
+ "ts_packetfilter_state",
+ "ts_transport",
+ "ts_tunnel",
+ "url",
+ "yoke",
+ "zerocopy",
+]
+
+[[package]]
+name = "ts_time"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390585318ae3a89c6e9147dc88efba0ec598c5b160d71973b7caadad3861df08"
+
+[[package]]
+name = "ts_tls_util"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed822ccf5117feb72d06aee1277e7efbeeb4f9b74f14fa1e2e2e4c53bcbd5f41"
+dependencies = [
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ts_transport"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af54d6d3737550d01cae33cbe2fd407ed522992fad0eec7c218f07e2aeb0925"
+dependencies = [
+ "dyn-eq",
+ "dyn-hash",
+ "smallbox",
+ "ts_hexdump",
+ "ts_keys",
+ "ts_packet",
+]
+
+[[package]]
+name = "ts_tunnel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b499248cd70449a8d2a34b65aee776b2097bdf16234003b669f6c76245e1e"
+dependencies = [
+ "aead",
+ "blake2",
+ "chacha20poly1305",
+ "itertools 0.14.0",
+ "rand 0.10.2",
+ "tracing",
+ "ts_keys",
+ "ts_noise",
+ "ts_packet",
+ "ts_time",
+ "zerocopy",
+]
+
+[[package]]
+name = "ts_underlay_router"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0456aa35525eb9b6020189f8f338a31a3f368b36044ef2547adac8b211c19295"
+dependencies = [
+ "ts_packet",
+ "ts_transport",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6002,6 +7443,15 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-parse"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06ff81122fcbf4df4c1660b15f7e3336058e7aec14437c9f85c6b31a0f279b9"
+dependencies = [
+ "regex-lite",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -6079,6 +7529,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -6883,6 +8343,18 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+ "zeroize",
+]
 
 [[package]]
 name = "xattr"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,6 +10,12 @@ description = "Agentic terminal facade for open-source and open-weight coding mo
 [lints]
 workspace = true
 
+[features]
+default = []
+# Embed a Tailscale node via official tailscale-rs. Off by default; without it
+# `codewhale web --tailscale` still publishes via the Tailscale CLI.
+tailscale = ["codewhale-tui/tailscale"]
+
 [[bin]]
 name = "codewhale"
 path = "src/main.rs"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -368,6 +368,7 @@ Forwarded serve options:
       --http                Start runtime HTTP/SSE API server
       --mobile              Start runtime HTTP/SSE API server with the mobile control page
       --web                 Start the embedded loopback-only browser client
+      --tailscale           Publish --web on this machine's Tailscale tailnet
       --qr                  Show a QR code for the mobile URL (requires --mobile)
       --acp                 Start ACP server over stdio for editor clients
       --host <HOST>         Bind host (default 127.0.0.1; --mobile defaults to 0.0.0.0)
@@ -638,6 +639,12 @@ struct WebArgs {
     /// Loopback port for the local Runtime API and embedded client.
     #[arg(long, default_value_t = 7878)]
     port: u16,
+    /// Publish the loopback web UI on this machine's Tailscale tailnet.
+    /// Prefers an embedded tsnet node (`codewhale.<tailnet>.ts.net`) when
+    /// built with `--features tailscale`; otherwise uses `tailscale serve`.
+    /// The HTTP listener stays on 127.0.0.1. Not Funnel and not a public tunnel.
+    #[arg(long, default_value_t = false)]
+    tailscale: bool,
 }
 
 #[derive(Debug, Args)]
@@ -4671,12 +4678,16 @@ fn app_server_serve_passthrough(args: &AppServerArgs) -> Vec<String> {
 }
 
 fn web_serve_passthrough(args: &WebArgs) -> Vec<String> {
-    vec![
+    let mut forwarded = vec![
         "serve".to_string(),
         "--web".to_string(),
         "--port".to_string(),
         args.port.to_string(),
-    ]
+    ];
+    if args.tailscale {
+        forwarded.push("--tailscale".to_string());
+    }
+    forwarded
 }
 
 fn app_server_token_from_env() -> Option<String> {
@@ -6169,6 +6180,7 @@ verbosity = "project-imported"
             other => panic!("expected web command, got {other:?}"),
         };
         assert_eq!(args.port, 9091);
+        assert!(!args.tailscale);
         let forwarded = web_serve_passthrough(&args);
         assert_eq!(forwarded, ["serve", "--web", "--port", "9091"]);
         assert!(!forwarded.iter().any(|arg| arg.contains("token")));
@@ -6179,18 +6191,45 @@ verbosity = "project-imported"
         let cli = parse_ok(&["codewhale", "web"]);
         assert!(matches!(
             cli.command,
-            Some(Commands::Web(WebArgs { port: 7878 }))
+            Some(Commands::Web(WebArgs {
+                port: 7878,
+                tailscale: false
+            }))
         ));
         let help = help_for(&["codewhale", "web", "--help"]);
         assert!(help.contains("--port"));
+        assert!(help.contains("--tailscale"));
         assert!(help.contains("one-time loopback bootstrap"));
         assert!(!help.contains("--auth-token"));
     }
 
     #[test]
+    fn web_tailscale_forwards_without_exposing_a_host_bind() {
+        let cli = parse_ok(&["codewhale", "web", "--tailscale", "--port", "8788"]);
+        let args = match cli.command {
+            Some(Commands::Web(args)) => args,
+            other => panic!("expected web command, got {other:?}"),
+        };
+        assert!(args.tailscale);
+        let forwarded = web_serve_passthrough(&args);
+        assert_eq!(
+            forwarded,
+            ["serve", "--web", "--port", "8788", "--tailscale"]
+        );
+        assert!(!forwarded.iter().any(|arg| arg == "--host"));
+    }
+
+    #[test]
     fn serve_help_documents_forwarded_runtime_modes() {
         let help = help_for(&["codewhale", "serve", "--help"]);
-        for flag in ["--http", "--mobile", "--web", "--mcp", "--acp"] {
+        for flag in [
+            "--http",
+            "--mobile",
+            "--web",
+            "--tailscale",
+            "--mcp",
+            "--acp",
+        ] {
             assert!(
                 help.contains(flag),
                 "serve help should document forwarded flag {flag}; help was:\n{help}"

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `codewhale web --tailscale` publishes the loopback browser client on the
+  current Tailscale tailnet. Default `codewhale web` stays loopback-only. The
+  preferred path is an embedded tsnet node from the official `tailscale` 0.5.0
+  crate (`Device::tcp_listen` + `axum::Listener`, hostname `codewhale`) when
+  built with `--features tailscale` and `CODEWHALE_TSNET_AUTHKEY`/`TS_AUTHKEY`.
+  Official 0.5.0 cannot mint HTTPS certificates, so the embedded listener is
+  HTTP :80 over WireGuard (`http://codewhale.<tailnet>.ts.net`). When embed
+  cannot auth or is not compiled, the process falls back to PR #5628's
+  `tailscale serve --bg --https=443 localhost:<port>` design (browser-trusted
+  TLS on the machine MagicDNS name). Not Funnel. Stopping the process turns
+  off only HTTPS:443 for the CLI fallback (not `serve reset`).
+
 - Added the managed Chat relay: account-owned Chat commands now execute on the
   native runtime thread engine through a new `runtime_chat_relay` module
   instead of a second execution path. Each Chat thread is a dedicated,

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -18,6 +18,9 @@ web = ["dep:schemaui", "schemaui/web", "json", "toml"]
 json = ["schemaui/json"]
 toml = ["schemaui/toml"]
 long-running-tests = []
+# Official tailscale-rs tsnet. Off by default so ordinary builds stay lean.
+# `codewhale web --tailscale` still works without it via the CLI serve fallback.
+tailscale = ["dep:tailscale"]
 
 [lib]
 name = "codewhale_tui"
@@ -132,6 +135,10 @@ arboard = "3.4"
 
 [target.'cfg(not(target_env = "ohos"))'.dependencies]
 portable-pty = "0.9"
+
+# Official tsnet (0.5.0): Linux x86_64/ARM64 and macOS ARM64 only.
+[target.'cfg(any(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")), all(target_os = "macos", target_arch = "aarch64")))'.dependencies]
+tailscale = { version = "0.5.0", optional = true, default-features = false, features = ["axum"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.3"

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1270,6 +1270,12 @@ struct ServeArgs {
     /// Disable runtime API auth when no token is configured. Only use on a trusted loopback.
     #[arg(long = "insecure")]
     insecure_no_auth: bool,
+    /// Publish `--web` on this machine's Tailscale tailnet.
+    /// Prefers an embedded tsnet node when built with `--features tailscale`;
+    /// otherwise uses `tailscale serve`. Loopback stays on 127.0.0.1.
+    /// Not Funnel; not a public tunnel.
+    #[arg(long, default_value_t = false, requires = "web")]
+    tailscale: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2338,6 +2344,7 @@ async fn run_async_main_dispatch(
                             mobile: args.mobile,
                             web: args.web,
                             show_qr: args.qr,
+                            tailscale: args.tailscale,
                             config_path: cli.config.clone(),
                             config_profile,
                         },
@@ -12599,6 +12606,34 @@ mod serve_bind_host_tests {
                 mobile_rebound_to_lan: false,
             }
         );
+    }
+
+    #[test]
+    fn tailscale_requires_web_on_serve() {
+        use clap::Parser;
+        let err = Cli::try_parse_from(["codewhale", "serve", "--tailscale"])
+            .expect_err("--tailscale without --web must fail");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("--web") || rendered.contains("tailscale"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn tailscale_with_web_parses_on_serve() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["codewhale", "serve", "--web", "--tailscale"])
+            .expect("serve --web --tailscale should parse");
+        match cli.command {
+            Some(Commands::Serve(args)) => {
+                assert!(args.web);
+                assert!(args.tailscale);
+                assert!(!args.http);
+                assert!(!args.mobile);
+            }
+            other => panic!("expected serve, got {other:?}"),
+        }
     }
 }
 

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -89,6 +89,7 @@ use codewhale_protocol::fleet::{
 
 mod auth;
 mod sessions;
+mod tailscale;
 mod web;
 mod workspace;
 #[cfg(test)]
@@ -172,6 +173,9 @@ pub struct RuntimeApiState {
     bind_port: u16,
     mobile_enabled: bool,
     web: Option<web::RuntimeWebState>,
+    /// Extra browser origins allowed for cookie-authenticated web requests.
+    /// Used when `--tailscale` publishes the loopback client on MagicDNS.
+    web_public_origins: Vec<String>,
     /// Executable used by Runtime API-owned Fleet manager loops. Stored on
     /// state so tests and embedded callers can provide a hermetic worker.
     fleet_codewhale_binary: String,
@@ -229,6 +233,11 @@ pub struct RuntimeApiOptions {
     pub web: bool,
     /// Show a QR code for the mobile URL in the terminal.
     pub show_qr: bool,
+    /// After binding loopback `--web`, publish it on the current Tailscale
+    /// tailnet. Prefers an embedded tsnet node when the `tailscale` Cargo
+    /// feature is enabled; otherwise (and when embed cannot auth) uses
+    /// `tailscale serve --bg --https=443 localhost:<port>` (PR #5628).
+    pub tailscale: bool,
     /// Original `--config` path used to load the initial config. When
     /// `Some`, GUI-driven config reloads and persistence target this file
     /// instead of the default discovery path.
@@ -249,6 +258,7 @@ impl Default for RuntimeApiOptions {
             mobile: false,
             web: false,
             show_qr: false,
+            tailscale: false,
             config_path: None,
             config_profile: None,
         }
@@ -829,13 +839,7 @@ fn open_runtime_threads_for_server(
     Ok((manager, workshop_activation))
 }
 
-/// Start the runtime API server.
-pub async fn run_http_server(
-    config: Config,
-    workspace: PathBuf,
-    plugin_discovery: Arc<crate::plugins::PluginDiscoveryContext>,
-    options: RuntimeApiOptions,
-) -> Result<()> {
+pub(crate) fn validate_runtime_api_options(options: &RuntimeApiOptions) -> Result<()> {
     if options.port == 0 {
         bail!("Port must be > 0");
     }
@@ -845,6 +849,22 @@ pub async fn run_http_server(
     if options.web && options.insecure_no_auth {
         bail!("Codewhale web requires Runtime authentication; remove --insecure");
     }
+    if options.tailscale && !options.web {
+        bail!(
+            "--tailscale requires --web; it publishes the loopback browser client, not a LAN bind"
+        );
+    }
+    Ok(())
+}
+
+/// Start the runtime API server.
+pub async fn run_http_server(
+    config: Config,
+    workspace: PathBuf,
+    plugin_discovery: Arc<crate::plugins::PluginDiscoveryContext>,
+    options: RuntimeApiOptions,
+) -> Result<()> {
+    validate_runtime_api_options(&options)?;
 
     let task_default_model = config.default_model();
     let task_cfg = TaskManagerConfig::from_runtime(
@@ -892,6 +912,16 @@ pub async fn run_http_server(
     } else {
         (None, None)
     };
+    let tailscale_publish = if options.tailscale {
+        Some(tailscale::plan_tailscale_front().await?)
+    } else {
+        None
+    };
+    let web_public_origins = tailscale_publish
+        .as_ref()
+        .map(|publish| vec![publish.front().public_origin.clone()])
+        .unwrap_or_default();
+    let mut tailscale_guard = tailscale::TailscaleGuard::new();
     let skill_state = SkillStateStore::load_default()
         .context("load persistent Skill activation state for Runtime API")?;
     let sub_agent_manager = runtime_api_sub_agent_manager(&workspace, options.workers);
@@ -901,7 +931,11 @@ pub async fn run_http_server(
         plugin_discovery,
         task_manager,
         runtime_threads,
-        cors_origins: options.cors_origins.clone(),
+        cors_origins: {
+            let mut origins = options.cors_origins.clone();
+            origins.extend(web_public_origins.iter().cloned());
+            origins
+        },
         sessions_dir,
         config_path: options.config_path.clone(),
         config_profile: options.config_profile.clone(),
@@ -914,6 +948,7 @@ pub async fn run_http_server(
         bind_port: options.port,
         mobile_enabled: options.mobile,
         web,
+        web_public_origins: web_public_origins.clone(),
         fleet_codewhale_binary: configured_codewhale_binary(),
         mcp_pool: Arc::new(Mutex::new(None)),
         #[cfg(test)]
@@ -946,9 +981,39 @@ pub async fn run_http_server(
             options.show_qr,
         );
     }
+    if let Some(publish) = tailscale_publish {
+        let front = publish.front().clone();
+        match publish {
+            tailscale::TailscalePublish::Cli(_) => {
+                tailscale::publish_loopback_web(bound_addr.port())?;
+                tailscale_guard.arm_cli();
+            }
+            tailscale::TailscalePublish::Embedded(node) => {
+                let handle = node.spawn_http80(app.clone()).await?;
+                tailscale_guard.arm_embedded(handle);
+            }
+        }
+        let kind = match front.kind {
+            tailscale::TailscaleFrontKind::EmbeddedHttp => "embedded tsnet HTTP",
+            tailscale::TailscaleFrontKind::CliServeHttps => "tailscale CLI serve HTTPS",
+        };
+        println!(
+            "Codewhale web advertised on Tailscale at {} (MagicDNS {}, {kind})",
+            front.public_origin, front.magic_dns
+        );
+    }
     if let Some(bootstrap) = web_bootstrap {
         println!("Codewhale web enabled at http://{bound_addr}/");
-        let bootstrap_url = web::bootstrap_url(bound_addr, &bootstrap);
+        let bootstrap_url = web_public_origins
+            .first()
+            .map(|origin| web::bootstrap_url_for_origin(origin, &bootstrap))
+            .unwrap_or_else(|| web::bootstrap_url(bound_addr, &bootstrap));
+        if !web_public_origins.is_empty() {
+            println!(
+                "Codewhale web tailnet URL: {}/",
+                web_public_origins[0].trim_end_matches('/')
+            );
+        }
         println!(
             "Codewhale web bootstrap (single-use, expires in {} min): {bootstrap_url}",
             web::BOOTSTRAP_TTL.as_secs() / 60
@@ -985,6 +1050,7 @@ pub async fn run_http_server(
     .map_err(|e| anyhow!("Runtime API server error: {e}"));
     scheduler_cancel.cancel();
     scheduler_handle.abort();
+    drop(tailscale_guard);
     serve_result
 }
 

--- a/crates/tui/src/runtime_api/auth.rs
+++ b/crates/tui/src/runtime_api/auth.rs
@@ -141,20 +141,49 @@ fn web_cookie_request_is_same_origin(req: &Request, state: &RuntimeApiState) -> 
         return false;
     }
 
-    let expected_origin = if state.bind_port == 80 {
-        format!("http://{}", state.bind_host)
-    } else {
-        format!("http://{}:{}", state.bind_host, state.bind_port)
-    };
     if let Some(origin) = req
         .headers()
         .get(header::ORIGIN)
         .and_then(|value| value.to_str().ok())
     {
-        return origin == expected_origin;
+        return web_cookie_origin_is_allowed(
+            origin,
+            &state.bind_host,
+            state.bind_port,
+            &state.web_public_origins,
+        );
     }
 
     matches!(*req.method(), Method::GET | Method::HEAD | Method::OPTIONS)
+}
+
+pub(super) fn web_loopback_origin(bind_host: &str, bind_port: u16) -> String {
+    if bind_port == 80 {
+        format!("http://{bind_host}")
+    } else {
+        format!("http://{bind_host}:{bind_port}")
+    }
+}
+
+pub(super) fn web_cookie_origin_is_allowed(
+    origin: &str,
+    bind_host: &str,
+    bind_port: u16,
+    public_origins: &[String],
+) -> bool {
+    origin == web_loopback_origin(bind_host, bind_port)
+        || public_origins.iter().any(|allowed| allowed == origin)
+}
+
+pub(super) fn host_matches_public_origin(host: &str, public_origins: &[String]) -> bool {
+    let request_host = host.split(':').next().unwrap_or(host);
+    public_origins.iter().any(|origin| {
+        origin
+            .split_once("://")
+            .map(|(_, rest)| rest.split('/').next().unwrap_or(rest))
+            .map(|origin_host| origin_host.split(':').next().unwrap_or(origin_host))
+            .is_some_and(|origin_host| origin_host.eq_ignore_ascii_case(request_host))
+    })
 }
 
 fn runtime_token_required_response() -> Response {
@@ -207,4 +236,53 @@ fn percent_decode_query_component(value: &str) -> Option<String> {
         }
     }
     String::from_utf8(decoded).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cookie_origin_allows_loopback_and_explicit_tailnet() {
+        let tailnet = "https://codewhale.tailnet.ts.net".to_string();
+        assert!(web_cookie_origin_is_allowed(
+            "http://127.0.0.1:7878",
+            "127.0.0.1",
+            7878,
+            std::slice::from_ref(&tailnet),
+        ));
+        assert!(web_cookie_origin_is_allowed(
+            &tailnet,
+            "127.0.0.1",
+            7878,
+            std::slice::from_ref(&tailnet),
+        ));
+        assert!(web_cookie_origin_is_allowed(
+            "http://codewhale.tailnet.ts.net",
+            "127.0.0.1",
+            7878,
+            &["http://codewhale.tailnet.ts.net".to_string()],
+        ));
+        assert!(!web_cookie_origin_is_allowed(
+            "https://evil.example",
+            "127.0.0.1",
+            7878,
+            std::slice::from_ref(&tailnet),
+        ));
+    }
+
+    #[test]
+    fn public_origin_host_match_is_host_only() {
+        let origins = ["https://codewhale.tailnet.ts.net".to_string()];
+        assert!(host_matches_public_origin(
+            "codewhale.tailnet.ts.net",
+            &origins
+        ));
+        assert!(host_matches_public_origin(
+            "codewhale.tailnet.ts.net:443",
+            &origins
+        ));
+        assert!(!host_matches_public_origin("127.0.0.1:7878", &origins));
+        assert!(!host_matches_public_origin("evil.example", &origins));
+    }
 }

--- a/crates/tui/src/runtime_api/tailscale.rs
+++ b/crates/tui/src/runtime_api/tailscale.rs
@@ -197,7 +197,9 @@ enum TailscaleGuardInner {
     Inactive,
     CliServe,
     #[allow(dead_code)]
-    Embedded { serve: tokio::task::JoinHandle<()> },
+    Embedded {
+        serve: tokio::task::JoinHandle<()>,
+    },
 }
 
 impl TailscaleGuard {
@@ -362,9 +364,9 @@ fn run_tailscale_output(args: &[impl AsRef<std::ffi::OsStr>]) -> Result<std::pro
 ))]
 mod embed {
     use super::*;
+    use ::tailscale::{AuthState, Config, Device};
     use anyhow::Context;
     use std::sync::Arc;
-    use ::tailscale::{AuthState, Config, Device};
 
     const EXPERIMENT_ENV: &str = "TS_RS_EXPERIMENT";
     const EXPERIMENT_VALUE: &str = "this_is_unstable_software";
@@ -403,9 +405,10 @@ mod embed {
             .self_node()
             .await
             .context("read embedded tsnet self node")?;
-        let magic_dns = node.fqdn_opt(false).filter(|dns| dns.contains('.')).unwrap_or_else(|| {
-            node.fqdn(false)
-        });
+        let magic_dns = node
+            .fqdn_opt(false)
+            .filter(|dns| dns.contains('.'))
+            .unwrap_or_else(|| node.fqdn(false));
         let magic_dns = magic_dns.trim_end_matches('.').to_string();
         if !magic_dns.contains('.') {
             bail!("embedded tsnet FQDN looks incomplete: {magic_dns}");

--- a/crates/tui/src/runtime_api/tailscale.rs
+++ b/crates/tui/src/runtime_api/tailscale.rs
@@ -1,0 +1,569 @@
+//! Tailnet front for the loopback web client.
+//!
+//! `codewhale web --tailscale` is opt-in. Default `codewhale web` stays
+//! loopback-only. This module prefers an embedded Tailscale node from the
+//! official [`tailscale`](https://docs.rs/tailscale/0.5.0/tailscale/) 0.5.0
+//! crate when the `tailscale` Cargo feature is enabled; otherwise (and when
+//! embed cannot auth) it falls back to the Tailscale CLI
+//! `tailscale serve --bg --https=443 localhost:<port>` design from PR #5628.
+//!
+//! ## Crate choice
+//!
+//! Official `tailscale` 0.5.0 **can listen**: `Device::tcp_listen` plus
+//! `tailscale::axum::Listener` wrapping `netstack::TcpListener` for
+//! `axum::serve`. `Config.requested_hostname` / `requested_tags` let us ask
+//! for `codewhale.<tailnet>.ts.net` via `NodeInfo::fqdn`. That is why this
+//! path uses the official crate rather than `geiserx_tailscale`.
+//!
+//! Official 0.5.0 **cannot mint HTTPS certificates**. The crate README lists
+//! "HTTPS Certificates", "MagicDNS", and "Tailscale Serve" as unsupported.
+//! Overlay traffic is still WireGuard-encrypted; browsers talking to the
+//! embedded listener see HTTP on port 80. Browser-trusted TLS is the CLI
+//! serve fallback (`https://<machine>.<tailnet>.ts.net`).
+//!
+//! Auth for embed: `CODEWHALE_TSNET_AUTHKEY` or `TS_AUTHKEY`. The crate also
+//! requires `TS_RS_EXPERIMENT=this_is_unstable_software`. Platform support
+//! in 0.5.0 is Linux (x86_64/ARM64) and macOS ARM64.
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use std::process::Command;
+
+/// Hostname advertised for an embedded tsnet node.
+#[allow(dead_code)]
+pub(crate) const DEFAULT_TSNET_HOSTNAME: &str = "codewhale";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TailscaleFrontKind {
+    /// Embedded `Device::tcp_listen` + axum on tailnet :80 (no crate certs).
+    #[allow(dead_code)]
+    EmbeddedHttp,
+    /// PR #5628 precursor: CLI `tailscale serve` HTTPS:443 → loopback.
+    CliServeHttps,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TailscaleWebFront {
+    pub public_origin: String,
+    pub magic_dns: String,
+    pub kind: TailscaleFrontKind,
+}
+
+pub(crate) fn magic_dns_from_status_json(json: &str) -> Result<String> {
+    let status: Value =
+        serde_json::from_str(json).context("tailscale status --json was not valid JSON")?;
+    let backend = status
+        .get("BackendState")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    if !backend.eq_ignore_ascii_case("Running") {
+        bail!("tailscale is not connected (BackendState={backend}); run `tailscale up`");
+    }
+    let dns = status
+        .pointer("/Self/DNSName")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .context("tailscale status JSON missing Self.DNSName; is MagicDNS enabled?")?;
+    let dns = dns.trim_end_matches('.');
+    if !dns.contains('.') {
+        bail!("tailscale MagicDNS name looks incomplete: {dns}");
+    }
+    Ok(dns.to_string())
+}
+
+pub(crate) fn public_origin_from_magic_dns(dns: &str, kind: TailscaleFrontKind) -> String {
+    let host = dns.trim_end_matches('.');
+    match kind {
+        TailscaleFrontKind::EmbeddedHttp => format!("http://{host}"),
+        TailscaleFrontKind::CliServeHttps => format!("https://{host}"),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn magic_dns_from_hostname_and_tailnet(hostname: &str, tailnet: &str) -> String {
+    let hostname = hostname.trim_end_matches('.');
+    let tailnet = tailnet.trim_end_matches('.');
+    format!("{hostname}.{tailnet}")
+}
+
+pub(crate) fn serve_https_args(port: u16) -> Vec<String> {
+    vec![
+        "serve".to_string(),
+        "--bg".to_string(),
+        "--https=443".to_string(),
+        format!("localhost:{port}"),
+    ]
+}
+
+pub(crate) fn withdraw_https_args() -> Vec<String> {
+    vec![
+        "serve".to_string(),
+        "--https=443".to_string(),
+        "off".to_string(),
+    ]
+}
+
+pub(crate) fn discover_cli_web_front() -> Result<TailscaleWebFront> {
+    let status = run_tailscale(&["status", "--json"])?;
+    let magic_dns = magic_dns_from_status_json(&status)?;
+    Ok(TailscaleWebFront {
+        public_origin: public_origin_from_magic_dns(&magic_dns, TailscaleFrontKind::CliServeHttps),
+        magic_dns,
+        kind: TailscaleFrontKind::CliServeHttps,
+    })
+}
+
+pub(crate) fn publish_loopback_web(port: u16) -> Result<()> {
+    let args = serve_https_args(port);
+    let output = run_tailscale_output(&args)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        bail!(
+            "tailscale serve failed (status {}): {}{}",
+            output.status,
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", stdout.trim())
+            }
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn withdraw_https_443() {
+    let args = withdraw_https_args();
+    let _ = Command::new("tailscale").args(&args).status();
+}
+
+pub(crate) fn embedded_tsnet_compiled() -> bool {
+    cfg!(all(
+        feature = "tailscale",
+        any(
+            all(
+                target_os = "linux",
+                any(target_arch = "x86_64", target_arch = "aarch64")
+            ),
+            all(target_os = "macos", target_arch = "aarch64")
+        )
+    ))
+}
+
+pub(crate) fn embed_disabled_by_env() -> bool {
+    std::env::var_os("CODEWHALE_TSNET_DISABLE").is_some_and(|value| value != "0")
+}
+
+/// Plan the tailnet front. Prefers embed when compiled and not disabled;
+/// falls back to CLI serve (PR #5628) when embed cannot auth or is absent.
+pub(crate) async fn plan_tailscale_front() -> Result<TailscalePublish> {
+    if embedded_tsnet_compiled() && !embed_disabled_by_env() {
+        match try_start_embedded_tsnet().await {
+            Ok(publish) => return Ok(publish),
+            Err(err) => {
+                eprintln!(
+                    "warning: embedded Tailscale node unavailable ({err}); falling back to `tailscale serve`"
+                );
+            }
+        }
+    }
+    Ok(TailscalePublish::Cli(discover_cli_web_front()?))
+}
+
+pub(crate) enum TailscalePublish {
+    Cli(TailscaleWebFront),
+    /// Constructed when the `tailscale` feature is compiled in on a supported
+    /// target. Default builds keep the CLI-serve fallback only.
+    #[allow(dead_code)]
+    Embedded(EmbeddedTsnet),
+}
+
+impl TailscalePublish {
+    pub(crate) fn front(&self) -> &TailscaleWebFront {
+        match self {
+            Self::Cli(front) => front,
+            Self::Embedded(node) => &node.front,
+        }
+    }
+}
+
+pub(crate) struct TailscaleGuard {
+    inner: TailscaleGuardInner,
+}
+
+enum TailscaleGuardInner {
+    Inactive,
+    CliServe,
+    #[allow(dead_code)]
+    Embedded { serve: tokio::task::JoinHandle<()> },
+}
+
+impl TailscaleGuard {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: TailscaleGuardInner::Inactive,
+        }
+    }
+
+    pub(crate) fn arm_cli(&mut self) {
+        self.inner = TailscaleGuardInner::CliServe;
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn arm_embedded(&mut self, serve: tokio::task::JoinHandle<()>) {
+        self.inner = TailscaleGuardInner::Embedded { serve };
+    }
+}
+
+impl Drop for TailscaleGuard {
+    fn drop(&mut self) {
+        match &mut self.inner {
+            TailscaleGuardInner::Inactive => {}
+            TailscaleGuardInner::CliServe => withdraw_https_443(),
+            TailscaleGuardInner::Embedded { serve } => serve.abort(),
+        }
+    }
+}
+
+async fn try_start_embedded_tsnet() -> Result<TailscalePublish> {
+    try_start_embedded_tsnet_impl().await
+}
+
+#[cfg(all(
+    feature = "tailscale",
+    any(
+        all(
+            target_os = "linux",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+async fn try_start_embedded_tsnet_impl() -> Result<TailscalePublish> {
+    embed::start().await.map(TailscalePublish::Embedded)
+}
+
+#[cfg(not(all(
+    feature = "tailscale",
+    any(
+        all(
+            target_os = "linux",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+)))]
+async fn try_start_embedded_tsnet_impl() -> Result<TailscalePublish> {
+    bail!(
+        "embedded tsnet is not compiled in this binary (build with --features tailscale on Linux or macOS ARM64)"
+    );
+}
+
+#[allow(dead_code)]
+pub(crate) struct EmbeddedTsnet {
+    pub front: TailscaleWebFront,
+    #[cfg(all(
+        feature = "tailscale",
+        any(
+            all(
+                target_os = "linux",
+                any(target_arch = "x86_64", target_arch = "aarch64")
+            ),
+            all(target_os = "macos", target_arch = "aarch64")
+        )
+    ))]
+    device: std::sync::Arc<::tailscale::Device>,
+}
+
+impl EmbeddedTsnet {
+    /// Serve the Runtime router on tailnet HTTP :80.
+    ///
+    /// Official 0.5.0 has no certificate API, so this is HTTP over WireGuard,
+    /// not browser-trusted HTTPS.
+    #[allow(dead_code)]
+    pub(crate) async fn spawn_http80(
+        &self,
+        app: axum::Router,
+    ) -> Result<tokio::task::JoinHandle<()>> {
+        #[cfg(all(
+            feature = "tailscale",
+            any(
+                all(
+                    target_os = "linux",
+                    any(target_arch = "x86_64", target_arch = "aarch64")
+                ),
+                all(target_os = "macos", target_arch = "aarch64")
+            )
+        ))]
+        {
+            let ipv4 = self
+                .device
+                .ipv4_addr()
+                .await
+                .context("embedded tsnet has no tailnet IPv4 address yet")?;
+            let listener = self
+                .device
+                .tcp_listen((ipv4, 80).into())
+                .await
+                .context("embedded tsnet tcp_listen(:80) failed")?;
+            let listener: ::tailscale::axum::Listener = listener.into();
+            Ok(tokio::spawn(async move {
+                let _ = axum::serve(listener, app.into_make_service()).await;
+            }))
+        }
+        #[cfg(not(all(
+            feature = "tailscale",
+            any(
+                all(
+                    target_os = "linux",
+                    any(target_arch = "x86_64", target_arch = "aarch64")
+                ),
+                all(target_os = "macos", target_arch = "aarch64")
+            )
+        )))]
+        {
+            let _ = (self, app);
+            bail!("embedded tsnet is not compiled in this binary");
+        }
+    }
+}
+
+fn run_tailscale(args: &[&str]) -> Result<String> {
+    let output = run_tailscale_output(args)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "tailscale {} failed: {}",
+            args.first().copied().unwrap_or("command"),
+            stderr.trim()
+        );
+    }
+    String::from_utf8(output.stdout).context("tailscale stdout was not UTF-8")
+}
+
+fn run_tailscale_output(args: &[impl AsRef<std::ffi::OsStr>]) -> Result<std::process::Output> {
+    Command::new("tailscale")
+        .args(args)
+        .output()
+        .context("tailscale CLI not found; install Tailscale and confirm `tailscale status` works")
+}
+
+#[cfg(all(
+    feature = "tailscale",
+    any(
+        all(
+            target_os = "linux",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+mod embed {
+    use super::*;
+    use anyhow::Context;
+    use std::sync::Arc;
+    use ::tailscale::{AuthState, Config, Device};
+
+    const EXPERIMENT_ENV: &str = "TS_RS_EXPERIMENT";
+    const EXPERIMENT_VALUE: &str = "this_is_unstable_software";
+
+    pub(super) async fn start() -> Result<EmbeddedTsnet> {
+        ensure_experiment_env();
+        let key_path = tsnet_key_path()?;
+        if let Some(parent) = key_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create tsnet state dir {}", parent.display()))?;
+        }
+        let mut config = Config::default_with_key_file(&key_path)
+            .await
+            .context("load embedded tsnet key file")?;
+        config.requested_hostname = Some(DEFAULT_TSNET_HOSTNAME.to_string());
+        if let Some(tags) = requested_tags_from_env() {
+            config.requested_tags = tags;
+        }
+        let auth_key = auth_key_from_env();
+        let device = Device::new(&config, auth_key)
+            .await
+            .context("start embedded Tailscale device")?;
+        match device
+            .is_authorized()
+            .await
+            .context("query embedded Tailscale auth state")?
+        {
+            AuthState::Authorized => {}
+            AuthState::NotAuthorized(url) => {
+                bail!(
+                    "embedded Tailscale node is not authorized; open {url} or set CODEWHALE_TSNET_AUTHKEY / TS_AUTHKEY"
+                );
+            }
+        }
+        let node = device
+            .self_node()
+            .await
+            .context("read embedded tsnet self node")?;
+        let magic_dns = node.fqdn_opt(false).filter(|dns| dns.contains('.')).unwrap_or_else(|| {
+            node.fqdn(false)
+        });
+        let magic_dns = magic_dns.trim_end_matches('.').to_string();
+        if !magic_dns.contains('.') {
+            bail!("embedded tsnet FQDN looks incomplete: {magic_dns}");
+        }
+        Ok(EmbeddedTsnet {
+            front: TailscaleWebFront {
+                public_origin: public_origin_from_magic_dns(
+                    &magic_dns,
+                    TailscaleFrontKind::EmbeddedHttp,
+                ),
+                magic_dns,
+                kind: TailscaleFrontKind::EmbeddedHttp,
+            },
+            device: Arc::new(device),
+        })
+    }
+
+    fn ensure_experiment_env() {
+        if std::env::var_os(EXPERIMENT_ENV).is_none() {
+            // SAFETY: process-local gate required by tailscale-rs 0.5.0
+            // until its third-party audit lands. Only set when unset, and
+            // only on the embed path.
+            unsafe {
+                std::env::set_var(EXPERIMENT_ENV, EXPERIMENT_VALUE);
+            }
+        }
+    }
+
+    fn tsnet_key_path() -> Result<std::path::PathBuf> {
+        let home = codewhale_paths::codewhale_home()
+            .ok()
+            .flatten()
+            .context("CODEWHALE_HOME / user home is required for embedded tsnet state")?;
+        Ok(home.join("tsnet").join("keys.json"))
+    }
+
+    fn auth_key_from_env() -> Option<String> {
+        ["CODEWHALE_TSNET_AUTHKEY", "TS_AUTHKEY"]
+            .into_iter()
+            .find_map(|name| {
+                std::env::var(name)
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty())
+            })
+    }
+
+    fn requested_tags_from_env() -> Option<Vec<String>> {
+        std::env::var("CODEWHALE_TSNET_TAGS").ok().map(|raw| {
+            raw.split(',')
+                .map(|tag| tag.trim().to_string())
+                .filter(|tag| !tag.is_empty())
+                .collect()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_api::{RuntimeApiOptions, validate_runtime_api_options};
+
+    #[test]
+    fn reads_magic_dns_and_strips_trailing_dot() {
+        let json = r#"{
+            "BackendState": "Running",
+            "Self": { "DNSName": "codewhale.tailnet.ts.net." }
+        }"#;
+        assert_eq!(
+            magic_dns_from_status_json(json).unwrap(),
+            "codewhale.tailnet.ts.net"
+        );
+        assert_eq!(
+            public_origin_from_magic_dns(
+                "codewhale.tailnet.ts.net.",
+                TailscaleFrontKind::CliServeHttps
+            ),
+            "https://codewhale.tailnet.ts.net"
+        );
+        assert_eq!(
+            public_origin_from_magic_dns(
+                "codewhale.tailnet.ts.net",
+                TailscaleFrontKind::EmbeddedHttp
+            ),
+            "http://codewhale.tailnet.ts.net"
+        );
+    }
+
+    #[test]
+    fn requested_hostname_is_codewhale() {
+        assert_eq!(DEFAULT_TSNET_HOSTNAME, "codewhale");
+        assert_eq!(
+            magic_dns_from_hostname_and_tailnet("codewhale", "tailnet.ts.net."),
+            "codewhale.tailnet.ts.net"
+        );
+    }
+
+    #[test]
+    fn rejects_disconnected_or_incomplete_status() {
+        let stopped = r#"{"BackendState":"Stopped","Self":{"DNSName":"x.tailnet.ts.net."}}"#;
+        let error = magic_dns_from_status_json(stopped).unwrap_err().to_string();
+        assert!(error.contains("not connected"), "{error}");
+
+        let empty = r#"{"BackendState":"Running","Self":{"DNSName":""}}"#;
+        assert!(magic_dns_from_status_json(empty).is_err());
+    }
+
+    #[test]
+    fn serve_mapping_is_https_443_only_and_does_not_reset() {
+        assert_eq!(
+            serve_https_args(7878),
+            ["serve", "--bg", "--https=443", "localhost:7878"]
+        );
+        let withdraw = withdraw_https_args();
+        assert_eq!(withdraw, ["serve", "--https=443", "off"]);
+        assert!(
+            !withdraw.iter().any(|arg| arg.contains("reset")),
+            "withdraw must not wipe other serve config"
+        );
+    }
+
+    #[test]
+    fn default_web_does_not_enable_tailscale() {
+        let options = RuntimeApiOptions::default();
+        assert!(!options.tailscale);
+        assert!(!options.web);
+        validate_runtime_api_options(&options).unwrap();
+    }
+
+    #[test]
+    fn tailscale_without_web_is_rejected() {
+        let err = validate_runtime_api_options(&RuntimeApiOptions {
+            tailscale: true,
+            web: false,
+            ..RuntimeApiOptions::default()
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--tailscale requires --web"), "{err}");
+    }
+
+    #[test]
+    fn tailscale_with_web_passes_option_validation() {
+        validate_runtime_api_options(&RuntimeApiOptions {
+            web: true,
+            tailscale: true,
+            ..RuntimeApiOptions::default()
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn embed_is_absent_from_default_builds() {
+        if cfg!(not(feature = "tailscale")) {
+            assert!(
+                !embedded_tsnet_compiled(),
+                "default builds must not link the tailscale crate"
+            );
+        }
+    }
+}

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -996,6 +996,7 @@ async fn spawn_test_server_with_root_token_mobile_workspace_and_overrides(
         bind_port: addr.port(),
         mobile_enabled,
         web: overrides.web,
+        web_public_origins: Vec::new(),
         fleet_codewhale_binary: overrides
             .fleet_codewhale_binary
             .unwrap_or_else(configured_codewhale_binary),

--- a/crates/tui/src/runtime_api/web.rs
+++ b/crates/tui/src/runtime_api/web.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use axum::body::Body;
-use axum::extract::{ConnectInfo, Path, State};
+use axum::extract::{ConnectInfo, Path, Request, State};
 use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use uuid::Uuid;
@@ -42,7 +42,6 @@ struct BootstrapCapability {
 enum BootstrapError {
     Invalid,
     Expired,
-    NonLoopback,
 }
 
 impl RuntimeWebState {
@@ -68,10 +67,7 @@ impl RuntimeWebState {
         (state, nonce)
     }
 
-    fn consume(&self, nonce: &str, peer_ip: IpAddr) -> Result<String, BootstrapError> {
-        if !peer_ip.is_loopback() {
-            return Err(BootstrapError::NonLoopback);
-        }
+    fn consume(&self, nonce: &str) -> Result<String, BootstrapError> {
         if !valid_bootstrap_nonce(nonce) {
             return Err(BootstrapError::Invalid);
         }
@@ -106,25 +102,52 @@ pub(super) fn bootstrap_url(addr: SocketAddr, nonce: &str) -> String {
     format!("http://{addr}/__codewhale/bootstrap/{nonce}")
 }
 
+pub(super) fn bootstrap_url_for_origin(origin: &str, nonce: &str) -> String {
+    format!(
+        "{}/__codewhale/bootstrap/{nonce}",
+        origin.trim_end_matches('/')
+    )
+}
+
+pub(super) fn bootstrap_peer_is_trusted(
+    peer_ip: Option<IpAddr>,
+    host: &str,
+    public_origins: &[String],
+) -> bool {
+    peer_ip.is_some_and(|ip| ip.is_loopback())
+        || super::auth::host_matches_public_origin(host, public_origins)
+}
+
 pub(super) async fn exchange_bootstrap(
     State(state): State<RuntimeApiState>,
-    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Path(nonce): Path<String>,
+    request: Request,
 ) -> Response {
     let Some(web) = state.web.as_ref() else {
         return not_found();
     };
-    let session_token = match web.consume(&nonce, peer.ip()) {
+    let host = request
+        .headers()
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    let peer_ip = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|info| info.0.ip());
+    if !bootstrap_peer_is_trusted(peer_ip, host, &state.web_public_origins) {
+        return secured_text(StatusCode::FORBIDDEN, "bootstrap unavailable");
+    }
+    let session_token = match web.consume(&nonce) {
         Ok(token) => token,
-        Err(BootstrapError::NonLoopback) => {
-            return secured_text(StatusCode::FORBIDDEN, "bootstrap unavailable");
-        }
         Err(BootstrapError::Invalid | BootstrapError::Expired) => {
             return secured_text(StatusCode::UNAUTHORIZED, "bootstrap unavailable");
         }
     };
 
-    let cookie = web_session_cookie(&session_token);
+    let secure = super::auth::host_matches_public_origin(host, &state.web_public_origins)
+        && host_origin_is_https(&state.web_public_origins);
+    let cookie = web_session_cookie(&session_token, secure);
     let mut response = (StatusCode::SEE_OTHER, "").into_response();
     response
         .headers_mut()
@@ -167,8 +190,19 @@ pub(super) async fn web_icon(State(state): State<RuntimeApiState>) -> Response {
     response
 }
 
-fn web_session_cookie(session_token: &str) -> String {
-    format!("{WEB_SESSION_COOKIE_NAME}={session_token}; HttpOnly; SameSite=Strict; Path=/")
+fn web_session_cookie(session_token: &str, secure: bool) -> String {
+    let mut cookie =
+        format!("{WEB_SESSION_COOKIE_NAME}={session_token}; HttpOnly; SameSite=Strict; Path=/");
+    if secure {
+        cookie.push_str("; Secure");
+    }
+    cookie
+}
+
+fn host_origin_is_https(public_origins: &[String]) -> bool {
+    public_origins
+        .iter()
+        .any(|origin| origin.starts_with("https://"))
 }
 
 fn cookie_value<'a>(cookie_header: Option<&'a str>, name: &str) -> Option<&'a str> {
@@ -244,26 +278,34 @@ mod tests {
     fn bootstrap_is_loopback_only_one_time_and_expires() {
         let (state, nonce) =
             RuntimeWebState::new_with_ttls(Duration::from_secs(60), Duration::from_secs(60));
-        assert_eq!(
-            state.consume(&nonce, "192.0.2.4".parse().unwrap()),
-            Err(BootstrapError::NonLoopback)
-        );
+        assert!(!bootstrap_peer_is_trusted(
+            Some("192.0.2.4".parse().unwrap()),
+            "127.0.0.1:7878",
+            &[]
+        ));
+        assert!(bootstrap_peer_is_trusted(
+            Some("127.0.0.1".parse().unwrap()),
+            "127.0.0.1:7878",
+            &[]
+        ));
+        assert!(bootstrap_peer_is_trusted(
+            Some("100.64.1.2".parse().unwrap()),
+            "codewhale.tailnet.ts.net",
+            &["http://codewhale.tailnet.ts.net".to_string()]
+        ));
         let session_token = state
-            .consume(&nonce, "127.0.0.1".parse().unwrap())
+            .consume(&nonce)
             .expect("valid loopback bootstrap");
         assert!(session_token.starts_with(WEB_SESSION_PREFIX));
         assert!(state.matches_session_cookie(Some(&format!(
             "theme=dark; {WEB_SESSION_COOKIE_NAME}={session_token}"
         ))));
-        assert_eq!(
-            state.consume(&nonce, "127.0.0.1".parse().unwrap()),
-            Err(BootstrapError::Invalid)
-        );
+        assert_eq!(state.consume(&nonce), Err(BootstrapError::Invalid));
 
         let (expired, expired_nonce) =
             RuntimeWebState::new_with_ttls(Duration::ZERO, Duration::from_secs(60));
         assert_eq!(
-            expired.consume(&expired_nonce, "::1".parse().unwrap()),
+            expired.consume(&expired_nonce),
             Err(BootstrapError::Expired)
         );
     }
@@ -273,7 +315,7 @@ mod tests {
         let (state, nonce) =
             RuntimeWebState::new_with_ttls(Duration::from_secs(60), Duration::from_secs(60));
         let session_token = state
-            .consume(&nonce, "127.0.0.1".parse().unwrap())
+            .consume(&nonce)
             .expect("valid loopback bootstrap");
         let cookie = format!("{WEB_SESSION_COOKIE_NAME}={session_token}");
         assert!(state.matches_session_cookie(Some(&cookie)));
@@ -299,7 +341,7 @@ mod tests {
         let (state, nonce) = RuntimeWebState::new();
         for invalid in ["", "cwwb_short", "cwwb_gggggggggggggggggggggggggggggggg"] {
             assert_eq!(
-                state.consume(invalid, "127.0.0.1".parse().unwrap()),
+                state.consume(invalid),
                 Err(BootstrapError::Invalid)
             );
         }
@@ -309,12 +351,12 @@ mod tests {
             wrong.replace_range(wrong.len() - 1.., "1");
         }
         assert_eq!(
-            state.consume(&wrong, "127.0.0.1".parse().unwrap()),
+            state.consume(&wrong),
             Err(BootstrapError::Invalid)
         );
         assert!(
             state
-                .consume(&nonce, "127.0.0.1".parse().unwrap())
+                .consume(&nonce)
                 .expect("valid bootstrap remains available")
                 .starts_with(WEB_SESSION_PREFIX)
         );
@@ -324,11 +366,12 @@ mod tests {
     fn cookie_has_exact_security_attributes_without_the_runtime_bearer() {
         let session_token = format!("{WEB_SESSION_PREFIX}{}", "01".repeat(16));
         let runtime_bearer = "cwrt_runtime_secret_never_in_browser_storage";
-        let cookie = web_session_cookie(&session_token);
+        let cookie = web_session_cookie(&session_token, false);
         assert_eq!(
             cookie,
             format!("codewhale_web_session={session_token}; HttpOnly; SameSite=Strict; Path=/")
         );
+        assert!(web_session_cookie(&session_token, true).ends_with("; Secure"));
         assert!(!cookie.contains(runtime_bearer));
         assert!(!cookie.contains("Domain="));
     }
@@ -341,6 +384,12 @@ mod tests {
         assert!(url.ends_with(&nonce));
         assert!(!url.contains(token));
         assert!(!url.contains('?'));
+        let tailnet = bootstrap_url_for_origin("https://codewhale.tailnet.ts.net", &nonce);
+        assert_eq!(
+            tailnet,
+            format!("https://codewhale.tailnet.ts.net/__codewhale/bootstrap/{nonce}")
+        );
+        assert!(!tailnet.contains(token));
         assert!(!url.contains('#'));
     }
 

--- a/crates/tui/src/runtime_api/web.rs
+++ b/crates/tui/src/runtime_api/web.rs
@@ -293,9 +293,7 @@ mod tests {
             "codewhale.tailnet.ts.net",
             &["http://codewhale.tailnet.ts.net".to_string()]
         ));
-        let session_token = state
-            .consume(&nonce)
-            .expect("valid loopback bootstrap");
+        let session_token = state.consume(&nonce).expect("valid loopback bootstrap");
         assert!(session_token.starts_with(WEB_SESSION_PREFIX));
         assert!(state.matches_session_cookie(Some(&format!(
             "theme=dark; {WEB_SESSION_COOKIE_NAME}={session_token}"
@@ -314,9 +312,7 @@ mod tests {
     fn web_session_survives_reload_then_expires_and_rejects_wrong_tokens() {
         let (state, nonce) =
             RuntimeWebState::new_with_ttls(Duration::from_secs(60), Duration::from_secs(60));
-        let session_token = state
-            .consume(&nonce)
-            .expect("valid loopback bootstrap");
+        let session_token = state.consume(&nonce).expect("valid loopback bootstrap");
         let cookie = format!("{WEB_SESSION_COOKIE_NAME}={session_token}");
         assert!(state.matches_session_cookie(Some(&cookie)));
         assert!(
@@ -340,20 +336,14 @@ mod tests {
     fn bootstrap_rejects_malformed_or_wrong_capabilities_without_consuming() {
         let (state, nonce) = RuntimeWebState::new();
         for invalid in ["", "cwwb_short", "cwwb_gggggggggggggggggggggggggggggggg"] {
-            assert_eq!(
-                state.consume(invalid),
-                Err(BootstrapError::Invalid)
-            );
+            assert_eq!(state.consume(invalid), Err(BootstrapError::Invalid));
         }
         let mut wrong = nonce.clone();
         wrong.replace_range(wrong.len() - 1.., "0");
         if wrong == nonce {
             wrong.replace_range(wrong.len() - 1.., "1");
         }
-        assert_eq!(
-            state.consume(&wrong),
-            Err(BootstrapError::Invalid)
-        );
+        assert_eq!(state.consume(&wrong), Err(BootstrapError::Invalid));
         assert!(
             state
                 .consume(&nonce)

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -59,9 +59,46 @@ API behavior.
 
 ## Local means local
 
-`codewhale web` accepts only `--port`; there is no `--host` or insecure-auth
-option on this command. Do not treat it as a public website or expose its port
-directly through router forwarding, a public reverse proxy, or a tunnel.
+`codewhale web` accepts `--port` and optional `--tailscale`. There is no
+`--host` or insecure-auth option on this command. Do not treat it as a public
+website or expose its port directly through router forwarding, a public reverse
+proxy, or a generic tunnel.
+
+## Tailnet (`--tailscale`)
+
+`codewhale web --tailscale` keeps the HTTP listener on `127.0.0.1` and
+publishes the same client onto the current Tailscale tailnet. Reachability is
+ACL-gated. This is not Funnel and not ngrok.
+
+Preferred path (opt-in Cargo feature `tailscale` on `codewhale-tui` /
+`codewhale-cli`): an embedded tsnet node from the official
+[`tailscale`](https://docs.rs/tailscale/0.5.0/tailscale/) 0.5.0 crate. The crate
+exposes `Device::tcp_listen` and `tailscale::axum::Listener`, and
+`Config.requested_hostname` is set to `codewhale`, so MagicDNS is
+`codewhale.<tailnet>.ts.net` (`NodeInfo::fqdn`). Auth is
+`CODEWHALE_TSNET_AUTHKEY` or `TS_AUTHKEY`. Official 0.5.0 does **not** implement
+HTTPS certificates (listed as unsupported in the crate README), so the embedded
+listener is HTTP on port 80 over the WireGuard overlay
+(`http://codewhale.<tailnet>.ts.net`). The crate also requires
+`TS_RS_EXPERIMENT=this_is_unstable_software` (set automatically for this path)
+and currently supports Linux (x86_64/ARM64) and macOS ARM64.
+
+Fallback (always compiled; precursor design from PR #5628): if embed is not
+compiled, is disabled with `CODEWHALE_TSNET_DISABLE`, or cannot auth, Codewhale
+asks the local Tailscale CLI to publish HTTPS:443 to the loopback port:
+
+```bash
+codewhale web --tailscale
+```
+
+CLI serve uses the **machine** MagicDNS name (`https://<machine>.<tailnet>.ts.net`),
+not `codewhale.<tailnet>.ts.net`. Stopping the process turns off only the
+HTTPS:443 serve mapping (`tailscale serve --https=443 off`). It does not run
+`tailscale serve reset`.
+
+Cookie-authenticated requests must present the advertised tailnet origin
+(`*.ts.net`). Bootstrap from a tailnet Host is allowed when that origin was
+published; default `codewhale web` without `--tailscale` remains loopback-only.
 
 The separate `codewhale app-server --mobile` and `--http` modes have different
 deployment and authentication contracts. Read [RUNTIME_API.md](RUNTIME_API.md)


### PR DESCRIPTION
## Summary
- Adds opt-in `codewhale web --tailscale` on top of origin/main. Default `codewhale web` stays loopback-only (`127.0.0.1`). `--tailscale` without `--web` is rejected (clap `requires = "web"` plus runtime validation).
- **Embed vs serve.** PR #5628 (`origin/cursor/enterprise-launch-readiness-8ed3`) is the precursor: it wraps the Tailscale CLI (`tailscale serve --bg --https=443 localhost:<port>`). This PR takes the next step the mission asked for: prefer an **embedded tsnet node** from the official crates.io `tailscale` 0.5.0 crate (`Device::new`, `Device::tcp_listen`, `tailscale::axum::Listener`, `Config.requested_hostname = "codewhale"` → `codewhale.<tailnet>.ts.net` via `NodeInfo::fqdn`). Cookie/CORS `*.ts.net` origin allowlisting is copied from 5628's `runtime_api/auth.rs` pattern.
- **Crate choice.** Official 0.5.0 *can* listen and serve HTTP through axum (verified with `cargo check -p codewhale-tui --features tailscale`). It **cannot** mint HTTPS certificates — the crate README lists HTTPS Certificates, MagicDNS, and Tailscale Serve as unsupported. Embedded traffic is HTTP :80 over the WireGuard overlay. When embed is not compiled, is disabled (`CODEWHALE_TSNET_DISABLE`), or cannot auth (`CODEWHALE_TSNET_AUTHKEY` / `TS_AUTHKEY`), the same `--tailscale` flag falls back to 5628's CLI serve (browser-trusted TLS on the *machine* MagicDNS name). `geiserx_tailscale` was not needed because official already has `tcp_listen`.
- Heavy dep is feature-gated (`tailscale` optional on `codewhale-tui` / `codewhale-cli`) so default builds stay lean. Tests stub the node; CI does not need a live tailnet.

## Test plan
- [x] `cargo test -p codewhale-tui --lib -- tailscale cookie_origin public_origin bootstrap_is_loopback launcher_url tailscale_requires_web …` (flag wiring, origin allowlist, `--tailscale` without `--web`, MagicDNS helpers)
- [x] `cargo test -p codewhale-cli --lib -- web_command web_tailscale serve_help_documents`
- [x] `cargo check -p codewhale-tui --features tailscale` (official crate API compiles)
- [ ] Manual: `codewhale web` still binds loopback only
- [ ] Manual: `codewhale web --tailscale` with Tailscale CLI connected uses CLI serve fallback in a default (no-feature) build
- [ ] Manual: build `--features tailscale` and set `TS_AUTHKEY` to get `http://codewhale.<tailnet>.ts.net`


Made with [Cursor](https://cursor.com)

No-Issue: Opt-in embedded tsnet for codewhale web; precursor design from #5628; no tracking issue to close.
