### PR TITLE
fix(config): shelter ConfigToml parses on a 16 MiB stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened the dispatcher-side config parse the same way: `ConfigStore`
+  loads and project-config parsing now deserialize `ConfigToml` on a
+  dedicated 16 MiB-stack thread (the guided-setup save path could overflow
+  a 2 MiB worker stack the same way the TUI's `ConfigFile` parse did), and
+  the #5585 setup-confirm toast test runs its runtime on an equally sized
+  thread instead of overflowing the default libtest stack.
 - Fixed detached interactive agents reporting worker usage after the parent
   turn ends with the usage missing from the session/live `/cost` total
   (#5597): interactive turns acquire an owner-scoped runtime usage lease,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3796,7 +3796,7 @@ pub fn load_project_config_outcome(workspace: &Path) -> ProjectConfigOutcome {
                 };
             }
         };
-        match toml::from_str::<ConfigToml>(&raw) {
+        match parse_config_toml_str(&raw) {
             Ok(config) => {
                 let raw_provider = toml::from_str::<toml::Value>(&raw)
                     .ok()
@@ -5123,12 +5123,39 @@ pub struct ConfigStore {
     original_raw: Option<String>,
 }
 
+/// Parse a [`ConfigToml`] on a dedicated thread with an explicit stack size.
+///
+/// `ConfigToml` nests the per-provider tables, fleet trust policy, and every
+/// typed sub-table in one struct, and the monomorphized toml/serde
+/// deserializer frames for a struct this large overflow the 2 MiB default
+/// stack of libtest and tokio worker threads in debug builds (the same
+/// hazard the TUI fixed for its `ConfigFile`; reproduced as the #5585 stack
+/// overflow through the guided-setup save path). Every production
+/// `ConfigToml` parse goes through here so config-store loads stay safe
+/// regardless of the calling thread's stack budget.
+fn parse_config_toml_str(contents: &str) -> Result<ConfigToml, toml::de::Error> {
+    std::thread::scope(|scope| {
+        match std::thread::Builder::new()
+            .name("config-toml-parse".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn_scoped(scope, || toml::from_str::<ConfigToml>(contents))
+        {
+            Ok(handle) => handle
+                .join()
+                .unwrap_or_else(|panic| std::panic::resume_unwind(panic)),
+            // Spawning can only fail under resource exhaustion; parsing on
+            // the caller's stack is still the best remaining option.
+            Err(_) => toml::from_str::<ConfigToml>(contents),
+        }
+    })
+}
+
 impl ConfigStore {
     pub fn load(path: Option<PathBuf>) -> Result<Self> {
         let path = resolve_config_path(path)?;
         let (config, original_raw) = if checked_path_exists(&path)? {
             let raw = read_checked_config_file(&path)?;
-            let mut parsed: ConfigToml = toml::from_str(&raw).map_err(|_| {
+            let mut parsed: ConfigToml = parse_config_toml_str(&raw).map_err(|_| {
                 anyhow::anyhow!(
                     "failed to parse config at {}; file contents were omitted",
                     quote_os_path(&path)

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -97,6 +97,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened the dispatcher-side config parse the same way: `ConfigStore`
+  loads and project-config parsing now deserialize `ConfigToml` on a
+  dedicated 16 MiB-stack thread (the guided-setup save path could overflow
+  a 2 MiB worker stack the same way the TUI's `ConfigFile` parse did), and
+  the #5585 setup-confirm toast test runs its runtime on an equally sized
+  thread instead of overflowing the default libtest stack.
 - Fixed detached interactive agents reporting worker usage after the parent
   turn ends with the usage missing from the session/live `/cost` total
   (#5597): interactive turns acquire an owner-scoped runtime usage lease,

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -7781,50 +7781,72 @@ async fn xai_api_key_confirmation_saves_only_the_selected_xai_slot() {
 /// #5195: the save confirmation must name where the key actually landed —
 /// the durable secret store, not the config path — and the scope it is
 /// visible from (user-global credential, available in all folders).
-#[tokio::test]
-async fn setup_confirm_toast_names_secret_store_and_global_scope() {
-    // ConfigPathEnvGuard holds the shared env lock for the whole test, so the
-    // home/backend overrides must be set after it (and never take the lock
-    // again — it is not reentrant).
-    let _config = ConfigPathEnvGuard::new();
-    let home = TempDir::new().expect("isolated toast home");
-    let _home = crate::test_support::EnvVarGuard::set(
-        "CODEWHALE_HOME",
-        home.path().to_string_lossy().as_ref(),
-    );
-    let _backend = crate::test_support::EnvVarGuard::set("CODEWHALE_SECRET_BACKEND", "file");
-    let mut app = create_test_app();
-    let mut engine = mock_engine_handle();
-    let mut config = Config::default();
-    let identity = picker_provider_identity(&config, ApiProvider::Openrouter, None)
-        .expect("OpenRouter identity");
+/// #5585: this test drives the full guided-setup save path (provider
+/// identity minting, key persistence, model/base-url pinning, and the
+/// settings/TOML round-trips they trigger). Those serde round-trips are deep
+/// enough that the default 2 MiB libtest thread stack overflows; the product
+/// paths run on the 8 MiB main thread or the sheltered 16 MiB parse threads
+/// (see `parse_config_file_str` in `config.rs` and `parse_config_toml_str`
+/// in `codewhale-config`), so this test runs its runtime on an equivalently
+/// sized stack instead of crashing.
+#[test]
+fn setup_confirm_toast_names_secret_store_and_global_scope() {
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime")
+                .block_on(async {
+                    // ConfigPathEnvGuard holds the shared env lock for the whole test, so the
+                    // home/backend overrides must be set after it (and never take the lock
+                    // again — it is not reentrant).
+                    let _config = ConfigPathEnvGuard::new();
+                    let home = TempDir::new().expect("isolated toast home");
+                    let _home = crate::test_support::EnvVarGuard::set(
+                        "CODEWHALE_HOME",
+                        home.path().to_string_lossy().as_ref(),
+                    );
+                    let _backend =
+                        crate::test_support::EnvVarGuard::set("CODEWHALE_SECRET_BACKEND", "file");
+                    let mut app = create_test_app();
+                    let mut engine = mock_engine_handle();
+                    let mut config = Config::default();
+                    let identity = picker_provider_identity(&config, ApiProvider::Openrouter, None)
+                        .expect("OpenRouter identity");
 
-    let switched = apply_provider_picker_setup_confirmed(
-        &mut app,
-        &mut engine.handle,
-        &mut config,
-        identity,
-        "toast-destination-key".to_string(),
-        "deepseek/deepseek-v4-pro".to_string(),
-        None,
-        None,
-    )
-    .await;
+                    let switched = apply_provider_picker_setup_confirmed(
+                        &mut app,
+                        &mut engine.handle,
+                        &mut config,
+                        identity,
+                        "toast-destination-key".to_string(),
+                        "deepseek/deepseek-v4-pro".to_string(),
+                        None,
+                        None,
+                    )
+                    .await;
 
-    assert!(switched, "setup confirm failed: {:?}", app.status_message);
-    let toast = app.status_message.as_deref().expect("save toast");
-    assert!(
-        toast.contains("secret store"),
-        "toast must name the secret store, got: {toast}"
-    );
-    assert!(
-        toast.contains("available in all folders"),
-        "toast must state the user-global scope, got: {toast}"
-    );
-    assert!(
-        !toast.contains("toast-destination-key"),
-        "toast must never include the key, got: {toast}"
-    );
+                    assert!(switched, "setup confirm failed: {:?}", app.status_message);
+                    let toast = app.status_message.as_deref().expect("save toast");
+                    assert!(
+                        toast.contains("secret store"),
+                        "toast must name the secret store, got: {toast}"
+                    );
+                    assert!(
+                        toast.contains("available in all folders"),
+                        "toast must state the user-global scope, got: {toast}"
+                    );
+                    assert!(
+                        !toast.contains("toast-destination-key"),
+                        "toast must never include the key, got: {toast}"
+                    );
+                })
+        })
+        .expect("spawn test thread")
+        .join()
+        .expect("test thread panicked");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Prevent the reproducible debug-build stack overflow in the guided provider-setup/config-save family.

- Parses the large dispatcher `ConfigToml` shape on a dedicated 16 MiB stack in both config-store and project-config paths.
- Preserves panic propagation and retains a caller-stack fallback if the helper thread cannot be spawned.
- Runs the full guided-setup regression on the same explicit stack budget instead of aborting the default 2 MiB test worker.
- Adds the exact 0.9.12 changelog receipt without importing unrelated integration-branch release notes.

This is a clean current-`main` integration of the verified #5585 fix.

## Verification

- `cargo fmt --all -- --check`
- 603 `codewhale-config` tests plus the guided-setup regression: 604/604 passed
- `cargo clippy -p codewhale-config -p codewhale-tui --lib --tests --locked -- -D warnings`
- co-author credit validation
- `git diff --check`

Closes #5585.
