### PR TITLE
test(tui): decouple timeline bound from durable status fsync

### DIFF
--- a/crates/tui/src/task_manager.rs
+++ b/crates/tui/src/task_manager.rs
@@ -3692,9 +3692,20 @@ mod tests {
             _cancel: CancellationToken,
         ) -> TaskExecutionResult {
             for i in 0..400 {
+                // Mirror the runtime path: each raw event is followed by its
+                // derived message delta. Alternating the two non-urgent stream
+                // kinds prevents timeline coalescing without turning this
+                // storage-bound test into hundreds of synchronous fsyncs.
                 let _ = events
-                    .send(TaskExecutionEvent::Status {
-                        message: format!("tick {i}"),
+                    .send(TaskExecutionEvent::RuntimeEvent {
+                        seq: i,
+                        event: "item.delta".to_string(),
+                        summary: format!("tick {i}"),
+                    })
+                    .await;
+                let _ = events
+                    .send(TaskExecutionEvent::MessageDelta {
+                        content: format!("chunk {i}"),
                     })
                     .await;
             }
@@ -4099,12 +4110,14 @@ mod tests {
     async fn long_stream_timeline_is_bounded() -> Result<()> {
         let root = std::env::temp_dir().join(format!("deepseek-task-test-{}", Uuid::new_v4()));
         let manager =
-            TaskManager::start_with_executor(test_config(root), Arc::new(FloodExecutor)).await?;
+            TaskManager::start_with_executor(test_config(root.clone()), Arc::new(FloodExecutor))
+                .await?;
         let task = manager
             .add_task(NewTaskRequest::from_prompt("flood the timeline"))
             .await?;
         let finished = wait_for_terminal_state(&manager, &task.id, Duration::from_secs(10)).await?;
         assert_eq!(finished.status, TaskStatus::Completed);
+        assert_eq!(finished.runtime_event_count, 400);
         assert!(
             finished.timeline.len() <= TIMELINE_ENTRY_LIMIT,
             "timeline grew to {}",
@@ -4121,6 +4134,18 @@ mod tests {
                 .iter()
                 .map(|e| e.kind.as_str())
                 .collect::<Vec<_>>()
+        );
+
+        let persisted_path = root.join("tasks").join(format!("{}.json", task.id));
+        let persisted: TaskRecord = serde_json::from_slice(&fs::read(&persisted_path)?)?;
+        assert_eq!(persisted.status, TaskStatus::Completed);
+        assert_eq!(persisted.runtime_event_count, 400);
+        assert!(persisted.timeline.len() <= TIMELINE_ENTRY_LIMIT);
+        assert!(
+            persisted
+                .timeline
+                .iter()
+                .any(|entry| entry.kind == "omitted")
         );
         Ok(())
     }


### PR DESCRIPTION
No-Issue: repairs a recurrent baseline CI test timeout without changing production behavior.\n\nThe long-stream timeline test used 400 urgent status events. Each urgent event follows the durable status path and can force synchronous persistence, so the test measured filesystem latency rather than the timeline bound and timed out repeatedly on Windows.\n\nThis keeps the product contract intact while making the test mirror the real stream path:\n- alternate runtime events and message deltas so entries do not coalesce;\n- assert the in-memory timeline remains bounded;\n- read the persisted task record and assert the durable timeline is also bounded;\n- confirm all 400 runtime events were counted.\n\nLocal evidence:\n- cargo fmt --all -- --check\n- cargo test -p codewhale-tui --lib --locked long_stream_timeline_is_bounded\n  - 1 passed in 0.09s after a clean compile\n- git diff --check\n\nThis is local macOS evidence. Windows CI is the required acceptance lane.