### PR TITLE
feat(runtime-api): rescue per-thread usage with CNY coverage

### DIFF
--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -66,7 +66,7 @@ use crate::runtime_threads::{
     CompactThreadRequest, CreateThreadRequest, ExternalApprovalDecision,
     MAX_RUNTIME_EVENT_REPLAY_TAIL, RuntimeThreadManager, RuntimeThreadManagerConfig,
     SharedRuntimeThreadManager, StartTurnRequest, SteerTurnRequest, ThreadDetail, ThreadListFilter,
-    ThreadRecord, TurnItemKind, TurnRecord, UpdateThreadRequest, UsageGroupBy,
+    ThreadRecord, TurnItemKind, TurnRecord, UpdateThreadRequest, UsageGroupBy, UsageTotals,
 };
 #[cfg(test)]
 pub(super) use crate::runtime_threads::{RuntimeTurnStatus, TurnItemLifecycleStatus};
@@ -1089,6 +1089,7 @@ pub fn build_router(state: RuntimeApiState) -> Router {
             post(deliver_dynamic_tool_result),
         )
         .route("/v1/threads/{id}/compact", post(compact_thread))
+        .route("/v1/threads/{id}/usage", get(get_thread_usage))
         .route("/v1/threads/{id}/events", get(stream_thread_events))
         .route("/v1/agent-mail", post(send_agent_mail))
         .route("/v1/threads/{id}/agent-mail", get(list_agent_mail))
@@ -3760,6 +3761,34 @@ async fn get_thread(
         .await
         .map_err(map_thread_err)?;
     Ok(Json(detail))
+}
+
+/// Response for `GET /v1/threads/{id}/usage`.
+///
+/// Thin adapter over `RuntimeThreadManager::aggregate_usage_for_thread`: the
+/// GUI's session-cost surface reads provider-aware, recorded-time pricing in
+/// both published currencies from the same accumulation that powers
+/// `/v1/usage`, instead of reimplementing rate tables client-side.
+#[derive(Debug, Serialize)]
+struct ThreadUsageResponse {
+    thread_id: String,
+    totals: UsageTotals,
+}
+
+async fn get_thread_usage(
+    State(state): State<RuntimeApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<ThreadUsageResponse>, ApiError> {
+    let totals = state
+        .runtime_threads
+        .aggregate_usage_for_thread(&id)
+        .await
+        .map_err(map_thread_err)?
+        .combined();
+    Ok(Json(ThreadUsageResponse {
+        thread_id: id,
+        totals,
+    }))
 }
 
 async fn update_thread(

--- a/crates/tui/src/runtime_api/sessions.rs
+++ b/crates/tui/src/runtime_api/sessions.rs
@@ -427,6 +427,8 @@ pub(super) async fn create_session_from_thread(
     let title = session.metadata.title.clone();
     let message_count = session.metadata.message_count;
 
+    persist_thread_cost(&state, thread_id, &mut session).await?;
+
     manager
         .save_session(&session)
         .map_err(|e| ApiError::internal(format!("Failed to save session: {e}")))?;
@@ -638,6 +640,58 @@ pub(super) fn messages_from_thread_detail(detail: &ThreadDetail) -> Vec<Message>
     messages
 }
 
+/// Merge the thread's authoritative cost into a session about to be saved.
+///
+/// The engine snapshot carries messages/tokens but no cost — cost lives in
+/// the turn records' route-audited usage — so derive it from the same
+/// accumulation that powers `/v1/usage` (recorded-time pricing, both
+/// published currencies). The parent/child split mirrors the TUI writer's
+/// field semantics (`sync_cost_to_metadata`): `session_cost_*` carries
+/// parent-turn spend and `subagent_cost_*` routed-child spend, so a session
+/// previously saved by the TUI never gets child spend counted twice in
+/// `total_estimate()`. Merging each side with max keeps a session resumed
+/// across threads from losing previously persisted spend, and extends the
+/// monotonic display guarantee (#244) to the persisted shape. Coverage
+/// travels with the money it qualifies (#4318): the counters are
+/// parent-turn coverage (the TUI's own session-level accounting), CNY
+/// included, and `coverage_recorded` marks that this writer computed them
+/// from audited turn records rather than deserializing a legacy default.
+async fn persist_thread_cost(
+    state: &RuntimeApiState,
+    thread_id: &str,
+    session: &mut crate::session_manager::SavedSession,
+) -> Result<(), ApiError> {
+    let usage = state
+        .runtime_threads
+        .aggregate_usage_for_thread(thread_id)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to aggregate thread usage: {e}")))?;
+    let combined = usage.combined();
+    let cost = &mut session.metadata.cost;
+    cost.session_cost_usd = cost.session_cost_usd.max(usage.parent.cost_usd);
+    cost.session_cost_cny = cost.session_cost_cny.max(usage.parent.cost_cny);
+    cost.subagent_cost_usd = cost.subagent_cost_usd.max(usage.routed_children.cost_usd);
+    cost.subagent_cost_cny = cost.subagent_cost_cny.max(usage.routed_children.cost_cny);
+    // The display total is session + subagent, so the high-water mark rides
+    // the combined figure in both currencies.
+    cost.displayed_cost_high_water_usd = cost.displayed_cost_high_water_usd.max(combined.cost_usd);
+    cost.displayed_cost_high_water_cny = cost.displayed_cost_high_water_cny.max(combined.cost_cny);
+    cost.priced_turns = cost
+        .priced_turns
+        .max(u32::try_from(usage.parent.priced_turns).unwrap_or(u32::MAX));
+    cost.unpriced_turns = cost
+        .unpriced_turns
+        .max(u32::try_from(usage.parent.unpriced_turns).unwrap_or(u32::MAX));
+    cost.cny_priced_turns = cost
+        .cny_priced_turns
+        .max(u32::try_from(usage.parent.cny_priced_turns).unwrap_or(u32::MAX));
+    cost.cny_unpriced_turns = cost
+        .cny_unpriced_turns
+        .max(u32::try_from(usage.parent.cny_unpriced_turns).unwrap_or(u32::MAX));
+    cost.coverage_recorded = true;
+    Ok(())
+}
+
 /// `PUT /v1/sessions` — save a thread's current engine state as a session.
 ///
 /// Unlike `POST /v1/sessions` (which reconstructs messages from stored turn
@@ -687,7 +741,7 @@ pub(super) async fn save_current_session(
     // Only `io::ErrorKind::NotFound` falls back to creating a new session;
     // other I/O errors (e.g. PermissionDenied) are propagated so callers
     // don't silently overwrite a corrupt or inaccessible session file.
-    let session = if let Some(ref existing_id) = req.session_id {
+    let mut session = if let Some(ref existing_id) = req.session_id {
         match manager.load_session(existing_id) {
             Ok(existing) => {
                 let mut updated = crate::session_manager::update_session(
@@ -742,6 +796,8 @@ pub(super) async fn save_current_session(
         );
         session
     };
+
+    persist_thread_cost(&state, &thread_id, &mut session).await?;
 
     // Save the session.
     manager

--- a/crates/tui/src/runtime_api/sessions.rs
+++ b/crates/tui/src/runtime_api/sessions.rs
@@ -688,6 +688,24 @@ async fn persist_thread_cost(
     cost.cny_unpriced_turns = cost
         .cny_unpriced_turns
         .max(u32::try_from(usage.parent.cny_unpriced_turns).unwrap_or(u32::MAX));
+    // Coverage travels with the money (#4318): reasons and classes are the
+    // qualifiers a reload needs to treat these totals as known, not a
+    // legacy-unknown complete zero. Parent-turn coverage only — the same
+    // field the TUI writer uses; routed-child spend lives in subagent_cost_*.
+    cost.unpriced_reasons
+        .extend(usage.parent.unpriced_reasons.iter().cloned());
+    cost.cny_unpriced_reasons
+        .extend(usage.parent.cny_unpriced_reasons.iter().cloned());
+    cost.unpriced_classes
+        .extend(usage.parent.unpriced_classes.iter().cloned());
+    cost.pricing_provenances
+        .extend(usage.parent.pricing_provenances.iter().cloned());
+    cost.live_pricing_defects
+        .extend(usage.parent.live_pricing_defects.iter().cloned());
+    cost.live_pricing_unusable_defects
+        .extend(usage.parent.live_pricing_unusable_defects.iter().cloned());
+    cost.route_receipts
+        .extend(usage.parent.route_receipts.iter().cloned());
     cost.coverage_recorded = true;
     Ok(())
 }

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -5356,6 +5356,8 @@ async fn thread_usage_endpoint_scopes_totals_to_one_thread() -> Result<()> {
     assert_eq!(usage["totals"]["turns"], 0);
     assert_eq!(usage["totals"]["priced_turns"], 0);
     assert_eq!(usage["totals"]["cny_priced_turns"], 0);
+    assert_eq!(usage["totals"]["cny_unpriced_turns"], 0);
+    assert_eq!(usage["totals"]["cny_unpriced_reasons"], json!([]));
     assert_eq!(usage["totals"]["cost_complete"], true);
 
     let missing = client
@@ -5529,6 +5531,11 @@ async fn session_save_merges_thread_cost_split_and_records_coverage() -> Result<
     assert_eq!(cost.unpriced_turns, 0);
     assert_eq!(cost.cny_priced_turns, 1);
     assert_eq!(cost.cny_unpriced_turns, 0);
+    assert!(cost.unpriced_reasons.is_empty());
+    assert!(
+        cost.cny_unpriced_reasons.is_empty(),
+        "DeepSeek first-party parent is CNY-priced; reasons must not invent a gap"
+    );
 
     // Re-saving is idempotent: max-merge never re-adds the same spend.
     client
@@ -5549,6 +5556,135 @@ async fn session_save_merges_thread_cost_split_and_records_coverage() -> Result<
         resaved.metadata.cost.subagent_cost_usd,
         cost.subagent_cost_usd
     );
+
+    handle.abort();
+    Ok(())
+}
+
+/// USD-unpriced parent + DeepSeek-priced child: coverage reasons persist
+/// with the parent columns (#4318) while routed spend still lands only in
+/// `subagent_cost_*` (no double-count on reload).
+#[tokio::test]
+async fn session_save_persists_parent_cny_unpriced_reasons_without_double_count() -> Result<()> {
+    let root = std::env::temp_dir().join(format!("deepseek-session-cny-{}", Uuid::new_v4()));
+    let sessions_dir = root.join("sessions");
+    let Some((addr, runtime_threads, handle)) =
+        spawn_test_server_with_root(root.clone(), sessions_dir.clone()).await?
+    else {
+        return Ok(());
+    };
+    let client = crate::tls::reqwest_client();
+
+    let created: serde_json::Value = client
+        .post(format!("http://{addr}/v1/threads"))
+        .json(&json!({
+            "model": "gpt-5.5",
+            "workspace": root.join("workspace")
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let thread_id = created["id"]
+        .as_str()
+        .context("missing thread id")?
+        .to_string();
+
+    let store = runtime_threads.test_store();
+    let now = Utc::now();
+    let mut turn = TurnRecord {
+        schema_version: 2,
+        id: "turn_cny_reasons".to_string(),
+        thread_id: thread_id.clone(),
+        status: RuntimeTurnStatus::Completed,
+        input_summary: "cny reasons".to_string(),
+        created_at: now,
+        started_at: Some(now),
+        ended_at: Some(now),
+        duration_ms: Some(0),
+        usage: Some(Usage {
+            input_tokens: 10_000,
+            output_tokens: 1_000,
+            ..Usage::default()
+        }),
+        permission_posture: None,
+        effective_provider: None,
+        effective_provider_id: None,
+        effective_billing_surface: None,
+        effective_endpoint_fingerprint: None,
+        effective_billing_mode: None,
+        effective_dispatched_at: None,
+        effective_model: None,
+        routed_usage: vec![crate::cost_status::EffectiveRouteUsage {
+            route: crate::cost_status::EffectiveRouteEnvelope {
+                provider: ApiProvider::Deepseek,
+                provider_identity: ApiProvider::Deepseek.as_str().to_string(),
+                model: "deepseek-v4-flash".to_string(),
+                billing_surface: Some(crate::pricing::FIRST_PARTY_PAYG_BILLING_SURFACE.to_string()),
+                endpoint_fingerprint: None,
+                billing_mode: crate::cost_status::RouteBillingMode::Metered,
+                dispatched_at: now,
+            },
+            usage: Usage {
+                input_tokens: 20_000,
+                output_tokens: 2_000,
+                ..Usage::default()
+            },
+        }],
+        routed_usage_source_ids: Vec::new(),
+        routed_usage_dropped_records: 0,
+        error: None,
+        item_ids: Vec::new(),
+        steer_count: 0,
+        agent_mail_message_id: None,
+    };
+    turn.effective_provider = Some(ApiProvider::Openai.as_str().to_string());
+    turn.effective_provider_id = Some(ApiProvider::Openai.as_str().to_string());
+    turn.effective_billing_surface = Some(crate::pricing::UNCLASSIFIED_BILLING_SURFACE.to_string());
+    turn.effective_endpoint_fingerprint = None;
+    turn.effective_billing_mode = Some(crate::cost_status::RouteBillingMode::Metered);
+    turn.effective_dispatched_at = Some(now);
+    turn.effective_model = Some("gpt-5.5".to_string());
+    store.save_turn(&turn)?;
+    let mut thread = store.load_thread(&thread_id)?;
+    thread.latest_turn_id = Some(turn.id.clone());
+    store.save_thread(&thread)?;
+
+    client
+        .put(format!("http://{addr}/v1/sessions"))
+        .json(&json!({
+            "thread_id": thread_id,
+            "session_id": "sess_cny_reasons"
+        }))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let session_manager = crate::session_manager::SessionManager::new(sessions_dir)?;
+    let saved = session_manager.load_session_by_prefix("sess_cny_reasons")?;
+    let cost = &saved.metadata.cost;
+    assert_eq!(
+        cost.session_cost_usd, 0.0,
+        "unpriced parent must not invent USD"
+    );
+    assert!(
+        cost.subagent_cost_usd > 0.0,
+        "routed DeepSeek child is priced"
+    );
+    assert_eq!(
+        cost.priced_turns, 0,
+        "parent coverage columns stay parent-only"
+    );
+    assert_eq!(cost.unpriced_turns, 1);
+    assert_eq!(cost.cny_unpriced_turns, 1);
+    assert!(!cost.unpriced_reasons.is_empty());
+    assert!(
+        !cost.cny_unpriced_reasons.is_empty(),
+        "CNY reasons must persist with the parent coverage counts (#4318)"
+    );
+    assert!(cost.coverage_recorded);
+    assert!(!cost.coverage_is_legacy_unknown());
 
     handle.abort();
     Ok(())

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -5319,6 +5319,241 @@ async fn usage_endpoint_returns_empty_aggregation_for_fresh_store() -> Result<()
     Ok(())
 }
 
+/// `GET /v1/threads/{id}/usage` reports the thread-scoped token + cost
+/// totals the GUI's session-cost surface consumes. A thread with no turns
+/// yields zeroed totals (both published currencies present in the payload);
+/// a thread that does not exist is a 404, never zeros, so the GUI cannot
+/// mistake a typo'd id for a free conversation.
+#[tokio::test]
+async fn thread_usage_endpoint_scopes_totals_to_one_thread() -> Result<()> {
+    let Some((addr, _runtime_threads, handle)) = spawn_test_server().await? else {
+        return Ok(());
+    };
+    let client = crate::tls::reqwest_client();
+
+    let created: serde_json::Value = client
+        .post(format!("http://{addr}/v1/threads"))
+        .json(&json!({}))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let id = created["id"].as_str().expect("thread id").to_string();
+
+    let usage: serde_json::Value = client
+        .get(format!("http://{addr}/v1/threads/{id}/usage"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(usage["thread_id"], id);
+    assert_eq!(usage["totals"]["input_tokens"], 0);
+    assert_eq!(usage["totals"]["output_tokens"], 0);
+    assert_eq!(usage["totals"]["cost_usd"], 0.0);
+    assert_eq!(usage["totals"]["cost_cny"], 0.0);
+    assert_eq!(usage["totals"]["turns"], 0);
+    assert_eq!(usage["totals"]["priced_turns"], 0);
+    assert_eq!(usage["totals"]["cny_priced_turns"], 0);
+    assert_eq!(usage["totals"]["cost_complete"], true);
+
+    let missing = client
+        .get(format!("http://{addr}/v1/threads/does-not-exist/usage"))
+        .send()
+        .await?;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+    handle.abort();
+    Ok(())
+}
+
+/// `PUT /v1/sessions` persists the thread's audited cost with the same
+/// field semantics the TUI writer uses: parent-turn spend in
+/// `session_cost_*`, routed-child spend in `subagent_cost_*`, so a session
+/// that already carries TUI-written sub-agent spend keeps one display total
+/// instead of counting child spend twice. Coverage rides along (#4318):
+/// `coverage_recorded` is set and the CNY counters describe the provider's
+/// own CNY rows, so a reload reads the totals as known, not legacy-unknown.
+#[tokio::test]
+async fn session_save_merges_thread_cost_split_and_records_coverage() -> Result<()> {
+    let root = std::env::temp_dir().join(format!("deepseek-session-cost-{}", Uuid::new_v4()));
+    let sessions_dir = root.join("sessions");
+    let Some((addr, runtime_threads, handle)) =
+        spawn_test_server_with_root(root.clone(), sessions_dir.clone()).await?
+    else {
+        return Ok(());
+    };
+    let client = crate::tls::reqwest_client();
+
+    let created: serde_json::Value = client
+        .post(format!("http://{addr}/v1/threads"))
+        .json(&json!({
+            "model": "deepseek-v4-flash",
+            "workspace": root.join("workspace")
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let thread_id = created["id"]
+        .as_str()
+        .context("missing thread id")?
+        .to_string();
+
+    // Seed one completed turn: a DeepSeek first-party parent call plus a
+    // large routed-child (sub-agent) call, both priced.
+    let store = runtime_threads.test_store();
+    let now = Utc::now();
+    let mut turn = TurnRecord {
+        schema_version: 2,
+        id: "turn_cost_merge".to_string(),
+        thread_id: thread_id.clone(),
+        status: RuntimeTurnStatus::Completed,
+        input_summary: "cost merge".to_string(),
+        created_at: now,
+        started_at: Some(now),
+        ended_at: Some(now),
+        duration_ms: Some(0),
+        usage: Some(Usage {
+            input_tokens: 10_000,
+            output_tokens: 1_000,
+            ..Usage::default()
+        }),
+        permission_posture: None,
+        effective_provider: None,
+        effective_provider_id: None,
+        effective_billing_surface: None,
+        effective_endpoint_fingerprint: None,
+        effective_billing_mode: None,
+        effective_dispatched_at: None,
+        effective_model: None,
+        routed_usage: vec![crate::cost_status::EffectiveRouteUsage {
+            route: crate::cost_status::EffectiveRouteEnvelope {
+                provider: ApiProvider::Deepseek,
+                provider_identity: ApiProvider::Deepseek.as_str().to_string(),
+                model: "deepseek-v4-flash".to_string(),
+                billing_surface: Some(crate::pricing::FIRST_PARTY_PAYG_BILLING_SURFACE.to_string()),
+                endpoint_fingerprint: None,
+                billing_mode: crate::cost_status::RouteBillingMode::Metered,
+                dispatched_at: now,
+            },
+            usage: Usage {
+                input_tokens: 20_000_000,
+                output_tokens: 2_000_000,
+                ..Usage::default()
+            },
+        }],
+        routed_usage_source_ids: Vec::new(),
+        routed_usage_dropped_records: 0,
+        error: None,
+        item_ids: Vec::new(),
+        steer_count: 0,
+        agent_mail_message_id: None,
+    };
+    // Mirror `TurnRecord::persist_effective_route` (private to the runtime
+    // threads module): persist the route envelope onto the turn so the
+    // recorded-time pricer sees a complete dispatch record.
+    turn.effective_provider = Some(ApiProvider::Deepseek.as_str().to_string());
+    turn.effective_provider_id = Some(ApiProvider::Deepseek.as_str().to_string());
+    turn.effective_billing_surface =
+        Some(crate::pricing::FIRST_PARTY_PAYG_BILLING_SURFACE.to_string());
+    turn.effective_endpoint_fingerprint = None;
+    turn.effective_billing_mode = Some(crate::cost_status::RouteBillingMode::Metered);
+    turn.effective_dispatched_at = Some(now);
+    turn.effective_model = Some("deepseek-v4-flash".to_string());
+    store.save_turn(&turn)?;
+    let mut thread = store.load_thread(&thread_id)?;
+    thread.latest_turn_id = Some(turn.id.clone());
+    store.save_thread(&thread)?;
+
+    let endpoint: serde_json::Value = client
+        .get(format!("http://{addr}/v1/threads/{thread_id}/usage"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let combined_usd = endpoint["totals"]["cost_usd"]
+        .as_f64()
+        .context("combined cost_usd")?;
+    assert!(combined_usd > 0.0);
+
+    // Pre-existing session file carrying TUI-written sub-agent spend — the
+    // shape a GUI save of a resumed TUI session merges into.
+    let session_manager = crate::session_manager::SessionManager::new(sessions_dir.clone())?;
+    let mut prior = crate::session_manager::create_saved_session_with_id_and_mode(
+        "sess_cost_merge".to_string(),
+        &[],
+        "deepseek-v4-flash",
+        &root,
+        0,
+        None,
+        None,
+    );
+    prior.metadata.cost.subagent_cost_usd = 0.5;
+    prior.metadata.cost.subagent_cost_cny = 3.0;
+    session_manager.save_session(&prior)?;
+
+    client
+        .put(format!("http://{addr}/v1/sessions"))
+        .json(&json!({
+            "thread_id": thread_id,
+            "session_id": "sess_cost_merge"
+        }))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let saved = session_manager.load_session_by_prefix("sess_cost_merge")?;
+    let cost = &saved.metadata.cost;
+    // Parent-turn spend lands in the parent field only, so the display
+    // total keeps exactly one copy of the child spend.
+    assert!(cost.session_cost_usd > 0.0);
+    assert!(cost.session_cost_usd < combined_usd);
+    let child_usd = combined_usd - cost.session_cost_usd;
+    assert!(child_usd > 0.5);
+    assert_eq!(cost.subagent_cost_usd, child_usd);
+    assert_eq!(
+        (cost.session_cost_usd + cost.subagent_cost_usd - combined_usd).abs(),
+        0.0
+    );
+    assert!(cost.subagent_cost_cny > 3.0);
+    assert!(cost.session_cost_cny > 0.0);
+    // Coverage the runtime computed reads back as known, with CNY counted
+    // under the provider's own CNY row.
+    assert!(cost.coverage_recorded);
+    assert!(!cost.coverage_is_legacy_unknown());
+    assert_eq!(cost.priced_turns, 1);
+    assert_eq!(cost.unpriced_turns, 0);
+    assert_eq!(cost.cny_priced_turns, 1);
+    assert_eq!(cost.cny_unpriced_turns, 0);
+
+    // Re-saving is idempotent: max-merge never re-adds the same spend.
+    client
+        .put(format!("http://{addr}/v1/sessions"))
+        .json(&json!({
+            "thread_id": thread_id,
+            "session_id": "sess_cost_merge"
+        }))
+        .send()
+        .await?
+        .error_for_status()?;
+    let resaved = session_manager.load_session_by_prefix("sess_cost_merge")?;
+    assert_eq!(
+        resaved.metadata.cost.session_cost_usd,
+        cost.session_cost_usd
+    );
+    assert_eq!(
+        resaved.metadata.cost.subagent_cost_usd,
+        cost.subagent_cost_usd
+    );
+
+    handle.abort();
+    Ok(())
+}
+
 #[tokio::test]
 async fn runtime_info_reports_bind_state() -> Result<()> {
     let Some((addr, _runtime_threads, handle)) = spawn_test_server().await? else {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2411,10 +2411,20 @@ pub struct UsageTotals {
     pub reasoning_replay_tokens: u64,
     pub cache_write_tokens: u64,
     pub cost_usd: f64,
+    /// Provider-published CNY subtotal, accrued only from turns whose route
+    /// published an authoritative CNY row (e.g. DeepSeek Platform). Never an
+    /// FX projection of `cost_usd`: USD-only routes contribute 0 here rather
+    /// than a fabricated amount, mirroring `SessionCostSnapshot`.
+    pub cost_cny: f64,
     /// Authoritative USD coverage for this aggregate. `cost_usd` is a priced
     /// subtotal whenever `unpriced_turns > 0`.
     pub priced_turns: u64,
     pub unpriced_turns: u64,
+    /// CNY-specific coverage over the same money-metered turns: a USD-only
+    /// route is CNY-unpriced rather than a fabricated complete zero, same
+    /// rule as `SessionCostSnapshot::cny_priced_turns`.
+    pub cny_priced_turns: u64,
+    pub cny_unpriced_turns: u64,
     pub nonmetered_turns: u64,
     pub cost_complete: bool,
     pub unpriced_reasons: std::collections::BTreeSet<String>,
@@ -2441,8 +2451,14 @@ pub struct UsageBucket {
     pub reasoning_replay_tokens: u64,
     pub cache_write_tokens: u64,
     pub cost_usd: f64,
+    /// Provider-published CNY subtotal; same coverage rule as the totals
+    /// field of the same name.
+    pub cost_cny: f64,
     pub priced_turns: u64,
     pub unpriced_turns: u64,
+    /// CNY-specific coverage; same rule as the totals field of the same name.
+    pub cny_priced_turns: u64,
+    pub cny_unpriced_turns: u64,
     pub nonmetered_turns: u64,
     pub cost_complete: bool,
     pub unpriced_reasons: std::collections::BTreeSet<String>,
@@ -2465,16 +2481,90 @@ pub struct UsageAggregation {
     pub buckets: Vec<UsageBucket>,
 }
 
+/// Thread-scoped usage split by spend owner, for session persistence.
+///
+/// The split mirrors `SessionCostSnapshot`'s field semantics
+/// (`session_cost_*` carries parent-turn spend, `subagent_cost_*` routed
+/// child spend) so a writer can persist each side into the field readers
+/// already project into one display total.
+#[derive(Debug, Clone, Default)]
+pub struct ThreadUsageSplit {
+    /// Parent-turn usage: the session's own provider calls.
+    pub parent: UsageTotals,
+    /// Routed child (sub-agent/background) usage recorded on those turns,
+    /// including dropped-record incompleteness markers.
+    pub routed_children: UsageTotals,
+}
+
+impl ThreadUsageSplit {
+    /// Whole-history combined totals — the figure the global `/v1/usage`
+    /// thread bucket reports and the per-thread endpoint returns.
+    #[must_use]
+    pub fn combined(&self) -> UsageTotals {
+        let mut combined = self.parent.clone();
+        merge_usage_totals(&mut combined, &self.routed_children);
+        finalize_usage_totals(&mut combined);
+        combined
+    }
+}
+
+/// Recompute the derived completeness flag after accumulation.
+fn finalize_usage_totals(totals: &mut UsageTotals) {
+    // Dropped fallback receipts also bump `unpriced_turns`, so one check
+    // covers both incompleteness markers.
+    totals.cost_complete = totals.unpriced_turns == 0;
+}
+
+/// Component-wise saturating merge of usage totals; used to rebuild the
+/// combined thread figure from the parent/child split.
+fn merge_usage_totals(into: &mut UsageTotals, from: &UsageTotals) {
+    into.input_tokens = into.input_tokens.saturating_add(from.input_tokens);
+    into.output_tokens = into.output_tokens.saturating_add(from.output_tokens);
+    into.cached_tokens = into.cached_tokens.saturating_add(from.cached_tokens);
+    into.reasoning_tokens = into.reasoning_tokens.saturating_add(from.reasoning_tokens);
+    into.reasoning_replay_tokens = into
+        .reasoning_replay_tokens
+        .saturating_add(from.reasoning_replay_tokens);
+    into.cache_write_tokens = into
+        .cache_write_tokens
+        .saturating_add(from.cache_write_tokens);
+    saturating_add_cost_amount(&mut into.cost_usd, from.cost_usd);
+    saturating_add_cost_amount(&mut into.cost_cny, from.cost_cny);
+    into.priced_turns = into.priced_turns.saturating_add(from.priced_turns);
+    into.unpriced_turns = into.unpriced_turns.saturating_add(from.unpriced_turns);
+    into.cny_priced_turns = into.cny_priced_turns.saturating_add(from.cny_priced_turns);
+    into.cny_unpriced_turns = into
+        .cny_unpriced_turns
+        .saturating_add(from.cny_unpriced_turns);
+    into.nonmetered_turns = into.nonmetered_turns.saturating_add(from.nonmetered_turns);
+    into.unpriced_reasons.extend(from.unpriced_reasons.clone());
+    into.unpriced_classes.extend(from.unpriced_classes.clone());
+    into.pricing_provenances
+        .extend(from.pricing_provenances.clone());
+    into.live_pricing_defects
+        .extend(from.live_pricing_defects.clone());
+    into.live_pricing_unusable_defects
+        .extend(from.live_pricing_unusable_defects.clone());
+    into.route_receipts.extend(from.route_receipts.clone());
+    into.dropped_usage_records = into
+        .dropped_usage_records
+        .saturating_add(from.dropped_usage_records);
+    into.turns = into.turns.saturating_add(from.turns);
+}
+
 fn accumulate_runtime_cost_coverage(
     audit: Option<&crate::pricing::TurnCostAudit>,
     priced_turns: &mut u64,
     unpriced_turns: &mut u64,
+    cny_priced_turns: &mut u64,
+    cny_unpriced_turns: &mut u64,
     nonmetered_turns: &mut u64,
     reasons: &mut std::collections::BTreeSet<String>,
     provenances: &mut std::collections::BTreeSet<String>,
 ) {
     let Some(audit) = audit else {
         *unpriced_turns = (*unpriced_turns).saturating_add(1);
+        *cny_unpriced_turns = (*cny_unpriced_turns).saturating_add(1);
         reasons.insert("unknown_provider_route".to_string());
         return;
     };
@@ -2492,6 +2582,14 @@ fn accumulate_runtime_cost_coverage(
         if let Some(reason) = audit.unpriced_reason {
             reasons.insert(reason.label().to_string());
         }
+    }
+    // CNY coverage counts the same money-metered turns under the provider's
+    // own CNY row: a USD-only route stays CNY-unpriced instead of reading as
+    // a complete zero (mirrors `cost_status`'s session-side accounting).
+    if audit.cny_priced {
+        *cny_priced_turns = (*cny_priced_turns).saturating_add(1);
+    } else {
+        *cny_unpriced_turns = (*cny_unpriced_turns).saturating_add(1);
     }
 }
 
@@ -2519,10 +2617,26 @@ fn accumulate_runtime_cost_details(
     }
 }
 
-fn saturating_add_usd(total: &mut f64, delta: f64) {
-    *total = crate::pricing::CostEstimate::usd_only(*total)
-        .saturating_add(crate::pricing::CostEstimate::usd_only(delta))
-        .usd;
+/// Add one priced amount to a running total without ever producing NaN,
+/// infinity, or a negative sum. Mirrors the component rule of
+/// `CostEstimate::saturating_add` so USD and CNY subtotals saturate
+/// identically.
+fn saturating_add_cost_amount(total: &mut f64, delta: f64) {
+    fn component(left: f64, right: f64) -> f64 {
+        let left = if left.is_finite() && left >= 0.0 {
+            left
+        } else {
+            0.0
+        };
+        let right = if right.is_finite() && right >= 0.0 {
+            right
+        } else {
+            0.0
+        };
+        let sum = left + right;
+        if sum.is_finite() { sum } else { f64::MAX }
+    }
+    *total = component(*total, delta);
 }
 
 fn runtime_usage_bucket_key(
@@ -2580,6 +2694,15 @@ fn accumulate_runtime_usage_record(
         .filter(|audit| audit.usd_priced)
         .and_then(|audit| audit.estimate)
         .map_or(0.0, |estimate| estimate.usd);
+    // CNY accrues only from provider-published CNY rows, never projected
+    // from the USD column, so routes without an authoritative CNY price
+    // contribute 0 rather than a fabricated amount (mirrors the session
+    // cost model in `tui/app.rs`).
+    let cost_cny = audit
+        .as_ref()
+        .filter(|audit| audit.cny_priced)
+        .and_then(|audit| audit.estimate)
+        .map_or(0.0, |estimate| estimate.cny);
     let receipt = route.zip(audit.as_ref()).map(|(route, audit)| {
         crate::cost_status::effective_route_usage_receipt(route, audit, usage)
     });
@@ -2594,11 +2717,14 @@ fn accumulate_runtime_usage_record(
     totals.cache_write_tokens = totals
         .cache_write_tokens
         .saturating_add(classes.cache_write);
-    saturating_add_usd(&mut totals.cost_usd, cost);
+    saturating_add_cost_amount(&mut totals.cost_usd, cost);
+    saturating_add_cost_amount(&mut totals.cost_cny, cost_cny);
     accumulate_runtime_cost_coverage(
         audit.as_ref(),
         &mut totals.priced_turns,
         &mut totals.unpriced_turns,
+        &mut totals.cny_priced_turns,
+        &mut totals.cny_unpriced_turns,
         &mut totals.nonmetered_turns,
         &mut totals.unpriced_reasons,
         &mut totals.pricing_provenances,
@@ -2629,11 +2755,14 @@ fn accumulate_runtime_usage_record(
     bucket.cache_write_tokens = bucket
         .cache_write_tokens
         .saturating_add(classes.cache_write);
-    saturating_add_usd(&mut bucket.cost_usd, cost);
+    saturating_add_cost_amount(&mut bucket.cost_usd, cost);
+    saturating_add_cost_amount(&mut bucket.cost_cny, cost_cny);
     accumulate_runtime_cost_coverage(
         audit.as_ref(),
         &mut bucket.priced_turns,
         &mut bucket.unpriced_turns,
+        &mut bucket.cny_priced_turns,
+        &mut bucket.cny_unpriced_turns,
         &mut bucket.nonmetered_turns,
         &mut bucket.unpriced_reasons,
         &mut bucket.pricing_provenances,
@@ -5129,6 +5258,75 @@ impl RuntimeThreadManager {
             totals,
             buckets: buckets.into_values().collect(),
         })
+    }
+
+    /// Thread-scoped token + cost totals for one thread's whole history,
+    /// split by spend owner.
+    ///
+    /// Reuses the exact per-record accumulation of [`Self::aggregate_usage`]
+    /// (parent usage, routed child usage, dropped-record markers) so the
+    /// per-thread figure and the global `/v1/usage` figure can never disagree
+    /// about how a turn is priced — including the CNY coverage rule. The
+    /// parent/child split mirrors the session-persistence field semantics
+    /// (`session_cost_*` vs `subagent_cost_*`), so a session resumed across
+    /// the TUI and runtime writers never double-counts child spend. A
+    /// missing thread is an error, matching [`Self::get_thread`].
+    pub async fn aggregate_usage_for_thread(&self, id: &str) -> Result<ThreadUsageSplit> {
+        let store = self.store.clone();
+        let thread_id = id.to_string();
+        let (thread, turns) = tokio::task::spawn_blocking(move || {
+            let thread = store
+                .load_thread(&thread_id)
+                .with_context(|| format!("Thread not found: {thread_id}"))?;
+            let turns = store.list_turns_for_thread(&thread_id)?;
+            Ok::<_, anyhow::Error>((thread, turns))
+        })
+        .await
+        .context("Runtime thread usage aggregation task failed")??;
+
+        let mut split = ThreadUsageSplit::default();
+        // Buckets are a discarded byproduct: the shared accumulator writes
+        // both totals and buckets, and this surface reports totals only.
+        let mut buckets: std::collections::BTreeMap<String, UsageBucket> =
+            std::collections::BTreeMap::new();
+        for turn in &turns {
+            let parent_route = turn.effective_route_envelope();
+            if let Some(usage) = turn.usage.as_ref() {
+                accumulate_runtime_usage_record(
+                    &mut split.parent,
+                    &mut buckets,
+                    UsageGroupBy::Thread,
+                    parent_route.as_ref(),
+                    usage,
+                    turn,
+                    &thread,
+                );
+            }
+            for child in &turn.routed_usage {
+                accumulate_runtime_usage_record(
+                    &mut split.routed_children,
+                    &mut buckets,
+                    UsageGroupBy::Thread,
+                    Some(&child.route),
+                    &child.usage,
+                    turn,
+                    &thread,
+                );
+            }
+            // Dropped fallback receipts are routed-child records, so the
+            // incompleteness marker lands on the child side.
+            accumulate_truncated_runtime_usage(
+                &mut split.routed_children,
+                &mut buckets,
+                UsageGroupBy::Thread,
+                turn.routed_usage_dropped_records,
+                turn,
+                &thread,
+            );
+        }
+        finalize_usage_totals(&mut split.parent);
+        finalize_usage_totals(&mut split.routed_children);
+        Ok(split)
     }
 
     pub async fn get_thread(&self, id: &str) -> Result<ThreadRecord> {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2425,6 +2425,9 @@ pub struct UsageTotals {
     /// rule as `SessionCostSnapshot::cny_priced_turns`.
     pub cny_priced_turns: u64,
     pub cny_unpriced_turns: u64,
+    /// Why CNY is missing on money-metered turns. USD-only routes record
+    /// `currency_not_published` rather than a fabricated complete zero.
+    pub cny_unpriced_reasons: std::collections::BTreeSet<String>,
     pub nonmetered_turns: u64,
     pub cost_complete: bool,
     pub unpriced_reasons: std::collections::BTreeSet<String>,
@@ -2459,6 +2462,8 @@ pub struct UsageBucket {
     /// CNY-specific coverage; same rule as the totals field of the same name.
     pub cny_priced_turns: u64,
     pub cny_unpriced_turns: u64,
+    /// Why CNY is missing; same rule as the totals field of the same name.
+    pub cny_unpriced_reasons: std::collections::BTreeSet<String>,
     pub nonmetered_turns: u64,
     pub cost_complete: bool,
     pub unpriced_reasons: std::collections::BTreeSet<String>,
@@ -2536,6 +2541,8 @@ fn merge_usage_totals(into: &mut UsageTotals, from: &UsageTotals) {
     into.cny_unpriced_turns = into
         .cny_unpriced_turns
         .saturating_add(from.cny_unpriced_turns);
+    into.cny_unpriced_reasons
+        .extend(from.cny_unpriced_reasons.clone());
     into.nonmetered_turns = into.nonmetered_turns.saturating_add(from.nonmetered_turns);
     into.unpriced_reasons.extend(from.unpriced_reasons.clone());
     into.unpriced_classes.extend(from.unpriced_classes.clone());
@@ -2560,12 +2567,14 @@ fn accumulate_runtime_cost_coverage(
     cny_unpriced_turns: &mut u64,
     nonmetered_turns: &mut u64,
     reasons: &mut std::collections::BTreeSet<String>,
+    cny_reasons: &mut std::collections::BTreeSet<String>,
     provenances: &mut std::collections::BTreeSet<String>,
 ) {
     let Some(audit) = audit else {
         *unpriced_turns = (*unpriced_turns).saturating_add(1);
         *cny_unpriced_turns = (*cny_unpriced_turns).saturating_add(1);
         reasons.insert("unknown_provider_route".to_string());
+        cny_reasons.insert("unknown_provider_route".to_string());
         return;
     };
     if let Some(provenance) = audit.provenance.as_ref() {
@@ -2590,6 +2599,12 @@ fn accumulate_runtime_cost_coverage(
         *cny_priced_turns = (*cny_priced_turns).saturating_add(1);
     } else {
         *cny_unpriced_turns = (*cny_unpriced_turns).saturating_add(1);
+        cny_reasons.insert(
+            audit
+                .unpriced_reason
+                .map_or("currency_not_published", |reason| reason.label())
+                .to_string(),
+        );
     }
 }
 
@@ -2727,6 +2742,7 @@ fn accumulate_runtime_usage_record(
         &mut totals.cny_unpriced_turns,
         &mut totals.nonmetered_turns,
         &mut totals.unpriced_reasons,
+        &mut totals.cny_unpriced_reasons,
         &mut totals.pricing_provenances,
     );
     accumulate_runtime_cost_details(
@@ -2765,6 +2781,7 @@ fn accumulate_runtime_usage_record(
         &mut bucket.cny_unpriced_turns,
         &mut bucket.nonmetered_turns,
         &mut bucket.unpriced_reasons,
+        &mut bucket.cny_unpriced_reasons,
         &mut bucket.pricing_provenances,
     );
     accumulate_runtime_cost_details(
@@ -2800,9 +2817,13 @@ fn accumulate_truncated_runtime_usage(
     }
     totals.dropped_usage_records = totals.dropped_usage_records.saturating_add(dropped);
     totals.unpriced_turns = totals.unpriced_turns.saturating_add(dropped);
+    totals.cny_unpriced_turns = totals.cny_unpriced_turns.saturating_add(dropped);
     totals.turns = totals.turns.saturating_add(dropped);
     totals
         .unpriced_reasons
+        .insert("runtime_usage_journal_truncated".to_string());
+    totals
+        .cny_unpriced_reasons
         .insert("runtime_usage_journal_truncated".to_string());
 
     let key = match group_by {
@@ -2816,9 +2837,13 @@ fn accumulate_truncated_runtime_usage(
     });
     bucket.dropped_usage_records = bucket.dropped_usage_records.saturating_add(dropped);
     bucket.unpriced_turns = bucket.unpriced_turns.saturating_add(dropped);
+    bucket.cny_unpriced_turns = bucket.cny_unpriced_turns.saturating_add(dropped);
     bucket.turns = bucket.turns.saturating_add(dropped);
     bucket
         .unpriced_reasons
+        .insert("runtime_usage_journal_truncated".to_string());
+    bucket
+        .cny_unpriced_reasons
         .insert("runtime_usage_journal_truncated".to_string());
 }
 

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -3397,12 +3397,28 @@ async fn aggregate_usage_marks_bounded_journal_truncation_incomplete() -> Result
         .await?;
     assert_eq!(report.totals.dropped_usage_records, 2);
     assert_eq!(report.totals.unpriced_turns, 2);
+    assert_eq!(report.totals.cny_unpriced_turns, 2);
     assert_eq!(report.totals.turns, 2);
     assert!(!report.totals.cost_complete);
     assert!(
         report
             .totals
             .unpriced_reasons
+            .contains("runtime_usage_journal_truncated")
+    );
+    assert!(
+        report
+            .totals
+            .cny_unpriced_reasons
+            .contains("runtime_usage_journal_truncated")
+    );
+    let bucket = report.buckets.first().expect("thread usage bucket");
+    assert_eq!(bucket.dropped_usage_records, 2);
+    assert_eq!(bucket.unpriced_turns, 2);
+    assert_eq!(bucket.cny_unpriced_turns, 2);
+    assert!(
+        bucket
+            .cny_unpriced_reasons
             .contains("runtime_usage_journal_truncated")
     );
     Ok(())

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -2872,6 +2872,128 @@ async fn aggregate_usage_keeps_codex_tokens_without_api_dollar_pricing() -> Resu
     Ok(())
 }
 
+/// `aggregate_usage_for_thread` scopes the same recorded-time pricing the
+/// global `/v1/usage` aggregate applies to exactly one thread, in both
+/// published currencies: DeepSeek's first-party rows carry native CNY, so a
+/// deepseek-priced turn must produce a non-zero `cost_cny` there, while a
+/// different thread's spend stays out of the figure. The parent/child split
+/// keeps routed-child (sub-agent) spend out of the parent figure — the split
+/// session persistence writes into `session_cost_*` vs `subagent_cost_*` —
+/// and CNY coverage counts turns under the provider's own CNY row.
+#[tokio::test]
+async fn aggregate_usage_for_thread_scopes_both_currencies_to_one_thread() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+
+    let billed = sample_thread("thr_thread_usage_billed");
+    manager.store.save_thread(&billed)?;
+    let mut turn = sample_turn(&billed.id, "turn_billed", RuntimeTurnStatus::Completed);
+    turn.usage = Some(Usage {
+        input_tokens: 10_000,
+        output_tokens: 1_000,
+        ..Usage::default()
+    });
+    set_test_turn_route(
+        &mut turn,
+        ApiProvider::Deepseek,
+        ApiProvider::Deepseek.as_str(),
+        "deepseek-v4-flash",
+        Some(crate::pricing::FIRST_PARTY_PAYG_BILLING_SURFACE),
+        crate::cost_status::RouteBillingMode::Metered,
+    );
+    turn.routed_usage = vec![crate::cost_status::EffectiveRouteUsage {
+        route: crate::cost_status::EffectiveRouteEnvelope {
+            provider: ApiProvider::Deepseek,
+            provider_identity: ApiProvider::Deepseek.as_str().to_string(),
+            model: "deepseek-v4-flash".to_string(),
+            billing_surface: Some(crate::pricing::FIRST_PARTY_PAYG_BILLING_SURFACE.to_string()),
+            endpoint_fingerprint: None,
+            billing_mode: crate::cost_status::RouteBillingMode::Metered,
+            dispatched_at: turn.created_at,
+        },
+        usage: Usage {
+            input_tokens: 2_000,
+            output_tokens: 200,
+            ..Usage::default()
+        },
+    }];
+    manager.store.save_turn(&turn)?;
+
+    // A second thread with its own priced turn must not leak into the
+    // first thread's figure.
+    let other = sample_thread("thr_thread_usage_other");
+    manager.store.save_thread(&other)?;
+    let mut other_turn = sample_turn(&other.id, "turn_other", RuntimeTurnStatus::Completed);
+    other_turn.usage = Some(Usage {
+        input_tokens: 500_000,
+        output_tokens: 500_000,
+        ..Usage::default()
+    });
+    set_test_turn_route(
+        &mut other_turn,
+        ApiProvider::Deepseek,
+        ApiProvider::Deepseek.as_str(),
+        "deepseek-v4-flash",
+        Some(crate::pricing::FIRST_PARTY_PAYG_BILLING_SURFACE),
+        crate::cost_status::RouteBillingMode::Metered,
+    );
+    manager.store.save_turn(&other_turn)?;
+
+    let split = manager.aggregate_usage_for_thread(&billed.id).await?;
+    // The split mirrors the persisted session fields: parent spend in
+    // `parent`, routed-child (sub-agent) spend in `routed_children`.
+    assert_eq!(split.parent.input_tokens, 10_000);
+    assert_eq!(split.parent.output_tokens, 1_000);
+    assert_eq!(split.parent.turns, 1);
+    assert!(split.parent.cost_usd > 0.0);
+    assert!(split.parent.cost_cny > 0.0);
+    assert_eq!(split.routed_children.input_tokens, 2_000);
+    assert_eq!(split.routed_children.turns, 1);
+    assert!(split.routed_children.cost_usd > 0.0);
+    assert!(split.routed_children.cost_cny > 0.0);
+
+    // Native CNY row: priced in CNY without any FX projection of the USD
+    // column, and the CNY coverage counters see the same money-metered
+    // turns the USD counters do.
+    assert_eq!(split.parent.priced_turns, 1);
+    assert_eq!(split.parent.unpriced_turns, 0);
+    assert_eq!(split.parent.cny_priced_turns, 1);
+    assert_eq!(split.parent.cny_unpriced_turns, 0);
+
+    let totals = split.combined();
+    assert_eq!(totals.input_tokens, 12_000);
+    assert_eq!(totals.turns, 2);
+    assert_eq!(
+        totals.cost_usd,
+        split.parent.cost_usd + split.routed_children.cost_usd
+    );
+    assert!(totals.cost_cny > 0.0);
+    assert_eq!(totals.priced_turns, 2);
+    assert_eq!(totals.unpriced_turns, 0);
+    assert_eq!(totals.cny_priced_turns, 2);
+    assert!(totals.cost_complete);
+
+    // The scoped figure agrees with the thread bucket of the global
+    // aggregate, so the GUI (per-thread endpoint) and `/v1/usage` can never
+    // disagree about the same thread.
+    let global = manager
+        .aggregate_usage(None, None, UsageGroupBy::Thread)
+        .await?;
+    let bucket = global
+        .buckets
+        .iter()
+        .find(|bucket| bucket.key == billed.id)
+        .expect("billed thread bucket");
+    assert_eq!(bucket.cost_usd, totals.cost_usd);
+    assert_eq!(bucket.cost_cny, totals.cost_cny);
+    assert_eq!(bucket.cny_priced_turns, totals.cny_priced_turns);
+
+    let missing = manager
+        .aggregate_usage_for_thread("thr_does_not_exist")
+        .await;
+    assert!(missing.is_err());
+    Ok(())
+}
+
 /// An aggregate in which nothing could be priced is unavailable, not zero.
 ///
 /// `cost_usd` is a `f64` and an all-unknown run leaves it at `0.0`, so the
@@ -3452,7 +3574,7 @@ async fn aggregate_usage_fails_closed_for_legacy_reconstructed_route() -> Result
 #[test]
 fn runtime_usage_accumulators_saturate_tokens_and_currency() {
     let mut total = f64::MAX;
-    saturating_add_usd(&mut total, f64::MAX);
+    saturating_add_cost_amount(&mut total, f64::MAX);
     assert_eq!(total, f64::MAX);
 
     let thread = sample_thread("thr_saturating");

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -2958,6 +2958,9 @@ async fn aggregate_usage_for_thread_scopes_both_currencies_to_one_thread() -> Re
     assert_eq!(split.parent.unpriced_turns, 0);
     assert_eq!(split.parent.cny_priced_turns, 1);
     assert_eq!(split.parent.cny_unpriced_turns, 0);
+    assert!(split.parent.cny_unpriced_reasons.is_empty());
+    assert_eq!(split.routed_children.cny_priced_turns, 1);
+    assert!(split.routed_children.cny_unpriced_reasons.is_empty());
 
     let totals = split.combined();
     assert_eq!(totals.input_tokens, 12_000);
@@ -3061,6 +3064,11 @@ async fn aggregate_usage_reports_an_all_unknown_run_as_unavailable_not_zero() ->
     assert!(
         !report.totals.unpriced_reasons.is_empty(),
         "an unpriced aggregate must say why"
+    );
+    assert_eq!(report.totals.cny_unpriced_turns, 2);
+    assert!(
+        !report.totals.cny_unpriced_reasons.is_empty(),
+        "CNY coverage must travel with the money (#4318)"
     );
     for bucket in &report.buckets {
         assert_eq!(bucket.priced_turns, 0);

--- a/crates/tui/src/tools/workflow/mod.rs
+++ b/crates/tui/src/tools/workflow/mod.rs
@@ -3422,6 +3422,11 @@ impl SubAgentWorkflowDriver {
         let recorded = if let Ok(mut runs) = self.state.runs.lock()
             && let Some(record) = runs.get_mut(&self.run_id)
         {
+            // A terminal run's event list is the cancel/complete receipt.
+            // Racing VM and child completions must not append after that.
+            if record.status != WorkflowRunStatus::Running {
+                return;
+            }
             record.push_event(event.clone());
             true
         } else {
@@ -3831,6 +3836,9 @@ impl SubAgentWorkflowDriver {
         if let Ok(mut runs) = self.state.runs.lock()
             && let Some(record) = runs.get_mut(&self.run_id)
         {
+            if record.status != WorkflowRunStatus::Running {
+                return;
+            }
             record.push_progress(progress_line.clone());
             record.push_event(ui_event.clone());
             record.push_dispatch_failure(failure);
@@ -4224,6 +4232,9 @@ impl WorkflowDriver for SubAgentWorkflowDriver {
         if let Ok(mut runs) = self.state.runs.lock()
             && let Some(record) = runs.get_mut(&self.run_id)
         {
+            if record.status != WorkflowRunStatus::Running {
+                return;
+            }
             record.push_progress(message.clone());
             record.push_event(ui_event.clone());
             if let Some(schema_error) = schema_error {

--- a/crates/tui/src/tools/workflow/mod.rs
+++ b/crates/tui/src/tools/workflow/mod.rs
@@ -10416,7 +10416,7 @@ FINAL RECEIPT
             .and_then(Value::as_str)
             .expect("run_id metadata");
 
-        tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        tokio::time::timeout(std::time::Duration::from_secs(15), async {
             while calls.load(Ordering::SeqCst) == 0 {
                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             }


### PR DESCRIPTION
## Summary

This is a clean, current-`main` rescue of contributor PR #5626.

- Preserves Ben Gao's original feature commit and authorship exactly.
- Adds `GET /v1/threads/{id}/usage` using the existing provider-aware usage ledger.
- Persists parent and routed-child session cost without double-counting.
- Preserves USD/CNY coverage and CNY unpriced-reason evidence across reloads.
- Adds a regression test for truncated CNY journal coverage.
- Retains the newer session-store ownership and post-compaction accounting already on `main`.
- Freezes live workflow events after a terminal cancel so a racing VM/child completion cannot append a duplicate cancel receipt (the ubuntu-latest failure on run 33050954290).

The source patches match the original contributor feature and maintainer follow-up. The only metadata repair is removal of an unrecognized Cursor co-author trailer that made the original PR's lint lane fail. Contributor credit remains attached to Ben's commit.

## Verification

- focused thread-usage endpoint coverage
- focused parent/child session-cost split and coverage
- focused CNY unpriced-reason persistence
- focused two-currency per-thread aggregation
- focused truncated-journal USD/CNY coverage
- `workflow_cancel_interrupts_vm_and_blocks_further_spawns` (10 local reruns)
- co-author credit validation
- rebased onto current `origin/main`

Supersedes #5626 after this rescue lands; do not close the contributor PR before merge.

No-Issue: Preserving-authorship rescue of existing contributor PR #5626.
