### PR TITLE
fix(routing): require explicit provider authority (#5588)

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
 
 use codewhale_config::{ProviderKind, opencode_go_chat_model_id};
 use serde::{Deserialize, Serialize};
@@ -48,11 +49,92 @@ pub struct ModelResolution {
     pub requested: Option<String>,
     /// The concrete model that was resolved.
     pub resolved: ModelInfo,
-    /// Whether a fallback was used because the requested model was not found.
+    /// Whether the provider-owned default was used because no model was requested.
     pub used_fallback: bool,
     /// The ordered list of resolution strategies that were attempted.
     pub fallback_chain: Vec<String>,
 }
+
+/// A model lookup that cannot name a provider-owned result truthfully.
+///
+/// The registry is metadata, not route authority. In particular, a missing
+/// provider must never be interpreted as permission to select DeepSeek (or
+/// any other provider), and an explicit provider with no registered models
+/// must never fall through to another provider's first catalog row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelResolutionError {
+    /// No provider was supplied. A model name alone is never route authority,
+    /// even when it happens to match one catalog entry.
+    ProviderRequired { requested: Option<String> },
+    /// The caller selected a provider for which this registry has no model
+    /// metadata to return.
+    ProviderHasNoModels {
+        provider: ProviderKind,
+        requested: Option<String>,
+    },
+    /// The caller selected a provider, then requested a model that provider's
+    /// registry rows and explicit pass-through contract do not serve.
+    ModelNotAvailableForProvider {
+        provider: ProviderKind,
+        requested: String,
+    },
+    /// The provider declares a default model, but the registry cannot return a
+    /// matching provider-owned row for it.
+    ProviderDefaultUnavailable {
+        provider: ProviderKind,
+        default_model: String,
+    },
+}
+
+impl fmt::Display for ModelResolutionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ProviderRequired {
+                requested: Some(requested),
+            } => write!(
+                formatter,
+                "model '{requested}' does not identify an unambiguous provider; select a provider explicitly"
+            ),
+            Self::ProviderRequired { requested: None } => {
+                formatter.write_str("model resolution requires an explicit provider")
+            }
+            Self::ProviderHasNoModels {
+                provider,
+                requested: Some(requested),
+            } => write!(
+                formatter,
+                "provider '{}' has no registered model for '{requested}'",
+                provider.as_str()
+            ),
+            Self::ProviderHasNoModels {
+                provider,
+                requested: None,
+            } => write!(
+                formatter,
+                "provider '{}' has no registered default model",
+                provider.as_str()
+            ),
+            Self::ModelNotAvailableForProvider {
+                provider,
+                requested,
+            } => write!(
+                formatter,
+                "model '{requested}' is not available from provider '{}'",
+                provider.as_str()
+            ),
+            Self::ProviderDefaultUnavailable {
+                provider,
+                default_model,
+            } => write!(
+                formatter,
+                "provider '{}' declares default model '{default_model}', but that model is not registered for the provider",
+                provider.as_str()
+            ),
+        }
+    }
+}
+
+impl Error for ModelResolutionError {}
 
 /// A registry of supported models and their aliases, used to resolve user-facing
 /// model names to concrete provider-specific model entries.
@@ -62,7 +144,6 @@ pub struct ModelResolution {
 #[derive(Debug, Clone)]
 pub struct ModelRegistry {
     models: Vec<ModelInfo>,
-    alias_map: HashMap<String, usize>,
 }
 
 /// Creates a registry pre-populated with all built-in models and their aliases.
@@ -637,10 +718,13 @@ impl Default for ModelRegistry {
             ModelInfo {
                 id: "deepseek-ai/DeepSeek-V4-Pro".to_string(),
                 provider: ProviderKind::Siliconflow,
+                // `deepseek-reasoner` and `deepseek-r1` deliberately do NOT
+                // appear here. Every other provider maps both to V4-Flash, so
+                // listing them on a Pro row made one alias mean two tiers —
+                // and Pro costs ~3x Flash per input token. An alias must name
+                // one model everywhere or it is a silent substitution.
                 aliases: vec![
                     "deepseek-v4-pro".to_string(),
-                    "deepseek-reasoner".to_string(),
-                    "deepseek-r1".to_string(),
                     "siliconflow-deepseek-v4-pro".to_string(),
                 ],
                 supports_tools: true,
@@ -1334,25 +1418,37 @@ impl Default for ModelRegistry {
 impl ModelRegistry {
     /// Creates a new registry from a list of [`ModelInfo`] entries.
     ///
-    /// Builds an internal alias map for fast lookup by model id or alias.
-    /// If multiple models share the same id or alias, the first one registered
-    /// takes priority.
     #[must_use]
     pub fn new(models: Vec<ModelInfo>) -> Self {
-        let mut alias_map = HashMap::new();
-        for (idx, model) in models.iter().enumerate() {
-            alias_map.entry(normalize(&model.id)).or_insert(idx);
-            for alias in &model.aliases {
-                alias_map.entry(normalize(alias)).or_insert(idx);
-            }
-        }
-        Self { models, alias_map }
+        Self { models }
     }
 
     /// Returns a clone of all models in the registry.
     #[must_use]
     pub fn list(&self) -> Vec<ModelInfo> {
         self.models.clone()
+    }
+
+    /// Returns whether a selector is known only outside the selected provider.
+    ///
+    /// This is rejection metadata, never route authority: callers may use it
+    /// to reject a clearly foreign model, but must not use the matching row to
+    /// select a provider or credential slot.
+    #[must_use]
+    pub fn is_known_for_other_provider(
+        &self,
+        requested: &str,
+        selected_provider: ProviderKind,
+    ) -> bool {
+        let known_here = self
+            .models
+            .iter()
+            .any(|model| model.provider == selected_provider && model_matches(model, requested));
+        !known_here
+            && self
+                .models
+                .iter()
+                .any(|model| model.provider != selected_provider && model_matches(model, requested))
     }
 
     /// Resolves a user-requested model name to a concrete [`ModelInfo`].
@@ -1362,17 +1458,24 @@ impl ModelRegistry {
     ///    support arbitrary local model tags like `qwen2.5-coder:7b`).
     /// 2. If a `provider_hint` is given, search for a model matching that
     ///    provider whose id or alias matches the request (case-insensitive).
-    /// 3. Look up the alias map for a case-insensitive match.
-    /// 4. Fall back to the first model belonging to the hinted provider
-    ///    (or DeepSeek if no hint was given).
-    /// 5. As a last resort, fall back to the first model in the registry.
-    #[must_use]
+    /// 3. Provider-specific pass-through contracts may preserve arbitrary
+    ///    model ids.
+    /// 4. An omitted model falls back to the explicitly selected provider's
+    ///    documented default.
+    /// 5. A requested model outside that provider fails closed. Model text is
+    ///    metadata and never authorizes a provider or credential switch.
     pub fn resolve(
         &self,
         requested: Option<&str>,
         provider_hint: Option<ProviderKind>,
-    ) -> ModelResolution {
+    ) -> Result<ModelResolution, ModelResolutionError> {
+        let requested = requested.filter(|name| !name.trim().is_empty());
         let mut fallback_chain = Vec::new();
+        let Some(provider) = provider_hint else {
+            return Err(ModelResolutionError::ProviderRequired {
+                requested: requested.map(ToOwned::to_owned),
+            });
+        };
 
         if let Some(name) = requested {
             fallback_chain.push(format!("requested:{name}"));
@@ -1380,7 +1483,7 @@ impl ModelRegistry {
                 provider_hint,
                 Some(ProviderKind::Ollama | ProviderKind::OllamaCloud)
             ) {
-                return ModelResolution {
+                return Ok(ModelResolution {
                     requested: Some(name.to_string()),
                     resolved: ModelInfo {
                         id: name.trim().to_string(),
@@ -1391,7 +1494,7 @@ impl ModelRegistry {
                     },
                     used_fallback: false,
                     fallback_chain,
-                };
+                });
             }
             // OpenCode Go's catalog spans Chat Completions and Anthropic
             // Messages, while Codewhale's provider slice intentionally speaks
@@ -1409,12 +1512,12 @@ impl ModelRegistry {
                     })
                     .cloned()
             {
-                return ModelResolution {
+                return Ok(ModelResolution {
                     requested: Some(name.to_string()),
                     resolved: model,
                     used_fallback: false,
                     fallback_chain,
-                };
+                });
             }
             if provider_hint != Some(ProviderKind::OpencodeGo)
                 && let Some(provider) = provider_hint
@@ -1424,88 +1527,81 @@ impl ModelRegistry {
                     .find(|m| m.provider == provider && model_matches(m, name))
                     .cloned()
             {
-                return ModelResolution {
+                return Ok(ModelResolution {
                     requested: Some(name.to_string()),
                     resolved: model,
                     used_fallback: false,
                     fallback_chain,
-                };
+                });
             }
             if provider_hint == Some(ProviderKind::Atlascloud)
                 && let Some(model) = atlascloud_passthrough_model(name)
             {
-                return ModelResolution {
+                return Ok(ModelResolution {
                     requested: Some(name.to_string()),
                     resolved: model,
                     used_fallback: false,
                     fallback_chain,
-                };
+                });
             }
             if provider_hint == Some(ProviderKind::Arcee)
                 && let Some(model) = arcee_passthrough_model(name)
             {
-                return ModelResolution {
+                return Ok(ModelResolution {
                     requested: Some(name.to_string()),
                     resolved: model,
                     used_fallback: false,
                     fallback_chain,
-                };
+                });
             }
             if provider_hint == Some(ProviderKind::XiaomiMimo)
                 && let Some(model) = xiaomi_mimo_passthrough_model(name)
             {
-                return ModelResolution {
+                return Ok(ModelResolution {
                     requested: Some(name.to_string()),
                     resolved: model,
                     used_fallback: false,
                     fallback_chain,
-                };
+                });
             }
-            // The global alias map is a *provider-less* convenience lookup. It
-            // must never answer a provider-scoped question with another
-            // vendor's model: before this fix, `--provider moonshot` asking for
-            // `kimi-k3` was answered with OpenCode Go's `kimi-k3` because the
-            // hinted provider had no such id. A hinted request that the hinted
-            // provider cannot serve falls through to that provider's default
-            // with `used_fallback: true`, which callers already surface.
-            if provider_hint != Some(ProviderKind::OpencodeGo)
-                && let Some(idx) = self.alias_map.get(&normalize(name))
-                && provider_hint.is_none_or(|hint| self.models[*idx].provider == hint)
-            {
-                return ModelResolution {
+            if !self.models.iter().any(|model| model.provider == provider) {
+                return Err(ModelResolutionError::ProviderHasNoModels {
+                    provider,
                     requested: Some(name.to_string()),
-                    resolved: preserve_requested_model_id_case(self.models[*idx].clone(), name),
-                    used_fallback: false,
-                    fallback_chain,
-                };
+                });
             }
+            return Err(ModelResolutionError::ModelNotAvailableForProvider {
+                provider,
+                requested: name.to_string(),
+            });
         }
 
-        let provider = provider_hint.unwrap_or(ProviderKind::Deepseek);
         fallback_chain.push(format!("provider_default:{}", provider.as_str()));
-        if let Some(model) = self.models.iter().find(|m| m.provider == provider).cloned() {
-            return ModelResolution {
-                requested: requested.map(ToOwned::to_owned),
+        if !self.models.iter().any(|model| model.provider == provider) {
+            return Err(ModelResolutionError::ProviderHasNoModels {
+                provider,
+                requested: None,
+            });
+        }
+        let default_model = provider.provider().default_model();
+        if let Some(model) = self
+            .models
+            .iter()
+            .find(|model| model.provider == provider && model_matches(model, default_model))
+            .cloned()
+        {
+            return Ok(ModelResolution {
+                requested: None,
                 resolved: model,
                 used_fallback: true,
                 fallback_chain,
-            };
+            });
         }
 
-        let final_fallback = self.models.first().cloned().unwrap_or(ModelInfo {
-            id: "deepseek-v4-pro".to_string(),
-            provider: ProviderKind::Deepseek,
-            aliases: Vec::new(),
-            supports_tools: true,
-            supports_reasoning: true,
-        });
-        fallback_chain.push("global_default:deepseek-v4-pro".to_string());
-        ModelResolution {
-            requested: requested.map(ToOwned::to_owned),
-            resolved: final_fallback,
-            used_fallback: true,
-            fallback_chain,
-        }
+        Err(ModelResolutionError::ProviderDefaultUnavailable {
+            provider,
+            default_model: default_model.to_string(),
+        })
     }
 }
 
@@ -1577,14 +1673,6 @@ fn model_matches(model: &ModelInfo, requested: &str) -> bool {
             .any(|alias| normalize(alias) == requested)
 }
 
-fn preserve_requested_model_id_case(mut model: ModelInfo, requested: &str) -> ModelInfo {
-    let requested = requested.trim();
-    if model.id.eq_ignore_ascii_case(requested) {
-        model.id = requested.to_string();
-    }
-    model
-}
-
 fn atlascloud_passthrough_model(requested: &str) -> Option<ModelInfo> {
     let requested = requested.trim();
     if requested.is_empty() || !requested.contains('/') {
@@ -1635,8 +1723,27 @@ fn xiaomi_mimo_passthrough_model(requested: &str) -> Option<ModelInfo> {
 mod tests {
     use super::*;
 
+    trait ModelRegistryTestExt {
+        fn resolve_ok(
+            &self,
+            requested: Option<&str>,
+            provider_hint: Option<ProviderKind>,
+        ) -> ModelResolution;
+    }
+
+    impl ModelRegistryTestExt for ModelRegistry {
+        fn resolve_ok(
+            &self,
+            requested: Option<&str>,
+            provider_hint: Option<ProviderKind>,
+        ) -> ModelResolution {
+            self.resolve(requested, provider_hint)
+                .expect("test route should resolve")
+        }
+    }
+
     #[test]
-    fn model_registry_new_builds_alias_map_correctly() {
+    fn model_registry_new_preserves_model_rows_and_aliases() {
         let models = vec![
             ModelInfo {
                 id: "Model-A".to_string(),
@@ -1648,7 +1755,7 @@ mod tests {
             ModelInfo {
                 id: "model-b".to_string(),
                 provider: ProviderKind::Deepseek,
-                aliases: vec!["alias-1".to_string()], // Duplicate alias, should not override
+                aliases: vec!["alias-1".to_string()],
                 supports_tools: true,
                 supports_reasoning: true,
             },
@@ -1656,20 +1763,130 @@ mod tests {
 
         let registry = ModelRegistry::new(models);
 
-        assert_eq!(registry.alias_map.len(), 4); // "model-a", "alias-1", "alias-2", "model-b"
-        assert_eq!(registry.alias_map.get("model-a"), Some(&0));
-        assert_eq!(registry.alias_map.get("alias-1"), Some(&0)); // First one wins
-        assert_eq!(registry.alias_map.get("alias-2"), Some(&0)); // Normalized
-        assert_eq!(registry.alias_map.get("model-b"), Some(&1));
+        let rows = registry.list();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].id, "Model-A");
+        assert_eq!(rows[0].aliases, ["alias-1", " ALIAS-2 "]);
+        assert_eq!(rows[1].id, "model-b");
     }
 
     #[test]
-    fn deepseek_v4_pro_alias_stays_deepseek_by_default() {
+    fn deepseek_v4_pro_alias_stays_deepseek_when_provider_selected() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-pro"), None);
+        let resolved = registry.resolve_ok(Some("deepseek-v4-pro"), Some(ProviderKind::Deepseek));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Deepseek);
         assert_eq!(resolved.resolved.id, "deepseek-v4-pro");
+    }
+
+    #[test]
+    fn providerless_unknown_model_requires_explicit_route_authority() {
+        let registry = ModelRegistry::default();
+
+        for requested in [None, Some("deepseek-v4-pro"), Some("not-in-the-catalog")] {
+            let error = ModelRegistry::resolve(&registry, requested, None)
+                .expect_err("provider-less fallback must fail closed");
+            assert_eq!(
+                error,
+                ModelResolutionError::ProviderRequired {
+                    requested: requested.map(str::to_string),
+                }
+            );
+            if requested.is_none() || requested == Some("not-in-the-catalog") {
+                assert!(!error.to_string().to_ascii_lowercase().contains("deepseek"));
+            }
+        }
+    }
+
+    #[test]
+    fn providerless_unknown_selectors_never_mint_provider_authority() {
+        let registry = ModelRegistry::default();
+
+        for requested in [
+            "deepseek-v4-not-a-real-model",
+            "gpt-not-a-real-model",
+            "provider/model-that-does-not-exist",
+        ] {
+            assert!(matches!(
+                ModelRegistry::resolve(&registry, Some(requested), None),
+                Err(ModelResolutionError::ProviderRequired {
+                    requested: Some(returned),
+                }) if returned == requested
+            ));
+        }
+        for requested in ["", "   "] {
+            assert!(matches!(
+                ModelRegistry::resolve(&registry, Some(requested), None),
+                Err(ModelResolutionError::ProviderRequired { requested: None })
+            ));
+        }
+    }
+
+    #[test]
+    fn explicit_provider_with_no_registry_rows_never_borrows_global_default() {
+        let registry = ModelRegistry::new(Vec::new());
+
+        let error = ModelRegistry::resolve(
+            &registry,
+            Some("provider-owned-model"),
+            Some(ProviderKind::Openrouter),
+        )
+        .expect_err("an empty provider catalog must not borrow another route");
+        assert_eq!(
+            error,
+            ModelResolutionError::ProviderHasNoModels {
+                provider: ProviderKind::Openrouter,
+                requested: Some("provider-owned-model".to_string()),
+            }
+        );
+        assert!(!error.to_string().to_ascii_lowercase().contains("deepseek"));
+    }
+
+    #[test]
+    fn explicit_deepseek_selection_retains_its_provider_owned_default() {
+        let registry = ModelRegistry::default();
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::Deepseek));
+
+        assert_eq!(resolved.resolved.provider, ProviderKind::Deepseek);
+        assert_eq!(resolved.resolved.id, "deepseek-v4-pro");
+        assert!(resolved.used_fallback);
+        assert_eq!(resolved.fallback_chain, ["provider_default:deepseek"]);
+    }
+
+    #[test]
+    fn explicit_openai_selection_uses_its_documented_default_not_first_catalog_row() {
+        let registry = ModelRegistry::default();
+
+        for requested in [None, Some(""), Some("   ")] {
+            let resolved = registry.resolve_ok(requested, Some(ProviderKind::Openai));
+            assert_eq!(resolved.requested, None);
+            assert_eq!(resolved.resolved.provider, ProviderKind::Openai);
+            assert_eq!(resolved.resolved.id, "gpt-5.6");
+            assert!(resolved.used_fallback);
+            assert_eq!(resolved.fallback_chain, ["provider_default:openai"]);
+        }
+    }
+
+    #[test]
+    fn missing_provider_default_row_fails_instead_of_borrowing_another_model() {
+        let registry = ModelRegistry::new(vec![ModelInfo {
+            id: "not-the-openai-default".to_string(),
+            provider: ProviderKind::Openai,
+            aliases: Vec::new(),
+            supports_tools: true,
+            supports_reasoning: true,
+        }]);
+
+        let error = registry
+            .resolve(None, Some(ProviderKind::Openai))
+            .expect_err("a missing provider default must fail closed");
+        assert_eq!(
+            error,
+            ModelResolutionError::ProviderDefaultUnavailable {
+                provider: ProviderKind::Openai,
+                default_model: "gpt-5.6".to_string(),
+            }
+        );
     }
 
     #[test]
@@ -1692,7 +1909,7 @@ mod tests {
             "flash-vision",
             "deepseek-v4flashvisionexp",
         ] {
-            let resolved = registry.resolve(Some(selector), Some(ProviderKind::Deepseek));
+            let resolved = registry.resolve_ok(Some(selector), Some(ProviderKind::Deepseek));
             assert_eq!(
                 resolved.resolved.id, "deepseek-v4-flash-vision-exp",
                 "{selector} must resolve to the experimental vision model"
@@ -1705,7 +1922,7 @@ mod tests {
     #[test]
     fn deepseek_v4_pro_alias_resolves_to_nvidia_nim_when_provider_hinted() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-pro"), Some(ProviderKind::NvidiaNim));
+        let resolved = registry.resolve_ok(Some("deepseek-v4-pro"), Some(ProviderKind::NvidiaNim));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::NvidiaNim);
         assert_eq!(resolved.resolved.id, "deepseek-ai/deepseek-v4-pro");
@@ -1714,7 +1931,7 @@ mod tests {
     #[test]
     fn nvidia_nim_default_uses_catalog_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::NvidiaNim));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::NvidiaNim));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::NvidiaNim);
         assert_eq!(resolved.resolved.id, "deepseek-ai/deepseek-v4-pro");
@@ -1723,7 +1940,8 @@ mod tests {
     #[test]
     fn deepseek_v4_flash_alias_resolves_to_nvidia_nim_when_provider_hinted() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-flash"), Some(ProviderKind::NvidiaNim));
+        let resolved =
+            registry.resolve_ok(Some("deepseek-v4-flash"), Some(ProviderKind::NvidiaNim));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::NvidiaNim);
         assert_eq!(resolved.resolved.id, "deepseek-ai/deepseek-v4-flash");
@@ -1732,7 +1950,7 @@ mod tests {
     #[test]
     fn atlascloud_default_uses_namespaced_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Atlascloud));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::Atlascloud));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Atlascloud);
         assert_eq!(resolved.resolved.id, "deepseek-ai/deepseek-v4-flash");
@@ -1742,7 +1960,8 @@ mod tests {
     #[test]
     fn deepseek_v4_flash_alias_resolves_to_atlascloud_when_provider_hinted() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-flash"), Some(ProviderKind::Atlascloud));
+        let resolved =
+            registry.resolve_ok(Some("deepseek-v4-flash"), Some(ProviderKind::Atlascloud));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Atlascloud);
         assert_eq!(resolved.resolved.id, "deepseek-ai/deepseek-v4-flash");
@@ -1751,7 +1970,7 @@ mod tests {
     #[test]
     fn deepseek_v4_pro_alias_resolves_to_atlascloud_when_provider_hinted() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-pro"), Some(ProviderKind::Atlascloud));
+        let resolved = registry.resolve_ok(Some("deepseek-v4-pro"), Some(ProviderKind::Atlascloud));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Atlascloud);
         assert_eq!(resolved.resolved.id, "deepseek-ai/deepseek-v4-pro");
@@ -1761,7 +1980,7 @@ mod tests {
     fn atlascloud_provider_hint_passes_through_explicit_model_id() {
         let registry = ModelRegistry::default();
         let resolved =
-            registry.resolve(Some("openai/gpt-5.2-chat"), Some(ProviderKind::Atlascloud));
+            registry.resolve_ok(Some("openai/gpt-5.2-chat"), Some(ProviderKind::Atlascloud));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Atlascloud);
         assert_eq!(resolved.resolved.id, "openai/gpt-5.2-chat");
@@ -1773,7 +1992,8 @@ mod tests {
     #[test]
     fn atlascloud_provider_hint_preserves_explicit_model_id_case() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("Qwen/Qwen3-Coder"), Some(ProviderKind::Atlascloud));
+        let resolved =
+            registry.resolve_ok(Some("Qwen/Qwen3-Coder"), Some(ProviderKind::Atlascloud));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Atlascloud);
         assert_eq!(resolved.resolved.id, "Qwen/Qwen3-Coder");
@@ -1781,19 +2001,25 @@ mod tests {
     }
 
     #[test]
-    fn atlascloud_plain_unknown_model_still_uses_provider_default() {
+    fn atlascloud_plain_unknown_model_rejects_instead_of_using_default() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("not-in-atlas"), Some(ProviderKind::Atlascloud));
+        let error = registry
+            .resolve(Some("not-in-atlas"), Some(ProviderKind::Atlascloud))
+            .expect_err("a requested unknown model must not become the provider default");
 
-        assert_eq!(resolved.resolved.provider, ProviderKind::Atlascloud);
-        assert_eq!(resolved.resolved.id, "deepseek-ai/deepseek-v4-flash");
-        assert!(resolved.used_fallback);
+        assert_eq!(
+            error,
+            ModelResolutionError::ModelNotAvailableForProvider {
+                provider: ProviderKind::Atlascloud,
+                requested: "not-in-atlas".to_string(),
+            }
+        );
     }
 
     #[test]
     fn openrouter_default_uses_namespaced_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Openrouter));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::Openrouter));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Openrouter);
         assert_eq!(resolved.resolved.id, "deepseek/deepseek-v4-pro");
@@ -1802,7 +2028,7 @@ mod tests {
     #[test]
     fn xiaomi_mimo_default_uses_canonical_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::XiaomiMimo));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::XiaomiMimo));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::XiaomiMimo);
         assert_eq!(resolved.resolved.id, "mimo-v2.5-pro");
@@ -1814,7 +2040,7 @@ mod tests {
         let registry = ModelRegistry::default();
 
         for requested in [None, Some("kimi"), Some("kimi-k2.7-code")] {
-            let resolved = registry.resolve(requested, Some(ProviderKind::Moonshot));
+            let resolved = registry.resolve_ok(requested, Some(ProviderKind::Moonshot));
 
             assert_eq!(resolved.resolved.provider, ProviderKind::Moonshot);
             assert_eq!(resolved.resolved.id, "kimi-k2.7-code");
@@ -1826,7 +2052,7 @@ mod tests {
     #[test]
     fn moonshot_explicit_kimi_k26_remains_available() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("kimi-k2.6"), Some(ProviderKind::Moonshot));
+        let resolved = registry.resolve_ok(Some("kimi-k2.6"), Some(ProviderKind::Moonshot));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Moonshot);
         assert_eq!(resolved.resolved.id, "kimi-k2.6");
@@ -1841,7 +2067,7 @@ mod tests {
         let registry = ModelRegistry::default();
 
         for (requested, expected) in [("kimi-k3", "kimi-k3"), ("k3", "k3")] {
-            let resolved = registry.resolve(Some(requested), Some(ProviderKind::Moonshot));
+            let resolved = registry.resolve_ok(Some(requested), Some(ProviderKind::Moonshot));
 
             assert_eq!(resolved.resolved.provider, ProviderKind::Moonshot);
             assert_eq!(resolved.resolved.id, expected, "{resolved:?}");
@@ -1861,14 +2087,14 @@ mod tests {
 
         assert_eq!(
             registry
-                .resolve(Some("kimi-k3"), Some(ProviderKind::Moonshot))
+                .resolve_ok(Some("kimi-k3"), Some(ProviderKind::Moonshot))
                 .resolved
                 .id,
             "kimi-k3"
         );
         assert_eq!(
             registry
-                .resolve(Some("k3"), Some(ProviderKind::Moonshot))
+                .resolve_ok(Some("k3"), Some(ProviderKind::Moonshot))
                 .resolved
                 .id,
             "k3"
@@ -1882,18 +2108,18 @@ mod tests {
     fn a_provider_hint_never_resolves_to_another_providers_model() {
         let registry = ModelRegistry::default();
 
-        let resolved = registry.resolve(Some("glm-5.2"), Some(ProviderKind::Moonshot));
+        let error = registry
+            .resolve(Some("glm-5.2"), Some(ProviderKind::Moonshot))
+            .expect_err("a Moonshot request must not be answered by Z.ai or a default");
         assert_eq!(
-            resolved.resolved.provider,
-            ProviderKind::Moonshot,
-            "a Moonshot request must not be answered by Z.ai: {resolved:?}"
-        );
-        assert!(
-            resolved.used_fallback,
-            "an unservable id must be reported as a fallback, not as the request: {resolved:?}"
+            error,
+            ModelResolutionError::ModelNotAvailableForProvider {
+                provider: ProviderKind::Moonshot,
+                requested: "glm-5.2".to_string(),
+            }
         );
 
-        let go = registry.resolve(Some("kimi-k3"), Some(ProviderKind::OpencodeGo));
+        let go = registry.resolve_ok(Some("kimi-k3"), Some(ProviderKind::OpencodeGo));
         assert_eq!(go.resolved.provider, ProviderKind::OpencodeGo);
         assert_eq!(go.resolved.id, "kimi-k3");
     }
@@ -1901,16 +2127,16 @@ mod tests {
     #[test]
     fn xiaomi_mimo_tts_aliases_resolve_when_provider_hinted() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("tts"), Some(ProviderKind::XiaomiMimo));
+        let resolved = registry.resolve_ok(Some("tts"), Some(ProviderKind::XiaomiMimo));
         assert_eq!(resolved.resolved.provider, ProviderKind::XiaomiMimo);
         assert_eq!(resolved.resolved.id, "mimo-v2.5-tts");
         assert!(!resolved.resolved.supports_tools);
         assert!(!resolved.resolved.supports_reasoning);
 
-        let resolved = registry.resolve(Some("voice-design"), Some(ProviderKind::XiaomiMimo));
+        let resolved = registry.resolve_ok(Some("voice-design"), Some(ProviderKind::XiaomiMimo));
         assert_eq!(resolved.resolved.id, "mimo-v2.5-tts-voicedesign");
 
-        let resolved = registry.resolve(Some("voiceclone"), Some(ProviderKind::XiaomiMimo));
+        let resolved = registry.resolve_ok(Some("voiceclone"), Some(ProviderKind::XiaomiMimo));
         assert_eq!(resolved.resolved.id, "mimo-v2.5-tts-voiceclone");
     }
 
@@ -1918,7 +2144,7 @@ mod tests {
     fn xiaomi_mimo_chat_aliases_resolve_when_provider_hinted() {
         let registry = ModelRegistry::default();
 
-        let resolved = registry.resolve(Some("omni"), Some(ProviderKind::XiaomiMimo));
+        let resolved = registry.resolve_ok(Some("omni"), Some(ProviderKind::XiaomiMimo));
         assert_eq!(resolved.resolved.provider, ProviderKind::XiaomiMimo);
         assert_eq!(resolved.resolved.id, "mimo-v2.5");
         assert!(resolved.resolved.supports_tools);
@@ -1928,7 +2154,7 @@ mod tests {
     fn xiaomi_mimo_provider_hint_preserves_custom_model_id() {
         let registry = ModelRegistry::default();
         let resolved =
-            registry.resolve(Some("account-custom-mimo"), Some(ProviderKind::XiaomiMimo));
+            registry.resolve_ok(Some("account-custom-mimo"), Some(ProviderKind::XiaomiMimo));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::XiaomiMimo);
         assert_eq!(resolved.resolved.id, "account-custom-mimo");
@@ -1938,7 +2164,7 @@ mod tests {
     #[test]
     fn xiaomi_mimo_provider_hint_does_not_reclassify_openrouter_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(
+        let resolved = registry.resolve_ok(
             Some("deepseek/deepseek-v4-pro"),
             Some(ProviderKind::XiaomiMimo),
         );
@@ -1951,7 +2177,7 @@ mod tests {
     #[test]
     fn wanjie_ark_default_uses_reasoner_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::WanjieArk));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::WanjieArk));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::WanjieArk);
         assert_eq!(resolved.resolved.id, "deepseek-reasoner");
@@ -1961,7 +2187,7 @@ mod tests {
     #[test]
     fn novita_default_uses_namespaced_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Novita));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::Novita));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Novita);
         assert_eq!(resolved.resolved.id, "deepseek/deepseek-v4-pro");
@@ -1970,7 +2196,7 @@ mod tests {
     #[test]
     fn fireworks_default_uses_canonical_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Fireworks));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::Fireworks));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Fireworks);
         assert_eq!(
@@ -1982,7 +2208,7 @@ mod tests {
     #[test]
     fn siliconflow_default_uses_canonical_pro_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Siliconflow));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::Siliconflow));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Siliconflow);
         assert_eq!(resolved.resolved.id, "deepseek-ai/DeepSeek-V4-Pro");
@@ -1992,7 +2218,7 @@ mod tests {
     #[test]
     fn arcee_default_uses_direct_trinity_large_thinking_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Arcee));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::Arcee));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Arcee);
         assert_eq!(resolved.resolved.id, "trinity-large-thinking");
@@ -2002,7 +2228,7 @@ mod tests {
     #[test]
     fn arcee_trinity_alias_resolves_to_direct_large_thinking_not_openrouter() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("trinity"), Some(ProviderKind::Arcee));
+        let resolved = registry.resolve_ok(Some("trinity"), Some(ProviderKind::Arcee));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Arcee);
         assert_eq!(resolved.resolved.id, "trinity-large-thinking");
@@ -2012,7 +2238,7 @@ mod tests {
     #[test]
     fn arcee_trinity_mini_remains_explicit_compatibility_model() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("trinity-mini"), Some(ProviderKind::Arcee));
+        let resolved = registry.resolve_ok(Some("trinity-mini"), Some(ProviderKind::Arcee));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Arcee);
         assert_eq!(resolved.resolved.id, "trinity-mini");
@@ -2023,7 +2249,7 @@ mod tests {
     #[test]
     fn arcee_provider_hint_preserves_explicit_future_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("trinity-large-next"), Some(ProviderKind::Arcee));
+        let resolved = registry.resolve_ok(Some("trinity-large-next"), Some(ProviderKind::Arcee));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Arcee);
         assert_eq!(resolved.resolved.id, "trinity-large-next");
@@ -2032,18 +2258,26 @@ mod tests {
     }
 
     #[test]
-    fn deepseek_reasoner_alias_resolves_to_siliconflow_pro_when_provider_hinted() {
+    fn deepseek_reasoner_does_not_silently_substitute_siliconflow_pro() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-reasoner"), Some(ProviderKind::Siliconflow));
+        let error = registry
+            .resolve(Some("deepseek-reasoner"), Some(ProviderKind::Siliconflow))
+            .expect_err("an absent alias must not become SiliconFlow's first/default row");
 
-        assert_eq!(resolved.resolved.provider, ProviderKind::Siliconflow);
-        assert_eq!(resolved.resolved.id, "deepseek-ai/DeepSeek-V4-Pro");
+        assert_eq!(
+            error,
+            ModelResolutionError::ModelNotAvailableForProvider {
+                provider: ProviderKind::Siliconflow,
+                requested: "deepseek-reasoner".to_string(),
+            }
+        );
     }
 
     #[test]
     fn deepseek_v4_flash_alias_resolves_to_siliconflow_flash_when_provider_hinted() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-flash"), Some(ProviderKind::Siliconflow));
+        let resolved =
+            registry.resolve_ok(Some("deepseek-v4-flash"), Some(ProviderKind::Siliconflow));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Siliconflow);
         assert_eq!(resolved.resolved.id, "deepseek-ai/DeepSeek-V4-Flash");
@@ -2052,7 +2286,7 @@ mod tests {
     #[test]
     fn sglang_default_uses_canonical_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Sglang));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::Sglang));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Sglang);
         assert_eq!(resolved.resolved.id, "deepseek-ai/DeepSeek-V4-Pro");
@@ -2064,7 +2298,7 @@ mod tests {
 
         // Keep the agent registry fallback aligned with codewhale-config's
         // DEFAULT_ZAI_MODEL.
-        let default = registry.resolve(None, Some(ProviderKind::Zai));
+        let default = registry.resolve_ok(None, Some(ProviderKind::Zai));
         assert_eq!(default.resolved.provider, ProviderKind::Zai);
         assert_eq!(default.resolved.id, "GLM-5.3");
         assert!(default.used_fallback);
@@ -2084,7 +2318,7 @@ mod tests {
             ("glm-5-turbo", "GLM-5-Turbo"),
             ("zai-glm-5-turbo", "GLM-5-Turbo"),
         ] {
-            let resolved = registry.resolve(Some(alias), Some(ProviderKind::Zai));
+            let resolved = registry.resolve_ok(Some(alias), Some(ProviderKind::Zai));
 
             assert_eq!(resolved.resolved.provider, ProviderKind::Zai);
             assert_eq!(resolved.resolved.id, expected);
@@ -2143,13 +2377,14 @@ mod tests {
             ]
         );
 
-        let default = registry.resolve(None, Some(ProviderKind::OpencodeGo));
+        let default = registry.resolve_ok(None, Some(ProviderKind::OpencodeGo));
         assert_eq!(default.resolved.provider, ProviderKind::OpencodeGo);
         assert_eq!(default.resolved.id, "deepseek-v4-pro");
 
         for model in ["grok-4.5", "kimi-k3"] {
             for requested in [model.to_string(), format!("opencode-go/{model}")] {
-                let resolved = registry.resolve(Some(&requested), Some(ProviderKind::OpencodeGo));
+                let resolved =
+                    registry.resolve_ok(Some(&requested), Some(ProviderKind::OpencodeGo));
                 assert_eq!(resolved.resolved.provider, ProviderKind::OpencodeGo);
                 assert_eq!(resolved.resolved.id, model);
                 assert!(!resolved.used_fallback);
@@ -2168,14 +2403,16 @@ mod tests {
                 messages_only.to_string(),
                 format!("opencode-go/{messages_only}"),
             ] {
-                let rejected = registry.resolve(Some(&requested), Some(ProviderKind::OpencodeGo));
-                assert!(rejected.used_fallback, "{requested}");
+                let rejected = registry
+                    .resolve(Some(&requested), Some(ProviderKind::OpencodeGo))
+                    .expect_err("Messages-only id must not fall back on the Chat-only route");
                 assert_eq!(
-                    rejected.resolved.provider,
-                    ProviderKind::OpencodeGo,
-                    "{requested} must not cross-route"
+                    rejected,
+                    ModelResolutionError::ModelNotAvailableForProvider {
+                        provider: ProviderKind::OpencodeGo,
+                        requested,
+                    }
                 );
-                assert_eq!(rejected.resolved.id, "deepseek-v4-pro", "{requested}");
             }
         }
     }
@@ -2184,17 +2421,17 @@ mod tests {
     fn xai_grok_models_resolve_when_provider_hinted() {
         let registry = ModelRegistry::default();
 
-        let default = registry.resolve(None, Some(ProviderKind::Xai));
+        let default = registry.resolve_ok(None, Some(ProviderKind::Xai));
         assert_eq!(default.resolved.provider, ProviderKind::Xai);
         assert_eq!(default.resolved.id, "grok-4.6");
         assert!(default.used_fallback);
 
-        let alias = registry.resolve(Some("grok"), Some(ProviderKind::Xai));
+        let alias = registry.resolve_ok(Some("grok"), Some(ProviderKind::Xai));
         assert_eq!(alias.resolved.provider, ProviderKind::Xai);
         assert_eq!(alias.resolved.id, "grok-4.6");
         assert!(!alias.used_fallback);
 
-        let fast = registry.resolve(
+        let fast = registry.resolve_ok(
             Some("grok-4.20-0309-non-reasoning"),
             Some(ProviderKind::Xai),
         );
@@ -2207,12 +2444,12 @@ mod tests {
     fn meta_muse_spark_resolves_when_provider_hinted() {
         let registry = ModelRegistry::default();
 
-        let default = registry.resolve(None, Some(ProviderKind::Meta));
+        let default = registry.resolve_ok(None, Some(ProviderKind::Meta));
         assert_eq!(default.resolved.provider, ProviderKind::Meta);
         assert_eq!(default.resolved.id, "muse-spark-1.2");
         assert!(default.used_fallback);
 
-        let alias = registry.resolve(Some("muse-spark"), Some(ProviderKind::Meta));
+        let alias = registry.resolve_ok(Some("muse-spark"), Some(ProviderKind::Meta));
         assert_eq!(alias.resolved.provider, ProviderKind::Meta);
         assert_eq!(alias.resolved.id, "muse-spark-1.2");
         assert!(!alias.used_fallback);
@@ -2223,7 +2460,7 @@ mod tests {
     fn openai_gpt56_family_resolves_when_provider_hinted() {
         let registry = ModelRegistry::default();
         for model in ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
-            let resolved = registry.resolve(Some(model), Some(ProviderKind::Openai));
+            let resolved = registry.resolve_ok(Some(model), Some(ProviderKind::Openai));
             assert_eq!(resolved.resolved.provider, ProviderKind::Openai, "{model}");
             assert_eq!(resolved.resolved.id, model, "{model}");
             assert!(resolved.resolved.supports_tools, "{model}");
@@ -2246,7 +2483,7 @@ mod tests {
     fn stepfun_and_minimax_direct_models_resolve_when_provider_hinted() {
         let registry = ModelRegistry::default();
 
-        let stepfun = registry.resolve(None, Some(ProviderKind::Stepfun));
+        let stepfun = registry.resolve_ok(None, Some(ProviderKind::Stepfun));
         assert_eq!(stepfun.resolved.provider, ProviderKind::Stepfun);
         assert_eq!(stepfun.resolved.id, "step-3.7-flash");
 
@@ -2258,7 +2495,7 @@ mod tests {
             ("minimax-m2.1", "MiniMax-M2.1"),
             ("minimax-m2", "MiniMax-M2"),
         ] {
-            let resolved = registry.resolve(Some(alias), Some(ProviderKind::Minimax));
+            let resolved = registry.resolve_ok(Some(alias), Some(ProviderKind::Minimax));
 
             assert_eq!(resolved.resolved.provider, ProviderKind::Minimax);
             assert_eq!(resolved.resolved.id, expected);
@@ -2277,7 +2514,7 @@ mod tests {
             ("minimax-m3", "MiniMax-M3"),
             ("minimax-m2.7", "MiniMax-M2.7"),
         ] {
-            let resolved = registry.resolve(Some(alias), Some(ProviderKind::MinimaxAnthropic));
+            let resolved = registry.resolve_ok(Some(alias), Some(ProviderKind::MinimaxAnthropic));
 
             assert_eq!(resolved.resolved.provider, ProviderKind::MinimaxAnthropic);
             assert_eq!(resolved.resolved.id, expected);
@@ -2290,7 +2527,8 @@ mod tests {
     #[test]
     fn deepseek_v4_flash_alias_resolves_to_openrouter_when_provider_hinted() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-flash"), Some(ProviderKind::Openrouter));
+        let resolved =
+            registry.resolve_ok(Some("deepseek-v4-flash"), Some(ProviderKind::Openrouter));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Openrouter);
         assert_eq!(resolved.resolved.id, "deepseek/deepseek-v4-flash");
@@ -2321,7 +2559,7 @@ mod tests {
                 "nvidia/nemotron-3-ultra-550b-a55b",
             ),
         ] {
-            let resolved = registry.resolve(Some(alias), Some(ProviderKind::Openrouter));
+            let resolved = registry.resolve_ok(Some(alias), Some(ProviderKind::Openrouter));
 
             assert_eq!(resolved.resolved.provider, ProviderKind::Openrouter);
             assert_eq!(resolved.resolved.id, expected);
@@ -2333,7 +2571,7 @@ mod tests {
     #[test]
     fn deepseek_v4_flash_alias_resolves_to_novita_when_provider_hinted() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-flash"), Some(ProviderKind::Novita));
+        let resolved = registry.resolve_ok(Some("deepseek-v4-flash"), Some(ProviderKind::Novita));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Novita);
         assert_eq!(resolved.resolved.id, "deepseek/deepseek-v4-flash");
@@ -2343,7 +2581,7 @@ mod tests {
     fn together_inkling_keeps_published_wire_identity() {
         let registry = ModelRegistry::default();
         for requested in ["thinkingmachines/inkling", "inkling", "together-inkling"] {
-            let resolved = registry.resolve(Some(requested), Some(ProviderKind::Together));
+            let resolved = registry.resolve_ok(Some(requested), Some(ProviderKind::Together));
 
             assert_eq!(resolved.resolved.provider, ProviderKind::Together);
             assert_eq!(resolved.resolved.id, "thinkingmachines/inkling");
@@ -2352,10 +2590,10 @@ mod tests {
             assert!(!resolved.used_fallback);
         }
 
-        let unscoped = registry.resolve(Some("inkling"), None);
-        assert_eq!(unscoped.resolved.provider, ProviderKind::Together);
-        assert_eq!(unscoped.resolved.id, "thinkingmachines/inkling");
-        assert!(!unscoped.used_fallback);
+        assert!(matches!(
+            registry.resolve(Some("inkling"), None),
+            Err(ModelResolutionError::ProviderRequired { .. })
+        ));
     }
 
     #[test]
@@ -2380,7 +2618,7 @@ mod tests {
                 "missing {model_id} ({}) from model list",
                 provider.as_str()
             );
-            let resolved = registry.resolve(Some(model_id), Some(provider));
+            let resolved = registry.resolve_ok(Some(model_id), Some(provider));
             assert_eq!(resolved.resolved.provider, provider, "{model_id}");
             assert_eq!(resolved.resolved.id, model_id, "{model_id}");
             assert!(!resolved.used_fallback, "{model_id}");
@@ -2391,12 +2629,12 @@ mod tests {
     fn gpt_55_stays_provider_scoped_between_openai_and_codex() {
         let registry = ModelRegistry::default();
 
-        let unscoped = registry.resolve(Some("gpt-5.5"), None);
-        assert_eq!(unscoped.resolved.provider, ProviderKind::Openai);
-        assert_eq!(unscoped.resolved.id, "gpt-5.5");
-        assert!(!unscoped.used_fallback);
+        assert!(matches!(
+            registry.resolve(Some("gpt-5.5"), None),
+            Err(ModelResolutionError::ProviderRequired { .. })
+        ));
 
-        let codex = registry.resolve(Some("gpt-5.5"), Some(ProviderKind::OpenaiCodex));
+        let codex = registry.resolve_ok(Some("gpt-5.5"), Some(ProviderKind::OpenaiCodex));
         assert_eq!(codex.resolved.provider, ProviderKind::OpenaiCodex);
         assert_eq!(codex.resolved.id, "gpt-5.5");
         assert!(!codex.used_fallback);
@@ -2405,7 +2643,7 @@ mod tests {
     #[test]
     fn deepseek_v4_flash_alias_resolves_to_sglang_when_provider_hinted() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-flash"), Some(ProviderKind::Sglang));
+        let resolved = registry.resolve_ok(Some("deepseek-v4-flash"), Some(ProviderKind::Sglang));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Sglang);
         assert_eq!(resolved.resolved.id, "deepseek-ai/DeepSeek-V4-Flash");
@@ -2414,7 +2652,7 @@ mod tests {
     #[test]
     fn vllm_default_uses_canonical_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Vllm));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::Vllm));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Vllm);
         assert_eq!(resolved.resolved.id, "deepseek-ai/DeepSeek-V4-Pro");
@@ -2423,7 +2661,7 @@ mod tests {
     #[test]
     fn ollama_default_uses_small_local_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Ollama));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::Ollama));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Ollama);
         assert_eq!(resolved.resolved.id, "deepseek-v4-flash");
@@ -2433,7 +2671,7 @@ mod tests {
     #[test]
     fn ollama_cloud_default_uses_the_hosted_catalog_model_id() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::OllamaCloud));
+        let resolved = registry.resolve_ok(None, Some(ProviderKind::OllamaCloud));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::OllamaCloud);
         assert_eq!(resolved.resolved.id, "gpt-oss:120b");
@@ -2443,7 +2681,7 @@ mod tests {
     #[test]
     fn ollama_requested_model_tag_is_preserved() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("qwen2.5-coder:7b"), Some(ProviderKind::Ollama));
+        let resolved = registry.resolve_ok(Some("qwen2.5-coder:7b"), Some(ProviderKind::Ollama));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Ollama);
         assert_eq!(resolved.resolved.id, "qwen2.5-coder:7b");
@@ -2453,25 +2691,25 @@ mod tests {
     #[test]
     fn deepseek_v4_flash_alias_resolves_to_vllm_when_provider_hinted() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-flash"), Some(ProviderKind::Vllm));
+        let resolved = registry.resolve_ok(Some("deepseek-v4-flash"), Some(ProviderKind::Vllm));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Vllm);
         assert_eq!(resolved.resolved.id, "deepseek-ai/DeepSeek-V4-Flash");
     }
 
     #[test]
-    fn preserves_requested_model_casing_for_third_party_providers() {
+    fn providerless_cased_model_text_does_not_authorize_deepseek() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("DeepSeek-V4-Pro"), None);
-
-        assert_eq!(resolved.resolved.provider, ProviderKind::Deepseek);
-        assert_eq!(resolved.resolved.id, "DeepSeek-V4-Pro");
+        assert!(matches!(
+            registry.resolve(Some("DeepSeek-V4-Pro"), None),
+            Err(ModelResolutionError::ProviderRequired { .. })
+        ));
     }
 
     #[test]
     fn registry_casing_takes_priority_over_requested_casing_with_provider_hint() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("DeepSeek-V4-Pro"), Some(ProviderKind::Deepseek));
+        let resolved = registry.resolve_ok(Some("DeepSeek-V4-Pro"), Some(ProviderKind::Deepseek));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Deepseek);
         // Registry's canonical id is used even when user provides different casing
@@ -2479,18 +2717,18 @@ mod tests {
     }
 
     #[test]
-    fn preserves_requested_model_casing_without_surrounding_whitespace() {
+    fn providerless_whitespace_model_text_does_not_authorize_deepseek() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("  DeepSeek-V4-Pro  "), None);
-
-        assert_eq!(resolved.resolved.provider, ProviderKind::Deepseek);
-        assert_eq!(resolved.resolved.id, "DeepSeek-V4-Pro");
+        assert!(matches!(
+            registry.resolve(Some("  DeepSeek-V4-Pro  "), None),
+            Err(ModelResolutionError::ProviderRequired { .. })
+        ));
     }
 
     #[test]
     fn alias_match_does_not_override_requested_casing() {
         let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-reasoner"), None);
+        let resolved = registry.resolve_ok(Some("deepseek-reasoner"), Some(ProviderKind::Deepseek));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Deepseek);
         assert_eq!(resolved.resolved.id, "deepseek-v4-flash");

--- a/crates/app-server/src/chat_completions.rs
+++ b/crates/app-server/src/chat_completions.rs
@@ -1,9 +1,10 @@
 //! Provider-neutral `/v1/chat/completions` pass-through endpoint.
 //!
-//! This module resolves a model through the [`ModelRegistry`], looks up the
-//! matching provider configuration, and forwards an OpenAI-compatible request
-//! body upstream.  It does **not** import or call any DeepSeek-named client
-//! APIs — routing stays in neutral config/provider types.
+//! This module resolves a model inside the configured provider's authority and
+//! forwards an OpenAI-compatible request body upstream. Model text is metadata:
+//! it never selects a provider configuration or credential slot. It does
+//! **not** import or call any DeepSeek-named client APIs — routing stays in
+//! neutral config/provider types.
 //!
 //! Only providers whose [`WireFormat`] is [`WireFormat::ChatCompletions`] are
 //! served.  Streaming requests are explicitly rejected for now.
@@ -51,19 +52,10 @@ fn resolve_endpoint(
     registry: &ModelRegistry,
     request_model: Option<&str>,
 ) -> Result<ResolvedModelEndpoint, RouteError> {
-    let configured_base_url = provider_base_url(config, config.provider);
-    let configured_endpoint_owns_models =
-        endpoint_preserves_raw_model_ids(config.provider, &configured_base_url);
-    let provider_kind = if configured_endpoint_owns_models {
-        config.provider
-    } else {
-        request_model
-            .filter(|model| !model.trim().is_empty())
-            .and_then(|model_name| {
-                inferred_provider_for_model(registry, config.provider, model_name)
-            })
-            .unwrap_or(config.provider)
-    };
+    // The configured provider is route authority. A request's model field can
+    // select only within that provider; it may never switch endpoints or
+    // credential slots by resembling another provider's catalog row.
+    let provider_kind = config.provider;
     let provider_cfg = config.providers.for_provider(provider_kind);
     let provider_meta = provider_kind.provider();
 
@@ -71,9 +63,9 @@ fn resolve_endpoint(
     let base_url = provider_base_url(config, provider_kind);
     let endpoint_owns_models = endpoint_preserves_raw_model_ids(provider_kind, &base_url);
 
-    // Keep provider inference and wire identity separate: ModelRegistry picks
-    // the provider for a known request alias, while RouteResolver owns the
-    // provider-scoped wire model and custom-endpoint passthrough contract.
+    // ModelRegistry canonicalizes provider-owned aliases and detects clearly
+    // foreign rows. RouteResolver remains authoritative for the provider-scoped
+    // wire model and custom-endpoint passthrough contract.
     let raw_selected_model = request_model
         .filter(|m| !m.trim().is_empty())
         .map(str::to_string)
@@ -87,11 +79,23 @@ fn resolve_endpoint(
     let selected_model = if endpoint_owns_models {
         raw_selected_model
     } else {
-        let resolved = registry.resolve(Some(&raw_selected_model), Some(provider_kind));
-        if !resolved.used_fallback && resolved.resolved.provider == provider_kind {
-            resolved.resolved.id
-        } else {
-            raw_selected_model
+        match registry.resolve(Some(&raw_selected_model), Some(provider_kind)) {
+            Ok(resolved)
+                if !resolved.used_fallback && resolved.resolved.provider == provider_kind =>
+            {
+                resolved.resolved.id
+            }
+            Err(_) if registry.is_known_for_other_provider(&raw_selected_model, provider_kind) => {
+                return Err(RouteError::ForeignModelForDirectProvider {
+                    provider: provider_kind.as_str().into(),
+                    model: raw_selected_model,
+                });
+            }
+            // Registry metadata is advisory. An unknown future id stays in the
+            // selected provider's scope, where RouteResolver either accepts the
+            // provider's pass-through contract or rejects the model. It never
+            // borrows another provider's default or credentials.
+            Ok(_) | Err(_) => raw_selected_model,
         }
     };
     let route = RouteResolver::new().resolve(&RouteRequest {
@@ -158,31 +162,6 @@ fn resolve_endpoint(
         insecure_skip_tls_verify,
         wire_format,
     })
-}
-
-/// Prefer the configured provider when a model id/alias exists on more than
-/// one provider. Only a genuine scoped miss may infer a different registry
-/// provider. This keeps `deepseek-v4-pro` on a configured OpenRouter route
-/// while still allowing a DeepSeek default to route an unambiguous `inkling`
-/// request to Together.
-fn inferred_provider_for_model(
-    registry: &ModelRegistry,
-    configured_provider: ProviderKind,
-    model_name: &str,
-) -> Option<ProviderKind> {
-    // OpenCode Go is an explicit Chat-only provider scope. A same-named model
-    // on OpenRouter/MiniMax must not escape that scope through the registry's
-    // global inference; RouteResolver owns the authoritative Go allowlist and
-    // will reject Messages-only ids.
-    if configured_provider == ProviderKind::OpencodeGo {
-        return Some(configured_provider);
-    }
-    let scoped = registry.resolve(Some(model_name), Some(configured_provider));
-    if !scoped.used_fallback && scoped.resolved.provider == configured_provider {
-        return Some(configured_provider);
-    }
-    let global = registry.resolve(Some(model_name), None);
-    (!global.used_fallback).then_some(global.resolved.provider)
 }
 
 fn resolve_upstream_api_key(
@@ -626,7 +605,7 @@ api_key = "arcee-configured-key"
         let config_path = tmp.path().join("config.toml");
         let config_content = format!(
             r#"
-provider = "deepseek"
+provider = "together"
 
 [providers.together]
 base_url = "{mock_base_url}"
@@ -845,20 +824,23 @@ api_key = {provider_api_key:?}
     }
 
     #[test]
-    fn official_together_inkling_aliases_resolve_to_the_exact_wire_model() {
+    fn providerless_together_aliases_are_rejected_under_deepseek_authority() {
         let config = ConfigToml::default();
         let registry = ModelRegistry::default();
 
         for requested in ["inkling", "together-inkling", "thinkingmachines/inkling"] {
-            let endpoint =
-                resolve_endpoint(&config, &registry, Some(requested)).expect("Inkling route");
-            assert_eq!(endpoint.provider, ProviderKind::Together, "{requested}");
-            assert_eq!(endpoint.model, "thinkingmachines/inkling", "{requested}");
+            assert!(
+                matches!(
+                    resolve_endpoint(&config, &registry, Some(requested)),
+                    Err(RouteError::ForeignModelForDirectProvider { .. })
+                ),
+                "model text must not switch the configured DeepSeek route to Together: {requested}"
+            );
         }
     }
 
     #[test]
-    fn shared_alias_prefers_the_configured_provider_before_global_inference() {
+    fn shared_alias_stays_inside_the_configured_provider() {
         let config = ConfigToml {
             provider: ProviderKind::Openrouter,
             ..ConfigToml::default()
@@ -869,6 +851,94 @@ api_key = {provider_api_key:?}
                 .expect("configured-provider route");
 
         assert_eq!(endpoint.provider, ProviderKind::Openrouter);
+    }
+
+    #[test]
+    fn unknown_model_under_zai_never_infers_deepseek_provider_authority() {
+        let config = ConfigToml {
+            provider: ProviderKind::Zai,
+            ..ConfigToml::default()
+        };
+        let registry = ModelRegistry::default();
+
+        let endpoint = resolve_endpoint(&config, &registry, Some("totally-unknown-model"))
+            .expect("unknown future id stays inside explicit Z.ai authority");
+        assert_eq!(endpoint.provider, ProviderKind::Zai);
+        assert_eq!(endpoint.model, "totally-unknown-model");
+        assert_eq!(endpoint.api_key, None);
+    }
+
+    #[test]
+    fn known_deepseek_model_under_zai_is_rejected_instead_of_switching_credentials() {
+        let mut config = ConfigToml {
+            provider: ProviderKind::Zai,
+            ..ConfigToml::default()
+        };
+        config.providers.zai.api_key = Some("zai-only-key".to_string());
+        config.providers.deepseek.api_key = Some("must-not-be-selected".to_string());
+
+        assert!(matches!(
+            resolve_endpoint(
+                &config,
+                &ModelRegistry::default(),
+                Some("deepseek-reasoner")
+            ),
+            Err(RouteError::ForeignModelForDirectProvider { .. })
+        ));
+    }
+
+    #[test]
+    fn configured_together_authority_canonicalizes_its_own_inkling_aliases() {
+        let config = ConfigToml {
+            provider: ProviderKind::Together,
+            ..ConfigToml::default()
+        };
+
+        for requested in ["inkling", "together-inkling", "thinkingmachines/inkling"] {
+            let endpoint = resolve_endpoint(&config, &ModelRegistry::default(), Some(requested))
+                .expect("configured Together route");
+            assert_eq!(endpoint.provider, ProviderKind::Together, "{requested}");
+            assert_eq!(endpoint.model, "thinkingmachines/inkling", "{requested}");
+        }
+    }
+
+    #[test]
+    fn configured_provider_is_required_for_each_official_alias() {
+        let registry = ModelRegistry::default();
+
+        for (requested, provider, expected) in [
+            (
+                "qwen3.7-plus",
+                ProviderKind::Openrouter,
+                "qwen/qwen3.7-plus",
+            ),
+            ("gpt53-codex", ProviderKind::Openai, "gpt-5.3-codex"),
+            ("arcee-trinity-mini", ProviderKind::Arcee, "trinity-mini"),
+        ] {
+            let config = ConfigToml {
+                provider,
+                ..ConfigToml::default()
+            };
+            let endpoint = resolve_endpoint(&config, &registry, Some(requested))
+                .expect("provider-owned known alias route");
+            assert_eq!(endpoint.provider, provider, "{requested}");
+            assert_eq!(endpoint.model, expected, "{requested}");
+        }
+    }
+
+    #[test]
+    fn default_deepseek_route_cannot_claim_foreign_official_aliases() {
+        let config = ConfigToml::default();
+
+        for requested in ["qwen3.7-plus", "gpt53-codex", "arcee-trinity-mini"] {
+            assert!(
+                matches!(
+                    resolve_endpoint(&config, &ModelRegistry::default(), Some(requested)),
+                    Err(RouteError::ForeignModelForDirectProvider { .. })
+                ),
+                "{requested} must not select another provider from model text"
+            );
+        }
     }
 
     #[test]
@@ -957,7 +1027,7 @@ api_key = {provider_api_key:?}
     }
 
     #[test]
-    fn root_auth_and_headers_do_not_bleed_across_inferred_providers() {
+    fn foreign_model_is_rejected_before_credentials_or_headers_can_cross() {
         let mut config = ConfigToml {
             provider: ProviderKind::Deepseek,
             auth_mode: Some("none".to_string()),
@@ -969,34 +1039,10 @@ api_key = {provider_api_key:?}
         );
         config.providers.together.api_key = Some("together-key".to_string());
 
-        let endpoint = resolve_endpoint(&config, &ModelRegistry::default(), Some("inkling"))
-            .expect("Together route");
-
-        assert_eq!(endpoint.provider, ProviderKind::Together);
-        assert!(!endpoint.auth_disabled);
-        assert_eq!(endpoint.api_key.as_deref(), Some("together-key"));
-        assert!(!endpoint.http_headers.contains_key("X-Root-Route"));
-    }
-
-    #[test]
-    fn official_endpoints_forward_canonical_registry_wire_ids() {
-        let config = ConfigToml::default();
-        let registry = ModelRegistry::default();
-
-        for (requested, provider, expected) in [
-            (
-                "qwen3.7-plus",
-                ProviderKind::Openrouter,
-                "qwen/qwen3.7-plus",
-            ),
-            ("gpt53-codex", ProviderKind::Openai, "gpt-5.3-codex"),
-            ("arcee-trinity-mini", ProviderKind::Arcee, "trinity-mini"),
-        ] {
-            let endpoint =
-                resolve_endpoint(&config, &registry, Some(requested)).expect("known alias route");
-            assert_eq!(endpoint.provider, provider, "{requested}");
-            assert_eq!(endpoint.model, expected, "{requested}");
-        }
+        assert!(matches!(
+            resolve_endpoint(&config, &ModelRegistry::default(), Some("inkling")),
+            Err(RouteError::ForeignModelForDirectProvider { .. })
+        ));
     }
 
     #[test]
@@ -1020,7 +1066,10 @@ api_key = {provider_api_key:?}
 
     #[test]
     fn custom_endpoint_preserves_known_registry_alias_verbatim() {
-        let mut config = ConfigToml::default();
+        let mut config = ConfigToml {
+            provider: ProviderKind::Openrouter,
+            ..ConfigToml::default()
+        };
         config
             .providers
             .for_provider_mut(ProviderKind::Openrouter)

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4392,22 +4392,11 @@ fn run_model_command(
             }
 
             // An explicit model or provider makes this a hypothetical query
-            // ("what would this name resolve to"), so answer it against the
-            // registry — but default the provider to the configured one rather
-            // than to any single vendor.
+            // inside a named route. The subcommand provider wins; otherwise
+            // the configured runtime provider remains authoritative. Model
+            // text never authorizes switching providers or credential slots.
             let provider_hint = subcommand_provider.or(Some(resolved_runtime.provider));
-            let mut resolved = registry.resolve(queried, provider_hint);
-            // The registry refuses to answer a provider-scoped question with
-            // another vendor's model. That is right when the *user* named the
-            // provider, but the hint above is often ours: when only a model was
-            // named, "what does this id mean" is still a global question, so
-            // retry unhinted rather than substituting the configured provider's
-            // default for the id the user typed.
-            let provider_named_by_user =
-                subcommand_provider.is_some() || top_level_provider.is_some();
-            if !provider_named_by_user && queried.is_some() && resolved.used_fallback {
-                resolved = registry.resolve(queried, None);
-            }
+            let resolved = registry.resolve(queried, provider_hint)?;
             println!("requested: {}", resolved.requested.unwrap_or_default());
             println!("resolved: {}", resolved.resolved.id);
             println!("provider: {}", resolved.resolved.provider.as_str());
@@ -4425,7 +4414,11 @@ fn run_model_command(
                 if queried.is_some() {
                     "argument"
                 } else {
-                    resolved_runtime.model_source.as_str()
+                    // This branch is reachable only for an explicit
+                    // subcommand provider with no requested model. The model
+                    // therefore came from that provider's default, not from
+                    // the configured runtime route we deliberately overrode.
+                    "provider default"
                 }
             );
             Ok(())

--- a/crates/cli/tests/model_resolve_provenance.rs
+++ b/crates/cli/tests/model_resolve_provenance.rs
@@ -49,6 +49,28 @@ fn resolve_with_config(config: &str, args: &[&str]) -> BTreeMap<String, String> 
         .collect()
 }
 
+/// Run a model query that must fail without reading ambient configuration or
+/// credentials. Keeping the raw output lets the regression prove the CLI did
+/// not print a fabricated provider route before exiting.
+fn resolve_failure_with_config(config: &str, args: &[&str]) -> std::process::Output {
+    let fixture = TempDir::new().expect("fixture root");
+    let home = fixture.path().join("sealed-home");
+    fs::create_dir_all(home.join(".codewhale")).expect("sealed config dir");
+    fs::write(home.join(".codewhale").join("config.toml"), config).expect("seed config");
+
+    Command::new(codewhale_binary())
+        .arg("model")
+        .arg("resolve")
+        .args(args)
+        .env_clear()
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("CODEWHALE_HOME", home.join(".codewhale"))
+        .env("CODEWHALE_SECRET_BACKEND", "file")
+        .output()
+        .expect("run failing model resolve")
+}
+
 #[test]
 fn resolve_reports_the_configured_provider_not_a_deepseek_fallback() {
     let report = resolve_with_config(
@@ -117,29 +139,65 @@ fn resolve_admits_when_nothing_was_configured() {
 }
 
 #[test]
-fn an_explicit_model_argument_still_answers_the_hypothetical() {
-    // Naming a model asks "what would this resolve to", which must keep
-    // working even when the configured provider is something else.
-    let report = resolve_with_config(
+fn a_foreign_model_argument_cannot_switch_the_configured_provider() {
+    let output = resolve_failure_with_config(
         "provider = \"zai\"\n\n[providers.zai]\napi_key = \"k\"\n",
         &["deepseek-v4-flash"],
     );
 
+    assert!(!output.status.success());
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+    .to_ascii_lowercase();
+    assert!(
+        combined.contains("not available from provider 'zai'"),
+        "{combined}"
+    );
+    assert!(!combined.contains("provider: deepseek"), "{combined}");
+}
+
+#[test]
+fn an_explicit_matching_provider_can_resolve_its_model() {
+    let report = resolve_with_config(
+        "provider = \"zai\"\n\n[providers.zai]\napi_key = \"k\"\n",
+        &["deepseek-v4-flash", "--provider", "deepseek"],
+    );
+
+    assert_eq!(report.get("provider").map(String::as_str), Some("deepseek"));
     assert_eq!(
         report.get("requested").map(String::as_str),
-        Some("deepseek-v4-flash"),
-        "{report:?}"
-    );
-    assert_eq!(
-        report.get("model_source").map(String::as_str),
-        Some("argument"),
-        "{report:?}"
+        Some("deepseek-v4-flash")
     );
     assert_eq!(
         report.get("used_fallback").map(String::as_str),
-        Some("false"),
-        "{report:?}"
+        Some("false")
     );
+    assert_eq!(
+        report.get("provider_source").map(String::as_str),
+        Some("--provider")
+    );
+}
+
+#[test]
+fn unknown_providerless_model_fails_without_printing_a_deepseek_route() {
+    let output = resolve_failure_with_config(
+        "provider = \"zai\"\n\n[providers.zai]\napi_key = \"k\"\n",
+        &["totally-unknown-model"],
+    );
+
+    assert!(!output.status.success(), "unknown model must fail closed");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+    let combined = format!("{stdout}\n{stderr}");
+    assert!(
+        combined.contains("not available from provider 'zai'"),
+        "{combined}"
+    );
+    assert!(!combined.contains("provider: deepseek"), "{combined}");
+    assert!(!combined.contains("deepseek-v4-pro"), "{combined}");
 }
 
 #[test]
@@ -154,6 +212,36 @@ fn an_explicit_provider_flag_is_reported_as_the_source() {
         report.get("provider_source").map(String::as_str),
         Some("--provider"),
         "{report:?}"
+    );
+}
+
+#[test]
+fn explicit_openai_without_a_model_reports_its_own_documented_default() {
+    let report = resolve_with_config(
+        "provider = \"zai\"\n\n[providers.zai]\napi_key = \"k\"\nmodel = \"GLM-5.2\"\n",
+        &["--provider", "openai"],
+    );
+
+    assert_eq!(report.get("provider").map(String::as_str), Some("openai"));
+    assert_eq!(
+        report.get("resolved").map(String::as_str),
+        Some("gpt-5.6"),
+        "an OpenAI query must use OpenAI's documented default, not the first catalog row or the configured Z.ai model: {report:?}"
+    );
+    assert_eq!(
+        report.get("used_fallback").map(String::as_str),
+        Some("true"),
+        "{report:?}"
+    );
+    assert_eq!(
+        report.get("provider_source").map(String::as_str),
+        Some("--provider"),
+        "{report:?}"
+    );
+    assert_eq!(
+        report.get("model_source").map(String::as_str),
+        Some("provider default"),
+        "the overridden Z.ai model provenance must not leak into the OpenAI hypothetical: {report:?}"
     );
 }
 
@@ -260,21 +348,25 @@ fn moonshot_k3_products_resolve_without_crossing_providers() {
     }
 }
 
-/// An id the selected provider cannot serve must be reported as a fallback,
-/// never as if the request had been honoured.
+/// An id the selected provider cannot serve must fail closed. Falling back
+/// after a concrete request would silently run a different model.
 #[test]
-fn an_unservable_model_on_the_selected_provider_is_reported_as_a_fallback() {
-    let report = resolve_with_global_flags(
+fn an_unservable_model_on_the_selected_provider_is_rejected() {
+    let output = resolve_failure_with_config(
         "provider = \"moonshot\"\n\n[providers.moonshot]\napi_key = \"k\"\n",
-        &[],
         &["glm-5.2", "--provider", "moonshot"],
     );
 
-    assert_eq!(report.get("provider").map(String::as_str), Some("moonshot"));
-    assert_eq!(
-        report.get("used_fallback").map(String::as_str),
-        Some("true"),
-        "an unservable id must not be presented as an honoured request: {report:?}"
+    assert!(!output.status.success());
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+    .to_ascii_lowercase();
+    assert!(
+        combined.contains("model 'glm-5.2' is not available from provider 'moonshot'"),
+        "{combined}"
     );
 }
 
@@ -304,28 +396,21 @@ fn a_new_glm_sibling_is_servable_on_zai_but_not_on_moonshot() {
         "a model the provider serves must not be reported as a fallback: {served:?}"
     );
 
-    let refused = resolve_with_global_flags(
+    let refused = resolve_failure_with_config(
         "provider = \"moonshot\"\n\n[providers.moonshot]\napi_key = \"k\"\n",
-        &[],
         &["glm-5.3", "--provider", "moonshot"],
     );
 
-    assert_eq!(
-        refused.get("provider").map(String::as_str),
-        Some("moonshot")
-    );
-    assert_eq!(
-        refused.get("used_fallback").map(String::as_str),
-        Some("true"),
-        "a Z.ai id must not be presented as honoured by Moonshot: {refused:?}"
-    );
-    let resolved = refused
-        .get("resolved")
-        .map(String::as_str)
-        .unwrap_or_default();
+    assert!(!refused.status.success());
+    let resolved = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&refused.stdout),
+        String::from_utf8_lossy(&refused.stderr)
+    )
+    .to_ascii_lowercase();
     assert!(
-        !resolved.to_ascii_lowercase().contains("glm"),
-        "a provider that cannot serve GLM must not be handed a fabricated GLM id: {refused:?}"
+        resolved.contains("model 'glm-5.3' is not available from provider 'moonshot'"),
+        "a provider that cannot serve GLM must fail instead of choosing its default: {resolved}"
     );
 }
 

--- a/crates/tui/src/fleet/manager.rs
+++ b/crates/tui/src/fleet/manager.rs
@@ -2549,7 +2549,29 @@ mod tests {
     use serde_json::json;
     use tempfile::TempDir;
 
+    fn test_manager(workspace: impl AsRef<Path>) -> Result<FleetManager> {
+        let mut providers = crate::config::ProvidersConfig::default();
+        providers.deepseek.api_key = Some("test-key".to_string());
+        providers.xai.api_key = Some("test-key".to_string());
+        providers.zai.api_key = Some("test-key".to_string());
+        let route_config = Config {
+            provider: Some("deepseek".to_string()),
+            api_key: Some("test-key".to_string()),
+            providers: Some(providers),
+            ..Config::default()
+        };
+        FleetManager::open(workspace).map(|manager| manager.with_route_config(route_config))
+    }
+
     fn select_test_fleet(workspace: &Path, members: &[(&str, &str)]) {
+        select_test_fleet_with_provider(workspace, members, None);
+    }
+
+    fn select_test_fleet_with_provider(
+        workspace: &Path,
+        members: &[(&str, &str)],
+        provider: Option<&str>,
+    ) {
         use crate::fleet::store::{FleetFile, FleetMember, FleetScope, save_fleet, set_selected};
 
         let mut fleet = FleetFile::new("Manager Test Fleet".to_string(), None).unwrap();
@@ -2559,8 +2581,8 @@ mod tests {
                 id: (*id).to_string(),
                 display_name: None,
                 role: (*role).to_string(),
-                model: None,
-                provider: None,
+                model: provider.map(|_| "private-model".to_string()),
+                provider: provider.map(str::to_string),
                 reasoning: None,
                 instructions: None,
                 requires: Vec::new(),
@@ -2638,7 +2660,7 @@ mod tests {
         std::fs::create_dir(tmp.path().join("nested")).unwrap();
         let coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(coordination.clone());
         let mut nested = task("nested");
@@ -2709,7 +2731,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(coordination.clone());
         let mut spec = task("read-only");
@@ -2753,7 +2775,7 @@ mod tests {
     #[test]
     fn invalid_worker_identity_is_rejected_before_run_journal_creation() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let error = manager
             .create_run(
                 FleetTaskSpecDocument {
@@ -2779,11 +2801,77 @@ mod tests {
     }
 
     #[test]
+    fn configless_manager_rejects_ambiguous_route_before_run_journal_creation() {
+        let tmp = TempDir::new().unwrap();
+        select_test_fleet(tmp.path(), &[("reviewer", "reviewer")]);
+        let manager = FleetManager::open(tmp.path()).expect("config-less manager");
+
+        let error = manager
+            .create_queued_run(
+                FleetTaskSpecDocument {
+                    name: Some("ambiguous route".to_string()),
+                    labels: BTreeMap::new(),
+                    security_policy: None,
+                    workers: Vec::new(),
+                    tasks: vec![task("task-a")],
+                    usage_ceiling: None,
+                },
+                1,
+            )
+            .expect_err("Fleet creation must not invent a default provider");
+        let message = error.to_string();
+        assert!(message.contains("no provider authority"), "{message}");
+        assert!(
+            message.contains("attach the resolved route config"),
+            "{message}"
+        );
+
+        let state = manager.rebuild_state().unwrap();
+        assert!(state.runs.is_empty());
+        assert!(state.tasks.is_empty());
+    }
+
+    #[test]
+    fn configless_manager_rejects_custom_provider_before_run_journal_creation() {
+        let tmp = TempDir::new().unwrap();
+        select_test_fleet_with_provider(
+            tmp.path(),
+            &[("private-reviewer", "reviewer")],
+            Some("private-gateway"),
+        );
+        let manager = FleetManager::open(tmp.path()).expect("config-less manager");
+
+        let error = manager
+            .create_queued_run(
+                FleetTaskSpecDocument {
+                    name: Some("unresolved custom route".to_string()),
+                    labels: BTreeMap::new(),
+                    security_policy: None,
+                    workers: Vec::new(),
+                    tasks: vec![task("task-a")],
+                    usage_ceiling: None,
+                },
+                1,
+            )
+            .expect_err("custom provider without live config must fail before journaling");
+        let message = error.to_string();
+        assert!(message.contains("provider=`private-gateway`"), "{message}");
+        assert!(
+            message.contains("attach the live route config"),
+            "{message}"
+        );
+
+        let state = manager.rebuild_state().unwrap();
+        assert!(state.runs.is_empty());
+        assert!(state.tasks.is_empty());
+    }
+
+    #[test]
     fn queued_creation_waits_for_explicit_idempotent_start() {
         let tmp = TempDir::new().unwrap();
         let coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(coordination.clone());
         let report = manager
@@ -2872,7 +2960,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(coordination.clone());
         let prepared = manager
@@ -2908,7 +2996,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(coordination);
         let write_task = |id: &str| {
@@ -2968,7 +3056,7 @@ mod tests {
             .try_read()
             .unwrap()
             .coordination_registration_snapshot();
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(coordination.clone());
         let mut spec = task("task-a");
@@ -3089,12 +3177,12 @@ mod tests {
         let tmp = TempDir::new().unwrap();
 
         // No session: legacy auto sentinel.
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         assert_eq!(manager.run_model(), "auto");
         assert_eq!(manager.session_model(), None);
 
         // The session route becomes the run model — the operator's model.
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_session_model("deepseek-v4-pro");
         assert_eq!(manager.run_model(), "deepseek-v4-pro");
@@ -3102,9 +3190,7 @@ mod tests {
 
         // "auto" and empty/whitespace inputs keep the resolver default.
         for noop in ["auto", "AUTO", "", "   "] {
-            let manager = FleetManager::open(tmp.path())
-                .unwrap()
-                .with_session_model(noop);
+            let manager = test_manager(tmp.path()).unwrap().with_session_model(noop);
             assert_eq!(manager.run_model(), "auto");
             assert_eq!(manager.session_model(), None);
         }
@@ -3360,7 +3446,7 @@ mod tests {
         );
 
         // Restart: a fresh manager over the same workspace resumes from ledger.
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_stale_after(Duration::from_secs(5));
         let outcome = manager.resume_run_at(&run_id, resume_now(30)).unwrap();
@@ -3421,7 +3507,7 @@ mod tests {
             RESUME_T0,
         );
 
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_stale_after(Duration::from_secs(5));
         let outcome = manager.resume_run_at(&run_id, resume_now(30)).unwrap();
@@ -3474,7 +3560,7 @@ mod tests {
             RESUME_T0,
         );
 
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_stale_after(Duration::from_secs(5));
         let first = manager.resume_run_at(&run_id, resume_now(30)).unwrap();
@@ -3515,7 +3601,7 @@ mod tests {
             &stale_ts,
         );
 
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_stale_after(Duration::from_secs(5));
         let outcome = manager.resume_run(&run_id).unwrap();
@@ -3527,7 +3613,7 @@ mod tests {
     #[test]
     fn fleet_manager_creates_run_and_starts_workers_up_to_cap() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(&tmp, vec![task("task-a"), task("task-b"), task("task-c")]);
 
         let report = manager.create_run_from_task_spec_path(&path, 2).unwrap();
@@ -3546,7 +3632,7 @@ mod tests {
     fn fleet_manager_rejects_unknown_agent_profile_before_run_creation() {
         let tmp = TempDir::new().unwrap();
         select_test_fleet(tmp.path(), &[("reviewer", "reviewer")]);
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let mut task = task("task-a");
         task.worker = Some(FleetTaskWorkerProfile {
             role: None,
@@ -3581,7 +3667,7 @@ mod tests {
     #[test]
     fn fleet_manager_inspect_exposes_heartbeat_artifacts_and_errors() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(&tmp, vec![task("task-a")]);
         let report = manager.create_run_from_task_spec_path(&path, 1).unwrap();
         let worker_id = &report.worker_ids[0];
@@ -3608,7 +3694,7 @@ mod tests {
         for alias in ["oracle", "advisor"] {
             let tmp = TempDir::new().unwrap();
             select_test_fleet(tmp.path(), &[(alias, alias)]);
-            let manager = FleetManager::open(tmp.path()).unwrap();
+            let manager = test_manager(tmp.path()).unwrap();
             let path = task_spec_file(&tmp, vec![role_task_with_retry("advice", alias, 1)]);
             let report = manager.create_run_from_task_spec_path(&path, 1).unwrap();
 
@@ -3644,8 +3730,8 @@ mod tests {
             return;
         }
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
-        let controller = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
+        let controller = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(&tmp, vec![task("task-a"), task("task-b")]);
         let pid_path = tmp.path().join("live-worker.pid");
         let first_worker_marker = tmp.path().join("first-worker-started");
@@ -3738,8 +3824,8 @@ sleep 30
             return;
         }
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
-        let controller = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
+        let controller = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(&tmp, vec![task("task-a")]);
         let first_worker_marker = tmp.path().join("first-attempt-started");
         let stopped_marker = tmp.path().join("first-attempt-stopped");
@@ -3822,7 +3908,7 @@ while :; do sleep 1; done
     #[test]
     fn fleet_manager_restart_and_stop_all_are_ledgered() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(&tmp, vec![task("task-a"), task("task-b")]);
         let report = manager.create_run_from_task_spec_path(&path, 1).unwrap();
         let worker_id = &report.worker_ids[0];
@@ -3849,7 +3935,7 @@ while :; do sleep 1; done
         let tmp = TempDir::new().unwrap();
         let coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 2);
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(coordination.clone());
         let path = task_spec_file(&tmp, vec![task("task-a")]);
@@ -3917,7 +4003,7 @@ exit 0
         let tmp = TempDir::new().unwrap();
         let coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 2);
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(coordination.clone());
         let path = task_spec_file(&tmp, vec![task("task-a")]);
@@ -3958,7 +4044,7 @@ exit 0
 
         let reloaded_coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 2);
-        let reloaded = FleetManager::open(tmp.path())
+        let reloaded = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(reloaded_coordination.clone());
         reloaded
@@ -3992,7 +4078,7 @@ exit 0
         let tmp = TempDir::new().unwrap();
         let coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 2);
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(coordination.clone());
         let path = task_spec_file(&tmp, vec![task("task-a")]);
@@ -4016,7 +4102,7 @@ exit 0
 
         let reloaded_coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 2);
-        let reloaded = FleetManager::open(tmp.path())
+        let reloaded = test_manager(tmp.path())
             .unwrap()
             .with_sub_agent_manager(reloaded_coordination);
         let error = reloaded
@@ -4043,7 +4129,7 @@ exit 0
         let tmp = TempDir::new().unwrap();
         let coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 2);
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_stale_after(Duration::from_secs(5))
             .with_sub_agent_manager(coordination.clone());
@@ -4068,7 +4154,7 @@ exit 0
 
         let reloaded_coordination =
             crate::tools::subagent::new_shared_subagent_manager(tmp.path().to_path_buf(), 2);
-        let reloaded = FleetManager::open(tmp.path())
+        let reloaded = test_manager(tmp.path())
             .unwrap()
             .with_stale_after(Duration::from_secs(5))
             .with_sub_agent_manager(reloaded_coordination.clone());
@@ -4111,8 +4197,8 @@ exit 0
     #[test]
     fn concurrent_manager_loops_launch_each_attempt_once() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
-        let standby = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
+        let standby = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(&tmp, vec![task("task-a")]);
         let starts = tmp.path().join("worker-starts");
         let fake = fake_codewhale(
@@ -4173,7 +4259,7 @@ exit 0
     #[test]
     fn fleet_manager_can_record_completed_local_smoke_tasks() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(&tmp, vec![task("task-a"), task("task-b"), task("task-c")]);
         let fake = fake_codewhale(
             &tmp,
@@ -4198,7 +4284,7 @@ exit 0
     #[test]
     fn fleet_task_spec_sample_launches_independent_worker_tasks() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(
             &tmp,
             vec![
@@ -4236,7 +4322,7 @@ exit 0
     #[test]
     fn fleet_task_spec_local_scorer_records_receipt_artifact() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let mut completed = task("task-a");
         completed.scorer = Some(FleetScorerSpec::ExitCode);
         let path = task_spec_file(&tmp, vec![completed]);
@@ -4275,7 +4361,7 @@ exit 0
     #[test]
     fn fleet_task_spec_unscored_zero_exit_records_partial_receipt() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(&tmp, vec![task("task-a")]);
         let fake = fake_codewhale(
             &tmp,
@@ -4320,7 +4406,7 @@ exit 0
     #[test]
     fn fleet_task_spec_unscored_worker_error_records_failed_receipt() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(&tmp, vec![task("task-a")]);
         let fake = fake_codewhale(
             &tmp,
@@ -4347,7 +4433,7 @@ exit 7
     #[test]
     fn fleet_task_spec_status_distinguishes_failure_sources() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let mut task_failed = task("a-task-failure");
         task_failed.scorer = Some(FleetScorerSpec::ExitCode);
         task_failed.instructions = "task-failure".to_string();
@@ -4429,7 +4515,7 @@ esac
             }),
             ..Default::default()
         };
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_session_model("manager-model-y")
             .with_route_config(manager_config);
@@ -4492,7 +4578,7 @@ printf '%s\n' '{"type":"done"}'
     fn headless_terminal_with_invalid_route_metadata_does_not_fall_back_to_manager_config() {
         let tmp = TempDir::new().unwrap();
         select_test_fleet(tmp.path(), &[("reviewer", "reviewer")]);
-        let manager = FleetManager::open(tmp.path())
+        let manager = test_manager(tmp.path())
             .unwrap()
             .with_session_model("manager-model-y")
             .with_route_config(Config {
@@ -4548,7 +4634,7 @@ printf '%s\n' '{"type":"done"}'
     #[test]
     fn fleet_smoke_runs_three_roles_ten_tasks_with_receipts_and_failure() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let fake = fake_codewhale(
             &tmp,
             r#"#!/bin/sh
@@ -4865,7 +4951,7 @@ esac
     #[test]
     fn fleet_status_counts_restarted_and_escalated_events() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let path = task_spec_file(&tmp, vec![task("task-a")]);
         let report = manager.create_run_from_task_spec_path(&path, 1).unwrap();
         let worker_id = &report.worker_ids[0];
@@ -4896,7 +4982,7 @@ esac
     #[test]
     fn fleet_status_inspect_exposes_task_context_host_and_alert() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let mut contextual = task("task-a");
         contextual.objective = Some("Review the release ledger".to_string());
         contextual.worker = Some(FleetTaskWorkerProfile {
@@ -5041,7 +5127,7 @@ esac
             },
         ];
 
-        let manager = FleetManager::open(&workspace).unwrap();
+        let manager = test_manager(&workspace).unwrap();
         let report = manager
             .create_run(
                 FleetTaskSpecDocument {
@@ -5068,7 +5154,7 @@ esac
     #[test]
     fn fleet_security_policy_is_rejected_for_new_runs() {
         let tmp = TempDir::new().unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         // Rewrite the spec file with a security_policy block.
         let doc = serde_json::json!({
             "name": "secure smoke",
@@ -5112,7 +5198,7 @@ esac
             "schema = \"fleet\"\nschema_revision = 2\nname = \"Broken\"\n[[members]]\nid = \"scout\"\nprovider = \"deepseek\"\n",
         )
         .unwrap();
-        let manager = FleetManager::open(tmp.path()).unwrap();
+        let manager = test_manager(tmp.path()).unwrap();
         let error = manager
             .create_queued_run(
                 FleetTaskSpecDocument {

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -237,8 +237,9 @@ pub(crate) fn freeze_fleet_task_members(
 /// no provider, when Luna lives on a different configured provider). The
 /// runtime never infers a provider from a model's spelling (#4093/#2608), so a
 /// pinned model that does not resolve is rejected here with a clear error
-/// instead of failing silently inside the worker. Models inherited from the
-/// session/run route (`run.model`) are not pins and are left alone.
+/// instead of failing silently inside the worker. Every task must have either
+/// the resolved session config or an explicit profile provider; inherited
+/// session/run models are validated within that already-authorized scope.
 pub fn validate_fleet_task_routes(
     tasks: &[FleetTaskSpec],
     agent_profiles: &[AgentProfile],
@@ -253,14 +254,25 @@ pub fn validate_fleet_task_routes(
             effective_fleet_model_with_source(run_model, task.worker.as_ref(), agent_profile);
         let pinned_model = matches!(source, "task.model" | "agent_profile.model");
         let explicit_provider = explicit_fleet_provider_id(agent_profile);
-        if pinned_model && explicit_provider.is_none() {
-            let (provider, base_url) = config.map_or_else(
-                || {
-                    let provider = ApiProvider::Deepseek;
-                    (provider, provider.default_base_url().to_string())
-                },
-                |config| (config.api_provider(), config.deepseek_base_url()),
+        if config.is_none() && explicit_provider.is_none() {
+            bail!(
+                "Fleet task `{}` has no provider authority for model `{model}` (source={source}); attach the resolved route config or set the agent profile provider explicitly",
+                task.id,
             );
+        }
+        if config.is_none()
+            && let Some(provider_id) = explicit_provider.as_deref()
+            && ApiProvider::parse(provider_id)
+                .is_none_or(|provider| provider == ApiProvider::Custom)
+        {
+            bail!(
+                "Fleet task `{}` names custom provider=`{provider_id}`, but a provider name alone does not prove its endpoint or model; attach the live route config before creating the run",
+                task.id,
+            );
+        }
+        if pinned_model && explicit_provider.is_none() {
+            let config = config.expect("provider authority checked above");
+            let (provider, base_url) = (config.api_provider(), config.deepseek_base_url());
             if let Err(reason) =
                 crate::route_runtime::validate_unpinned_model_provider(provider, &model, &base_url)
             {
@@ -269,31 +281,31 @@ pub fn validate_fleet_task_routes(
         }
 
         let route = resolve_fleet_route_with_config(task, agent_profiles, session_model, config);
-        if route.is_some() {
-            validate_fleet_reasoning_effort(task, agent_profiles, session_model, config)?;
-        }
-        if !pinned_model {
-            continue;
-        }
-        // A concrete model is pinned at the task/profile level; it must resolve
-        // to a real provider route or the worker cannot launch.
-        if route.is_some() {
-            continue;
-        }
         let provider = explicit_provider
             .map(|provider| format!("provider=`{provider}`"))
             .unwrap_or_else(|| {
                 "no explicit provider (resolves against the session/default provider)".to_string()
             });
-        bail!(
-            "Fleet task `{}` pins model `{}` with {} (source={source}), but that route does not \
-             resolve to a real model on any configured provider, so the worker cannot launch. \
-             The runtime never infers a provider from a model's spelling — set an explicit \
-             provider for this model in the profile, or switch the role to `inherit`.",
-            task.id,
-            model,
-            provider
-        );
+        if route.is_none() {
+            if pinned_model {
+                bail!(
+                    "Fleet task `{}` pins model `{}` with {} (source={source}), but that route does not \
+                     resolve to a real model on any configured provider, so the worker cannot launch. \
+                     The runtime never infers a provider from a model's spelling — set an explicit \
+                     provider for this model in the profile, or switch the role to `inherit`.",
+                    task.id,
+                    model,
+                    provider
+                );
+            }
+            bail!(
+                "Fleet task `{}` cannot resolve its inherited model `{model}` with {provider} \
+                 (source={source}); attach the live route config for custom providers before \
+                 creating the run",
+                task.id,
+            );
+        }
+        validate_fleet_reasoning_effort(task, agent_profiles, session_model, config)?;
     }
     Ok(())
 }
@@ -605,12 +617,11 @@ fn fleet_coordination_contracts(task_spec: &FleetTaskSpec) -> Result<Vec<String>
 /// - The provider comes from the resolved agent profile's own explicit
 ///   `provider` field when it has one (#4093) — a Fleet worker profile can be
 ///   pinned to a route independent of the parent/current session provider.
-///   Absent an explicit pin, the worker profile carries no provider authority
-///   and resolution falls back to the existing default scope. Either way, the
-///   provider is NEVER inferred by sniffing a substring/prefix out of `model`
-///   (EPIC #2608: explicit config only). A task-level `model` selector is
-///   forwarded as the model selector. No reasoning/pricing fields are
-///   fabricated.
+///   Absent an explicit pin, the worker profile carries no provider authority;
+///   callers must supply the resolved live [`Config`]. The provider is NEVER
+///   inferred by sniffing a substring/prefix out of `model` (EPIC #2608:
+///   explicit config only). A task-level `model` selector is forwarded as the
+///   model selector. No reasoning/pricing fields are fabricated.
 ///
 /// Returns `None` (never a fabricated route) when resolution fails, so callers
 /// degrade gracefully without inventing detail.
@@ -672,16 +683,11 @@ pub(crate) fn resolve_fleet_route_with_config(
             "runtime_route",
         )
     } else {
-        let provider = match explicit_provider_id.as_deref() {
-            Some(provider_id) => {
-                let provider = ApiProvider::parse(provider_id)?;
-                if provider == ApiProvider::Custom {
-                    return None;
-                }
-                provider
-            }
-            None => ApiProvider::Deepseek,
-        };
+        let provider_id = explicit_provider_id.as_deref()?;
+        let provider = ApiProvider::parse(provider_id)?;
+        if provider == ApiProvider::Custom {
+            return None;
+        }
         let candidate = resolve_route_candidate(provider, model_selector, None, None, None).ok()?;
         let provider_id = candidate.provider_id().as_str().to_string();
         (candidate, provider_id, None, "resolver")
@@ -1629,6 +1635,14 @@ mod tests {
     use codewhale_protocol::fleet::{FleetHostSpec, FleetTaskBudget, FleetWorkspaceRequirements};
     use std::path::{Path, PathBuf};
 
+    fn explicit_deepseek_config() -> Config {
+        Config {
+            provider: Some("deepseek".to_string()),
+            api_key: Some("test-key".to_string()),
+            ..Config::default()
+        }
+    }
+
     #[test]
     fn read_only_roles_report_the_narrowed_shell_they_actually_run_under() {
         use crate::tools::subagent::FleetRole;
@@ -2058,7 +2072,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_fleet_route_mints_secret_free_snapshot_from_resolver() {
+    fn resolved_config_mints_secret_free_fleet_route_snapshot() {
         let task = fleet_task(
             "route-1",
             Some(worker_profile(
@@ -2070,8 +2084,9 @@ mod tests {
                 vec!["read_file"],
             )),
         );
-        let route =
-            resolve_fleet_route(&task, &[], None).expect("default route should resolve offline");
+        let config = explicit_deepseek_config();
+        let route = resolve_fleet_route_with_config(&task, &[], None, Some(&config))
+            .expect("explicit default route should resolve offline");
 
         // Honest, non-empty route shape from the resolver.
         assert!(!route.provider_id.is_empty());
@@ -2087,7 +2102,7 @@ mod tests {
         assert_eq!(route.loadout_source.as_deref(), Some("task.loadout"));
         assert_eq!(route.model_class_source, None);
         assert_eq!(route.model_source.as_deref(), Some("resolver.default"));
-        assert_eq!(route.source, "resolver");
+        assert_eq!(route.source, "runtime_route");
 
         // No-secrets: the serialized snapshot carries no credential markers.
         let json = serde_json::to_string(&route).unwrap();
@@ -2129,7 +2144,9 @@ mod tests {
                 vec!["read_file"],
             )),
         );
-        let route = resolve_fleet_route(&task, &[], None).expect("route should resolve");
+        let config = explicit_deepseek_config();
+        let route = resolve_fleet_route_with_config(&task, &[], None, Some(&config))
+            .expect("route should resolve");
         assert_eq!(route.role.as_deref(), Some("scout"));
         assert!(route.loadout.is_none());
         assert_eq!(route.loadout_source, None);
@@ -2162,7 +2179,8 @@ mod tests {
                 "prompt must not emit compatibility alias {alias}: {prompt}"
             );
 
-            let resolved = resolve_fleet_route(&task, &[], None)
+            let config = explicit_deepseek_config();
+            let resolved = resolve_fleet_route_with_config(&task, &[], None, Some(&config))
                 .expect("compatibility role should resolve a receipt route");
             assert_eq!(resolved.role.as_deref(), Some("consultant"));
             assert_eq!(resolved.role_source.as_deref(), Some("task.role"));
@@ -2201,8 +2219,9 @@ mod tests {
                 vec!["read_file"],
             )),
         );
-        let route =
-            resolve_fleet_route(&task, &[profile], None).expect("profile route should resolve");
+        let config = explicit_deepseek_config();
+        let route = resolve_fleet_route_with_config(&task, &[profile], None, Some(&config))
+            .expect("profile route should resolve");
 
         assert_eq!(route.role.as_deref(), Some("reviewer"));
         assert_eq!(route.role_source.as_deref(), Some("agent_profile.role"));
@@ -2465,8 +2484,14 @@ mod tests {
                     fleet_worker_launch_reasoning_effort(&task, &[]).as_deref(),
                     Some("high")
                 );
-                let route = resolve_fleet_route(&task, &[], Some("deepseek-v4-pro"))
-                    .expect("receipt route resolves");
+                let config = explicit_deepseek_config();
+                let route = resolve_fleet_route_with_config(
+                    &task,
+                    &[],
+                    Some("deepseek-v4-pro"),
+                    Some(&config),
+                )
+                .expect("receipt route resolves");
                 assert_eq!(route.role.as_deref(), Some("consultant"));
                 assert_eq!(route.reasoning_effort.as_deref(), Some("high"));
             }
@@ -2523,10 +2548,15 @@ mod tests {
     fn resolve_fleet_route_uses_session_model_as_run_fallback() {
         // Route receipts must agree with dispatch: when neither the task nor
         // a roster profile pins a model, the session route is the run-level
-        // fallback and the receipt records it came from `run.model`.
+        // fallback and the receipt records it came from `run.model`. A model
+        // name alone is not provider authority, so the config-less helper
+        // refuses to invent a route.
         let task = fleet_task("route-session", None);
-        let route = resolve_fleet_route(&task, &[], Some("deepseek-v4-flash"))
-            .expect("session-model route should resolve offline");
+        assert!(resolve_fleet_route(&task, &[], Some("deepseek-v4-flash")).is_none());
+        let config = explicit_deepseek_config();
+        let route =
+            resolve_fleet_route_with_config(&task, &[], Some("deepseek-v4-flash"), Some(&config))
+                .expect("resolved config should authorize the session-model route");
         assert_eq!(route.model_source.as_deref(), Some("run.model"));
         assert_eq!(route.wire_model_id, "deepseek-v4-flash");
 
@@ -2549,8 +2579,13 @@ mod tests {
                 vec![],
             )),
         );
-        let pinned = resolve_fleet_route(&pinned_task, &[profile], Some("deepseek-v4-flash"))
-            .expect("pinned route should resolve");
+        let pinned = resolve_fleet_route_with_config(
+            &pinned_task,
+            &[profile],
+            Some("deepseek-v4-flash"),
+            Some(&config),
+        )
+        .expect("pinned route should resolve under the configured provider");
         assert_eq!(pinned.model_source.as_deref(), Some("agent_profile.model"));
         assert_eq!(pinned.wire_model_id, "deepseek-v4-pro");
     }
@@ -2588,6 +2623,121 @@ mod tests {
             msg.contains("provider") || msg.contains("inherit"),
             "error tells the user how to fix it: {msg}"
         );
+    }
+
+    #[test]
+    fn configless_fleet_rejects_providerless_deepseek_named_work() {
+        let mut profile = agent_profile(
+            "unscoped",
+            "builder",
+            None,
+            codewhale_config::FleetLoadout::Inherit,
+        );
+        profile.profile.model = Some("deepseek-v4-flash".to_string());
+        let task = fleet_task(
+            "unscoped-build",
+            Some(worker_profile(
+                Some("unscoped"),
+                None,
+                None,
+                None,
+                None,
+                vec![],
+            )),
+        );
+
+        let error = validate_fleet_task_routes(
+            std::slice::from_ref(&task),
+            std::slice::from_ref(&profile),
+            Some("deepseek-v4-flash"),
+            None,
+        )
+        .expect_err("model spelling must not select a provider");
+        let message = error.to_string();
+        assert!(message.contains("no provider authority"), "{message}");
+        assert!(
+            message.contains("set the agent profile provider"),
+            "{message}"
+        );
+        assert!(resolve_fleet_route(&task, &[profile], Some("deepseek-v4-flash")).is_none());
+    }
+
+    #[test]
+    fn configless_fleet_keeps_explicit_non_deepseek_provider_authority() {
+        let mut profile = agent_profile(
+            "grok-builder",
+            "builder",
+            None,
+            codewhale_config::FleetLoadout::Inherit,
+        );
+        profile.profile.provider = Some("xai".to_string());
+        let task = fleet_task(
+            "grok-build",
+            Some(worker_profile(
+                Some("grok-builder"),
+                None,
+                None,
+                None,
+                None,
+                vec![],
+            )),
+        );
+
+        validate_fleet_task_routes(
+            std::slice::from_ref(&task),
+            std::slice::from_ref(&profile),
+            None,
+            None,
+        )
+        .expect("an explicit built-in provider is route authority");
+        let route = resolve_fleet_route(&task, &[profile], None)
+            .expect("explicit xAI route should resolve without borrowing session config");
+        assert_eq!(route.provider_id, "xai");
+        assert_eq!(route.provider_kind, "xai");
+        assert_eq!(route.wire_model_id, "grok-4.6");
+        assert!(
+            !serde_json::to_string(&route)
+                .expect("route json")
+                .to_ascii_lowercase()
+                .contains("credential")
+        );
+    }
+
+    #[test]
+    fn configless_fleet_rejects_explicit_custom_provider_without_live_route_config() {
+        let mut profile = agent_profile(
+            "private-gateway-builder",
+            "builder",
+            None,
+            codewhale_config::FleetLoadout::Inherit,
+        );
+        profile.profile.provider = Some("private-gateway".to_string());
+        let task = fleet_task(
+            "private-build",
+            Some(worker_profile(
+                Some("private-gateway-builder"),
+                None,
+                None,
+                None,
+                None,
+                vec![],
+            )),
+        );
+
+        let error = validate_fleet_task_routes(
+            std::slice::from_ref(&task),
+            std::slice::from_ref(&profile),
+            None,
+            None,
+        )
+        .expect_err("a custom provider name is not endpoint or model authority");
+        let message = error.to_string();
+        assert!(message.contains("provider=`private-gateway`"), "{message}");
+        assert!(
+            message.contains("attach the live route config"),
+            "{message}"
+        );
+        assert!(resolve_fleet_route(&task, &[profile], None).is_none());
     }
 
     #[test]
@@ -2645,6 +2795,7 @@ mod tests {
             codewhale_config::FleetLoadout::Inherit,
         );
         good.profile.model = Some("deepseek-v4-flash".to_string());
+        good.profile.provider = Some("deepseek".to_string());
         let good_task = fleet_task(
             "ds-build",
             Some(worker_profile(
@@ -2677,8 +2828,13 @@ mod tests {
                 vec![],
             )),
         );
-        validate_fleet_task_routes(&[inherit_task], &[inherit], None, None)
-            .expect("inherit (no model pin) must pass");
+        validate_fleet_task_routes(
+            &[inherit_task],
+            &[inherit],
+            None,
+            Some(&explicit_deepseek_config()),
+        )
+        .expect("inherit (no model pin) must pass");
     }
 
     #[test]
@@ -2720,6 +2876,7 @@ mod tests {
             codewhale_config::FleetLoadout::Inherit,
         );
         profile.profile.model = Some("deepseek-v4-flash".to_string());
+        profile.profile.provider = Some("deepseek".to_string());
         profile.profile.reasoning_effort = Some("high".to_string());
         let task = fleet_task(
             "deep-build",

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -1945,6 +1945,19 @@ async fn workspace_and_automation_endpoints_work() -> Result<()> {
     Ok(())
 }
 
+fn test_fleet_route_config() -> crate::config::Config {
+    let mut providers = crate::config::ProvidersConfig::default();
+    providers.deepseek.api_key = Some("test-key".to_string());
+    providers.xai.api_key = Some("test-key".to_string());
+    providers.zai.api_key = Some("test-key".to_string());
+    crate::config::Config {
+        provider: Some("deepseek".to_string()),
+        api_key: Some("test-key".to_string()),
+        providers: Some(providers),
+        ..crate::config::Config::default()
+    }
+}
+
 #[tokio::test]
 async fn fleet_status_runtime_api_exposes_state_and_actions() -> Result<()> {
     let root = std::env::temp_dir().join(format!("codewhale-fleet-api-{}", Uuid::new_v4()));
@@ -1953,7 +1966,8 @@ async fn fleet_status_runtime_api_exposes_state_and_actions() -> Result<()> {
     let sub_agent_manager = runtime_api_sub_agent_manager(&workspace, 2);
     let manager = FleetManager::open(&workspace)?
         .with_sub_agent_manager(sub_agent_manager.clone())
-        .with_session_model(DEFAULT_TEXT_MODEL);
+        .with_session_model(DEFAULT_TEXT_MODEL)
+        .with_route_config(test_fleet_route_config());
     let task = codewhale_protocol::fleet::FleetTaskSpec {
         id: "task-a".to_string(),
         name: "Task A".to_string(),
@@ -8939,7 +8953,8 @@ async fn fleet_receipt_api_list_and_get_round_trip() -> Result<()> {
         metadata: std::collections::BTreeMap::new(),
     };
     let manager = crate::fleet::manager::FleetManager::open(&workspace)?
-        .with_session_model(crate::config::DEFAULT_TEXT_MODEL);
+        .with_session_model(crate::config::DEFAULT_TEXT_MODEL)
+        .with_route_config(test_fleet_route_config());
     let report = manager.create_run(
         FleetTaskSpecDocument {
             name: Some("receipt-api-smoke".to_string()),


### PR DESCRIPTION
## Summary

Cherry-pick only the explicit provider-authority slice of #5588 onto current main. The original branch `codex/v0912-5588-routing-truth-20260825` also carries unrelated computer-use, browser-bridge, and MCP work; this PR does not merge that branch.

A model name is metadata, not route authority:
- `ModelRegistry::resolve` now requires an explicit provider and fails closed instead of minting DeepSeek (or any other provider) from a bare selector.
- App-server and `model resolve` stay inside the configured provider; foreign aliases cannot switch credentials or endpoints.
- Config-less fleet workers no longer fabricate `ApiProvider::Deepseek`. Absent an explicit pin they reject the route.

Source: `33691d29cc323afe4c424598e133bf23f01c6f6f` on `codex/v0912-5588-routing-truth-20260825`. Original author preserved (`CodeWhale Bot <bot@codewhale.net>`). The 3-way cherry-pick dropped the SiliconFlow catalog hunk that removed `deepseek-reasoner`/`deepseek-r1` from the Pro row; that hunk is restored so the fail-closed test matches the original patch.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy` on touched crates (`codewhale-agent`, `codewhale-app-server`, `codewhale-cli`, `codewhale-tui`) `--all-targets --all-features --locked` under the CI allow list
- [x] `python3 scripts/check-coauthor-trailers.py --range origin/main..HEAD --check-authors`
- [x] `cargo nextest run -p codewhale-agent --lib --locked` (69 passed)
- [x] `cargo nextest run -p codewhale-app-server --lib --locked` (88 passed, including provider-authority gates)
- [x] `cargo nextest run -p codewhale-cli --test model_resolve_provenance --locked` (15 passed)
- [x] `cargo nextest run -p codewhale-tui --lib --locked configless_` (5 passed)

There is no standalone 18-gate test harness. These are the provider-authority / routing-truth tests from the unique #5588 patch.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

## Issues

Refs #5588 (explicit provider-authority gate only).

No-Issue: #5588 stays open; remaining neutrality gates (balance chip, prompt suggestions, auto-router catalog pair, default_model validator, resolver pass-through, api_provider fallback, hooks env aliases) are not in this slice.