### PR TITLE
fix(web): replace marketing pricing and legal 404s with honest pages

### DIFF
--- a/web/app/[locale]/legal/page.tsx
+++ b/web/app/[locale]/legal/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default async function LegalIndexPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  redirect(`/${locale}/legal/terms`);
+}

--- a/web/app/[locale]/legal/privacy/page.tsx
+++ b/web/app/[locale]/legal/privacy/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { buildPageMetadata } from "@/lib/page-meta";
+import { LEGAL_UPDATED, PRIVACY_SECTIONS } from "@/lib/legal-copy";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/legal/privacy",
+    locale,
+    title: isZh ? "隐私政策 · Codewhale" : "Privacy policy · Codewhale",
+    description: isZh
+      ? "Shannon Labs 如何在你使用 Codewhale 时处理信息。"
+      : "How Shannon Labs handles information when you use Codewhale.",
+  });
+}
+
+export default async function PrivacyPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return (
+    <div className="portal-home">
+      <article className="legal-doc">
+        <p className="legal-doc-kicker">{isZh ? "法律" : "Legal"}</p>
+        <h1>{isZh ? "隐私政策" : "Privacy policy"}</h1>
+        <p className="legal-doc-updated">
+          {isZh ? "生效并最近更新于" : "Effective and last updated"} {LEGAL_UPDATED}
+          {isZh ? "。以下为具有约束力的英文文本。" : "."}
+        </p>
+        <p>This policy explains how Shannon Labs handles information when you use Codewhale.</p>
+        {PRIVACY_SECTIONS.map((section) => (
+          <section key={section.title}>
+            <h2>{section.title}</h2>
+            <p>{section.body}</p>
+          </section>
+        ))}
+        <p className="legal-doc-nav">
+          <Link href={`/${locale}/legal/terms`}>{isZh ? "服务条款" : "Terms of service"}</Link>
+          <Link href={`/${locale}/pricing`}>{isZh ? "价格" : "Pricing"}</Link>
+          <Link href={`/${locale}`}>{isZh ? "返回首页" : "Back home"}</Link>
+        </p>
+      </article>
+    </div>
+  );
+}

--- a/web/app/[locale]/legal/terms/page.tsx
+++ b/web/app/[locale]/legal/terms/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { buildPageMetadata } from "@/lib/page-meta";
+import { LEGAL_UPDATED, TERMS_SECTIONS } from "@/lib/legal-copy";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/legal/terms",
+    locale,
+    title: isZh ? "服务条款 · Codewhale" : "Terms of service · Codewhale",
+    description: isZh
+      ? "Shannon Labs 产品 Codewhale 的服务条款。"
+      : "Terms that govern your use of Codewhale, a Shannon Labs product.",
+  });
+}
+
+export default async function TermsPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return (
+    <div className="portal-home">
+      <article className="legal-doc">
+        <p className="legal-doc-kicker">{isZh ? "法律" : "Legal"}</p>
+        <h1>{isZh ? "服务条款" : "Terms of service"}</h1>
+        <p className="legal-doc-updated">
+          {isZh ? "生效并最近更新于" : "Effective and last updated"} {LEGAL_UPDATED}
+          {isZh ? "。以下为具有约束力的英文文本。" : "."}
+        </p>
+        <p>
+          These terms govern your use of Codewhale, a Shannon Labs product. By creating an
+          account or using the service, you agree to them.
+        </p>
+        {TERMS_SECTIONS.map((section) => (
+          <section key={section.title}>
+            <h2>{section.title}</h2>
+            <p>{section.body}</p>
+          </section>
+        ))}
+        <p className="legal-doc-nav">
+          <Link href={`/${locale}/legal/privacy`}>{isZh ? "隐私政策" : "Privacy policy"}</Link>
+          <Link href={`/${locale}/pricing`}>{isZh ? "价格" : "Pricing"}</Link>
+          <Link href={`/${locale}`}>{isZh ? "返回首页" : "Back home"}</Link>
+        </p>
+      </article>
+    </div>
+  );
+}

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { APP_LOGIN_URL } from "@/lib/i18n/links";
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/pricing",
+    locale,
+    title: isZh ? "价格 · Codewhale" : "Pricing · Codewhale",
+    description: isZh
+      ? "Codewhale 开源运行时免费。托管会员计费已实现但尚未对公众开放。"
+      : "The Codewhale open-source runtime is free. Hosted membership billing is built but not for sale yet.",
+  });
+}
+
+export default async function PricingPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return (
+    <div className="portal-home">
+      <section className="portal-section">
+        <div className="portal-container pricing-page">
+          <p className="legal-doc-kicker">{isZh ? "价格" : "Pricing"}</p>
+          <h1>{isZh ? "现在没有可以付款的套餐。" : "There is nothing to pay for yet."}</h1>
+          <p className="portal-lede">
+            {isZh
+              ? "开源运行时免费，自带模型密钥（BYOK）。托管计算的 $10/月会员已经写进产品，但生产环境的计费开关仍是休眠状态——没有结账按钮，也就不会误收一笔钱。"
+              : "The open-source runtime is free. Bring your own model key. The $10/month Member plan for hosted compute is implemented in the product, but production billing is dormant — so there is no checkout button that could charge anyone by accident."}
+          </p>
+          <ul className="pricing-list">
+            <li>
+              <strong>{isZh ? "开源 / 自托管" : "Open source / self-hosted"}</strong>
+              <span>{isZh ? "免费。在你的机器上运行，使用你自己的模型密钥。" : "Free. Run on your machine with your own model keys."}</span>
+            </li>
+            <li>
+              <strong>{isZh ? "托管会员" : "Hosted Member"}</strong>
+              <span>
+                {isZh
+                  ? "$10/月、每期 $10 可结转的托管计算额度——已实现，尚未对公众销售。"
+                  : "$10/month with $10 of rollover hosted-compute credits each paid period — built, not for sale to the public."}
+              </span>
+            </li>
+          </ul>
+          <p className="pricing-note">
+            {isZh
+              ? "模型用量由你连接的提供商计费，Codewhale 不加价。我们不会在计费休眠期间展示一个会失败的“立即购买”。"
+              : "Model tokens are billed by the provider you connect. Codewhale does not mark them up. We will not show a Buy button that 503s while billing is dormant."}
+          </p>
+          <div className="portal-actions">
+            <Link className="portal-button portal-button-primary" href={`/${locale}/install`}>
+              {isZh ? "安装 →" : "Install →"}
+            </Link>
+            <a className="portal-button portal-button-secondary" href={APP_LOGIN_URL}>
+              {isZh ? "打开应用" : "Open the app"}
+            </a>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/app/[locale]/privacy/page.tsx
+++ b/web/app/[locale]/privacy/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default async function PrivacyAliasPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  redirect(`/${locale}/legal/privacy`);
+}

--- a/web/app/[locale]/terms/page.tsx
+++ b/web/app/[locale]/terms/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default async function TermsAliasPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  redirect(`/${locale}/legal/terms`);
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1231,6 +1231,78 @@ a.body-link:hover { background-size: 100% 6px; color: var(--ink); }
   background: var(--paper-deep);
 }
 
+.legal-doc {
+  width: var(--container);
+  margin-inline: auto;
+  padding-block: clamp(3.25rem, 6vw, 4.75rem);
+  max-width: 42rem;
+}
+
+.legal-doc-kicker {
+  margin: 0 0 0.75rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-muted, color-mix(in srgb, var(--ink) 62%, var(--paper)));
+}
+
+.legal-doc h1 {
+  margin: 0 0 0.5rem;
+  font-family: var(--font-display), serif;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.15;
+}
+
+.legal-doc-updated,
+.legal-doc p,
+.legal-doc section p {
+  margin: 0 0 1.15rem;
+  line-height: 1.6;
+}
+
+.legal-doc section h2 {
+  margin: 1.75rem 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.legal-doc-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  margin-top: 2rem;
+}
+
+.legal-doc-nav a {
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+}
+
+.pricing-page {
+  max-width: 42rem;
+}
+
+.pricing-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.pricing-list li {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 0;
+  border-top: 1px solid var(--hairline);
+}
+
+.pricing-list li:last-child {
+  border-bottom: 1px solid var(--hairline);
+}
+
+.pricing-note {
+  margin: 0 0 1.5rem;
+  line-height: 1.6;
+}
+
 /* ---------- read-only settings reference ---------- */
 .settings-preview {
   background: color-mix(in srgb, var(--paper-deep) 52%, var(--paper));

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -4,7 +4,7 @@ import { SITE_URL } from "@/lib/page-meta";
 
 // Public, indexable routes (locale-prefixed). /admin and /api are
 // intentionally excluded; see app/robots.ts.
-const PATHS = ["", "/install", "/constitution", "/models", "/runtime", "/docs", "/docs/configuration", "/docs/constitution", "/docs/fleet", "/docs/guide", "/docs/hooks", "/docs/mcp", "/docs/modes", "/docs/runtime-api", "/docs/sandbox", "/docs/subagents", "/docs/tools", "/docs/troubleshooting", "/docs/vocabulary", "/docs/web", "/docs/work", "/faq", "/roadmap", "/feed", "/digest", "/contribute", "/community"];
+const PATHS = ["", "/install", "/constitution", "/models", "/runtime", "/docs", "/docs/configuration", "/docs/constitution", "/docs/fleet", "/docs/guide", "/docs/hooks", "/docs/mcp", "/docs/modes", "/docs/runtime-api", "/docs/sandbox", "/docs/subagents", "/docs/tools", "/docs/troubleshooting", "/docs/vocabulary", "/docs/web", "/docs/work", "/faq", "/roadmap", "/feed", "/digest", "/contribute", "/community", "/pricing", "/legal/terms", "/legal/privacy"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return PATHS.flatMap((path) =>

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { GITEE_ENABLED, type Locale } from "@/lib/i18n/config";
 import { getChrome } from "@/lib/i18n/dictionaries";
 import {
+  footerLegalLinks,
   footerProductLinks,
   footerProjectLinks,
   REPO_RELEASES_URL,
@@ -20,6 +21,7 @@ export function Footer({ locale = "en" }: { locale?: Locale }) {
   const homeHref = `/${locale}`;
   const product = footerProductLinks(locale, chrome);
   const project = footerProjectLinks(locale, chrome);
+  const legal = footerLegalLinks(locale);
 
   return (
     <footer className="site-footer">
@@ -52,6 +54,7 @@ export function Footer({ locale = "en" }: { locale?: Locale }) {
           <a href={REPO_RELEASES_URL}>{chrome.footerReleasesLink}</a>
         </p>
         <div>
+          {legal.map((item) => <Link key={item.href} href={item.href}>{item.label}</Link>)}
           {GITEE_ENABLED && <a href="https://gitee.com/Hmbown/CodeWhale">Gitee</a>}
           <a href="https://cnb.cool/codewhale.net/codewhale">CNB</a>
           <a href="https://npmmirror.com/package/codewhale">npmmirror</a>

--- a/web/lib/docs-ia.test.ts
+++ b/web/lib/docs-ia.test.ts
@@ -17,6 +17,7 @@ import { contentLocalesForPath } from "./i18n/content-locales";
 import { getChrome, getHome } from "./i18n/dictionaries";
 import {
   currentNavHref,
+  footerLegalLinks,
   footerProductLinks,
   footerProjectLinks,
   navLinks as buildNavLinks,
@@ -88,7 +89,13 @@ describe("sitemap and hreflang preservation", () => {
   });
 
   it("keeps sitemap and hreflang output aligned with real translation coverage", () => {
-    expect(sitemapEntries).toHaveLength(78);
+    expect(sitemapEntries).toHaveLength(84);
+    for (const path of ["/pricing", "/legal/terms", "/legal/privacy"]) {
+      expect(
+        sitemapEntries.some((entry) => entry.url === `${SITE_URL}/en${path}`),
+        path,
+      ).toBe(true);
+    }
     for (const [path, expectedLocales] of [
       ["/", locales],
       ["/docs/guide", contentLocalesForPath("/docs/guide")],
@@ -199,6 +206,11 @@ describe("navigation parity and accessibility", () => {
         `/${locale}/contribute`,
         "https://github.com/Hmbown/CodeWhale/blob/main/LICENSE",
       ]);
+      expect(footerLegalLinks(locale).map((l) => l.href), `${locale} footer legal`).toEqual([
+        `/${locale}/pricing`,
+        `/${locale}/legal/terms`,
+        `/${locale}/legal/privacy`,
+      ]);
     }
   });
 
@@ -283,6 +295,7 @@ describe("navigation parity and accessibility", () => {
     });
     expect(footer).toContain("footerProductLinks(locale, chrome)");
     expect(footer).toContain("footerProjectLinks(locale, chrome)");
+    expect(footer).toContain("footerLegalLinks(locale)");
   });
 });
 

--- a/web/lib/i18n/links.ts
+++ b/web/lib/i18n/links.ts
@@ -80,6 +80,15 @@ export function footerProjectLinks(locale: string, chrome: ChromeDict): ChromeLi
   ];
 }
 
+/** Footer legal / pricing destinations — reachable, never a 404. */
+export function footerLegalLinks(locale: string): ChromeLink[] {
+  return [
+    { href: `/${locale}/pricing`, label: "Pricing" },
+    { href: `/${locale}/legal/terms`, label: "Terms" },
+    { href: `/${locale}/legal/privacy`, label: "Privacy" },
+  ];
+}
+
 /**
  * The one link in a chrome set that names the page currently being viewed.
  *

--- a/web/lib/legal-copy.ts
+++ b/web/lib/legal-copy.ts
@@ -1,0 +1,65 @@
+/** Binding legal text for Shannon Labs / Codewhale. Same body as app.codewhale.net/legal. */
+
+export const LEGAL_UPDATED = "July 23, 2026";
+
+export const TERMS_SECTIONS = [
+  {
+    title: "Your account",
+    body: "You are responsible for your account, connected providers, repositories, runners, and credentials. Keep access methods secure and provide accurate information. Do not share authority you are not permitted to grant.",
+  },
+  {
+    title: "Acceptable use",
+    body: "Do not use Codewhale to break the law, harm people or systems, evade access controls, distribute malware, interfere with the service, or process data you lack authority to use. Automated actions remain subject to the permissions, reviews, and stop conditions shown in the product.",
+  },
+  {
+    title: "Your content and connected services",
+    body: "You retain ownership of your content. You give Shannon Labs the limited permission needed to process it to provide Codewhale. Model, repository, compute, and other third-party providers have their own terms. You are responsible for charges you authorize with those providers.",
+  },
+  {
+    title: "Plans and charges",
+    body: "Features described as free do not create a Codewhale payment obligation. If paid Codewhale features become active, the product will show the price and obtain authorization before charging. Provider-billed model usage remains outside Codewhale charges.",
+  },
+  {
+    title: "Service changes and termination",
+    body: "We may change, suspend, or discontinue features and may restrict accounts that violate these terms or threaten the service. You may stop using Codewhale and use the available account deletion process. Required security, audit, deletion, and financial receipts may survive account deletion as described in the privacy policy.",
+  },
+  {
+    title: "Disclaimers and liability",
+    body: "Codewhale is provided on an “as is” and “as available” basis to the extent permitted by law. Software agents can make mistakes; review important changes and keep independent backups. Shannon Labs does not promise uninterrupted or error-free operation and is not responsible for third-party services outside its control.",
+  },
+  {
+    title: "Changes",
+    body: "We may update these terms. The effective date above identifies the current version. Continued use after an update means you accept the revised terms.",
+  },
+] as const;
+
+export const PRIVACY_SECTIONS = [
+  {
+    title: "Information we collect",
+    body: "We collect the identity information needed to create and protect your account, including your GitHub identity, display name, and a primary verified email when GitHub makes one available. We also store product information you create, such as preferences, projects, conversations, Work runs, approvals, and security or operational receipts.",
+  },
+  {
+    title: "How we use it",
+    body: "We use this information to authenticate you, operate and secure Codewhale, preserve your requested product state, provide support, and—only when you have enabled the relevant communication—send product or waitlist updates. We do not sell personal information.",
+  },
+  {
+    title: "Storage and processing",
+    body: "Codewhale is one global product. There is no residency selector, no region-specific account, and no promise that your account data stays in a particular jurisdiction. Account authentication and session state is stored in Cloudflare Durable Objects, today configured in Cloudflare’s US jurisdiction; that placement is an operational choice we may change, and we will update this policy when we do. Durable product state is owned by Codewhale’s private product runtime. Cloudflare may perform TLS, request routing, and cryptographic processing on its global edge, so we do not describe edge processing as US-only. Hosted compute is a separate system from account storage and, when enabled, identifies its placement before launch.",
+  },
+  {
+    title: "Model providers and repositories",
+    body: "Codewhale sends content to a model provider only when you choose or connect that provider. Bring-your-own provider credentials remain separate from Codewhale billing. Repository access is limited to the grants you approve with the source provider.",
+  },
+  {
+    title: "Retention and deletion",
+    body: "You can review export and deletion controls after signing in under Account, Data & privacy. Content is deleted according to the displayed retention and deletion process. Privacy-minimal security, audit, deletion, and financial receipts may be retained when necessary to prove an action, prevent abuse, or meet legal obligations. Provider-backed resources are not treated as deleted until the provider confirms deletion.",
+  },
+  {
+    title: "Questions and requests",
+    body: "Use Account, Data & privacy after signing in to request an export or deletion. If you cannot sign in, use the public support channel shown in the product once it is verified. Codewhale does not present an unverified mailbox as monitored.",
+  },
+  {
+    title: "Changes",
+    body: "We may update this policy as the product and its processors change. The effective date above identifies the version that applies.",
+  },
+] as const;

--- a/web/lib/llms-txt.test.ts
+++ b/web/lib/llms-txt.test.ts
@@ -35,6 +35,9 @@ describe("llms.txt", () => {
       "/en/community",
       "/en/contribute",
       "/en/docs",
+      "/en/pricing",
+      "/en/legal/terms",
+      "/en/legal/privacy",
     ]) {
       expect(body, path).toContain(`${SITE_URL}${path}`);
     }

--- a/web/lib/llms-txt.ts
+++ b/web/lib/llms-txt.ts
@@ -56,6 +56,21 @@ const EXTRA_PAGES: readonly { path: string; title: string; description: string }
     title: "Contribute",
     description: "The pull-request workflow: scoped issue, fork, test the change, explain the result.",
   },
+  {
+    path: "/pricing",
+    title: "Pricing",
+    description: "The open-source runtime is free. Hosted membership billing is built but not for sale yet.",
+  },
+  {
+    path: "/legal/terms",
+    title: "Terms of service",
+    description: "Terms that govern your use of Codewhale, a Shannon Labs product.",
+  },
+  {
+    path: "/legal/privacy",
+    title: "Privacy policy",
+    description: "How Shannon Labs handles information when you use Codewhale.",
+  },
 ];
 
 function topicSitePath(topic: (typeof DOC_TOPICS)[number]): string | null {

--- a/web/lib/page-meta.test.ts
+++ b/web/lib/page-meta.test.ts
@@ -112,6 +112,9 @@ describe("page metadata", () => {
       ["faq", "/faq"],
       ["feed", "/feed"],
       ["roadmap", "/roadmap"],
+      ["pricing", "/pricing"],
+      ["legal/terms", "/legal/terms"],
+      ["legal/privacy", "/legal/privacy"],
     ]) {
       const source = readFileSync(
         new URL(`../app/[locale]/${route}/page.tsx`, import.meta.url),

--- a/web/lib/public-billing-legal-routes.test.ts
+++ b/web/lib/public-billing-legal-routes.test.ts
@@ -1,0 +1,31 @@
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { footerLegalLinks } from "./i18n/links";
+import { LEGAL_UPDATED, PRIVACY_SECTIONS, TERMS_SECTIONS } from "./legal-copy";
+
+const webRoot = new URL("../", import.meta.url);
+
+describe("marketing pricing and legal routes", () => {
+  it("ships real pages for the URLs that used to 404", () => {
+    for (const path of [
+      "app/[locale]/pricing/page.tsx",
+      "app/[locale]/legal/terms/page.tsx",
+      "app/[locale]/legal/privacy/page.tsx",
+      "app/[locale]/privacy/page.tsx",
+      "app/[locale]/terms/page.tsx",
+    ]) {
+      expect(existsSync(new URL(path, webRoot)), path).toBe(true);
+    }
+  });
+
+  it("aliases /privacy and /terms onto the legal paths instead of inventing a second policy", () => {
+    expect(footerLegalLinks("en").map((l) => l.href)).toEqual([
+      "/en/pricing",
+      "/en/legal/terms",
+      "/en/legal/privacy",
+    ]);
+    expect(LEGAL_UPDATED).toBe("July 23, 2026");
+    expect(TERMS_SECTIONS.some((s) => s.title === "Plans and charges")).toBe(true);
+    expect(PRIVACY_SECTIONS.some((s) => s.title === "Retention and deletion")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `/en/pricing` is a real page: open-source is free, hosted Member is built but not for sale (no Buy button while production billing is dormant).
- `/en/legal/terms` and `/en/legal/privacy` carry the same Shannon Labs body as `app.codewhale.net/legal/*`.
- `/en/privacy`, `/en/terms`, and `/en/legal` 307 to those paths. Footer now links Pricing / Terms / Privacy.

## Test plan
- [x] Local `next dev :3456`: `/en/pricing` 200, `/en/legal/terms` 200, `/en/legal/privacy` 200
- [x] `/en/privacy` → 307 `/en/legal/privacy`; `/pricing` → 307 `/en/pricing`
- [x] vitest: docs-ia, llms-txt, page-meta, public-billing-legal-routes (35 passed)
- [ ] After merge + `gh workflow run web.yml --ref main`: live `https://codewhale.net/en/pricing` is not 404

Closes the marketing half of Hmbown/cwc#262.

Made with [Cursor](https://cursor.com)