### PR TITLE
feat(tui): add focused transcript actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session token totals now include display-only per-model-call deltas while a
   turn is running, including input/output and cache-class counters; the
   authoritative `TurnComplete` totals still reconcile exactly once (#5581).
+- Transcript focus now exposes per-block actions: `y` copies content, `Y`
+  copies the rendered metadata view, Enter opens a fullscreen block pager, and
+  `r` opens raw detail; the existing Tasks rail shortcuts remain unchanged
+  (#5551).
 - Provider neutrality (#5588): model resolution of omitted/aliased models is
   now provider-relative, OpenAI-native defaults no longer route through
   another provider's table, CLI credentials stay provider-scoped, and NVIDIA

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -83,6 +83,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session token totals now include display-only per-model-call deltas while a
   turn is running, including input/output and cache-class counters; the
   authoritative `TurnComplete` totals still reconcile exactly once (#5581).
+- Transcript focus now exposes per-block actions: `y` copies content, `Y`
+  copies the rendered metadata view, Enter opens a fullscreen block pager, and
+  `r` opens raw detail; the existing Tasks rail shortcuts remain unchanged
+  (#5551).
 - Provider neutrality (#5588): model resolution of omitted/aliased models is
   now provider-relative, OpenAI-native defaults no longer route through
   another provider's table, CLI credentials stay provider-scoped, and NVIDIA

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -163,11 +163,12 @@ use super::widgets::{ChatWidget, ComposerWidget, Renderable};
 // import the ui-internal entry points used from this file's own body.
 pub(crate) use self::activity_detail::{
     completed_assistant_answer_text, copy_cell_to_clipboard, detail_target_label,
-    open_details_pager_for_cell, turn_handoff_markdown,
+    open_details_pager_for_cell, open_focused_cell_pager, turn_handoff_markdown,
 };
 use self::activity_detail::{
-    copy_focused_cell, detail_target_cell_index, extract_reasoning_header,
-    open_reasoning_detail_pager, open_tool_details_pager, open_turn_inspector_pager,
+    copy_focused_cell, copy_focused_cell_metadata, detail_target_cell_index,
+    extract_reasoning_header, open_reasoning_detail_pager, open_tool_details_pager,
+    open_turn_inspector_pager,
 };
 // Ctrl+O now opens the full recorded Reasoning Detail for the selected or
 // current reasoning block. The whole-turn Turn Inspector moved to Ctrl+Alt+O

--- a/crates/tui/src/tui/ui/activity_detail.rs
+++ b/crates/tui/src/tui/ui/activity_detail.rs
@@ -11,10 +11,10 @@ use crate::localization::{MessageId, tr};
 use crate::snapshot::SnapshotRepo;
 use crate::tui::app::App;
 use crate::tui::footer_ui::one_line_summary;
-use crate::tui::history::{HistoryCell, ToolCell, ToolStatus};
+use crate::tui::history::{HistoryCell, ToolCell, ToolStatus, TranscriptRenderOptions};
 use crate::tui::pager::{PagerPage, PagerView};
 use crate::tui::ui_text::{
-    history_cell_to_clipboard_text, history_cell_to_text, truncate_line_to_width,
+    history_cell_to_clipboard_text, history_cell_to_text, line_to_plain, truncate_line_to_width,
 };
 
 fn selected_transcript_cell_index(app: &App) -> Option<usize> {
@@ -503,6 +503,38 @@ pub(crate) fn open_details_pager_for_cell(app: &mut App, cell_index: usize) -> b
     true
 }
 
+/// Open the focused transcript cell as a full-screen readable pager.
+pub(crate) fn open_focused_cell_pager(app: &mut App) -> bool {
+    let Some(cell_index) = detail_target_cell_index(app) else {
+        return false;
+    };
+    let Some(cell) = app.cell_at_virtual_index(cell_index) else {
+        return false;
+    };
+    let title = match cell {
+        HistoryCell::User { .. } => "You",
+        HistoryCell::Assistant { .. } => "Assistant",
+        HistoryCell::System { .. } => "Note",
+        HistoryCell::Error { .. } => "Error",
+        HistoryCell::Thinking { .. } => "Reasoning",
+        HistoryCell::Tool(_) => "Tool",
+        HistoryCell::SubAgent(_) => "Sub-agent",
+        HistoryCell::ArchivedContext { .. } => "Archived Context",
+    };
+    let width = app
+        .viewport
+        .last_transcript_area
+        .map(|area| area.width)
+        .unwrap_or(80);
+    let content = history_cell_to_text(cell, width);
+    let mut pager = PagerView::from_text(title, &content, width.saturating_sub(2));
+    if let Some(answer) = completed_assistant_answer_text(cell, width) {
+        pager = pager.with_copy_answer(answer);
+    }
+    app.view_stack.push(pager);
+    true
+}
+
 /// Copy the "focused" transcript cell to the system clipboard.
 /// The focused cell is determined by the detail-target heuristic
 /// (viewport centre or most recent cell). Returns true when text
@@ -513,6 +545,40 @@ pub(super) fn copy_focused_cell(app: &mut App) -> bool {
         return false;
     };
     copy_cell_to_clipboard(app, index)
+}
+
+/// Copy the focused cell with the transcript's role/metadata presentation.
+/// Unlike content copy, this retains the metadata prefixes used by the
+/// transcript surface and is useful for sharing a receipt or event record.
+pub(super) fn copy_focused_cell_metadata(app: &mut App) -> bool {
+    let Some(index) = detail_target_cell_index(app) else {
+        return false;
+    };
+    let Some(cell) = app.cell_at_virtual_index(index) else {
+        return false;
+    };
+    let width = app
+        .viewport
+        .last_transcript_area
+        .map(|area| area.width)
+        .unwrap_or(80);
+    let text = cell
+        .lines_with_copy_metadata(width, TranscriptRenderOptions::default())
+        .into_iter()
+        .map(|line| line_to_plain(&line.line))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if text.trim().is_empty() {
+        app.status_message = Some("Message is empty".to_string());
+        return false;
+    }
+    if app.clipboard.write_text(&text).is_ok() {
+        app.status_message = Some("Message metadata copied".to_string());
+        true
+    } else {
+        app.status_message = Some("Copy failed".to_string());
+        false
+    }
 }
 
 pub(crate) fn copy_cell_to_clipboard(app: &mut App, cell_index: usize) -> bool {
@@ -1933,6 +1999,34 @@ mod tests {
 
         assert!(copy_cell_to_clipboard(&mut app, 0));
         assert_eq!(app.clipboard.last_written_text(), Some(content));
+    }
+
+    #[test]
+    fn focused_pager_and_metadata_copy_use_the_same_cell_target() {
+        let mut app = test_app();
+        app.history = vec![HistoryCell::Assistant {
+            content: "focused markdown **answer**".to_string(),
+            streaming: false,
+        }];
+        app.resync_history_revisions();
+        app.viewport.last_transcript_area = Some(ratatui::layout::Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        assert!(open_focused_cell_pager(&mut app));
+        assert_eq!(
+            app.view_stack.top_kind(),
+            Some(crate::tui::views::ModalKind::Pager)
+        );
+        app.view_stack.pop();
+        assert!(copy_focused_cell_metadata(&mut app));
+        assert_eq!(
+            app.clipboard.last_written_text(),
+            Some("● focused markdown answer")
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -112,6 +112,23 @@ pub(super) fn handle_plain_key_before_composer(
     crate::tui::paste::handle_paste_burst_key(app, key, now)
 }
 
+/// Handle transcript actions after the paste-burst ambiguity window has
+/// resolved a typed character. The real transcript selection is required;
+/// `detail_target_cell_index` alone falls back to the latest cell and would
+/// arm these shortcuts while the composer is simply being typed into.
+fn handle_focused_transcript_action_char(app: &mut App, ch: char) -> bool {
+    if !app.input.is_empty() || !app.viewport.transcript_selection.is_active() {
+        return false;
+    }
+    match ch {
+        'y' => copy_focused_cell(app),
+        'Y' => copy_focused_cell_metadata(app),
+        'r' => detail_target_cell_index(app)
+            .is_some_and(|index| open_details_pager_for_cell(app, index)),
+        _ => false,
+    }
+}
+
 /// Flush a raw-paste ambiguity window without losing a leading Space.
 ///
 /// `FlushResult::Paste` is always composer payload. A lone typed Space is a
@@ -121,6 +138,11 @@ pub(super) fn flush_paste_burst_before_composer(app: &mut App, now: Instant) -> 
     match app.take_paste_burst_flush_if_enabled(now) {
         crate::tui::paste_burst::FlushResult::Paste(text) => {
             app.insert_str(&text);
+            true
+        }
+        crate::tui::paste_burst::FlushResult::Typed(ch)
+            if handle_focused_transcript_action_char(app, ch) =>
+        {
             true
         }
         crate::tui::paste_burst::FlushResult::Typed(' ')
@@ -4413,27 +4435,6 @@ pub(crate) async fn run_event_loop(
                         app.status_message = Some(format!("Copied {detail}"));
                     }
                     continue;
-                }
-            }
-
-            // Focused transcript actions are deliberately below the Tasks rail
-            // shortcuts so y/Y keep their existing meaning when that panel
-            // owns focus. They only fire with an empty composer and no modal.
-            if app.view_stack.is_empty()
-                && app.input.is_empty()
-                && key.modifiers == KeyModifiers::NONE
-                && detail_target_cell_index(app).is_some()
-            {
-                match key.code {
-                    KeyCode::Char('y') if copy_focused_cell(app) => continue,
-                    KeyCode::Char('Y') if copy_focused_cell_metadata(app) => continue,
-                    KeyCode::Char('r')
-                        if detail_target_cell_index(app)
-                            .is_some_and(|index| open_details_pager_for_cell(app, index)) =>
-                    {
-                        continue;
-                    }
-                    _ => {}
                 }
             }
 

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -4416,6 +4416,27 @@ pub(crate) async fn run_event_loop(
                 }
             }
 
+            // Focused transcript actions are deliberately below the Tasks rail
+            // shortcuts so y/Y keep their existing meaning when that panel
+            // owns focus. They only fire with an empty composer and no modal.
+            if app.view_stack.is_empty()
+                && app.input.is_empty()
+                && key.modifiers == KeyModifiers::NONE
+                && detail_target_cell_index(app).is_some()
+            {
+                match key.code {
+                    KeyCode::Char('y') if copy_focused_cell(app) => continue,
+                    KeyCode::Char('Y') if copy_focused_cell_metadata(app) => continue,
+                    KeyCode::Char('r')
+                        if detail_target_cell_index(app)
+                            .is_some_and(|index| open_details_pager_for_cell(app, index)) =>
+                    {
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+
             // Shifted shortcuts toggle the file-tree pane. Keep plain Ctrl+E
             // reserved for the composer end-of-line binding used by shells.
             if key_shortcuts::is_file_tree_toggle_shortcut(&key) {
@@ -4692,6 +4713,14 @@ pub(crate) async fn run_event_loop(
                         && app.input.is_empty()
                         && app.viewport.transcript_selection.is_active()
                         && open_pager_for_selection(app) =>
+                {
+                    continue;
+                }
+                KeyCode::Enter
+                    if key.modifiers == KeyModifiers::NONE
+                        && app.input.is_empty()
+                        && detail_target_cell_index(app).is_some()
+                        && open_focused_cell_pager(app) =>
                 {
                     continue;
                 }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4540,6 +4540,12 @@ fn typed_command_burst_keeps_r_and_y_out_of_transcript_actions() {
         streaming: false,
     }];
     app.resync_history_revisions();
+    let _ = render_underwater_test_app(&mut app, 60, 16);
+    select_original_cell(&mut app, 0);
+    assert!(
+        app.viewport.transcript_selection.is_active(),
+        "precondition: a standing transcript selection must arm block actions"
+    );
 
     let now = Instant::now();
     let command = "/plugin trust demo";

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4531,6 +4531,40 @@ fn active_raw_paste_keeps_space_as_payload_over_reasoning_action() {
 }
 
 #[test]
+fn typed_command_burst_keeps_r_and_y_out_of_transcript_actions() {
+    let mut app = create_test_app();
+    app.use_paste_burst_detection = true;
+    app.bracketed_paste_seen = false;
+    app.history = vec![HistoryCell::Assistant {
+        content: "previous command output".to_string(),
+        streaming: false,
+    }];
+    app.resync_history_revisions();
+
+    let now = Instant::now();
+    let command = "/plugin trust demo";
+    for (offset, ch) in command.chars().enumerate() {
+        let at = now + Duration::from_millis(offset as u64);
+        let key = KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE);
+        let _ = flush_paste_burst_before_composer(&mut app, at);
+        assert!(
+            handle_plain_key_before_composer(&mut app, &key, at),
+            "paste-burst input should retain {ch:?}"
+        );
+    }
+    assert!(flush_paste_burst_before_composer(
+        &mut app,
+        now + Duration::from_millis(500),
+    ));
+
+    assert_eq!(app.input, command);
+    assert!(
+        app.view_stack.is_empty(),
+        "typed command must not open a pager"
+    );
+}
+
+#[test]
 fn active_streaming_reasoning_keeps_its_visible_owner_across_a_delta() {
     let mut app = create_test_app();
     app.push_history_cell(running_exec_cell());

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -154,6 +154,10 @@ When `[memory] enabled = true`, typing `# foo` and pressing `Enter` appends `foo
 | `Alt-[` / `Alt-]`    | Jump between tool output blocks                     |
 | `Esc Esc`            | Backtrack to a previous user message (`←`/`→` steps, `Enter` rewinds) |
 | `Esc`                | Return focus to composer                           |
+| `y`                  | Copy the focused transcript block content          |
+| `Y`                  | Copy the focused transcript block with metadata    |
+| `Enter`              | Open the focused transcript block fullscreen       |
+| `r`                  | Open the focused block's raw markdown/detail view  |
 | Mouse drag           | Select transcript text in Codewhale                |
 | `Ctrl-C`             | Copy an active Codewhale selection                 |
 | `Cmd-click` (macOS) / `Ctrl-click` (Linux/Windows) | Open an OSC 8 link in a supporting terminal (terminal-owned) |


### PR DESCRIPTION
## Summary

Rescue of @wuisabel-gif's #5608 onto current `main`. Authorship of the feature and paste-burst fix commits is preserved (`Isabel Wu <231155141+wuisabel-gif@users.noreply.github.com>`). The original PR was closed as already integrated on a 0.9.12 integration branch, but the work never reached `origin/main`.

When the transcript is focused and the composer is empty, the current focused block now supports:

- `y` — copy canonical block content;
- `Y` — copy the rendered metadata/receipt view;
- `Enter` — open the block in a fullscreen readable pager;
- `r` — open the existing raw detail view.

`y`/`Y`/`r` are handled after the paste-burst ambiguity window resolves and require an active transcript selection, so a standing selection cannot steal characters from a typed command such as `/plugin trust demo`. Tasks rail `y`/`Y` shortcuts remain unchanged.

`docs/KEYBINDINGS.md` and the changelog are updated.

Original: https://github.com/Hmbown/CodeWhale/pull/5608

## Testing

- [x] `python3 scripts/check-coauthor-trailers.py --range origin/main..HEAD` (passed for 3 commits)
- [x] `cargo test -p codewhale-tui --lib 'tui::ui::activity_detail' --locked` (11 passed, including `focused_pager_and_metadata_copy_use_the_same_cell_target`)
- [x] `cargo test -p codewhale-tui --lib typed_command_burst_keeps_r_and_y_out_of_transcript_actions --locked` (1 passed)
- [x] `git diff --check`

No-Issue: Re-lands the already-reviewed #5608 / #5551 transcript-action slice; does not close the broader #5551 issue.