### PR TITLE
refactor(tui): adopt command shapes in plugins group (FEAT-020)

### DIFF
--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -310,6 +310,8 @@ pub struct PluginSummary {
 /// projected here (D10).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PluginDetail {
+    /// Inventory summary string (host-computed, e.g. `skills=1 mcp=0`).
+    pub inventory_summary: String,
     pub name: String,
     pub id: String,
     pub version: String,
@@ -436,6 +438,8 @@ pub struct PluginMarketplaceCandidate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PluginMarketplaceCatalog {
     pub id: String,
+    /// Source document path (for the `show` provenance line).
+    pub source_path: Option<String>,
     pub display_name: Option<String>,
     pub description: Option<String>,
     pub format: String,
@@ -467,8 +471,11 @@ pub struct PluginMarketplaceState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PluginSuggestion {
     pub name: String,
+    /// State label rendered beside the plugin name (active/not-reviewed/…).
+    pub state_label: String,
     pub description: String,
     pub why: Vec<String>,
+    /// The actionable next step rendered under the suggestion.
     pub next_step: String,
 }
 
@@ -496,6 +503,9 @@ pub trait CommandPluginContext {
     fn validation_is_clean(&self) -> bool;
     /// Read-only: registry length (used by list/reload empty branches).
     fn len(&self) -> usize;
+    /// Mutation: rediscover the workspace registry and refresh the skill
+    /// cache; returns the new registry length for the reload message.
+    fn reload(&mut self) -> Result<usize, String>;
     /// Read-only: whether the registry is empty.
     fn is_empty(&self) -> bool;
     /// Read-only: persistence store path for marketplace state.

--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -533,6 +533,11 @@ pub trait CommandPluginContext {
     fn update(&mut self, selector: &str) -> Result<PluginMutationReceipt, String>;
     /// Async-bridged uninstall; returns a synchronous portable receipt (D11).
     fn uninstall(&mut self, selector: &str) -> Result<PluginMutationReceipt, String>;
+    /// File-level removal of a just-installed bundle whose content hash
+    /// mismatched (rollback). Unlike [`Self::uninstall`] it does not resolve a
+    /// registry selector and triggers no rediscovery or skill-cache side
+    /// effects; the host adapter owns the `crate::plugins` call (D1).
+    fn uninstall_path(&mut self, name: &str, plugins_dir: &Path) -> Result<(), String>;
     /// Read-only: export a loaded bundle to a target directory.
     fn export(&self, selector: &str, target: &Path) -> Result<PluginExportReceipt, String>;
     /// Read-only: scan legacy executable plugin tools.

--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -233,3 +233,319 @@ pub trait CommandMemoryContext {
     /// Delete the given workspace scope; workspace path is the first argument.
     fn delete_workspace(&self, workspace: &Path) -> Result<MemoryDelete, String>;
 }
+
+// ---------------------------------------------------------------------------
+// Plugin (FEAT-020 D1/D2/D10/D11)
+// ---------------------------------------------------------------------------
+
+/// Portable plugin diagnostic level (FEAT-020 D2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginDiagnosticLevel {
+    Warning,
+    Error,
+}
+
+/// Portable plugin diagnostic entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginDiagnostic {
+    pub level: PluginDiagnosticLevel,
+    pub code: String,
+    pub message: String,
+    pub path: Option<PathBuf>,
+}
+
+/// Portable MCP transport classification for the capability review body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginMcpTransport {
+    Stdio,
+    Http,
+    Invalid,
+}
+
+/// Portable MCP server detail for the capability review body (FEAT-020 D2).
+///
+/// Carries only the semantic fields `render_mcp_inventory` consumes:
+/// transport, command/url, argv, cwd, env provenance, timeouts, required,
+/// enabled/disabled tool lists, and the enabled flag. Host `McpServerConfig`
+/// never crosses the boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginMcpServerDetail {
+    pub name: String,
+    pub transport: PluginMcpTransport,
+    pub command: Option<String>,
+    pub argv: Vec<String>,
+    pub cwd: Option<PathBuf>,
+    pub env: Vec<(String, String)>,
+    pub url: Option<String>,
+    pub env_headers: Vec<(String, String)>,
+    pub bearer_token_env_var: Option<String>,
+    pub connect_timeout_secs: Option<u64>,
+    pub execute_timeout_secs: Option<u64>,
+    pub read_timeout_secs: Option<u64>,
+    pub required: bool,
+    pub enabled_tools: Vec<String>,
+    pub disabled_tools: Vec<String>,
+    pub enabled: bool,
+}
+
+/// Portable summary of one loaded plugin bundle (list output, FEAT-020 D2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginSummary {
+    pub name: String,
+    pub id: String,
+    pub state_label: String,
+    pub scope: String,
+    pub trust_status: String,
+    pub compatibility: String,
+    pub inventory: String,
+    pub active: bool,
+    pub trusted: bool,
+    pub enabled: bool,
+}
+
+/// Portable full bundle detail for show/review/validate rendering (FEAT-020 D2).
+///
+/// Carries every semantic value the render helpers consume. The complete
+/// `LoadedPlugin` never crosses the boundary; only branch-consumed fields are
+/// projected here (D10).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginDetail {
+    pub name: String,
+    pub id: String,
+    pub version: String,
+    pub origin: String,
+    pub scope: String,
+    pub state_label: String,
+    pub trust_status: String,
+    pub compatibility: String,
+    pub content_hash: String,
+    pub capability_hash: String,
+    pub canonical_root: PathBuf,
+    pub active: bool,
+    pub trusted: bool,
+    pub enabled: bool,
+    pub unsupported_labels: Vec<String>,
+    pub supported_labels: Vec<String>,
+    pub skills: Vec<String>,
+    pub filesystem_roots: Vec<String>,
+    pub network_hosts: Vec<String>,
+    pub stdio_mcp_servers: usize,
+    pub lifecycle_mutation: bool,
+    pub mcp_servers: Vec<PluginMcpServerDetail>,
+    pub diagnostics: Vec<PluginDiagnostic>,
+}
+
+/// Portable outcome of a plugin mutation (FEAT-020 D2/D11).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluginMutationOutcome {
+    Installed,
+    Updated,
+    NoChange,
+    Uninstalled,
+    NeedsApproval(String),
+    NetworkDenied(String),
+}
+
+/// Portable mutation receipt returned synchronously by the facet (FEAT-020 D11).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginMutationReceipt {
+    pub name: String,
+    pub path: Option<PathBuf>,
+    pub content_hash: Option<String>,
+    pub installed_content_hash: Option<String>,
+    pub outcome: PluginMutationOutcome,
+}
+
+/// Portable bundle export receipt (FEAT-020 D2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginExportReceipt {
+    pub exported_name: String,
+    pub target: PathBuf,
+    pub display_name: Option<String>,
+    pub wrote_mcp_json: bool,
+    pub files_copied: u64,
+    pub skills_normalized: bool,
+}
+
+/// Portable legacy executable-tool detail (FEAT-020 D2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginLegacyTool {
+    pub name: String,
+    pub description: String,
+    pub approval: String,
+    pub input_schema: Option<String>,
+    pub path: PathBuf,
+}
+
+/// Portable legacy-tool scan result: directory and discovered tools.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginLegacyScan {
+    pub dir: PathBuf,
+    pub tools: Vec<PluginLegacyTool>,
+}
+
+/// Portable Kimi managed-plugin candidate (FEAT-020 D2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginManagedCandidate {
+    pub name: String,
+    pub version: String,
+    pub license: Option<String>,
+    pub canonical_path: PathBuf,
+    pub content_hash: String,
+    pub capability_hash: String,
+    pub inventory: String,
+    pub applicable: bool,
+}
+
+/// Portable Kimi managed-scan result (FEAT-020 D2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginManagedScan {
+    pub root: PathBuf,
+    pub candidates: Vec<PluginManagedCandidate>,
+    pub rejected: Vec<String>,
+}
+
+/// Portable marketplace candidate install plan (FEAT-020 D2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluginMarketplaceInstallPlan {
+    Supported { spec: String, source_kind: String },
+    Unsupported { reason: String },
+}
+
+/// Portable marketplace candidate (FEAT-020 D2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginMarketplaceCandidate {
+    pub name: String,
+    pub display_name: Option<String>,
+    pub version: Option<String>,
+    pub tier: String,
+    pub compatibility: Option<String>,
+    pub install_plan: PluginMarketplaceInstallPlan,
+    pub description: Option<String>,
+    pub homepage: Option<String>,
+    pub repository: Option<String>,
+    pub author: Option<String>,
+    pub license: Option<String>,
+    pub keywords: Vec<String>,
+    pub when: Option<String>,
+    pub diagnostics: Vec<PluginDiagnostic>,
+    pub has_errors: bool,
+}
+
+/// Portable marketplace catalog (FEAT-020 D2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginMarketplaceCatalog {
+    pub id: String,
+    pub display_name: Option<String>,
+    pub description: Option<String>,
+    pub format: String,
+    pub tier: String,
+    pub publisher: Option<String>,
+    pub total_candidates: usize,
+    pub warning_count: usize,
+    pub candidates: Vec<PluginMarketplaceCandidate>,
+    pub diagnostics: Vec<PluginDiagnostic>,
+}
+
+/// Portable marketplace add receipt (FEAT-020 D2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginMarketplaceAddReceipt {
+    pub name: String,
+    pub candidate_count: usize,
+    pub warning_count: usize,
+    pub catalog: PluginMarketplaceCatalog,
+}
+
+/// Portable marketplace state: stored catalogs plus the builtin `official` one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginMarketplaceState {
+    pub official: PluginMarketplaceCatalog,
+    pub stored: Vec<PluginMarketplaceCatalog>,
+}
+
+/// Portable suggestion for the `/plugin suggest` recommendation output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginSuggestion {
+    pub name: String,
+    pub description: String,
+    pub why: Vec<String>,
+    pub next_step: String,
+}
+
+/// Host plugin data for the plugin command group (FEAT-020 D1).
+///
+/// One object-safe, synchronous facet exposing the exact-minimum typed
+/// operations the live `/plugin` branch closure consumes. Registry reads and
+/// mutations, async-bridged install/update/uninstall (returning synchronous
+/// portable receipts), export, legacy executable-tool scan, Kimi managed
+/// import, and marketplace operations are all represented. The handler never
+/// names `crate::plugins`, `PluginRegistry`, `LoadedPlugin`, `Config`, or
+/// another concrete host service; implementation errors cross as safe text.
+///
+/// Post-mutation side effects (rediscovery, skill-cache refresh, active-skill
+/// reset) happen host-side inside the facet implementation; the handler only
+/// renders the returned receipt (D11).
+pub trait CommandPluginContext {
+    /// Read-only: registry summaries for list output.
+    fn summaries(&self) -> Result<Vec<PluginSummary>, String>;
+    /// Read-only: full portable detail for show/review/validate.
+    fn detail(&self, selector: &str) -> Result<PluginDetail, String>;
+    /// Read-only: registry-level diagnostics.
+    fn registry_diagnostics(&self) -> Vec<PluginDiagnostic>;
+    /// Read-only: whether validation reports no errors.
+    fn validation_is_clean(&self) -> bool;
+    /// Read-only: registry length (used by list/reload empty branches).
+    fn len(&self) -> usize;
+    /// Read-only: whether the registry is empty.
+    fn is_empty(&self) -> bool;
+    /// Read-only: persistence store path for marketplace state.
+    fn state_path(&self) -> Option<PathBuf>;
+    /// Read-only: recommend installed bundles for a task without side effects.
+    fn suggest(&self, task: &str) -> Result<Vec<PluginSuggestion>, String>;
+    /// Mutation: trust a bundle by exact review token; returns a portable receipt.
+    fn trust(&mut self, selector: &str, token: &str) -> Result<PluginMutationReceipt, String>;
+    /// Mutation: enable a bundle; returns a portable receipt.
+    fn enable(&mut self, selector: &str) -> Result<PluginMutationReceipt, String>;
+    /// Mutation: disable a bundle; returns a portable receipt.
+    fn disable(&mut self, selector: &str) -> Result<PluginMutationReceipt, String>;
+    /// Mutation: revoke trust; returns a portable receipt.
+    fn revoke_trust(&mut self, selector: &str) -> Result<PluginMutationReceipt, String>;
+    /// Async-bridged install; returns a synchronous portable receipt (D11).
+    fn install(
+        &mut self,
+        source: &str,
+        expected_content_hash: Option<&str>,
+    ) -> Result<PluginMutationReceipt, String>;
+    /// Async-bridged update; returns a synchronous portable receipt (D11).
+    fn update(&mut self, selector: &str) -> Result<PluginMutationReceipt, String>;
+    /// Async-bridged uninstall; returns a synchronous portable receipt (D11).
+    fn uninstall(&mut self, selector: &str) -> Result<PluginMutationReceipt, String>;
+    /// Read-only: export a loaded bundle to a target directory.
+    fn export(&self, selector: &str, target: &Path) -> Result<PluginExportReceipt, String>;
+    /// Read-only: scan legacy executable plugin tools.
+    fn legacy_scan(&self) -> Result<Option<PluginLegacyScan>, String>;
+    /// Read-only: Kimi managed-plugin directory scan.
+    fn managed_scan(&self, home_override: Option<&Path>) -> Result<PluginManagedScan, String>;
+    /// Mutation: install a Kimi managed candidate by exact content hash.
+    fn managed_install(
+        &mut self,
+        canonical_path: &Path,
+        expected_content_hash: &str,
+    ) -> Result<PluginMutationReceipt, String>;
+    /// Read-only: marketplace state (builtin official + stored catalogs).
+    fn marketplace_state(&self) -> Result<PluginMarketplaceState, String>;
+    /// Mutation: add a local catalog document to the marketplace store.
+    fn marketplace_add(
+        &mut self,
+        name: &str,
+        path: &Path,
+    ) -> Result<PluginMarketplaceAddReceipt, String>;
+    /// Mutation: remove a stored marketplace catalog.
+    fn marketplace_remove(&mut self, name: &str) -> Result<bool, String>;
+    /// Mutation: install a marketplace candidate through the reviewed installer.
+    fn marketplace_install(
+        &mut self,
+        catalog: &str,
+        candidate: &str,
+    ) -> Result<PluginMutationReceipt, String>;
+}

--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -502,14 +502,17 @@ pub trait CommandPluginContext {
     fn state_path(&self) -> Option<PathBuf>;
     /// Read-only: recommend installed bundles for a task without side effects.
     fn suggest(&self, task: &str) -> Result<Vec<PluginSuggestion>, String>;
-    /// Mutation: trust a bundle by exact review token; returns a portable receipt.
-    fn trust(&mut self, selector: &str, token: &str) -> Result<PluginMutationReceipt, String>;
-    /// Mutation: enable a bundle; returns a portable receipt.
-    fn enable(&mut self, selector: &str) -> Result<PluginMutationReceipt, String>;
-    /// Mutation: disable a bundle; returns a portable receipt.
-    fn disable(&mut self, selector: &str) -> Result<PluginMutationReceipt, String>;
-    /// Mutation: revoke trust; returns a portable receipt.
-    fn revoke_trust(&mut self, selector: &str) -> Result<PluginMutationReceipt, String>;
+    /// Mutation: trust a bundle by exact review token. Success means the
+    /// mutation was applied; the handler renders the action word from its own
+    /// dispatch arm and may re-read `detail` for post-mutation state.
+    fn trust(&mut self, selector: &str, token: &str) -> Result<(), String>;
+    /// Mutation: enable a bundle. Success means enabled; re-read `detail` for
+    /// the post-mutation compatibility note.
+    fn enable(&mut self, selector: &str) -> Result<(), String>;
+    /// Mutation: disable a bundle.
+    fn disable(&mut self, selector: &str) -> Result<(), String>;
+    /// Mutation: revoke trust.
+    fn revoke_trust(&mut self, selector: &str) -> Result<(), String>;
     /// Async-bridged install; returns a synchronous portable receipt (D11).
     fn install(
         &mut self,

--- a/crates/command-contract/src/handler.rs
+++ b/crates/command-contract/src/handler.rs
@@ -6,8 +6,8 @@
 
 use crate::facets::{
     CommandCostContext, CommandMediaContext, CommandMemoryContext, CommandModePolicyContext,
-    CommandModelContext, CommandPresentationContext, CommandSessionContext, CommandSkillsContext,
-    CommandSystemPromptContext, CommandWorkspaceContext,
+    CommandModelContext, CommandPluginContext, CommandPresentationContext, CommandSessionContext,
+    CommandSkillsContext, CommandSystemPromptContext, CommandWorkspaceContext,
 };
 
 /// Exact host capabilities exposed to one contextual command handler.
@@ -31,6 +31,8 @@ impl CommandCapabilities {
     pub const MEDIA: Self = Self(1 << 8);
     /// Memory-group host data (FEAT-019 D1).
     pub const MEMORY: Self = Self(1 << 9);
+    /// Plugin-group host data (FEAT-020 D1).
+    pub const PLUGIN: Self = Self(1 << 10);
 
     pub const fn union(self, other: Self) -> Self {
         Self(self.0 | other.0)
@@ -75,6 +77,7 @@ pub struct CommandContexts<'a> {
     presentation: Option<&'a mut dyn CommandPresentationContext>,
     media: Option<&'a mut dyn CommandMediaContext>,
     memory: Option<&'a mut dyn CommandMemoryContext>,
+    plugin: Option<&'a mut dyn CommandPluginContext>,
 }
 
 /// Consumed envelope used when one handler needs several independent facets.
@@ -89,6 +92,7 @@ pub struct ContextParts<'a> {
     pub presentation: Option<&'a mut dyn CommandPresentationContext>,
     pub media: Option<&'a mut dyn CommandMediaContext>,
     pub memory: Option<&'a mut dyn CommandMemoryContext>,
+    pub plugin: Option<&'a mut dyn CommandPluginContext>,
 }
 
 impl<'a> CommandContexts<'a> {
@@ -104,6 +108,7 @@ impl<'a> CommandContexts<'a> {
             presentation: None,
             media: None,
             memory: None,
+            plugin: None,
         }
     }
 
@@ -119,6 +124,7 @@ impl<'a> CommandContexts<'a> {
             presentation: self.presentation,
             media: self.media,
             memory: self.memory,
+            plugin: self.plugin,
         }
     }
 
@@ -195,6 +201,14 @@ impl<'a> CommandContexts<'a> {
         assert!(
             self.memory.replace(value).is_none(),
             "memory facet already set"
+        );
+        self
+    }
+
+    pub fn with_plugin(mut self, value: &'a mut dyn CommandPluginContext) -> Self {
+        assert!(
+            self.plugin.replace(value).is_none(),
+            "plugin facet already set"
         );
         self
     }

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -844,48 +844,24 @@ impl CommandPluginContext for FakePlugin {
         }])
     }
 
-    fn trust(&mut self, _selector: &str, token: &str) -> Result<PluginMutationReceipt, String> {
+    fn trust(&mut self, _selector: &str, token: &str) -> Result<(), String> {
         if token == "abc.def" {
-            Ok(PluginMutationReceipt {
-                name: "demo".to_string(),
-                path: None,
-                content_hash: None,
-                installed_content_hash: None,
-                outcome: PluginMutationOutcome::NoChange,
-            })
+            Ok(())
         } else {
             Err("Review token does not match this bundle content and capability set".to_string())
         }
     }
 
-    fn enable(&mut self, _selector: &str) -> Result<PluginMutationReceipt, String> {
-        Ok(PluginMutationReceipt {
-            name: "demo".to_string(),
-            path: None,
-            content_hash: None,
-            installed_content_hash: None,
-            outcome: PluginMutationOutcome::NoChange,
-        })
+    fn enable(&mut self, _selector: &str) -> Result<(), String> {
+        Ok(())
     }
 
-    fn disable(&mut self, _selector: &str) -> Result<PluginMutationReceipt, String> {
-        Ok(PluginMutationReceipt {
-            name: "demo".to_string(),
-            path: None,
-            content_hash: None,
-            installed_content_hash: None,
-            outcome: PluginMutationOutcome::NoChange,
-        })
+    fn disable(&mut self, _selector: &str) -> Result<(), String> {
+        Ok(())
     }
 
-    fn revoke_trust(&mut self, _selector: &str) -> Result<PluginMutationReceipt, String> {
-        Ok(PluginMutationReceipt {
-            name: "demo".to_string(),
-            path: None,
-            content_hash: None,
-            installed_content_hash: None,
-            outcome: PluginMutationOutcome::NoChange,
-        })
+    fn revoke_trust(&mut self, _selector: &str) -> Result<(), String> {
+        Ok(())
     }
 
     fn install(
@@ -1075,6 +1051,7 @@ fn plugin_mutation_receipts_distinguish_outcomes() {
     let uninstalled = plugin.uninstall("demo").unwrap();
     assert_eq!(uninstalled.outcome, PluginMutationOutcome::Uninstalled);
 
+    plugin.trust("demo", "abc.def").unwrap();
     let trust_err = plugin.trust("demo", "bad.token").unwrap_err();
     assert!(trust_err.contains("Review token does not match"));
 }

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -910,6 +910,10 @@ impl CommandPluginContext for FakePlugin {
         })
     }
 
+    fn uninstall_path(&mut self, _name: &str, _plugins_dir: &Path) -> Result<(), String> {
+        Ok(())
+    }
+
     fn export(&self, _selector: &str, target: &Path) -> Result<PluginExportReceipt, String> {
         Ok(PluginExportReceipt {
             exported_name: "demo".to_string(),

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -769,6 +769,7 @@ impl FakePlugin {
             detail: Some(PluginDetail {
                 name: "demo".to_string(),
                 id: "demo@1.0.0".to_string(),
+                inventory_summary: "skills=1 mcp=0".to_string(),
                 version: "1.0.0".to_string(),
                 origin: "local".to_string(),
                 scope: "user".to_string(),
@@ -824,6 +825,10 @@ impl CommandPluginContext for FakePlugin {
         self.summaries.len()
     }
 
+    fn reload(&mut self) -> Result<usize, String> {
+        Ok(self.summaries.len())
+    }
+
     fn is_empty(&self) -> bool {
         self.summaries.is_empty()
     }
@@ -838,6 +843,7 @@ impl CommandPluginContext for FakePlugin {
         }
         Ok(vec![PluginSuggestion {
             name: "demo".to_string(),
+            state_label: "active".to_string(),
             description: "Demo bundle".to_string(),
             why: vec![task.to_string()],
             next_step: "Already active: /plugin show demo".to_string(),
@@ -948,6 +954,7 @@ impl CommandPluginContext for FakePlugin {
         Ok(PluginMarketplaceState {
             official: PluginMarketplaceCatalog {
                 id: "official".to_string(),
+                source_path: None,
                 display_name: None,
                 description: Some("Built into this release".to_string()),
                 format: "codewhale".to_string(),
@@ -978,6 +985,7 @@ impl CommandPluginContext for FakePlugin {
             warning_count: 0,
             catalog: PluginMarketplaceCatalog {
                 id: name.to_string(),
+                source_path: None,
                 display_name: None,
                 description: None,
                 format: "kimi".to_string(),

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -875,10 +875,10 @@ impl CommandPluginContext for FakePlugin {
         _source: &str,
         expected_content_hash: Option<&str>,
     ) -> Result<PluginMutationReceipt, String> {
-        if let Some(expected) = expected_content_hash {
-            if expected != "abc" {
-                return Err("content hash mismatch".to_string());
-            }
+        if let Some(expected) = expected_content_hash
+            && expected != "abc"
+        {
+            return Err("content hash mismatch".to_string());
         }
         self.installed = true;
         Ok(PluginMutationReceipt {

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -738,3 +738,454 @@ fn envelope_rejects_duplicate_memory_slot_deterministically() {
     }));
     assert!(result.is_err(), "duplicate memory slot must assert");
 }
+
+// ---------------------------------------------------------------------------
+// FEAT-020: plugin capability, portable DTOs, and envelope slot (D1-D11)
+// ---------------------------------------------------------------------------
+
+/// Deterministic fake plugin facet over portable values only.
+struct FakePlugin {
+    summaries: Vec<PluginSummary>,
+    detail: Option<PluginDetail>,
+    installed: bool,
+    managed_candidates: Vec<PluginManagedCandidate>,
+}
+
+impl FakePlugin {
+    fn new() -> Self {
+        Self {
+            summaries: vec![PluginSummary {
+                name: "demo".to_string(),
+                id: "demo@1.0.0".to_string(),
+                state_label: "active".to_string(),
+                scope: "user".to_string(),
+                trust_status: "trusted".to_string(),
+                compatibility: "full".to_string(),
+                inventory: "skills=1 mcp=0".to_string(),
+                active: true,
+                trusted: true,
+                enabled: true,
+            }],
+            detail: Some(PluginDetail {
+                name: "demo".to_string(),
+                id: "demo@1.0.0".to_string(),
+                version: "1.0.0".to_string(),
+                origin: "local".to_string(),
+                scope: "user".to_string(),
+                state_label: "active".to_string(),
+                trust_status: "trusted".to_string(),
+                compatibility: "full".to_string(),
+                content_hash: "abc".to_string(),
+                capability_hash: "def".to_string(),
+                canonical_root: PathBuf::from("/plugins/demo"),
+                active: true,
+                trusted: true,
+                enabled: true,
+                unsupported_labels: Vec::new(),
+                supported_labels: vec!["skills".to_string()],
+                skills: vec!["demo:demo-skill".to_string()],
+                filesystem_roots: Vec::new(),
+                network_hosts: Vec::new(),
+                stdio_mcp_servers: 0,
+                lifecycle_mutation: false,
+                mcp_servers: Vec::new(),
+                diagnostics: Vec::new(),
+            }),
+            installed: false,
+            managed_candidates: Vec::new(),
+        }
+    }
+}
+
+impl CommandPluginContext for FakePlugin {
+    fn summaries(&self) -> Result<Vec<PluginSummary>, String> {
+        Ok(self.summaries.clone())
+    }
+
+    fn detail(&self, selector: &str) -> Result<PluginDetail, String> {
+        if selector == "demo" {
+            self.detail
+                .clone()
+                .ok_or_else(|| "missing detail".to_string())
+        } else {
+            Err(format!("no plugin named {selector}"))
+        }
+    }
+
+    fn registry_diagnostics(&self) -> Vec<PluginDiagnostic> {
+        Vec::new()
+    }
+
+    fn validation_is_clean(&self) -> bool {
+        true
+    }
+
+    fn len(&self) -> usize {
+        self.summaries.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.summaries.is_empty()
+    }
+
+    fn state_path(&self) -> Option<PathBuf> {
+        Some(PathBuf::from("/plugins/state.json"))
+    }
+
+    fn suggest(&self, task: &str) -> Result<Vec<PluginSuggestion>, String> {
+        if task.len() < 3 {
+            return Err("task too short".to_string());
+        }
+        Ok(vec![PluginSuggestion {
+            name: "demo".to_string(),
+            description: "Demo bundle".to_string(),
+            why: vec![task.to_string()],
+            next_step: "Already active: /plugin show demo".to_string(),
+        }])
+    }
+
+    fn trust(&mut self, _selector: &str, token: &str) -> Result<PluginMutationReceipt, String> {
+        if token == "abc.def" {
+            Ok(PluginMutationReceipt {
+                name: "demo".to_string(),
+                path: None,
+                content_hash: None,
+                installed_content_hash: None,
+                outcome: PluginMutationOutcome::NoChange,
+            })
+        } else {
+            Err("Review token does not match this bundle content and capability set".to_string())
+        }
+    }
+
+    fn enable(&mut self, _selector: &str) -> Result<PluginMutationReceipt, String> {
+        Ok(PluginMutationReceipt {
+            name: "demo".to_string(),
+            path: None,
+            content_hash: None,
+            installed_content_hash: None,
+            outcome: PluginMutationOutcome::NoChange,
+        })
+    }
+
+    fn disable(&mut self, _selector: &str) -> Result<PluginMutationReceipt, String> {
+        Ok(PluginMutationReceipt {
+            name: "demo".to_string(),
+            path: None,
+            content_hash: None,
+            installed_content_hash: None,
+            outcome: PluginMutationOutcome::NoChange,
+        })
+    }
+
+    fn revoke_trust(&mut self, _selector: &str) -> Result<PluginMutationReceipt, String> {
+        Ok(PluginMutationReceipt {
+            name: "demo".to_string(),
+            path: None,
+            content_hash: None,
+            installed_content_hash: None,
+            outcome: PluginMutationOutcome::NoChange,
+        })
+    }
+
+    fn install(
+        &mut self,
+        _source: &str,
+        expected_content_hash: Option<&str>,
+    ) -> Result<PluginMutationReceipt, String> {
+        if let Some(expected) = expected_content_hash {
+            if expected != "abc" {
+                return Err("content hash mismatch".to_string());
+            }
+        }
+        self.installed = true;
+        Ok(PluginMutationReceipt {
+            name: "demo".to_string(),
+            path: Some(PathBuf::from("/plugins/demo")),
+            content_hash: Some("abc".to_string()),
+            installed_content_hash: Some("abc".to_string()),
+            outcome: PluginMutationOutcome::Installed,
+        })
+    }
+
+    fn update(&mut self, _selector: &str) -> Result<PluginMutationReceipt, String> {
+        Ok(PluginMutationReceipt {
+            name: "demo".to_string(),
+            path: None,
+            content_hash: None,
+            installed_content_hash: None,
+            outcome: PluginMutationOutcome::NoChange,
+        })
+    }
+
+    fn uninstall(&mut self, _selector: &str) -> Result<PluginMutationReceipt, String> {
+        Ok(PluginMutationReceipt {
+            name: "demo".to_string(),
+            path: None,
+            content_hash: None,
+            installed_content_hash: None,
+            outcome: PluginMutationOutcome::Uninstalled,
+        })
+    }
+
+    fn export(&self, _selector: &str, target: &Path) -> Result<PluginExportReceipt, String> {
+        Ok(PluginExportReceipt {
+            exported_name: "demo".to_string(),
+            target: target.to_path_buf(),
+            display_name: Some("Demo Bundle".to_string()),
+            wrote_mcp_json: false,
+            files_copied: 2,
+            skills_normalized: false,
+        })
+    }
+
+    fn legacy_scan(&self) -> Result<Option<PluginLegacyScan>, String> {
+        Ok(None)
+    }
+
+    fn managed_scan(&self, _home_override: Option<&Path>) -> Result<PluginManagedScan, String> {
+        Ok(PluginManagedScan {
+            root: PathBuf::from("/kimi/managed"),
+            candidates: self.managed_candidates.clone(),
+            rejected: Vec::new(),
+        })
+    }
+
+    fn managed_install(
+        &mut self,
+        canonical_path: &Path,
+        expected_content_hash: &str,
+    ) -> Result<PluginMutationReceipt, String> {
+        if expected_content_hash != "abc" {
+            return Err("Kimi candidate changed".to_string());
+        }
+        Ok(PluginMutationReceipt {
+            name: "kimi-demo".to_string(),
+            path: Some(canonical_path.to_path_buf()),
+            content_hash: Some("abc".to_string()),
+            installed_content_hash: Some("abc".to_string()),
+            outcome: PluginMutationOutcome::Installed,
+        })
+    }
+
+    fn marketplace_state(&self) -> Result<PluginMarketplaceState, String> {
+        Ok(PluginMarketplaceState {
+            official: PluginMarketplaceCatalog {
+                id: "official".to_string(),
+                display_name: None,
+                description: Some("Built into this release".to_string()),
+                format: "codewhale".to_string(),
+                tier: "official".to_string(),
+                publisher: Some("Codewhale".to_string()),
+                total_candidates: 1,
+                warning_count: 0,
+                candidates: Vec::new(),
+                diagnostics: Vec::new(),
+            },
+            stored: Vec::new(),
+        })
+    }
+
+    fn marketplace_add(
+        &mut self,
+        name: &str,
+        _path: &Path,
+    ) -> Result<PluginMarketplaceAddReceipt, String> {
+        if name == "official" {
+            return Err(
+                "`official` is the catalog built into Codewhale; pick another name.".to_string(),
+            );
+        }
+        Ok(PluginMarketplaceAddReceipt {
+            name: name.to_string(),
+            candidate_count: 0,
+            warning_count: 0,
+            catalog: PluginMarketplaceCatalog {
+                id: name.to_string(),
+                display_name: None,
+                description: None,
+                format: "kimi".to_string(),
+                tier: "community".to_string(),
+                publisher: None,
+                total_candidates: 0,
+                warning_count: 0,
+                candidates: Vec::new(),
+                diagnostics: Vec::new(),
+            },
+        })
+    }
+
+    fn marketplace_remove(&mut self, _name: &str) -> Result<bool, String> {
+        Ok(true)
+    }
+
+    fn marketplace_install(
+        &mut self,
+        _catalog: &str,
+        _candidate: &str,
+    ) -> Result<PluginMutationReceipt, String> {
+        Ok(PluginMutationReceipt {
+            name: "market-demo".to_string(),
+            path: None,
+            content_hash: None,
+            installed_content_hash: None,
+            outcome: PluginMutationOutcome::Installed,
+        })
+    }
+}
+
+#[test]
+fn plugin_facet_is_object_safe_and_typed() {
+    fn plugin(_: &dyn CommandPluginContext) {}
+    plugin(&FakePlugin::new());
+
+    let plugin = FakePlugin::new();
+    assert_eq!(plugin.len(), 1);
+    assert!(!plugin.is_empty());
+    assert!(plugin.validation_is_clean());
+    let summaries = plugin.summaries().unwrap();
+    assert_eq!(summaries[0].name, "demo");
+    assert_eq!(summaries[0].state_label, "active");
+}
+
+#[test]
+fn plugin_detail_preserves_semantic_values() {
+    let plugin = FakePlugin::new();
+    let detail = plugin.detail("demo").unwrap();
+    assert_eq!(detail.content_hash, "abc");
+    assert_eq!(detail.capability_hash, "def");
+    assert_eq!(detail.compatibility, "full");
+    assert!(detail.active);
+    assert_eq!(detail.skills, vec!["demo:demo-skill"]);
+    // Unknown selector fails safely.
+    assert!(plugin.detail("nope").is_err());
+}
+
+#[test]
+fn plugin_mutation_receipts_distinguish_outcomes() {
+    let mut plugin = FakePlugin::new();
+    let installed = plugin.install("path:/demo", Some("abc")).unwrap();
+    assert_eq!(installed.outcome, PluginMutationOutcome::Installed);
+    assert_eq!(installed.installed_content_hash.as_deref(), Some("abc"));
+
+    // Exact-hash mismatch fails before any install side effect.
+    let err = plugin.install("path:/demo", Some("wrong")).unwrap_err();
+    assert!(err.contains("content hash mismatch"));
+
+    let uninstalled = plugin.uninstall("demo").unwrap();
+    assert_eq!(uninstalled.outcome, PluginMutationOutcome::Uninstalled);
+
+    let trust_err = plugin.trust("demo", "bad.token").unwrap_err();
+    assert!(trust_err.contains("Review token does not match"));
+}
+
+#[test]
+fn plugin_managed_and_marketplace_values_are_portable() {
+    let mut plugin = FakePlugin::new();
+    let scan = plugin.managed_scan(None).unwrap();
+    assert_eq!(scan.root, PathBuf::from("/kimi/managed"));
+    assert!(scan.candidates.is_empty());
+
+    plugin.managed_candidates.push(PluginManagedCandidate {
+        name: "kimi-demo".to_string(),
+        version: "1.0.0".to_string(),
+        license: Some("MIT".to_string()),
+        canonical_path: PathBuf::from("/kimi/managed/kimi-demo"),
+        content_hash: "abc".to_string(),
+        capability_hash: "def".to_string(),
+        inventory: "skills=1".to_string(),
+        applicable: true,
+    });
+    let scan = plugin.managed_scan(None).unwrap();
+    assert_eq!(scan.candidates[0].name, "kimi-demo");
+    assert_eq!(scan.candidates[0].license.as_deref(), Some("MIT"));
+
+    let state = plugin.marketplace_state().unwrap();
+    assert_eq!(state.official.id, "official");
+    assert_eq!(state.official.tier, "official");
+    assert!(state.stored.is_empty());
+
+    let add = plugin
+        .marketplace_add("custom", Path::new("/catalog.json"))
+        .unwrap();
+    assert_eq!(add.name, "custom");
+    assert_eq!(add.catalog.format, "kimi");
+
+    let err = plugin
+        .marketplace_add("official", Path::new("/x.json"))
+        .unwrap_err();
+    assert!(err.contains("built into Codewhale"));
+}
+
+#[test]
+fn plugin_suggest_is_read_only_and_safe() {
+    let plugin = FakePlugin::new();
+    let err = plugin.suggest("ab").unwrap_err();
+    assert!(err.contains("too short"));
+    let suggestions = plugin.suggest("translate").unwrap();
+    assert_eq!(suggestions[0].name, "demo");
+    assert_eq!(
+        suggestions[0].next_step,
+        "Already active: /plugin show demo"
+    );
+}
+
+#[test]
+fn plugin_facet_transports_through_envelope_when_declared() {
+    let mut plugin = FakePlugin::new();
+    let parts = CommandContexts::empty()
+        .with_plugin(&mut plugin)
+        .into_parts();
+    assert!(parts.plugin.is_some());
+    assert!(parts.session.is_none());
+    assert!(parts.memory.is_none());
+
+    // Undeclared slots stay absent when the plugin facet is carried alone.
+    let mut workspace = Workspace;
+    let parts = CommandContexts::empty()
+        .with_plugin(&mut plugin)
+        .with_workspace(&mut workspace)
+        .into_parts();
+    assert!(parts.plugin.is_some());
+    assert!(parts.workspace.is_some());
+    assert!(parts.presentation.is_none());
+}
+
+#[test]
+fn envelope_rejects_duplicate_plugin_slot_deterministically() {
+    let mut a = FakePlugin::new();
+    let mut b = FakePlugin::new();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        CommandContexts::empty()
+            .with_plugin(&mut a)
+            .with_plugin(&mut b);
+    }));
+    assert!(result.is_err(), "duplicate plugin slot must assert");
+}
+
+#[test]
+fn plugin_capability_bit_is_stable_and_distinct() {
+    let plugin = CommandCapabilities::PLUGIN;
+    assert_eq!(plugin, CommandCapabilities::PLUGIN);
+    assert!(plugin.contains(CommandCapabilities::PLUGIN));
+    assert!(!plugin.contains(CommandCapabilities::MEMORY));
+    assert!(!plugin.contains(CommandCapabilities::WORKSPACE));
+    // Existing bits are unchanged by the plugin extension.
+    assert_eq!(CommandCapabilities::MEMORY, CommandCapabilities::MEMORY);
+    assert_eq!(CommandCapabilities::SESSION, CommandCapabilities::SESSION);
+
+    let plugin_workspace = CommandCapabilities::PLUGIN.union(CommandCapabilities::WORKSPACE);
+    assert!(plugin_workspace.contains(CommandCapabilities::PLUGIN));
+    assert!(plugin_workspace.contains(CommandCapabilities::WORKSPACE));
+    assert!(!plugin_workspace.contains(CommandCapabilities::MEMORY));
+
+    // The plugin group declares exactly WORKSPACE | PRESENTATION | PLUGIN.
+    let exact = CommandCapabilities::WORKSPACE
+        .union(CommandCapabilities::PRESENTATION)
+        .union(CommandCapabilities::PLUGIN);
+    assert!(exact.contains(CommandCapabilities::PLUGIN));
+    assert!(exact.contains(CommandCapabilities::PRESENTATION));
+    assert!(!exact.contains(CommandCapabilities::MEDIA));
+    assert!(!exact.contains(CommandCapabilities::MEMORY));
+    assert!(!exact.contains(CommandCapabilities::SKILLS));
+}

--- a/crates/computer-use/src/drivers/linux.rs
+++ b/crates/computer-use/src/drivers/linux.rs
@@ -6,7 +6,7 @@
 //! `spectacle` for capture. Wayland: `grim` (or `spectacle`/`gnome-screenshot`)
 //! for capture, `ydotool` for input (`wtype` for text when present).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::config::LinuxConfig;
@@ -159,7 +159,7 @@ impl LinuxDriver {
             .collect()
     }
 
-    fn run(&self, program: &PathBuf, args: &[&str]) -> Result<process::Output, DriverError> {
+    fn run(&self, program: &Path, args: &[&str]) -> Result<process::Output, DriverError> {
         let out = process::run_with_env(program, args, &self.env_refs(), Duration::from_secs(30))?;
         if out.success() {
             Ok(out)

--- a/crates/config/src/catalog/tests.rs
+++ b/crates/config/src/catalog/tests.rs
@@ -835,9 +835,7 @@ fn ga_family_minor(prefix: &str, wire: &str, extra_allowed_suffixes: &[&str]) ->
         None => (rest, None),
     };
     if let Some(suffix) = suffix
-        && !extra_allowed_suffixes
-            .iter()
-            .any(|allowed| suffix == *allowed)
+        && !extra_allowed_suffixes.contains(&suffix)
     {
         return None;
     }
@@ -1098,6 +1096,7 @@ fn bundled_tui_catalog_asset_output_never_exceeds_context() {
 }
 
 #[test]
+#[allow(clippy::type_complexity)]
 fn bundled_assets_do_not_split_limit_facts_for_the_same_model_id() {
     use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -1126,15 +1126,11 @@ fn portable_marketplace_candidate(
             spec: spec.clone(),
             source_kind: source_kind.clone(),
         },
-        crate::plugins::marketplace::types::MarketplaceInstallPlan::Unsupported { reason, raw } => {
-            PluginMarketplaceInstallPlan::Unsupported {
-                reason: if raw.is_empty() {
-                    reason.clone()
-                } else {
-                    reason.clone()
-                },
-            }
-        }
+        crate::plugins::marketplace::types::MarketplaceInstallPlan::Unsupported {
+            reason, ..
+        } => PluginMarketplaceInstallPlan::Unsupported {
+            reason: reason.clone(),
+        },
     };
     PluginMarketplaceCandidate {
         name: candidate.name.clone(),

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -1796,6 +1796,13 @@ impl CommandPluginContext for PluginAdapter<'_> {
         }
     }
 
+    fn uninstall_path(&mut self, name: &str, plugins_dir: &Path) -> Result<(), String> {
+        // File-level rollback removal for a bundle whose content hash
+        // mismatched; no registry resolution, rediscovery, or skill side
+        // effects (FEAT-020 D1 — the `crate::plugins` call stays host-side).
+        crate::plugins::install::uninstall(name, plugins_dir).map_err(|error| format!("{error:#}"))
+    }
+
     fn export(&self, selector: &str, target: &Path) -> Result<PluginExportReceipt, String> {
         let app = self.host.app.borrow();
         let plugin = app

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -72,9 +72,8 @@ use crate::tui::app::{App, ReasoningEffort};
 /// (`scripts/check-command-migration-manifest.py`) reads this exact
 /// declaration by source regex and the Rust frontier tests assert it.
 #[allow(dead_code)]
-pub(crate) const PENDING_GROUPS: &[&str] = &[
-    "config", "core", "debug", "plugins", "project", "session", "skills",
-];
+pub(crate) const PENDING_GROUPS: &[&str] =
+    &["config", "core", "debug", "project", "session", "skills"];
 
 // ---------------------------------------------------------------------------
 // Boundary-value mappings (D8)

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -38,10 +38,11 @@ use codewhale_command_contract::facets::{
     MediaAttachmentReceipt, MemoryDelete, MemoryDeleteScope, MemoryExport, MemoryGetOutcome,
     MemoryHit, MemoryImportOutcome, MemoryReindex, MemoryRememberTarget, MemoryRemembered,
     MemoryStatus, PluginDetail, PluginDiagnostic, PluginDiagnosticLevel, PluginExportReceipt,
-    PluginLegacyScan, PluginLegacyTool, PluginManagedScan, PluginMarketplaceAddReceipt,
-    PluginMarketplaceCandidate, PluginMarketplaceCatalog, PluginMarketplaceInstallPlan,
-    PluginMarketplaceState, PluginMcpServerDetail, PluginMcpTransport, PluginMutationOutcome,
-    PluginMutationReceipt, PluginSuggestion, PluginSummary,
+    PluginLegacyScan, PluginLegacyTool, PluginManagedCandidate, PluginManagedScan,
+    PluginMarketplaceAddReceipt, PluginMarketplaceCandidate, PluginMarketplaceCatalog,
+    PluginMarketplaceInstallPlan, PluginMarketplaceState, PluginMcpServerDetail,
+    PluginMcpTransport, PluginMutationOutcome, PluginMutationReceipt, PluginSuggestion,
+    PluginSummary,
 };
 #[cfg(test)]
 use codewhale_command_contract::handler::ContextParts;
@@ -528,14 +529,83 @@ pub(crate) struct PresentationAdapter<'a> {
 
 impl CommandPresentationContext for PresentationAdapter<'_> {
     fn translate(&self, key: &str, replacements: &[(&str, &str)]) -> Result<String, String> {
-        let Some(message_id) = key_to_utility_message_id(key) else {
-            return Err("unknown translation key".to_string());
-        };
+        let message_id = key_to_utility_message_id(key)
+            .or_else(|| key_to_plugin_message_id(key))
+            .ok_or_else(|| "unknown translation key".to_string())?;
         let locale = self.host.app.borrow().ui_locale;
         let template = tr(locale, message_id);
         apply_named_replacements(&template, replacements)
             .ok_or_else(|| "invalid translation replacement contract".to_string())
     }
+}
+
+/// Resolve a stable plugin message key to the current catalog id (FEAT-020 D5).
+///
+/// Every plugin-group catalog message uses a stable snake_case key; the TUI
+/// adapter maps it to the current `MessageId` value and preserves the
+/// authoritative English fallback. Unknown keys fail safely.
+pub(crate) fn key_to_plugin_message_id(key: &str) -> Option<MessageId> {
+    Some(match key {
+        "cmd_plugin_action_failed" => MessageId::CmdPluginActionFailed,
+        "cmd_plugin_bundle_detail" => MessageId::CmdPluginBundleDetail,
+        "cmd_plugin_bundle_diagnostics_header" => MessageId::CmdPluginBundleDiagnosticsHeader,
+        "cmd_plugin_bundle_list_header" => MessageId::CmdPluginBundleListHeader,
+        "cmd_plugin_bundle_mutation_success" => MessageId::CmdPluginBundleMutationSuccess,
+        "cmd_plugin_bundle_none_found" => MessageId::CmdPluginBundleNoneFound,
+        "cmd_plugin_bundle_not_found" => MessageId::CmdPluginBundleNotFound,
+        "cmd_plugin_bundle_reloaded" => MessageId::CmdPluginBundleReloaded,
+        "cmd_plugin_bundle_usage" => MessageId::CmdPluginBundleUsage,
+        "cmd_plugin_detail_description" => MessageId::CmdPluginDetailDescription,
+        "cmd_plugin_detail_approval" => MessageId::CmdPluginDetailApproval,
+        "cmd_plugin_detail_path" => MessageId::CmdPluginDetailPath,
+        "cmd_plugin_detail_schema" => MessageId::CmdPluginDetailSchema,
+        "cmd_plugin_legacy_list_header" => MessageId::CmdPluginLegacyListHeader,
+        "cmd_plugin_none_found" => MessageId::CmdPluginNoneFound,
+        "cmd_plugin_not_found" => MessageId::CmdPluginNotFound,
+        "plugin_kimi_applicable" => MessageId::PluginKimiApplicable,
+        "plugin_kimi_candidate_changed" => MessageId::PluginKimiCandidateChanged,
+        "plugin_kimi_candidate_details" => MessageId::PluginKimiCandidateDetails,
+        "plugin_kimi_candidate_missing" => MessageId::PluginKimiCandidateMissing,
+        "plugin_kimi_candidate_summary" => MessageId::PluginKimiCandidateSummary,
+        "plugin_kimi_directory_name_mismatch" => MessageId::PluginKimiDirectoryNameMismatch,
+        "plugin_kimi_entry_canonicalize_failed" => MessageId::PluginKimiEntryCanonicalizeFailed,
+        "plugin_kimi_entry_inspect_failed" => MessageId::PluginKimiEntryInspectFailed,
+        "plugin_kimi_entry_limit" => MessageId::PluginKimiEntryLimit,
+        "plugin_kimi_entry_links_refused" => MessageId::PluginKimiEntryLinksRefused,
+        "plugin_kimi_entry_outside_root" => MessageId::PluginKimiEntryOutsideRoot,
+        "plugin_kimi_entry_read_failed" => MessageId::PluginKimiEntryReadFailed,
+        "plugin_kimi_hash_unavailable" => MessageId::PluginKimiHashUnavailable,
+        "plugin_kimi_home_missing" => MessageId::PluginKimiHomeMissing,
+        "plugin_kimi_inspection_footer" => MessageId::PluginKimiInspectionFooter,
+        "plugin_kimi_license_unspecified" => MessageId::PluginKimiLicenseUnspecified,
+        "plugin_kimi_managed_root_heading" => MessageId::PluginKimiManagedRootHeading,
+        "plugin_kimi_manifest_invalid" => MessageId::PluginKimiManifestInvalid,
+        "plugin_kimi_manifest_must_be_file" => MessageId::PluginKimiManifestMustBeFile,
+        "plugin_kimi_manifest_unreadable" => MessageId::PluginKimiManifestUnreadable,
+        "plugin_kimi_marketplace_gzip_tarball" => MessageId::PluginKimiMarketplaceGzipTarball,
+        "kimi_zip_unsupported" => MessageId::PluginKimiMarketplaceZipUnsupported,
+        "kimi_remote_archive_unsupported" => MessageId::PluginKimiMarketplaceRemoteUnsupported,
+        "kimi_gzip_tarball_url" => MessageId::PluginKimiMarketplaceGzipTarball,
+        "plugin_kimi_marketplace_remote_unsupported" => {
+            MessageId::PluginKimiMarketplaceRemoteUnsupported
+        }
+        "plugin_kimi_marketplace_zip_unsupported" => MessageId::PluginKimiMarketplaceZipUnsupported,
+        "plugin_kimi_mismatch_removed" => MessageId::PluginKimiMismatchRemoved,
+        "plugin_kimi_mismatch_rollback_failed" => MessageId::PluginKimiMismatchRollbackFailed,
+        "plugin_kimi_none_found" => MessageId::PluginKimiNoneFound,
+        "plugin_kimi_not_applicable" => MessageId::PluginKimiNotApplicable,
+        "plugin_kimi_rejected_heading" => MessageId::PluginKimiRejectedHeading,
+        "plugin_kimi_rollback_destination_missing" => {
+            MessageId::PluginKimiRollbackDestinationMissing
+        }
+        "plugin_kimi_root_canonicalize_failed" => MessageId::PluginKimiRootCanonicalizeFailed,
+        "plugin_kimi_root_inspect_failed" => MessageId::PluginKimiRootInspectFailed,
+        "plugin_kimi_root_list_failed" => MessageId::PluginKimiRootListFailed,
+        "plugin_kimi_root_must_be_directory" => MessageId::PluginKimiRootMustBeDirectory,
+        "plugin_kimi_usage" => MessageId::PluginKimiUsage,
+        "plugin_kimi_user_plugin_directory" => MessageId::PluginKimiUserPluginDirectory,
+        _ => return None,
+    })
 }
 
 /// Resolve a stable utility message key to the current catalog id.
@@ -940,6 +1010,7 @@ fn portable_detail(plugin: &crate::plugins::types::LoadedPlugin) -> PluginDetail
     PluginDetail {
         name: plugin.name().to_string(),
         id: plugin.id.as_str().to_string(),
+        inventory_summary: plugin.inventory.summary(),
         version: plugin.manifest.plugin.version.clone(),
         origin: plugin.origin.as_str().to_string(),
         scope: plugin.scope.as_str().to_string(),
@@ -1096,8 +1167,17 @@ fn portable_marketplace_candidate(
 fn portable_marketplace_catalog(
     catalog: &crate::plugins::marketplace::types::MarketplaceCatalog,
 ) -> PluginMarketplaceCatalog {
+    portable_marketplace_catalog_with_source(catalog, None)
+}
+
+/// Convert one stored TUI marketplace catalog (with its source path).
+fn portable_marketplace_catalog_with_source(
+    catalog: &crate::plugins::marketplace::types::MarketplaceCatalog,
+    source_path: Option<&str>,
+) -> PluginMarketplaceCatalog {
     PluginMarketplaceCatalog {
         id: catalog.id.as_str().to_string(),
+        source_path: source_path.map(str::to_string),
         display_name: catalog.display_name.clone(),
         description: catalog.description.clone(),
         format: catalog.format.as_str().to_string(),
@@ -1115,6 +1195,293 @@ fn portable_marketplace_catalog(
             .iter()
             .map(portable_marketplace_diagnostic)
             .collect(),
+    }
+}
+
+/// Kimi managed-plugin scan (host-side, FEAT-020 D1). Mirrors the legacy
+/// `/plugin import kimi` scan exactly: only immediate canonical children of
+/// `~/.kimi-code/plugins/managed`, rejecting symlinks/reparse points,
+/// non-directories, and children that escape the root. Returns portable
+/// candidate values; rejection reasons cross as safe text.
+fn scan_managed_plugins_portable(
+    home_override: Option<&Path>,
+) -> Result<PluginManagedScan, String> {
+    use std::fs;
+    use std::path::PathBuf;
+
+    const MAX_MANAGED_CHILDREN: usize = 128;
+    const KIMI_PLUGIN_JSON_NAME: &str = crate::plugins::agent_plugin::KIMI_PLUGIN_JSON_NAME;
+
+    struct Candidate {
+        name: String,
+        version: String,
+        license: Option<String>,
+        canonical_path: PathBuf,
+        content_hash: String,
+        capability_hash: String,
+        inventory: String,
+        applicable: bool,
+    }
+
+    fn inspect_candidate(canonical_path: &Path) -> Result<Candidate, String> {
+        let manifest_path = canonical_path.join(KIMI_PLUGIN_JSON_NAME);
+        let metadata = fs::symlink_metadata(&manifest_path).map_err(|error| {
+            format!(
+                "Kimi manifest unreadable at {}: {}",
+                canonical_path.display(),
+                error
+            )
+        })?;
+        if crate::plugins::metadata_is_link_or_reparse(&metadata) || !metadata.is_file() {
+            return Err(format!(
+                "Kimi manifest must be a regular file at {}",
+                canonical_path.display()
+            ));
+        }
+        let validated = crate::plugins::manifest::PluginManifest::validate_from_path(
+            &manifest_path,
+        )
+        .map_err(|error| {
+            format!(
+                "Kimi manifest invalid at {}: {error}",
+                canonical_path.display()
+            )
+        })?;
+        let name = validated.manifest.plugin.name.clone();
+        if canonical_path.file_name().and_then(|part| part.to_str()) != Some(name.as_str()) {
+            return Err(format!(
+                "Kimi directory name `{}` does not match manifest name `{}`",
+                canonical_path.display(),
+                name
+            ));
+        }
+        Ok(Candidate {
+            name,
+            version: validated.manifest.plugin.version.clone(),
+            license: validated.manifest.plugin.license.clone(),
+            canonical_path: validated.canonical_root,
+            content_hash: validated.content_hash,
+            capability_hash: validated.capability_hash,
+            inventory: validated.inventory.summary(),
+            applicable: validated.applicable,
+        })
+    }
+
+    let home = match home_override {
+        Some(home) => home.to_path_buf(),
+        None => crate::config::effective_home_dir().ok_or_else(|| {
+            tr(
+                crate::localization::Locale::En,
+                crate::localization::MessageId::PluginKimiHomeMissing,
+            )
+            .into_owned()
+            .to_string()
+        })?,
+    };
+    let configured_root = home.join(".kimi-code/plugins/managed");
+    let metadata = match fs::symlink_metadata(&configured_root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(PluginManagedScan {
+                root: configured_root,
+                candidates: Vec::new(),
+                rejected: Vec::new(),
+            });
+        }
+        Err(error) => {
+            let root_text = escape_review_text(&configured_root.display().to_string());
+            let error_text = escape_review_text(&error.to_string());
+            return Err(tr(
+                crate::localization::Locale::En,
+                crate::localization::MessageId::PluginKimiRootInspectFailed,
+            )
+            .replace("{root}", &root_text)
+            .replace("{error}", &error_text));
+        }
+    };
+    if crate::plugins::metadata_is_link_or_reparse(&metadata) || !metadata.is_dir() {
+        let root_text = escape_review_text(&configured_root.display().to_string());
+        return Err(tr(
+            crate::localization::Locale::En,
+            crate::localization::MessageId::PluginKimiRootMustBeDirectory,
+        )
+        .replace("{root}", &root_text));
+    }
+    let canonical_root = configured_root.canonicalize().map_err(|error| {
+        let root_text = escape_review_text(&configured_root.display().to_string());
+        let error_text = escape_review_text(&error.to_string());
+        tr(
+            crate::localization::Locale::En,
+            crate::localization::MessageId::PluginKimiRootCanonicalizeFailed,
+        )
+        .replace("{root}", &root_text)
+        .replace("{error}", &error_text)
+    })?;
+    let mut entries = fs::read_dir(&canonical_root)
+        .map_err(|error| {
+            let root_text = escape_review_text(&canonical_root.display().to_string());
+            let error_text = escape_review_text(&error.to_string());
+            tr(
+                crate::localization::Locale::En,
+                crate::localization::MessageId::PluginKimiRootListFailed,
+            )
+            .replace("{root}", &root_text)
+            .replace("{error}", &error_text)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            let error_text = escape_review_text(&error.to_string());
+            tr(
+                crate::localization::Locale::En,
+                crate::localization::MessageId::PluginKimiEntryReadFailed,
+            )
+            .replace("{error}", &error_text)
+        })?;
+    if entries.len() > MAX_MANAGED_CHILDREN {
+        return Err(tr(
+            crate::localization::Locale::En,
+            crate::localization::MessageId::PluginKimiEntryLimit,
+        )
+        .replace("{count}", &entries.len().to_string())
+        .replace("{max}", &MAX_MANAGED_CHILDREN.to_string()));
+    }
+    entries.sort_by_key(fs::DirEntry::file_name);
+
+    let mut candidates = Vec::new();
+    let mut rejected = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                let path_text = escape_review_text(&path.display().to_string());
+                let error_text = escape_review_text(&error.to_string());
+                rejected.push(
+                    tr(
+                        crate::localization::Locale::En,
+                        crate::localization::MessageId::PluginKimiEntryInspectFailed,
+                    )
+                    .replace("{path}", &path_text)
+                    .replace("{error}", &error_text),
+                );
+                continue;
+            }
+        };
+        if crate::plugins::metadata_is_link_or_reparse(&metadata) {
+            let path_text = escape_review_path(&path);
+            rejected.push(
+                tr(
+                    crate::localization::Locale::En,
+                    crate::localization::MessageId::PluginKimiEntryLinksRefused,
+                )
+                .replace("{path}", &path_text),
+            );
+            continue;
+        }
+        if !metadata.is_dir() {
+            continue;
+        }
+        let canonical_path = match path.canonicalize() {
+            Ok(path) if path.parent() == Some(canonical_root.as_path()) => path,
+            Ok(canonical_path) => {
+                let path_text = escape_review_text(&path.display().to_string());
+                let canonical_text = escape_review_text(&canonical_path.display().to_string());
+                rejected.push(
+                    tr(
+                        crate::localization::Locale::En,
+                        crate::localization::MessageId::PluginKimiEntryOutsideRoot,
+                    )
+                    .replace("{path}", &path_text)
+                    .replace("{canonical_path}", &canonical_text),
+                );
+                continue;
+            }
+            Err(error) => {
+                let path_text = escape_review_text(&path.display().to_string());
+                let error_text = escape_review_text(&error.to_string());
+                rejected.push(
+                    tr(
+                        crate::localization::Locale::En,
+                        crate::localization::MessageId::PluginKimiEntryCanonicalizeFailed,
+                    )
+                    .replace("{path}", &path_text)
+                    .replace("{error}", &error_text),
+                );
+                continue;
+            }
+        };
+        match inspect_candidate(&canonical_path) {
+            Ok(candidate) => candidates.push(candidate),
+            Err(error) => rejected.push(error),
+        }
+    }
+    candidates.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(PluginManagedScan {
+        root: canonical_root,
+        candidates: candidates
+            .into_iter()
+            .map(|candidate| PluginManagedCandidate {
+                name: candidate.name,
+                version: candidate.version,
+                license: candidate.license,
+                canonical_path: candidate.canonical_path,
+                content_hash: candidate.content_hash,
+                capability_hash: candidate.capability_hash,
+                inventory: candidate.inventory,
+                applicable: candidate.applicable,
+            })
+            .collect(),
+        rejected,
+    })
+}
+
+/// Escape review text exactly like the plugin render helpers (FEAT-020 D2).
+fn escape_review_text(value: &str) -> String {
+    crate::commands::groups::plugins::render::escape_review_text(value)
+}
+
+/// Escape a review path exactly like the plugin render helpers (FEAT-020 D2).
+fn escape_review_path(path: &Path) -> String {
+    crate::commands::groups::plugins::render::escape_review_path(path)
+}
+
+/// The catalog built into every Codewhale release. It lists bundles that
+/// ship inside the binary (`builtin:<name>` install specs), so there is
+/// nothing to fetch; installing still goes through the reviewed installer
+/// and lands disabled and untrusted like everything else.
+fn builtin_official_catalog() -> crate::plugins::marketplace::store::StoredMarketplaceCatalog {
+    fn official_catalog_document() -> serde_json::Value {
+        serde_json::json!({
+            "name": "official",
+            "description": "Plugins built into this Codewhale release",
+            "version": crate::plugins::install::BUILTIN_BUNDLE_NAMES.len().to_string(),
+            "plugins": [
+                {
+                    "name": codewhale_computer_use::bundle::BUNDLE_NAME,
+                    "source": format!("builtin:{}", codewhale_computer_use::bundle::BUNDLE_NAME),
+                    "version": codewhale_computer_use::bundle::version(),
+                    "description": "See and operate this desktop or an attached Android / HarmonyOS device with a vision model (deepseek-v4-flash-vision-exp): screenshots, clicks, typing, scrolling, app launch. Also: `codewhale computer-use setup`.",
+                    "homepage": "https://github.com/Hmbown/CodeWhale/blob/main/docs/COMPUTER_USE.md"
+                }
+            ]
+        })
+    }
+    use crate::plugins::marketplace::parsers::{MarketplaceDocument, parse_catalog};
+    use crate::plugins::marketplace::types::{
+        CatalogTier, MarketplaceCatalogId, MarketplaceFormat,
+    };
+    let mut catalog = parse_catalog(MarketplaceDocument {
+        catalog_id: MarketplaceCatalogId::new("official"),
+        format: MarketplaceFormat::Codewhale,
+        root: official_catalog_document(),
+        base: None,
+    });
+    catalog.provenance.tier = CatalogTier::Official;
+    catalog.provenance.publisher = Some("Codewhale".to_string());
+    crate::plugins::marketplace::store::StoredMarketplaceCatalog {
+        added_at: "builtin".to_string(),
+        source_path: "builtin:official".to_string(),
+        catalog,
     }
 }
 
@@ -1159,6 +1526,14 @@ impl CommandPluginContext for PluginAdapter<'_> {
 
     fn is_empty(&self) -> bool {
         self.host.app.borrow().plugin_registry.is_empty()
+    }
+
+    fn reload(&mut self) -> Result<usize, String> {
+        let mut app = self.host.app.borrow_mut();
+        let workspace = app.workspace.clone();
+        app.plugin_registry = app.plugin_registry.rediscover_for_workspace(&workspace);
+        app.refresh_skill_cache();
+        Ok(app.plugin_registry.len())
     }
 
     fn state_path(&self) -> Option<PathBuf> {
@@ -1232,6 +1607,7 @@ impl CommandPluginContext for PluginAdapter<'_> {
             };
             suggestions.push(PluginSuggestion {
                 name: plugin.name().to_string(),
+                state_label: plugin.state_label().to_string(),
                 description,
                 why: recommendation.matched_terms.clone(),
                 next_step,
@@ -1245,7 +1621,7 @@ impl CommandPluginContext for PluginAdapter<'_> {
             let app = self.host.app.borrow();
             app.plugin_registry
                 .get(selector)
-                .map(crate::commands::groups::plugins::render::review_token)
+                .map(|plugin| format!("{}.{}", plugin.content_hash, plugin.capability_hash))
                 .ok_or_else(|| format!("no plugin named {selector}"))?
         };
         if token != expected {
@@ -1469,7 +1845,7 @@ impl CommandPluginContext for PluginAdapter<'_> {
     }
 
     fn managed_scan(&self, home_override: Option<&Path>) -> Result<PluginManagedScan, String> {
-        crate::commands::groups::plugins::kimi_import::scan_managed_plugins_portable(home_override)
+        scan_managed_plugins_portable(home_override)
     }
 
     fn managed_install(
@@ -1517,7 +1893,7 @@ impl CommandPluginContext for PluginAdapter<'_> {
 
     fn marketplace_state(&self) -> Result<PluginMarketplaceState, String> {
         let app = self.host.app.borrow();
-        let official = crate::commands::groups::plugins::marketplace::builtin_official_catalog();
+        let official = builtin_official_catalog();
         let official = portable_marketplace_catalog(&official.catalog);
         let store = crate::plugins::marketplace::store::MarketplaceStore::open(
             app.plugin_registry.state_path(),
@@ -1530,7 +1906,12 @@ impl CommandPluginContext for PluginAdapter<'_> {
         let stored = state
             .catalogs()
             .values()
-            .map(|entry| portable_marketplace_catalog(&entry.catalog))
+            .map(|entry| {
+                portable_marketplace_catalog_with_source(
+                    &entry.catalog,
+                    Some(entry.source_path.as_str()),
+                )
+            })
             .collect();
         Ok(PluginMarketplaceState { official, stored })
     }
@@ -1540,7 +1921,6 @@ impl CommandPluginContext for PluginAdapter<'_> {
         name: &str,
         path: &Path,
     ) -> Result<PluginMarketplaceAddReceipt, String> {
-        use crate::commands::groups::plugins::marketplace::OFFICIAL_CATALOG_NAME;
         let name_valid = !name.is_empty()
             && name.len() <= 64
             && name
@@ -1552,10 +1932,10 @@ impl CommandPluginContext for PluginAdapter<'_> {
                     .to_string(),
             );
         }
-        if name == OFFICIAL_CATALOG_NAME {
-            return Err(format!(
-                "`{OFFICIAL_CATALOG_NAME}` is the catalog built into Codewhale; pick another name."
-            ));
+        if name == "official" {
+            return Err(
+                "`official` is the catalog built into Codewhale; pick another name.".to_string(),
+            );
         }
         let app = self.host.app.borrow();
         let store = crate::plugins::marketplace::store::MarketplaceStore::open(
@@ -1612,11 +1992,8 @@ impl CommandPluginContext for PluginAdapter<'_> {
     }
 
     fn marketplace_remove(&mut self, name: &str) -> Result<bool, String> {
-        use crate::commands::groups::plugins::marketplace::OFFICIAL_CATALOG_NAME;
-        if name == OFFICIAL_CATALOG_NAME {
-            return Err(format!(
-                "`{OFFICIAL_CATALOG_NAME}` is built into Codewhale and cannot be removed."
-            ));
+        if name == "official" {
+            return Err("`official` is built into Codewhale and cannot be removed.".to_string());
         }
         let app = self.host.app.borrow();
         let store = crate::plugins::marketplace::store::MarketplaceStore::open(
@@ -1634,7 +2011,6 @@ impl CommandPluginContext for PluginAdapter<'_> {
         catalog: &str,
         candidate: &str,
     ) -> Result<PluginMutationReceipt, String> {
-        use crate::commands::groups::plugins::marketplace::OFFICIAL_CATALOG_NAME;
         let app = self.host.app.borrow();
         let store = crate::plugins::marketplace::store::MarketplaceStore::open(
             app.plugin_registry.state_path(),
@@ -1644,8 +2020,8 @@ impl CommandPluginContext for PluginAdapter<'_> {
                 .to_string()
         })?;
         let state = store.load()?;
-        let entry = if catalog == OFFICIAL_CATALOG_NAME {
-            Some(crate::commands::groups::plugins::marketplace::builtin_official_catalog())
+        let entry = if catalog == "official" {
+            Some(builtin_official_catalog())
         } else {
             state.get(catalog).cloned()
         };
@@ -2709,9 +3085,8 @@ mod tests {
         let discovery = crate::plugins::PluginDiscoveryContext::capture_pre_dotenv();
         app.plugin_registry = discovery.registry_for_workspace(tmp.path());
         // Capture the review token before borrowing the mutable facet.
-        let token = crate::commands::groups::plugins::render::review_token(
-            app.plugin_registry.get("demo").unwrap(),
-        );
+        let demo = app.plugin_registry.get("demo").unwrap();
+        let token = format!("{}.{}", demo.content_hash, demo.capability_hash);
 
         let mut bundle = app.command_contexts();
         let mut parts = bundle.contexts(CommandCapabilities::PLUGIN).into_parts();

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -33,10 +33,15 @@ use std::rc::Rc;
 
 use codewhale_command_contract::facets::{
     CommandCostContext, CommandMediaContext, CommandMemoryContext, CommandModePolicyContext,
-    CommandModelContext, CommandPresentationContext, CommandSessionContext, CommandSkillsContext,
-    CommandSystemPromptContext, CommandWorkspaceContext, MediaAttachmentReceipt, MemoryDelete,
-    MemoryDeleteScope, MemoryExport, MemoryGetOutcome, MemoryHit, MemoryImportOutcome,
-    MemoryReindex, MemoryRememberTarget, MemoryRemembered, MemoryStatus,
+    CommandModelContext, CommandPluginContext, CommandPresentationContext, CommandSessionContext,
+    CommandSkillsContext, CommandSystemPromptContext, CommandWorkspaceContext,
+    MediaAttachmentReceipt, MemoryDelete, MemoryDeleteScope, MemoryExport, MemoryGetOutcome,
+    MemoryHit, MemoryImportOutcome, MemoryReindex, MemoryRememberTarget, MemoryRemembered,
+    MemoryStatus, PluginDetail, PluginDiagnostic, PluginDiagnosticLevel, PluginExportReceipt,
+    PluginLegacyScan, PluginLegacyTool, PluginManagedScan, PluginMarketplaceAddReceipt,
+    PluginMarketplaceCandidate, PluginMarketplaceCatalog, PluginMarketplaceInstallPlan,
+    PluginMarketplaceState, PluginMcpServerDetail, PluginMcpTransport, PluginMutationOutcome,
+    PluginMutationReceipt, PluginSuggestion, PluginSummary,
 };
 #[cfg(test)]
 use codewhale_command_contract::handler::ContextParts;
@@ -48,6 +53,7 @@ use codewhale_config::AppMode;
 use codewhale_core::request::{Message, SystemPrompt};
 use codewhale_execpolicy::ApprovalMode;
 
+use crate::commands::groups::plugins::{plugin_network_policy, run_async};
 use crate::localization::{MessageId, tr};
 use crate::pricing::CostCurrency;
 use crate::tui::app::{App, ReasoningEffort};
@@ -817,7 +823,950 @@ impl CommandMemoryContext for MemoryAdapter<'_> {
 // Envelope construction (D1)
 // ---------------------------------------------------------------------------
 
-/// Owns ten facet objects sharing one synchronous TUI host proxy.
+/// Plugin host-data adapter (FEAT-020 D1/D11).
+///
+/// Owns every concrete plugin service the live `/plugin` branch closure
+/// consumes: registry reads/mutations, the async mutation/network-policy
+/// bridge (D11), export, legacy executable-tool scan, Kimi managed import,
+/// and the marketplace store (including the builtin `official` catalog).
+/// Every method borrows `App` only for the duration of one call and converts
+/// host values to portable contract values before returning. Handlers receive
+/// only the portable facet and never name `PluginRegistry`, `LoadedPlugin`,
+/// `Config`, or another concrete host service.
+pub(crate) struct PluginAdapter<'a> {
+    host: SharedCommandHost<'a>,
+}
+
+/// Convert a TUI-owned diagnostic to the portable contract diagnostic.
+fn portable_diagnostic(diagnostic: &crate::plugins::types::PluginDiagnostic) -> PluginDiagnostic {
+    PluginDiagnostic {
+        level: match diagnostic.level {
+            crate::plugins::types::PluginDiagnosticLevel::Warning => PluginDiagnosticLevel::Warning,
+            crate::plugins::types::PluginDiagnosticLevel::Error => PluginDiagnosticLevel::Error,
+        },
+        code: diagnostic.code.to_string(),
+        message: diagnostic.message.clone(),
+        path: diagnostic.path.clone(),
+    }
+}
+
+/// Convert a TUI marketplace diagnostic into the portable contract diagnostic.
+fn portable_marketplace_diagnostic(
+    diagnostic: &crate::plugins::marketplace::types::MarketplaceDiagnostic,
+) -> PluginDiagnostic {
+    PluginDiagnostic {
+        level: match diagnostic.level {
+            crate::plugins::types::PluginDiagnosticLevel::Warning => PluginDiagnosticLevel::Warning,
+            crate::plugins::types::PluginDiagnosticLevel::Error => PluginDiagnosticLevel::Error,
+        },
+        code: diagnostic.code.clone(),
+        message: diagnostic.message.clone(),
+        path: None,
+    }
+}
+
+/// Convert a TUI-owned loaded plugin into the portable list summary.
+fn portable_summary(plugin: &crate::plugins::types::LoadedPlugin) -> PluginSummary {
+    PluginSummary {
+        name: plugin.name().to_string(),
+        id: plugin.id.as_str().to_string(),
+        state_label: plugin.state_label().to_string(),
+        scope: plugin.scope.as_str().to_string(),
+        trust_status: plugin.trust_status.as_str().to_string(),
+        compatibility: plugin.compatibility().as_str().to_string(),
+        inventory: plugin.inventory.summary(),
+        active: plugin.active(),
+        trusted: plugin.trusted(),
+        enabled: plugin.enabled,
+    }
+}
+
+/// Convert one TUI MCP server config into the portable review detail.
+fn portable_mcp_server(name: &str, server: &crate::mcp::McpServerConfig) -> PluginMcpServerDetail {
+    let transport = if server.url.is_some() {
+        PluginMcpTransport::Http
+    } else if server.command.is_some() {
+        PluginMcpTransport::Stdio
+    } else {
+        PluginMcpTransport::Invalid
+    };
+    let mut env = server
+        .env
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect::<Vec<_>>();
+    env.sort_unstable();
+    let mut env_headers = server
+        .env_headers
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect::<Vec<_>>();
+    env_headers.sort_unstable();
+    PluginMcpServerDetail {
+        name: name.to_string(),
+        transport,
+        command: server.command.clone(),
+        argv: server.args.clone(),
+        cwd: server.cwd.clone(),
+        env,
+        url: server.url.clone(),
+        env_headers,
+        bearer_token_env_var: server.bearer_token_env_var.clone(),
+        connect_timeout_secs: server.connect_timeout,
+        execute_timeout_secs: server.execute_timeout,
+        read_timeout_secs: server.read_timeout,
+        required: server.required,
+        enabled_tools: server.enabled_tools.clone(),
+        disabled_tools: server.disabled_tools.clone(),
+        enabled: server.is_enabled(),
+    }
+}
+
+/// Convert a TUI-owned loaded plugin into the portable full detail.
+fn portable_detail(plugin: &crate::plugins::types::LoadedPlugin) -> PluginDetail {
+    let mcp_servers = plugin
+        .manifest
+        .mcp_servers
+        .as_ref()
+        .map(|servers| {
+            let mut list = servers
+                .iter()
+                .map(|(name, server)| portable_mcp_server(name, server))
+                .collect::<Vec<_>>();
+            list.sort_by(|a, b| a.name.cmp(&b.name));
+            list
+        })
+        .unwrap_or_default();
+    PluginDetail {
+        name: plugin.name().to_string(),
+        id: plugin.id.as_str().to_string(),
+        version: plugin.manifest.plugin.version.clone(),
+        origin: plugin.origin.as_str().to_string(),
+        scope: plugin.scope.as_str().to_string(),
+        state_label: plugin.state_label().to_string(),
+        trust_status: plugin.trust_status.as_str().to_string(),
+        compatibility: plugin.compatibility().as_str().to_string(),
+        content_hash: plugin.content_hash.clone(),
+        capability_hash: plugin.capability_hash.clone(),
+        canonical_root: plugin.canonical_root.clone(),
+        active: plugin.active(),
+        trusted: plugin.trusted(),
+        enabled: plugin.enabled,
+        unsupported_labels: plugin
+            .inventory
+            .unsupported_labels()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        supported_labels: plugin
+            .inventory
+            .supported_labels()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        skills: plugin
+            .skill_snapshots
+            .iter()
+            .map(|skill| format!("{}:{}", plugin.name(), skill.name))
+            .collect(),
+        filesystem_roots: plugin.inventory.filesystem_roots.clone(),
+        network_hosts: plugin.inventory.network_hosts.clone(),
+        stdio_mcp_servers: plugin.inventory.stdio_mcp_servers,
+        lifecycle_mutation: plugin.inventory.lifecycle_mutation,
+        mcp_servers,
+        diagnostics: plugin.diagnostics.iter().map(portable_diagnostic).collect(),
+    }
+}
+
+/// Convert a TUI mutation receipt into the portable contract receipt.
+fn portable_mutation_receipt(
+    receipt: &crate::plugins::mutation::PluginMutationReceipt,
+) -> PluginMutationReceipt {
+    let outcome = match &receipt.outcome {
+        crate::plugins::mutation::PluginMutationOutcome::Installed => {
+            PluginMutationOutcome::Installed
+        }
+        crate::plugins::mutation::PluginMutationOutcome::Updated => PluginMutationOutcome::Updated,
+        crate::plugins::mutation::PluginMutationOutcome::NoChange => {
+            PluginMutationOutcome::NoChange
+        }
+        crate::plugins::mutation::PluginMutationOutcome::Uninstalled => {
+            PluginMutationOutcome::Uninstalled
+        }
+        crate::plugins::mutation::PluginMutationOutcome::NeedsApproval(host) => {
+            PluginMutationOutcome::NeedsApproval(host.clone())
+        }
+        crate::plugins::mutation::PluginMutationOutcome::NetworkDenied(host) => {
+            PluginMutationOutcome::NetworkDenied(host.clone())
+        }
+    };
+    PluginMutationReceipt {
+        name: receipt.name.clone(),
+        path: receipt.path.clone(),
+        content_hash: receipt.content_hash.clone(),
+        installed_content_hash: receipt.installed_content_hash.clone(),
+        outcome,
+    }
+}
+
+/// Convert a TUI export receipt into the portable contract receipt.
+fn portable_export_receipt(
+    receipt: &crate::plugins::export::PluginExportReceipt,
+) -> PluginExportReceipt {
+    PluginExportReceipt {
+        exported_name: receipt.exported_name.clone(),
+        target: receipt.target.clone(),
+        display_name: receipt.display_name.clone(),
+        wrote_mcp_json: receipt.wrote_mcp_json,
+        files_copied: receipt.files_copied as u64,
+        skills_normalized: receipt.skills_normalized,
+    }
+}
+
+/// Convert one TUI legacy tool entry into the portable value.
+fn portable_legacy_tool(
+    path: &Path,
+    metadata: &crate::tools::plugin::PluginMetadata,
+) -> PluginLegacyTool {
+    PluginLegacyTool {
+        name: metadata.name.clone(),
+        description: metadata.description.clone(),
+        approval: match metadata.approval {
+            crate::tools::spec::ApprovalRequirement::Auto => "auto",
+            crate::tools::spec::ApprovalRequirement::Suggest => "suggest",
+            crate::tools::spec::ApprovalRequirement::Required => "required",
+        }
+        .to_string(),
+        input_schema: Some(
+            serde_json::to_string_pretty(&metadata.input_schema).unwrap_or_default(),
+        ),
+        path: path.to_path_buf(),
+    }
+}
+
+/// Convert one TUI marketplace candidate into the portable value.
+fn portable_marketplace_candidate(
+    candidate: &crate::plugins::marketplace::types::MarketplaceCandidate,
+) -> PluginMarketplaceCandidate {
+    let install_plan = match &candidate.install_plan {
+        crate::plugins::marketplace::types::MarketplaceInstallPlan::Supported {
+            spec,
+            source_kind,
+        } => PluginMarketplaceInstallPlan::Supported {
+            spec: spec.clone(),
+            source_kind: source_kind.clone(),
+        },
+        crate::plugins::marketplace::types::MarketplaceInstallPlan::Unsupported { reason, raw } => {
+            PluginMarketplaceInstallPlan::Unsupported {
+                reason: if raw.is_empty() {
+                    reason.clone()
+                } else {
+                    reason.clone()
+                },
+            }
+        }
+    };
+    PluginMarketplaceCandidate {
+        name: candidate.name.clone(),
+        display_name: candidate.display_name.clone(),
+        version: candidate.version.clone(),
+        tier: candidate.provenance.tier.as_str().to_string(),
+        compatibility: candidate
+            .compatibility
+            .as_ref()
+            .map(|c| c.as_str().to_string()),
+        install_plan,
+        description: candidate.description.clone(),
+        homepage: candidate.homepage.clone(),
+        repository: candidate.repository.clone(),
+        author: candidate.author.clone(),
+        license: candidate.license.clone(),
+        keywords: candidate.keywords.clone(),
+        when: candidate.when.as_ref().map(|when| format!("{when:?}")),
+        diagnostics: candidate
+            .diagnostics
+            .iter()
+            .map(portable_marketplace_diagnostic)
+            .collect(),
+        has_errors: candidate.has_errors(),
+    }
+}
+
+/// Convert one TUI marketplace catalog into the portable value.
+fn portable_marketplace_catalog(
+    catalog: &crate::plugins::marketplace::types::MarketplaceCatalog,
+) -> PluginMarketplaceCatalog {
+    PluginMarketplaceCatalog {
+        id: catalog.id.as_str().to_string(),
+        display_name: catalog.display_name.clone(),
+        description: catalog.description.clone(),
+        format: catalog.format.as_str().to_string(),
+        tier: catalog.provenance.tier.as_str().to_string(),
+        publisher: catalog.provenance.publisher.clone(),
+        total_candidates: catalog.total_candidates(),
+        warning_count: catalog.warning_count(),
+        candidates: catalog
+            .candidates
+            .iter()
+            .map(portable_marketplace_candidate)
+            .collect(),
+        diagnostics: catalog
+            .diagnostics
+            .iter()
+            .map(portable_marketplace_diagnostic)
+            .collect(),
+    }
+}
+
+impl CommandPluginContext for PluginAdapter<'_> {
+    fn summaries(&self) -> Result<Vec<PluginSummary>, String> {
+        let app = self.host.app.borrow();
+        Ok(app
+            .plugin_registry
+            .list()
+            .iter()
+            .map(|plugin| portable_summary(plugin))
+            .collect())
+    }
+
+    fn detail(&self, selector: &str) -> Result<PluginDetail, String> {
+        let app = self.host.app.borrow();
+        let plugin = app
+            .plugin_registry
+            .get(selector)
+            .ok_or_else(|| format!("no plugin named {selector}"))?;
+        Ok(portable_detail(plugin))
+    }
+
+    fn registry_diagnostics(&self) -> Vec<PluginDiagnostic> {
+        self.host
+            .app
+            .borrow()
+            .plugin_registry
+            .diagnostics()
+            .iter()
+            .map(portable_diagnostic)
+            .collect()
+    }
+
+    fn validation_is_clean(&self) -> bool {
+        self.host.app.borrow().plugin_registry.validation_is_clean()
+    }
+
+    fn len(&self) -> usize {
+        self.host.app.borrow().plugin_registry.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.host.app.borrow().plugin_registry.is_empty()
+    }
+
+    fn state_path(&self) -> Option<PathBuf> {
+        self.host
+            .app
+            .borrow()
+            .plugin_registry
+            .state_path()
+            .map(Path::to_path_buf)
+    }
+
+    fn suggest(&self, task: &str) -> Result<Vec<PluginSuggestion>, String> {
+        let task = task.trim();
+        if task.chars().count() < 3 {
+            return Err("Usage: /plugin suggest <task of at least 3 characters>".to_string());
+        }
+        let app = self.host.app.borrow();
+        let mut skills = std::collections::BTreeMap::new();
+        for plugin in app.plugin_registry.list() {
+            let mut description_parts = plugin
+                .manifest
+                .plugin
+                .description
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>();
+            let mut keywords = Vec::new();
+            for skill in &plugin.skill_snapshots {
+                description_parts.push(skill.name.clone());
+                description_parts.push(skill.description.clone());
+                keywords.push(skill.name.clone());
+                keywords.extend(skill.aliases.iter().cloned());
+            }
+            skills.insert(
+                plugin.name().to_string(),
+                crate::skills::RegistryEntry {
+                    source: plugin.id.as_str().to_string(),
+                    description: (!description_parts.is_empty())
+                        .then(|| description_parts.join(" ")),
+                    keywords,
+                    domains: plugin.inventory.network_hosts.clone(),
+                },
+            );
+        }
+        let index = crate::skills::RegistryDocument { skills };
+        let recommendations = crate::skills::recommend::recommend_remote_skills(task, &index, 3);
+        let mut suggestions = Vec::new();
+        for recommendation in recommendations {
+            let Some(plugin) = app.plugin_registry.get(&recommendation.entry.source) else {
+                continue;
+            };
+            let description = plugin
+                .manifest
+                .plugin
+                .description
+                .as_deref()
+                .filter(|description| !description.trim().is_empty())
+                .unwrap_or("No description provided.")
+                .to_string();
+            let next_step = if plugin.active() {
+                format!("Already active: /plugin show {}", plugin.name())
+            } else if !plugin.trusted() {
+                format!("Review before enabling: /plugin trust {}", plugin.name())
+            } else if !plugin.enabled {
+                format!(
+                    "Enable if that review still applies: /plugin enable {}",
+                    plugin.name()
+                )
+            } else {
+                format!("Inspect its inactive state: /plugin show {}", plugin.name())
+            };
+            suggestions.push(PluginSuggestion {
+                name: plugin.name().to_string(),
+                description,
+                why: recommendation.matched_terms.clone(),
+                next_step,
+            });
+        }
+        Ok(suggestions)
+    }
+
+    fn trust(&mut self, selector: &str, token: &str) -> Result<(), String> {
+        let expected = {
+            let app = self.host.app.borrow();
+            app.plugin_registry
+                .get(selector)
+                .map(crate::commands::groups::plugins::render::review_token)
+                .ok_or_else(|| format!("no plugin named {selector}"))?
+        };
+        if token != expected {
+            return Err(
+                "Review token does not match this bundle content and capability set; run `/plugin trust <name>` again"
+                    .to_string(),
+            );
+        }
+        {
+            let mut app = self.host.app.borrow_mut();
+            std::sync::Arc::make_mut(&mut app.plugin_registry).trust(selector)?;
+            app.refresh_skill_cache();
+        }
+        Ok(())
+    }
+
+    fn enable(&mut self, selector: &str) -> Result<(), String> {
+        let needs_review = self
+            .host
+            .app
+            .borrow()
+            .plugin_registry
+            .get(selector)
+            .is_some_and(|plugin| !plugin.trusted());
+        if needs_review {
+            // Enabling is the natural entry point; open the capability review
+            // instead of an opaque denial (matches the legacy handler).
+            return Err("plugin requires review before enabling".to_string());
+        }
+        let mut app = self.host.app.borrow_mut();
+        std::sync::Arc::make_mut(&mut app.plugin_registry).enable(selector)?;
+        app.refresh_skill_cache();
+        Ok(())
+    }
+
+    fn disable(&mut self, selector: &str) -> Result<(), String> {
+        let mut app = self.host.app.borrow_mut();
+        std::sync::Arc::make_mut(&mut app.plugin_registry).disable(selector)?;
+        app.refresh_skill_cache();
+        app.active_skill = None;
+        app.active_skill_provenance = None;
+        Ok(())
+    }
+
+    fn revoke_trust(&mut self, selector: &str) -> Result<(), String> {
+        let mut app = self.host.app.borrow_mut();
+        std::sync::Arc::make_mut(&mut app.plugin_registry).revoke_trust(selector)?;
+        app.refresh_skill_cache();
+        app.active_skill = None;
+        app.active_skill_provenance = None;
+        Ok(())
+    }
+
+    fn install(
+        &mut self,
+        source: &str,
+        expected_content_hash: Option<&str>,
+    ) -> Result<PluginMutationReceipt, String> {
+        use crate::plugins::install::PluginInstallSource;
+        use crate::plugins::mutation::{
+            PluginMutationContext, PluginMutationOutcome, PluginMutationRequest,
+        };
+
+        let plugin_source = PluginInstallSource::parse(source).map_err(|error| {
+            format!(
+                "Invalid plugin install source `{source}`: {error:#}\n\
+                 Expected a local path, github:owner/repo, an HTTPS tarball URL, or builtin:<name>."
+            )
+        })?;
+        let network = plugin_network_policy();
+        let expected_content_hash = expected_content_hash.map(str::to_string);
+        let expected_for_request = expected_content_hash.clone();
+        let mut app = self.host.app.borrow_mut();
+        let registry = std::sync::Arc::make_mut(&mut app.plugin_registry);
+        let outcome = run_async(async move {
+            let ctx = PluginMutationContext {
+                network: &network,
+                max_size: crate::plugins::install::DEFAULT_MAX_SIZE_BYTES,
+            };
+            let request = match expected_for_request {
+                Some(expected_content_hash) => PluginMutationRequest::InstallExact {
+                    source: plugin_source,
+                    expected_content_hash,
+                },
+                None => PluginMutationRequest::Install {
+                    source: plugin_source,
+                },
+            };
+            crate::plugins::mutation::execute(request, &ctx, registry).await
+        });
+        match outcome {
+            Ok(receipt) => {
+                let portable = portable_mutation_receipt(&receipt);
+                // Rediscover and refresh the skill cache after any install.
+                if matches!(receipt.outcome, PluginMutationOutcome::Installed) {
+                    let workspace = app.workspace.clone();
+                    app.plugin_registry = app.plugin_registry.rediscover_for_workspace(&workspace);
+                    app.refresh_skill_cache();
+                }
+                Ok(portable)
+            }
+            Err(error) => Err(format!("Plugin install failed: {error:#}")),
+        }
+    }
+
+    fn update(&mut self, selector: &str) -> Result<PluginMutationReceipt, String> {
+        use crate::plugins::mutation::{
+            PluginMutationContext, PluginMutationOutcome, PluginMutationRequest,
+        };
+        let network = plugin_network_policy();
+        let selector_owned = selector.to_string();
+        let mut app = self.host.app.borrow_mut();
+        let registry = std::sync::Arc::make_mut(&mut app.plugin_registry);
+        let outcome = run_async(async move {
+            let ctx = PluginMutationContext {
+                network: &network,
+                max_size: crate::plugins::install::DEFAULT_MAX_SIZE_BYTES,
+            };
+            crate::plugins::mutation::execute(
+                PluginMutationRequest::Update {
+                    selector: selector_owned,
+                },
+                &ctx,
+                registry,
+            )
+            .await
+        });
+        match outcome {
+            Ok(receipt) => {
+                let portable = portable_mutation_receipt(&receipt);
+                if matches!(receipt.outcome, PluginMutationOutcome::Updated) {
+                    let workspace = app.workspace.clone();
+                    app.plugin_registry = app.plugin_registry.rediscover_for_workspace(&workspace);
+                    app.refresh_skill_cache();
+                }
+                Ok(portable)
+            }
+            Err(error) => Err(format!("Plugin update failed: {error:#}")),
+        }
+    }
+
+    fn uninstall(&mut self, selector: &str) -> Result<PluginMutationReceipt, String> {
+        use crate::plugins::mutation::{
+            PluginMutationContext, PluginMutationOutcome, PluginMutationRequest,
+        };
+        let network = plugin_network_policy();
+        let selector_owned = selector.to_string();
+        let mut app = self.host.app.borrow_mut();
+        let registry = std::sync::Arc::make_mut(&mut app.plugin_registry);
+        let outcome = run_async(async move {
+            let ctx = PluginMutationContext {
+                network: &network,
+                max_size: crate::plugins::install::DEFAULT_MAX_SIZE_BYTES,
+            };
+            crate::plugins::mutation::execute(
+                PluginMutationRequest::Uninstall {
+                    selector: selector_owned,
+                },
+                &ctx,
+                registry,
+            )
+            .await
+        });
+        match outcome {
+            Ok(receipt) => {
+                let portable = portable_mutation_receipt(&receipt);
+                if matches!(receipt.outcome, PluginMutationOutcome::Uninstalled) {
+                    let workspace = app.workspace.clone();
+                    app.plugin_registry = app.plugin_registry.rediscover_for_workspace(&workspace);
+                    app.refresh_skill_cache();
+                    app.active_skill = None;
+                    app.active_skill_provenance = None;
+                }
+                Ok(portable)
+            }
+            Err(error) => Err(format!("Plugin uninstall failed: {error:#}")),
+        }
+    }
+
+    fn export(&self, selector: &str, target: &Path) -> Result<PluginExportReceipt, String> {
+        let app = self.host.app.borrow();
+        let plugin = app
+            .plugin_registry
+            .get(selector)
+            .ok_or_else(|| format!("no plugin named {selector}"))?
+            .clone();
+        let existing_names: std::collections::BTreeSet<String> = app
+            .plugin_registry
+            .list()
+            .iter()
+            .map(|other| other.name().to_string())
+            .filter(|name| name != plugin.name())
+            .collect();
+        let target = if target.is_absolute() {
+            target.to_path_buf()
+        } else {
+            app.workspace.join(target)
+        };
+        crate::plugins::export::export_plugin_bundle(&plugin, &target, &existing_names)
+            .map(|receipt| portable_export_receipt(&receipt))
+            .map_err(|error| format!("Export of `{}` failed: {}", plugin.name(), error))
+    }
+
+    fn legacy_scan(&self) -> Result<Option<PluginLegacyScan>, String> {
+        let app = self.host.app.borrow();
+        let Some(dir) = app
+            .legacy_plugin_tools_dir
+            .clone()
+            .or_else(default_codewhale_tools_dir)
+        else {
+            return Ok(None);
+        };
+        if !dir.exists() {
+            return Ok(None);
+        }
+        let tools = crate::tools::plugin::scan_plugin_dir(&dir)
+            .into_iter()
+            .map(|(path, metadata)| portable_legacy_tool(&path, &metadata))
+            .collect();
+        Ok(Some(PluginLegacyScan { dir, tools }))
+    }
+
+    fn managed_scan(&self, home_override: Option<&Path>) -> Result<PluginManagedScan, String> {
+        crate::commands::groups::plugins::kimi_import::scan_managed_plugins_portable(home_override)
+    }
+
+    fn managed_install(
+        &mut self,
+        canonical_path: &Path,
+        expected_content_hash: &str,
+    ) -> Result<PluginMutationReceipt, String> {
+        use crate::plugins::install::PluginInstallSource;
+        use crate::plugins::mutation::{
+            PluginMutationContext, PluginMutationOutcome, PluginMutationRequest,
+        };
+        let network = plugin_network_policy();
+        let expected_content_hash = expected_content_hash.to_string();
+        let path = canonical_path.to_path_buf();
+        let mut app = self.host.app.borrow_mut();
+        let registry = std::sync::Arc::make_mut(&mut app.plugin_registry);
+        let outcome = run_async(async move {
+            let ctx = PluginMutationContext {
+                network: &network,
+                max_size: crate::plugins::install::DEFAULT_MAX_SIZE_BYTES,
+            };
+            crate::plugins::mutation::execute(
+                PluginMutationRequest::InstallExact {
+                    source: PluginInstallSource::LocalPath(path),
+                    expected_content_hash,
+                },
+                &ctx,
+                registry,
+            )
+            .await
+        });
+        match outcome {
+            Ok(receipt) => {
+                let portable = portable_mutation_receipt(&receipt);
+                if matches!(receipt.outcome, PluginMutationOutcome::Installed) {
+                    let workspace = app.workspace.clone();
+                    app.plugin_registry = app.plugin_registry.rediscover_for_workspace(&workspace);
+                    app.refresh_skill_cache();
+                }
+                Ok(portable)
+            }
+            Err(error) => Err(format!("Plugin install failed: {error:#}")),
+        }
+    }
+
+    fn marketplace_state(&self) -> Result<PluginMarketplaceState, String> {
+        let app = self.host.app.borrow();
+        let official = crate::commands::groups::plugins::marketplace::builtin_official_catalog();
+        let official = portable_marketplace_catalog(&official.catalog);
+        let store = crate::plugins::marketplace::store::MarketplaceStore::open(
+            app.plugin_registry.state_path(),
+        )
+        .ok_or_else(|| {
+            "This plugin registry has no persistence store, so marketplace catalogs cannot be saved."
+                .to_string()
+        })?;
+        let state = store.load()?;
+        let stored = state
+            .catalogs()
+            .values()
+            .map(|entry| portable_marketplace_catalog(&entry.catalog))
+            .collect();
+        Ok(PluginMarketplaceState { official, stored })
+    }
+
+    fn marketplace_add(
+        &mut self,
+        name: &str,
+        path: &Path,
+    ) -> Result<PluginMarketplaceAddReceipt, String> {
+        use crate::commands::groups::plugins::marketplace::OFFICIAL_CATALOG_NAME;
+        let name_valid = !name.is_empty()
+            && name.len() <= 64
+            && name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.');
+        if !name_valid {
+            return Err(
+                "Marketplace name must be 1-64 characters of letters, digits, `-`, `_`, or `.`"
+                    .to_string(),
+            );
+        }
+        if name == OFFICIAL_CATALOG_NAME {
+            return Err(format!(
+                "`{OFFICIAL_CATALOG_NAME}` is the catalog built into Codewhale; pick another name."
+            ));
+        }
+        let app = self.host.app.borrow();
+        let store = crate::plugins::marketplace::store::MarketplaceStore::open(
+            app.plugin_registry.state_path(),
+        )
+        .ok_or_else(|| {
+            "This plugin registry has no persistence store, so marketplace catalogs cannot be saved."
+                .to_string()
+        })?;
+        let path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            app.workspace.join(path)
+        };
+        let canonical = canonical_document(&path)?;
+        let body = read_bounded(&canonical)?;
+        let root = serde_json::from_str::<serde_json::Value>(&body).map_err(|error| {
+            format!(
+                "Catalog at {} is not valid JSON: {error}",
+                canonical.display()
+            )
+        })?;
+        let document = crate::plugins::marketplace::parsers::MarketplaceDocument {
+            catalog_id: crate::plugins::marketplace::types::MarketplaceCatalogId::new(name),
+            format: crate::plugins::marketplace::types::MarketplaceFormat::Auto,
+            root,
+            base: Some(canonical.display().to_string()),
+        };
+        let catalog = crate::plugins::marketplace::parsers::parse_catalog(document);
+        if catalog.candidates.is_empty() && catalog.error_count() > 0 {
+            return Err(format!(
+                "Catalog `{}` could not be parsed as any known marketplace format (kimi, claude, codex, codewhale):\n{}",
+                name,
+                render_diagnostics_inline(&catalog.diagnostics)
+            ));
+        }
+        let candidate_count = catalog.total_candidates();
+        let warning_count = catalog.warning_count();
+        let portable_catalog = portable_marketplace_catalog(&catalog);
+        let entry = crate::plugins::marketplace::store::StoredMarketplaceCatalog {
+            added_at: chrono::Utc::now().to_rfc3339(),
+            source_path: canonical.display().to_string(),
+            catalog,
+        };
+        store
+            .add(&entry.catalog.id.clone(), entry)
+            .map_err(|error| error.to_string())?;
+        Ok(PluginMarketplaceAddReceipt {
+            name: name.to_string(),
+            candidate_count,
+            warning_count,
+            catalog: portable_catalog,
+        })
+    }
+
+    fn marketplace_remove(&mut self, name: &str) -> Result<bool, String> {
+        use crate::commands::groups::plugins::marketplace::OFFICIAL_CATALOG_NAME;
+        if name == OFFICIAL_CATALOG_NAME {
+            return Err(format!(
+                "`{OFFICIAL_CATALOG_NAME}` is built into Codewhale and cannot be removed."
+            ));
+        }
+        let app = self.host.app.borrow();
+        let store = crate::plugins::marketplace::store::MarketplaceStore::open(
+            app.plugin_registry.state_path(),
+        )
+        .ok_or_else(|| {
+            "This plugin registry has no persistence store, so marketplace catalogs cannot be saved."
+                .to_string()
+        })?;
+        store.remove(name)
+    }
+
+    fn marketplace_install(
+        &mut self,
+        catalog: &str,
+        candidate: &str,
+    ) -> Result<PluginMutationReceipt, String> {
+        use crate::commands::groups::plugins::marketplace::OFFICIAL_CATALOG_NAME;
+        let app = self.host.app.borrow();
+        let store = crate::plugins::marketplace::store::MarketplaceStore::open(
+            app.plugin_registry.state_path(),
+        )
+        .ok_or_else(|| {
+            "This plugin registry has no persistence store, so marketplace catalogs cannot be saved."
+                .to_string()
+        })?;
+        let state = store.load()?;
+        let entry = if catalog == OFFICIAL_CATALOG_NAME {
+            Some(crate::commands::groups::plugins::marketplace::builtin_official_catalog())
+        } else {
+            state.get(catalog).cloned()
+        };
+        let Some(entry) = entry else {
+            return Err(format!(
+                "No marketplace named `{}`. Use /plugin marketplace list.",
+                catalog
+            ));
+        };
+        let Some(candidate_entry) = entry.catalog.candidate_by_name(candidate) else {
+            return Err(format!(
+                "No candidate `{}` in marketplace `{}`.",
+                candidate, catalog
+            ));
+        };
+        if candidate_entry.has_errors() {
+            return Err(format!(
+                "Candidate `{}` has parse errors and cannot be installed:\n{}",
+                candidate,
+                render_diagnostics_inline(&candidate_entry.diagnostics)
+            ));
+        }
+        let crate::plugins::marketplace::types::MarketplaceInstallPlan::Supported { spec, .. } =
+            &candidate_entry.install_plan
+        else {
+            return Err(format!(
+                "Candidate `{}` cannot be installed by Codewhale.",
+                candidate
+            ));
+        };
+        let spec = resolve_marketplace_spec(&entry.source_path, &candidate_entry.source, spec);
+        drop(app);
+        self.install(&spec, None)
+    }
+}
+
+/// Resolve the default Codewhale tools directory (mirrors the legacy handler).
+fn default_codewhale_tools_dir() -> Option<PathBuf> {
+    codewhale_config::codewhale_home()
+        .ok()
+        .map(|home| home.join("tools"))
+}
+
+/// Resolve a user-supplied document path to an existing regular file without
+/// following a final symlink (the document is untrusted input).
+fn canonical_document(path: &Path) -> Result<PathBuf, String> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|e| format!("Cannot read catalog at {}: {e}", path.display()))?;
+    if metadata.is_symlink() {
+        return Err(format!(
+            "Catalog path {} is a symlink; marketplace documents must be regular files",
+            path.display()
+        ));
+    }
+    if !metadata.is_file() {
+        return Err(format!(
+            "Catalog path {} is not a regular file",
+            path.display()
+        ));
+    }
+    Ok(path.to_path_buf())
+}
+
+/// Read a catalog document with a bounded size (4 MiB cap, mirrors legacy).
+fn read_bounded(path: &Path) -> Result<String, String> {
+    use std::io::Read;
+    const MAX_CATALOG_BYTES: u64 = 4 * 1024 * 1024;
+    let file = std::fs::File::open(path)
+        .map_err(|e| format!("Cannot read catalog at {}: {e}", path.display()))?;
+    if file.metadata().map_err(|e| e.to_string())?.len() > MAX_CATALOG_BYTES {
+        return Err(format!(
+            "Catalog at {} exceeds the {} byte limit",
+            path.display(),
+            MAX_CATALOG_BYTES
+        ));
+    }
+    let mut text = String::new();
+    let mut limited = file.take(MAX_CATALOG_BYTES + 1);
+    limited
+        .read_to_string(&mut text)
+        .map_err(|e| format!("Cannot read catalog at {}: {e}", path.display()))?;
+    Ok(text)
+}
+
+/// Resolve a marketplace install spec against the catalog's own directory.
+fn resolve_marketplace_spec(
+    source_path: &str,
+    source: &crate::plugins::marketplace::types::MarketplaceSourceSpec,
+    spec: &str,
+) -> String {
+    if let crate::plugins::marketplace::types::MarketplaceSourceSpec::LocalPath { path } = source
+        && path.is_relative()
+        && let Some(dir) = Path::new(source_path).parent()
+    {
+        return format!("path:{}", dir.join(path).display());
+    }
+    spec.to_string()
+}
+
+/// Inline diagnostics renderer shared by marketplace error paths.
+fn render_diagnostics_inline(
+    diagnostics: &[crate::plugins::marketplace::types::MarketplaceDiagnostic],
+) -> String {
+    diagnostics
+        .iter()
+        .map(|d| {
+            format!(
+                "{} {}: {}",
+                match d.level {
+                    crate::plugins::types::PluginDiagnosticLevel::Error => "error",
+                    crate::plugins::types::PluginDiagnosticLevel::Warning => "warning",
+                },
+                d.code,
+                d.message
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Owns eleven facet objects sharing one synchronous TUI host proxy.
 ///
 /// Handlers borrow only these adapters. Every method delegates to the real App
 /// authority and releases its `RefCell` borrow before returning, so facets can
@@ -833,6 +1782,7 @@ pub(crate) struct CommandContextBundle<'a> {
     presentation: PresentationAdapter<'a>,
     media: MediaAdapter<'a>,
     memory: MemoryAdapter<'a>,
+    plugin: PluginAdapter<'a>,
 }
 
 impl<'a> CommandContextBundle<'a> {
@@ -869,6 +1819,9 @@ impl<'a> CommandContextBundle<'a> {
         if capabilities.contains(CommandCapabilities::MEMORY) {
             contexts = contexts.with_memory(&mut self.memory);
         }
+        if capabilities.contains(CommandCapabilities::PLUGIN) {
+            contexts = contexts.with_plugin(&mut self.plugin);
+        }
         contexts
     }
 
@@ -884,7 +1837,8 @@ impl<'a> CommandContextBundle<'a> {
             .union(CommandCapabilities::WORKSPACE)
             .union(CommandCapabilities::PRESENTATION)
             .union(CommandCapabilities::MEDIA)
-            .union(CommandCapabilities::MEMORY);
+            .union(CommandCapabilities::MEMORY)
+            .union(CommandCapabilities::PLUGIN);
         self.contexts(all_test_capabilities).into_parts()
     }
 }
@@ -906,7 +1860,8 @@ impl App {
             workspace: WorkspaceAdapter { host: host.clone() },
             presentation: PresentationAdapter { host: host.clone() },
             media: MediaAdapter { host: host.clone() },
-            memory: MemoryAdapter { host },
+            memory: MemoryAdapter { host: host.clone() },
+            plugin: PluginAdapter { host },
         }
     }
 }
@@ -1673,5 +2628,155 @@ mod tests {
         let parts = bundle.contexts(CommandCapabilities::SESSION).into_parts();
         assert!(parts.session.is_some());
         assert!(parts.memory.is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // FEAT-020 plugin adapter tests
+    // ------------------------------------------------------------------
+
+    fn plugin_test_app(tmpdir: &TempDir) -> App {
+        let options = crate::test_support::test_tui_options(tmpdir.path());
+        let mut app = crate::test_support::test_app_with_options(options);
+        app.ui_locale = Locale::En;
+        app
+    }
+
+    /// Write a minimal plugin bundle into the temp workspace's
+    /// `.codewhale/plugins` so the adapter can read real host data.
+    fn write_demo_bundle(root: &Path) {
+        let bundle = root.join(".codewhale/plugins/demo");
+        std::fs::create_dir_all(bundle.join("skills/hello")).unwrap();
+        std::fs::write(
+            bundle.join("plugin.toml"),
+            "schema_version = 1\n[plugin]\nname = \"demo\"\nversion = \"1.0.0\"\ndescription = \"Import spreadsheet data safely\"\n[skills]\npath = \"skills\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            bundle.join("skills/hello/SKILL.md"),
+            "---\nname: hello\ndescription: hello\n---\nbody\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn plugin_adapter_summaries_and_detail_project_host_data() {
+        let tmp = TempDir::new().unwrap();
+        write_demo_bundle(tmp.path());
+        let mut app = plugin_test_app(&tmp);
+        let discovery = crate::plugins::PluginDiscoveryContext::capture_pre_dotenv();
+        app.plugin_registry = discovery.registry_for_workspace(tmp.path());
+        let mut bundle = app.command_contexts();
+        let mut parts = bundle
+            .contexts(
+                CommandCapabilities::WORKSPACE
+                    .union(CommandCapabilities::PRESENTATION)
+                    .union(CommandCapabilities::PLUGIN),
+            )
+            .into_parts();
+        let plugin = parts.plugin.as_deref_mut().unwrap();
+
+        let summaries = plugin.summaries().unwrap();
+        assert!(!summaries.is_empty());
+        let summary = summaries
+            .iter()
+            .find(|s| s.name == "demo")
+            .expect("demo summary");
+        assert_eq!(summary.compatibility, "full");
+        assert!(
+            summary.inventory.starts_with("skills=1"),
+            "inventory summary: {}",
+            summary.inventory
+        );
+
+        let detail = plugin.detail("demo").unwrap();
+        assert_eq!(detail.name, "demo");
+        assert_eq!(detail.version, "1.0.0");
+        assert_eq!(detail.skills, vec!["demo:hello"]);
+        assert_eq!(detail.trust_status, "not-reviewed");
+
+        // Unknown selector fails safely.
+        assert!(plugin.detail("nope").is_err());
+        // Registry diagnostics empty for a clean bundle.
+        assert!(plugin.registry_diagnostics().is_empty());
+        assert!(plugin.validation_is_clean());
+    }
+
+    #[test]
+    fn plugin_adapter_registry_mutations_and_suggest_are_behavior_faithful() {
+        let tmp = TempDir::new().unwrap();
+        write_demo_bundle(tmp.path());
+        let mut app = plugin_test_app(&tmp);
+        let discovery = crate::plugins::PluginDiscoveryContext::capture_pre_dotenv();
+        app.plugin_registry = discovery.registry_for_workspace(tmp.path());
+        // Capture the review token before borrowing the mutable facet.
+        let token = crate::commands::groups::plugins::render::review_token(
+            app.plugin_registry.get("demo").unwrap(),
+        );
+
+        let mut bundle = app.command_contexts();
+        let mut parts = bundle.contexts(CommandCapabilities::PLUGIN).into_parts();
+        let plugin = parts.plugin.as_deref_mut().unwrap();
+
+        // Read-only suggest does not mutate anything.
+        let before = plugin.len();
+        let _ = plugin.suggest("spreadsheet");
+        assert_eq!(plugin.len(), before);
+        assert_eq!(plugin.summaries().unwrap().len(), before);
+
+        // enable on an untrusted bundle routes to review (safe error), not a mutation.
+        let err = plugin.enable("demo").unwrap_err();
+        assert!(err.contains("requires review"));
+
+        // trust with a wrong token fails safely.
+        assert!(plugin.trust("demo", "bogus.token").is_err());
+
+        // trust with the exact token succeeds.
+        plugin.trust("demo", &token).unwrap();
+        assert!(plugin.detail("demo").unwrap().trusted);
+
+        // enable now succeeds.
+        plugin.enable("demo").unwrap();
+        assert!(plugin.detail("demo").unwrap().enabled);
+
+        // disable clears active skill and marks disabled.
+        plugin.disable("demo").unwrap();
+        assert!(!plugin.detail("demo").unwrap().enabled);
+
+        // revoke_trust flips trust back off.
+        plugin.revoke_trust("demo").unwrap();
+        assert!(!plugin.detail("demo").unwrap().trusted);
+    }
+
+    #[test]
+    fn plugin_adapter_exposure_is_exactly_declared_capabilities() {
+        let tmp = TempDir::new().unwrap();
+        let mut app = plugin_test_app(&tmp);
+        let mut bundle = app.command_contexts();
+
+        // Plugin-only: plugin present, everything else absent.
+        let parts = bundle.contexts(CommandCapabilities::PLUGIN).into_parts();
+        assert!(parts.plugin.is_some());
+        assert!(parts.workspace.is_none());
+        assert!(parts.presentation.is_none());
+        assert!(parts.memory.is_none());
+
+        // Workspace | PRESENTATION | PLUGIN: all three present, media/memory absent.
+        let parts = bundle
+            .contexts(
+                CommandCapabilities::WORKSPACE
+                    .union(CommandCapabilities::PRESENTATION)
+                    .union(CommandCapabilities::PLUGIN),
+            )
+            .into_parts();
+        assert!(parts.plugin.is_some());
+        assert!(parts.workspace.is_some());
+        assert!(parts.presentation.is_some());
+        assert!(parts.media.is_none());
+        assert!(parts.memory.is_none());
+
+        // Undeclared capability: plugin absent.
+        let parts = bundle.contexts(CommandCapabilities::SESSION).into_parts();
+        assert!(parts.session.is_some());
+        assert!(parts.plugin.is_none());
     }
 }

--- a/crates/tui/src/commands/groups/plugins/kimi_import.rs
+++ b/crates/tui/src/commands/groups/plugins/kimi_import.rs
@@ -6,88 +6,68 @@
 //! ordinary reviewed installer. The resulting Codewhale plugin still starts
 //! disabled and untrusted; this module never launches or probes an external
 //! Kimi application, daemon, MCP binary, or permission grant.
+//!
+//! FEAT-020: the managed-directory scan runs host-side in the TUI adapter;
+//! the handler consumes the portable `PluginManagedScan` and renders it.
 
 use std::fmt::Write as _;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use super::render::{escape_review_path, escape_review_text};
+use codewhale_command_contract::facets::{CommandPluginContext, CommandPresentationContext};
+
 use crate::commands::CommandResult;
-use crate::localization::{Locale, MessageId, tr};
-use crate::plugins::agent_plugin::KIMI_PLUGIN_JSON_NAME;
-use crate::plugins::manifest::PluginManifest;
-use crate::plugins::metadata_is_link_or_reparse;
-use crate::tui::app::App;
 
-const MAX_MANAGED_CHILDREN: usize = 128;
 const LIST_COMMAND: &str = "/plugin import kimi [list]";
 const APPROVE_COMMAND: &str = "/plugin import kimi approve <name> <content-hash>";
 
-#[derive(Debug)]
-struct Candidate {
-    name: String,
-    version: String,
-    license: Option<String>,
-    canonical_path: PathBuf,
-    content_hash: String,
-    capability_hash: String,
-    inventory: String,
-    applicable: bool,
-}
-
-#[derive(Debug)]
-struct Scan {
-    root: PathBuf,
-    candidates: Vec<Candidate>,
-    rejected: Vec<String>,
-}
-
-fn message(locale: Locale, id: MessageId, replacements: &[(&str, &str)]) -> String {
-    let mut rendered = tr(locale, id).into_owned();
-    for (placeholder, value) in replacements {
-        rendered = rendered.replace(placeholder, value);
-    }
-    rendered
-}
-
-pub(super) fn usage(locale: Locale) -> String {
-    message(
-        locale,
-        MessageId::PluginKimiUsage,
-        &[
-            ("{list_command}", LIST_COMMAND),
-            ("{approve_command}", APPROVE_COMMAND),
-        ],
-    )
+pub(super) fn usage(presentation: &mut dyn CommandPresentationContext) -> String {
+    presentation
+        .translate(
+            "plugin_kimi_usage",
+            &[
+                ("list_command", LIST_COMMAND),
+                ("approve_command", APPROVE_COMMAND),
+            ],
+        )
+        .unwrap_or_default()
 }
 
 pub(super) fn dispatch(
-    app: &mut App,
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
     words: &[&str],
     home_override: Option<&Path>,
 ) -> CommandResult {
     match words {
-        [] | ["list"] => list(app.ui_locale, home_override),
-        ["approve", name, content_hash] => approve(app, name, content_hash, home_override),
-        _ => CommandResult::error(usage(app.ui_locale)),
+        [] | ["list"] => list(presentation, plugin, home_override),
+        ["approve", name, content_hash] => {
+            approve(presentation, plugin, name, content_hash, home_override)
+        }
+        _ => CommandResult::error(usage(presentation)),
     }
 }
 
-fn list(locale: Locale, home_override: Option<&Path>) -> CommandResult {
-    let scan = match scan_managed_plugins(locale, home_override) {
+fn list(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &dyn CommandPluginContext,
+    home_override: Option<&Path>,
+) -> CommandResult {
+    let scan = match plugin.managed_scan(home_override) {
         Ok(scan) => scan,
         Err(error) => return CommandResult::error(error),
     };
     let root = escape_review_path(&scan.root);
-    let mut output = message(
-        locale,
-        MessageId::PluginKimiManagedRootHeading,
-        &[("{root}", &root)],
-    );
+    let mut output = presentation
+        .translate("plugin_kimi_managed_root_heading", &[("root", &root)])
+        .unwrap_or_default();
     output.push('\n');
     if scan.candidates.is_empty() {
         output.push_str("  ");
-        output.push_str(&tr(locale, MessageId::PluginKimiNoneFound));
+        output.push_str(
+            &presentation
+                .translate("plugin_kimi_none_found", &[])
+                .unwrap_or_default(),
+        );
         output.push('\n');
     }
     for candidate in &scan.candidates {
@@ -97,27 +77,34 @@ fn list(locale: Locale, home_override: Option<&Path>) -> CommandResult {
             .license
             .as_deref()
             .map(escape_review_text)
-            .unwrap_or_else(|| tr(locale, MessageId::PluginKimiLicenseUnspecified).into_owned());
-        let applicability = tr(
-            locale,
-            if candidate.applicable {
-                MessageId::PluginKimiApplicable
-            } else {
-                MessageId::PluginKimiNotApplicable
-            },
-        );
+            .unwrap_or_else(|| {
+                presentation
+                    .translate("plugin_kimi_license_unspecified", &[])
+                    .unwrap_or_default()
+            });
+        let applicability = presentation
+            .translate(
+                if candidate.applicable {
+                    "plugin_kimi_applicable"
+                } else {
+                    "plugin_kimi_not_applicable"
+                },
+                &[],
+            )
+            .unwrap_or_default();
         let inventory = escape_review_text(&candidate.inventory);
-        let summary = message(
-            locale,
-            MessageId::PluginKimiCandidateSummary,
-            &[
-                ("{name}", &name),
-                ("{version}", &version),
-                ("{license}", &license),
-                ("{applicability}", &applicability),
-                ("{inventory}", &inventory),
-            ],
-        );
+        let summary = presentation
+            .translate(
+                "plugin_kimi_candidate_summary",
+                &[
+                    ("name", &name),
+                    ("version", &version),
+                    ("license", &license),
+                    ("applicability", &applicability),
+                    ("inventory", &inventory),
+                ],
+            )
+            .unwrap_or_default();
         let _ = writeln!(output, "\n{summary}");
 
         let path = escape_review_path(&candidate.canonical_path);
@@ -125,38 +112,48 @@ fn list(locale: Locale, home_override: Option<&Path>) -> CommandResult {
             "/plugin import kimi approve {} {}",
             candidate.name, candidate.content_hash
         );
-        let details = message(
-            locale,
-            MessageId::PluginKimiCandidateDetails,
-            &[
-                ("{path}", &path),
-                ("{content_hash}", &candidate.content_hash),
-                ("{capability_hash}", &candidate.capability_hash),
-                ("{approve_command}", &approve_command),
-            ],
-        );
+        let details = presentation
+            .translate(
+                "plugin_kimi_candidate_details",
+                &[
+                    ("path", &path),
+                    ("content_hash", &candidate.content_hash),
+                    ("capability_hash", &candidate.capability_hash),
+                    ("approve_command", &approve_command),
+                ],
+            )
+            .unwrap_or_default();
         let _ = writeln!(output, "{details}");
     }
     if !scan.rejected.is_empty() {
         output.push('\n');
-        output.push_str(&tr(locale, MessageId::PluginKimiRejectedHeading));
+        output.push_str(
+            &presentation
+                .translate("plugin_kimi_rejected_heading", &[])
+                .unwrap_or_default(),
+        );
         output.push('\n');
         for rejection in &scan.rejected {
             let _ = writeln!(output, "  - {rejection}");
         }
     }
     output.push('\n');
-    output.push_str(&tr(locale, MessageId::PluginKimiInspectionFooter));
+    output.push_str(
+        &presentation
+            .translate("plugin_kimi_inspection_footer", &[])
+            .unwrap_or_default(),
+    );
     CommandResult::message(output)
 }
 
 fn approve(
-    app: &mut App,
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
     name: &str,
     expected_hash: &str,
     home_override: Option<&Path>,
 ) -> CommandResult {
-    let scan = match scan_managed_plugins(app.ui_locale, home_override) {
+    let scan = match plugin.managed_scan(home_override) {
         Ok(scan) => scan,
         Err(error) => return CommandResult::error(error),
     };
@@ -166,253 +163,48 @@ fn approve(
         .find(|candidate| candidate.name == name)
     else {
         let name = escape_review_text(name);
-        return CommandResult::error(message(
-            app.ui_locale,
-            MessageId::PluginKimiCandidateMissing,
-            &[("{name}", &name), ("{list_command}", "/plugin import kimi")],
-        ));
+        return CommandResult::error(
+            presentation
+                .translate(
+                    "plugin_kimi_candidate_missing",
+                    &[("name", &name), ("list_command", "/plugin import kimi")],
+                )
+                .unwrap_or_default(),
+        );
     };
     if candidate.content_hash != expected_hash {
         let name = escape_review_text(name);
         let expected = escape_review_text(expected_hash);
-        return CommandResult::error(message(
-            app.ui_locale,
-            MessageId::PluginKimiCandidateChanged,
-            &[
-                ("{name}", &name),
-                ("{expected}", &expected),
-                ("{actual}", &candidate.content_hash),
-                ("{list_command}", "/plugin import kimi"),
-            ],
-        ));
+        return CommandResult::error(
+            presentation
+                .translate(
+                    "plugin_kimi_candidate_changed",
+                    &[
+                        ("name", &name),
+                        ("expected", &expected),
+                        ("actual", &candidate.content_hash),
+                        ("list_command", "/plugin import kimi"),
+                    ],
+                )
+                .unwrap_or_default(),
+        );
     }
 
-    // `install_bundle` revalidates and copies the source through the ordinary
-    // local installer. Its result is always rediscovered disabled/untrusted
-    // and presents the post-copy authority review before any activation.
-    super::install_bundle_with_expected_hash(app, &candidate.canonical_path, expected_hash)
+    // The facet revalidates and copies the source through the ordinary local
+    // installer; its result is always rediscovered disabled/untrusted and
+    // presents the post-copy authority review before any activation.
+    super::install_bundle_with_expected_hash(
+        presentation,
+        plugin,
+        &candidate.canonical_path,
+        expected_hash,
+    )
 }
 
-fn scan_managed_plugins(locale: Locale, home_override: Option<&Path>) -> Result<Scan, String> {
-    let home = match home_override {
-        Some(home) => home.to_path_buf(),
-        None => crate::config::effective_home_dir()
-            .ok_or_else(|| tr(locale, MessageId::PluginKimiHomeMissing).into_owned())?,
-    };
-    let configured_root = home.join(".kimi-code/plugins/managed");
-    let metadata = match fs::symlink_metadata(&configured_root) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(Scan {
-                root: configured_root,
-                candidates: Vec::new(),
-                rejected: Vec::new(),
-            });
-        }
-        Err(error) => {
-            let root = escape_review_path(&configured_root);
-            let error = escape_review_text(&error.to_string());
-            return Err(message(
-                locale,
-                MessageId::PluginKimiRootInspectFailed,
-                &[("{root}", &root), ("{error}", &error)],
-            ));
-        }
-    };
-    if metadata_is_link_or_reparse(&metadata) || !metadata.is_dir() {
-        let root = escape_review_path(&configured_root);
-        return Err(message(
-            locale,
-            MessageId::PluginKimiRootMustBeDirectory,
-            &[("{root}", &root)],
-        ));
-    }
-    let canonical_root = configured_root.canonicalize().map_err(|error| {
-        let root = escape_review_path(&configured_root);
-        let error = escape_review_text(&error.to_string());
-        message(
-            locale,
-            MessageId::PluginKimiRootCanonicalizeFailed,
-            &[("{root}", &root), ("{error}", &error)],
-        )
-    })?;
-    let mut entries = fs::read_dir(&canonical_root)
-        .map_err(|error| {
-            let root = escape_review_path(&canonical_root);
-            let error = escape_review_text(&error.to_string());
-            message(
-                locale,
-                MessageId::PluginKimiRootListFailed,
-                &[("{root}", &root), ("{error}", &error)],
-            )
-        })?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| {
-            let error = escape_review_text(&error.to_string());
-            message(
-                locale,
-                MessageId::PluginKimiEntryReadFailed,
-                &[("{error}", &error)],
-            )
-        })?;
-    if entries.len() > MAX_MANAGED_CHILDREN {
-        let count = entries.len().to_string();
-        let max = MAX_MANAGED_CHILDREN.to_string();
-        return Err(message(
-            locale,
-            MessageId::PluginKimiEntryLimit,
-            &[("{count}", &count), ("{max}", &max)],
-        ));
-    }
-    entries.sort_by_key(fs::DirEntry::file_name);
-
-    let mut candidates = Vec::new();
-    let mut rejected = Vec::new();
-    for entry in entries {
-        let path = entry.path();
-        let metadata = match fs::symlink_metadata(&path) {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                let path = escape_review_path(&path);
-                let error = escape_review_text(&error.to_string());
-                rejected.push(message(
-                    locale,
-                    MessageId::PluginKimiEntryInspectFailed,
-                    &[("{path}", &path), ("{error}", &error)],
-                ));
-                continue;
-            }
-        };
-        if metadata_is_link_or_reparse(&metadata) {
-            let path = escape_review_path(&path);
-            rejected.push(message(
-                locale,
-                MessageId::PluginKimiEntryLinksRefused,
-                &[("{path}", &path)],
-            ));
-            continue;
-        }
-        if !metadata.is_dir() {
-            continue;
-        }
-        let canonical_path = match path.canonicalize() {
-            Ok(path) if path.parent() == Some(canonical_root.as_path()) => path,
-            Ok(canonical_path) => {
-                let path = escape_review_path(&entry.path());
-                let canonical_path = escape_review_path(&canonical_path);
-                rejected.push(message(
-                    locale,
-                    MessageId::PluginKimiEntryOutsideRoot,
-                    &[("{path}", &path), ("{canonical_path}", &canonical_path)],
-                ));
-                continue;
-            }
-            Err(error) => {
-                let path = escape_review_path(&path);
-                let error = escape_review_text(&error.to_string());
-                rejected.push(message(
-                    locale,
-                    MessageId::PluginKimiEntryCanonicalizeFailed,
-                    &[("{path}", &path), ("{error}", &error)],
-                ));
-                continue;
-            }
-        };
-        match inspect_candidate(locale, &canonical_path) {
-            Ok(candidate) => candidates.push(candidate),
-            Err(error) => rejected.push(error),
-        }
-    }
-    candidates.sort_by(|left, right| left.name.cmp(&right.name));
-    Ok(Scan {
-        root: canonical_root,
-        candidates,
-        rejected,
-    })
+pub(super) fn escape_review_path(path: &Path) -> String {
+    super::escape_review_path(path)
 }
 
-fn inspect_candidate(locale: Locale, canonical_path: &Path) -> Result<Candidate, String> {
-    let manifest_path = canonical_path.join(KIMI_PLUGIN_JSON_NAME);
-    let metadata = fs::symlink_metadata(&manifest_path).map_err(|error| {
-        let path = escape_review_path(canonical_path);
-        let error = escape_review_text(&error.to_string());
-        message(
-            locale,
-            MessageId::PluginKimiManifestUnreadable,
-            &[
-                ("{path}", &path),
-                ("{manifest}", KIMI_PLUGIN_JSON_NAME),
-                ("{error}", &error),
-            ],
-        )
-    })?;
-    if metadata_is_link_or_reparse(&metadata) || !metadata.is_file() {
-        let path = escape_review_path(canonical_path);
-        return Err(message(
-            locale,
-            MessageId::PluginKimiManifestMustBeFile,
-            &[("{path}", &path), ("{manifest}", KIMI_PLUGIN_JSON_NAME)],
-        ));
-    }
-    let validated = PluginManifest::validate_from_path(&manifest_path).map_err(|error| {
-        let path = escape_review_path(canonical_path);
-        let error = escape_review_text(&error.to_string());
-        message(
-            locale,
-            MessageId::PluginKimiManifestInvalid,
-            &[("{path}", &path), ("{error}", &error)],
-        )
-    })?;
-    let name = validated.manifest.plugin.name.clone();
-    if canonical_path.file_name().and_then(|part| part.to_str()) != Some(name.as_str()) {
-        let path = escape_review_path(canonical_path);
-        let escaped_name = escape_review_text(&name);
-        return Err(message(
-            locale,
-            MessageId::PluginKimiDirectoryNameMismatch,
-            &[("{path}", &path), ("{name}", &escaped_name)],
-        ));
-    }
-    Ok(Candidate {
-        name,
-        version: validated.manifest.plugin.version.clone(),
-        license: validated.manifest.plugin.license.clone(),
-        canonical_path: validated.canonical_root,
-        content_hash: validated.content_hash,
-        capability_hash: validated.capability_hash,
-        inventory: validated.inventory.summary(),
-        applicable: validated.applicable,
-    })
-}
-
-/// Portable wrapper over [`scan_managed_plugins`] for the FEAT-020 adapter.
-///
-/// Runs the same host scan and converts every candidate to the contract-owned
-/// portable value. Locale is fixed to the default English catalog for
-/// rejection messages because the adapter has no handler locale; the portable
-/// scan carries semantic fields only and rendering happens handler-side.
-pub(crate) fn scan_managed_plugins_portable(
-    home_override: Option<&Path>,
-) -> Result<codewhale_command_contract::facets::PluginManagedScan, String> {
-    let scan = scan_managed_plugins(crate::localization::Locale::En, home_override)?;
-    Ok(codewhale_command_contract::facets::PluginManagedScan {
-        root: scan.root,
-        candidates: scan
-            .candidates
-            .into_iter()
-            .map(
-                |candidate| codewhale_command_contract::facets::PluginManagedCandidate {
-                    name: candidate.name,
-                    version: candidate.version,
-                    license: candidate.license,
-                    canonical_path: candidate.canonical_path,
-                    content_hash: candidate.content_hash,
-                    capability_hash: candidate.capability_hash,
-                    inventory: candidate.inventory,
-                    applicable: candidate.applicable,
-                },
-            )
-            .collect(),
-        rejected: scan.rejected,
-    })
+pub(super) fn escape_review_text(value: &str) -> String {
+    super::escape_review_text(value)
 }

--- a/crates/tui/src/commands/groups/plugins/kimi_import.rs
+++ b/crates/tui/src/commands/groups/plugins/kimi_import.rs
@@ -384,3 +384,35 @@ fn inspect_candidate(locale: Locale, canonical_path: &Path) -> Result<Candidate,
         applicable: validated.applicable,
     })
 }
+
+/// Portable wrapper over [`scan_managed_plugins`] for the FEAT-020 adapter.
+///
+/// Runs the same host scan and converts every candidate to the contract-owned
+/// portable value. Locale is fixed to the default English catalog for
+/// rejection messages because the adapter has no handler locale; the portable
+/// scan carries semantic fields only and rendering happens handler-side.
+pub(crate) fn scan_managed_plugins_portable(
+    home_override: Option<&Path>,
+) -> Result<codewhale_command_contract::facets::PluginManagedScan, String> {
+    let scan = scan_managed_plugins(crate::localization::Locale::En, home_override)?;
+    Ok(codewhale_command_contract::facets::PluginManagedScan {
+        root: scan.root,
+        candidates: scan
+            .candidates
+            .into_iter()
+            .map(
+                |candidate| codewhale_command_contract::facets::PluginManagedCandidate {
+                    name: candidate.name,
+                    version: candidate.version,
+                    license: candidate.license,
+                    canonical_path: candidate.canonical_path,
+                    content_hash: candidate.content_hash,
+                    capability_hash: candidate.capability_hash,
+                    inventory: candidate.inventory,
+                    applicable: candidate.applicable,
+                },
+            )
+            .collect(),
+        rejected: scan.rejected,
+    })
+}

--- a/crates/tui/src/commands/groups/plugins/legacy.rs
+++ b/crates/tui/src/commands/groups/plugins/legacy.rs
@@ -4,130 +4,124 @@
 //! scanning a directory, they carry their own approval requirement, and
 //! they never share bundle trust state. `/plugin tools` reports them
 //! read-only — nothing here installs, trusts, or executes anything.
+//!
+//! FEAT-020: this module consumes the portable `PluginLegacyScan` from the
+//! plugin facet; no concrete `App` or `PluginMetadata` crosses the boundary.
 
+use codewhale_command_contract::facets::{CommandPluginContext, CommandPresentationContext};
 use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
 
 use crate::commands::CommandResult;
-use crate::localization::{MessageId, tr};
-use crate::tools::plugin::{PluginMetadata, scan_plugin_dir};
-use crate::tools::spec::ApprovalRequirement;
-use crate::tui::app::App;
 
-use super::action_error;
-
-pub(super) fn legacy_tools(app: &App, name: Option<&str>) -> CommandResult {
-    let Some(plugin_dir) = plugin_dir_for(app) else {
-        return action_error(
-            app,
-            "Could not resolve the legacy executable plugin-tool directory",
-        );
+pub(super) fn legacy_tools(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &dyn CommandPluginContext,
+    name: Option<&str>,
+) -> CommandResult {
+    let scan = match plugin.legacy_scan() {
+        Ok(Some(scan)) => scan,
+        Ok(None) | Err(_) => {
+            return super::action_error(
+                presentation,
+                "Could not resolve the legacy executable plugin-tool directory",
+            );
+        }
     };
-    if !plugin_dir.exists() {
-        return CommandResult::message(
-            tr(app.ui_locale, MessageId::CmdPluginNoneFound)
-                .replace("{dir}", &plugin_dir.display().to_string()),
-        );
-    }
-    let discovered = scan_plugin_dir(&plugin_dir);
     match name {
-        Some(name) => show_legacy_tool_detail(app, name, &discovered),
-        None => list_legacy_tools(app, &plugin_dir, &discovered),
+        Some(name) => show_legacy_tool_detail(presentation, name, &scan),
+        None => list_legacy_tools(presentation, &scan),
     }
 }
 
 fn list_legacy_tools(
-    app: &App,
-    plugin_dir: &Path,
-    discovered: &[(PathBuf, PluginMetadata)],
+    presentation: &mut dyn CommandPresentationContext,
+    scan: &codewhale_command_contract::facets::PluginLegacyScan,
 ) -> CommandResult {
-    if discovered.is_empty() {
+    if scan.tools.is_empty() {
         return CommandResult::message(
-            tr(app.ui_locale, MessageId::CmdPluginNoneFound)
-                .replace("{dir}", &plugin_dir.display().to_string()),
+            presentation
+                .translate(
+                    "cmd_plugin_none_found",
+                    &[("dir", &scan.dir.display().to_string())],
+                )
+                .unwrap_or_default(),
         );
     }
-    let mut output = tr(app.ui_locale, MessageId::CmdPluginLegacyListHeader)
-        .replace("{count}", &discovered.len().to_string())
-        .replace("{dir}", &plugin_dir.display().to_string());
+    let mut output = presentation
+        .translate(
+            "cmd_plugin_legacy_list_header",
+            &[
+                ("count", &scan.tools.len().to_string()),
+                ("dir", &scan.dir.display().to_string()),
+            ],
+        )
+        .unwrap_or_default();
     output.push('\n');
-    for (path, metadata) in discovered {
+    for tool in &scan.tools {
         let _ = writeln!(
             output,
             "• {} — {}\n  {}",
-            metadata.name,
-            metadata.description,
-            path.display()
+            tool.name,
+            tool.description,
+            tool.path.display()
         );
     }
     CommandResult::message(output)
 }
 
 fn show_legacy_tool_detail(
-    app: &App,
+    presentation: &mut dyn CommandPresentationContext,
     name: &str,
-    discovered: &[(PathBuf, PluginMetadata)],
+    scan: &codewhale_command_contract::facets::PluginLegacyScan,
 ) -> CommandResult {
-    let Some((path, metadata)) = discovered
-        .iter()
-        .find(|(_, metadata)| metadata.name == name)
-    else {
+    let Some(tool) = scan.tools.iter().find(|tool| tool.name == name) else {
         return CommandResult::error(
-            tr(app.ui_locale, MessageId::CmdPluginNotFound).replace("{name}", name),
+            presentation
+                .translate("cmd_plugin_not_found", &[("name", name)])
+                .unwrap_or_default(),
         );
     };
-    let schema = serde_json::to_string_pretty(&metadata.input_schema).unwrap_or_default();
-    let mut output = format!("{}\n{:=<40}\n", metadata.name, "");
+    let schema = tool
+        .input_schema
+        .clone()
+        .unwrap_or_else(|| "{}".to_string());
+    let mut output = format!("{}\n{:=<40}\n", tool.name, "");
     let _ = writeln!(
         output,
         "{}",
-        tr(app.ui_locale, MessageId::CmdPluginDetailDescription)
-            .replace("{description}", &metadata.description)
+        presentation
+            .translate(
+                "cmd_plugin_detail_description",
+                &[("description", &tool.description)],
+            )
+            .unwrap_or_default()
     );
     let _ = writeln!(
         output,
         "{}",
-        tr(app.ui_locale, MessageId::CmdPluginDetailSchema).replace("{schema}", &schema)
+        presentation
+            .translate("cmd_plugin_detail_schema", &[("schema", &schema)])
+            .unwrap_or_default()
     );
     let _ = writeln!(
         output,
         "{}",
-        tr(app.ui_locale, MessageId::CmdPluginDetailApproval)
-            .replace("{approval}", approval_label(metadata.approval))
+        presentation
+            .translate(
+                "cmd_plugin_detail_approval",
+                &[("approval", &tool.approval)]
+            )
+            .unwrap_or_default()
     );
     let _ = writeln!(
         output,
         "{}",
-        tr(app.ui_locale, MessageId::CmdPluginDetailPath)
-            .replace("{path}", &path.display().to_string())
+        presentation
+            .translate(
+                "cmd_plugin_detail_path",
+                &[("path", &tool.path.display().to_string())]
+            )
+            .unwrap_or_default()
     );
     CommandResult::message(output)
-}
-
-pub(super) fn scan_legacy_tools(app: &App) -> Option<(PathBuf, Vec<(PathBuf, PluginMetadata)>)> {
-    let dir = plugin_dir_for(app)?;
-    dir.exists().then(|| {
-        let tools = scan_plugin_dir(&dir);
-        (dir, tools)
-    })
-}
-
-fn approval_label(approval: ApprovalRequirement) -> &'static str {
-    match approval {
-        ApprovalRequirement::Auto => "auto",
-        ApprovalRequirement::Suggest => "suggest",
-        ApprovalRequirement::Required => "required",
-    }
-}
-
-fn plugin_dir_for(app: &App) -> Option<PathBuf> {
-    app.legacy_plugin_tools_dir
-        .clone()
-        .or_else(default_codewhale_tools_dir)
-}
-
-fn default_codewhale_tools_dir() -> Option<PathBuf> {
-    codewhale_config::codewhale_home()
-        .ok()
-        .map(|home| home.join("tools"))
 }

--- a/crates/tui/src/commands/groups/plugins/marketplace.rs
+++ b/crates/tui/src/commands/groups/plugins/marketplace.rs
@@ -291,8 +291,7 @@ fn render_candidates(
         let _ = writeln!(out);
         let compatibility = candidate
             .compatibility
-            .as_ref()
-            .map(|c| c.clone())
+            .clone()
             .unwrap_or_else(|| "decided at install review".to_string());
         let _ = writeln!(out, "    compatibility: {compatibility}");
         match &candidate.install_plan {

--- a/crates/tui/src/commands/groups/plugins/marketplace.rs
+++ b/crates/tui/src/commands/groups/plugins/marketplace.rs
@@ -10,83 +10,20 @@
 //! Catalog-declared tiers and provenance are display-only: nothing in this
 //! module grants trust, enables anything, or auto-installs (Codex
 //! `INSTALLED_BY_DEFAULT` is visibly ignored).
+//!
+//! FEAT-020: the marketplace store/parse/install machinery runs host-side in
+//! the TUI adapter; the handler consumes portable marketplace values and
+//! renders them.
 
 use std::fmt::Write as _;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use super::render::{escape_review_path, escape_review_text};
+use codewhale_command_contract::facets::{
+    CommandPluginContext, CommandPresentationContext, PluginMarketplaceCatalog,
+    PluginMarketplaceInstallPlan,
+};
+
 use crate::commands::CommandResult;
-use crate::localization::{Locale, MessageId, tr};
-use crate::plugins::marketplace::parsers::kimi::{
-    KIMI_GZIP_TARBALL_SOURCE_KIND, KIMI_REMOTE_UNSUPPORTED_REASON, KIMI_ZIP_UNSUPPORTED_REASON,
-};
-use crate::plugins::marketplace::parsers::{MarketplaceDocument, parse_catalog};
-use crate::plugins::marketplace::store::{
-    MarketplaceState, MarketplaceStore, StoredMarketplaceCatalog,
-};
-use crate::plugins::marketplace::types::{
-    CatalogTier, MarketplaceCatalog, MarketplaceCatalogId, MarketplaceFormat,
-    MarketplaceInstallPlan, MarketplaceSourceSpec,
-};
-use crate::plugins::types::PluginDiagnosticLevel;
-use crate::tui::app::App;
-
-/// Catalog documents are JSON text; four megabytes is far beyond any real
-/// published catalog and caps the parse cost of a user-supplied file.
-const MAX_CATALOG_BYTES: u64 = 4 * 1024 * 1024;
-
-/// The catalog built into every Codewhale release. It lists bundles that
-/// ship inside the binary (`builtin:<name>` install specs), so there is
-/// nothing to fetch; installing still goes through the reviewed installer
-/// and lands disabled and untrusted like everything else.
-pub(crate) const OFFICIAL_CATALOG_NAME: &str = "official";
-
-fn official_catalog_document() -> serde_json::Value {
-    serde_json::json!({
-        "name": OFFICIAL_CATALOG_NAME,
-        "description": "Plugins built into this Codewhale release",
-        "version": crate::plugins::install::BUILTIN_BUNDLE_NAMES.len().to_string(),
-        "plugins": [
-            {
-                "name": codewhale_computer_use::bundle::BUNDLE_NAME,
-                "source": format!("builtin:{}", codewhale_computer_use::bundle::BUNDLE_NAME),
-                "version": codewhale_computer_use::bundle::version(),
-                "description": "See and operate this desktop or an attached Android / HarmonyOS device with a vision model (deepseek-v4-flash-vision-exp): screenshots, clicks, typing, scrolling, app launch. Also: `codewhale computer-use setup`.",
-                "homepage": "https://github.com/Hmbown/CodeWhale/blob/main/docs/COMPUTER_USE.md"
-            }
-        ]
-    })
-}
-
-pub(crate) fn builtin_official_catalog() -> StoredMarketplaceCatalog {
-    let mut catalog = parse_catalog(MarketplaceDocument {
-        catalog_id: MarketplaceCatalogId::new(OFFICIAL_CATALOG_NAME),
-        format: MarketplaceFormat::Codewhale,
-        root: official_catalog_document(),
-        base: None,
-    });
-    catalog.provenance.tier = CatalogTier::Official;
-    catalog.provenance.publisher = Some("Codewhale".to_string());
-    for candidate in &mut catalog.candidates {
-        candidate.provenance.tier = CatalogTier::Official;
-        candidate.provenance.publisher = Some("Codewhale".to_string());
-    }
-    StoredMarketplaceCatalog {
-        added_at: "built-in".to_string(),
-        source_path: "(built into this Codewhale)".to_string(),
-        catalog,
-    }
-}
-
-/// Stored catalogs plus the built-in `official` one. A stored catalog can
-/// never shadow the built-in name because `add` refuses it.
-fn lookup_catalog(state: &MarketplaceState, name: &str) -> Option<StoredMarketplaceCatalog> {
-    if name == OFFICIAL_CATALOG_NAME {
-        return Some(builtin_official_catalog());
-    }
-    state.get(name).cloned()
-}
 
 const USAGE: &str = "Usage: /plugin marketplace add|list|show|remove|install\n\
      \x20 add <name> <path>    read a local catalog file (kimi/claude/codex/codewhale)\n\
@@ -95,119 +32,53 @@ const USAGE: &str = "Usage: /plugin marketplace add|list|show|remove|install\n\
      \x20 remove <name>        forget a catalog (installed plugins unaffected)\n\
      \x20 install <catalog> <candidate>  install via the reviewed installer";
 
-pub(super) fn dispatch(app: &mut App, words: &[&str]) -> CommandResult {
+pub(super) fn dispatch(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    words: &[&str],
+) -> CommandResult {
     match words {
-        [] | ["list"] => list(app),
-        ["add", name, path] => add(app, name, path),
-        ["show", name] => show(app, name),
-        ["remove", name] => remove(app, name),
-        ["install", catalog, candidate] => install(app, catalog, candidate),
+        [] | ["list"] => list(presentation, plugin),
+        ["add", name, path] => add(presentation, plugin, name, path),
+        ["show", name] => show(presentation, plugin, name),
+        ["remove", name] => remove(presentation, plugin, name),
+        ["install", catalog, candidate] => install(presentation, plugin, catalog, candidate),
         _ => CommandResult::error(USAGE),
     }
 }
 
-fn open_store(app: &App) -> Result<MarketplaceStore, Box<CommandResult>> {
-    MarketplaceStore::open(app.plugin_registry.state_path()).ok_or_else(|| {
-        Box::new(CommandResult::error(
-            "This plugin registry has no persistence store, so marketplace catalogs cannot be saved.",
-        ))
-    })
-}
-
-/// Conservative catalog name: it becomes a key, appears in candidate IDs,
-/// and is rendered back to the operator.
-fn valid_name(name: &str) -> bool {
-    !name.is_empty()
-        && name.len() <= 64
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
-}
-
-fn add(app: &mut App, name: &str, raw_path: &str) -> CommandResult {
-    if !valid_name(name) {
-        return CommandResult::error(
-            "Marketplace name must be 1-64 characters of letters, digits, `-`, `_`, or `.`",
-        );
-    }
-    if name == OFFICIAL_CATALOG_NAME {
-        return CommandResult::error(format!(
-            "`{OFFICIAL_CATALOG_NAME}` is the catalog built into Codewhale; pick another name."
-        ));
-    }
-    let store = match open_store(app) {
-        Ok(store) => store,
-        Err(result) => return *result,
-    };
+fn add(
+    _presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    name: &str,
+    raw_path: &str,
+) -> CommandResult {
     let path = PathBuf::from(raw_path.trim());
     let path = if path.is_absolute() {
         path
     } else {
-        app.workspace.join(path)
+        PathBuf::from(".").join(path)
     };
-    let path = match canonical_document(&path) {
-        Ok(path) => path,
-        Err(error) => return CommandResult::error(error),
-    };
-
-    let body = match read_bounded(&path) {
-        Ok(text) => text,
-        Err(error) => return CommandResult::error(error),
-    };
-    let root = match serde_json::from_str::<serde_json::Value>(&body) {
-        Ok(root) => root,
-        Err(error) => {
-            return CommandResult::error(format!(
-                "Catalog at {} is not valid JSON: {error}",
-                escape_review_path(&path)
-            ));
+    match plugin.marketplace_add(name, &path) {
+        Ok(receipt) => {
+            let summary = render_catalog_summary(name, &receipt.catalog);
+            CommandResult::message(format!(
+                "Added marketplace `{}` ({} candidate(s), {} warning(s)).\n{summary}\n\
+                 Tiers and provenance are display-only. Nothing was installed, trusted, or enabled.",
+                escape_review_text(name),
+                receipt.candidate_count,
+                receipt.warning_count,
+            ))
         }
-    };
-
-    let document = MarketplaceDocument {
-        catalog_id: crate::plugins::marketplace::types::MarketplaceCatalogId::new(name),
-        format: MarketplaceFormat::Auto,
-        root,
-        base: Some(path.display().to_string()),
-    };
-    let catalog = crate::plugins::marketplace::parsers::parse_catalog(document);
-
-    // A document-level error (unknown/ambiguous format, not-an-object) means
-    // nothing useful was parsed; do not persist it.
-    if catalog.candidates.is_empty() && catalog.error_count() > 0 {
-        return CommandResult::error(format!(
-            "Catalog `{}` could not be parsed as any known marketplace format (kimi, claude, codex, codewhale):\n{}",
-            escape_review_text(name),
-            render_diagnostics_inline(&catalog.diagnostics)
-        ));
-    }
-
-    let entry = StoredMarketplaceCatalog {
-        added_at: chrono::Utc::now().to_rfc3339(),
-        source_path: path.display().to_string(),
-        catalog,
-    };
-    let candidate_count = entry.catalog.total_candidates();
-    let warning_count = entry.catalog.warning_count();
-    let summary = render_catalog_summary(name, &entry.catalog);
-    match store.add(&entry.catalog.id.clone(), entry) {
-        Ok(()) => CommandResult::message(format!(
-            "Added marketplace `{}` ({} candidate(s), {} warning(s)).\n{summary}\n\
-             Tiers and provenance are display-only. Nothing was installed, trusted, or enabled.",
-            escape_review_text(name),
-            candidate_count,
-            warning_count,
-        )),
         Err(error) => CommandResult::error(error),
     }
 }
 
-fn list(app: &mut App) -> CommandResult {
-    let store = match open_store(app) {
-        Ok(store) => store,
-        Err(result) => return *result,
-    };
-    let state = match store.load() {
+fn list(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &dyn CommandPluginContext,
+) -> CommandResult {
+    let state = match plugin.marketplace_state() {
         Ok(state) => state,
         Err(error) => {
             return CommandResult::error(format!(
@@ -216,24 +87,20 @@ fn list(app: &mut App) -> CommandResult {
         }
     };
     let mut output = String::from("Marketplace catalogs:\n");
-    let official = builtin_official_catalog();
     output.push('\n');
-    output.push_str(&render_catalog_summary(
-        OFFICIAL_CATALOG_NAME,
-        &official.catalog,
-    ));
+    output.push_str(&render_catalog_summary("official", &state.official));
     output.push_str("  built into this Codewhale release; nothing is downloaded\n");
-    output.push_str(&render_candidates(app.ui_locale, &official.catalog, false));
-    if state.catalogs().is_empty() {
+    output.push_str(&render_candidates(presentation, &state.official, false));
+    if state.stored.is_empty() {
         output.push_str(&format!(
             "\nNo other catalogs are registered.\n{USAGE}\n\
              `add` reads a LOCAL catalog file; nothing is fetched over the network.\n"
         ));
     }
-    for (name, entry) in state.catalogs() {
+    for catalog in &state.stored {
         output.push('\n');
-        output.push_str(&render_catalog_summary(name, &entry.catalog));
-        output.push_str(&render_candidates(app.ui_locale, &entry.catalog, false));
+        output.push_str(&render_catalog_summary(&catalog.id, catalog));
+        output.push_str(&render_candidates(presentation, catalog, false));
     }
     output.push_str(
         "\nTiers and provenance are display-only. Install with /plugin marketplace install <catalog> <candidate>; \
@@ -242,12 +109,12 @@ fn list(app: &mut App) -> CommandResult {
     CommandResult::message(output)
 }
 
-fn show(app: &mut App, name: &str) -> CommandResult {
-    let store = match open_store(app) {
-        Ok(store) => store,
-        Err(result) => return *result,
-    };
-    let state = match store.load() {
+fn show(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &dyn CommandPluginContext,
+    name: &str,
+) -> CommandResult {
+    let state = match plugin.marketplace_state() {
         Ok(state) => state,
         Err(error) => {
             return CommandResult::error(format!(
@@ -255,34 +122,37 @@ fn show(app: &mut App, name: &str) -> CommandResult {
             ));
         }
     };
-    let Some(entry) = lookup_catalog(&state, name) else {
+    let catalog = if name == "official" {
+        Some(&state.official)
+    } else {
+        state.stored.iter().find(|catalog| catalog.id == name)
+    };
+    let Some(catalog) = catalog else {
         return CommandResult::error(format!(
             "No marketplace named `{}`. Use /plugin marketplace list.",
             escape_review_text(name)
         ));
     };
-    let mut output = render_catalog_summary(name, &entry.catalog);
+    let mut output = render_catalog_summary(name, catalog);
     output.push_str("\n  added from: ");
     let _ = writeln!(
         output,
         "{}",
-        escape_review_path(Path::new(&entry.source_path))
+        escape_review_path(Path::new(catalog.source_path.as_deref().unwrap_or(name)))
     );
-    output.push_str(&render_candidates(app.ui_locale, &entry.catalog, true));
+    output.push_str(&render_candidates(presentation, catalog, true));
     CommandResult::message(output)
 }
 
-fn remove(app: &mut App, name: &str) -> CommandResult {
-    if name == OFFICIAL_CATALOG_NAME {
-        return CommandResult::error(format!(
-            "`{OFFICIAL_CATALOG_NAME}` is built into Codewhale and cannot be removed."
-        ));
+fn remove(
+    _presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    name: &str,
+) -> CommandResult {
+    if name == "official" {
+        return CommandResult::error("`official` is built into Codewhale and cannot be removed.");
     }
-    let store = match open_store(app) {
-        Ok(store) => store,
-        Err(result) => return *result,
-    };
-    match store.remove(name) {
+    match plugin.marketplace_remove(name) {
         Ok(true) => CommandResult::message(format!(
             "Removed marketplace `{}`. Installed plugins and their trust state are unaffected.",
             escape_review_text(name)
@@ -295,105 +165,68 @@ fn remove(app: &mut App, name: &str) -> CommandResult {
     }
 }
 
-fn install(app: &mut App, catalog_name: &str, candidate_name: &str) -> CommandResult {
-    let store = match open_store(app) {
-        Ok(store) => store,
-        Err(result) => return *result,
-    };
-    let state = match store.load() {
-        Ok(state) => state,
-        Err(error) => {
-            return CommandResult::error(format!(
-                "Marketplace state is fail-closed and will not be rewritten: {error}"
-            ));
+fn install(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    catalog_name: &str,
+    candidate_name: &str,
+) -> CommandResult {
+    match plugin.marketplace_install(catalog_name, candidate_name) {
+        Ok(receipt) => {
+            use codewhale_command_contract::facets::PluginMutationOutcome;
+            match receipt.outcome {
+                PluginMutationOutcome::Installed => {
+                    // Marketplace installs route through the same reviewed
+                    // installer as `/plugin install`: the result is disabled
+                    // and untrusted and drops into the trust review.
+                    let name = receipt.name;
+                    let mut output = format!(
+                        "Installed plugin '{name}' from marketplace `{}`.\n\
+                         It is disabled and untrusted. Review its requested authority below, then trust and enable it.\n",
+                        escape_review_text(catalog_name)
+                    );
+                    if let Some(review) = super::review_bundle(presentation, plugin, &name).message
+                    {
+                        output.push('\n');
+                        output.push_str(&review);
+                    }
+                    CommandResult::with_message_and_action(
+                        output,
+                        crate::tui::app::AppAction::PluginRegistryChanged,
+                    )
+                }
+                PluginMutationOutcome::NeedsApproval(host) => {
+                    CommandResult::error(needs_approval_message(&host))
+                }
+                PluginMutationOutcome::NetworkDenied(host) => {
+                    CommandResult::error(network_denied_message(&host))
+                }
+                _ => CommandResult::message(format!(
+                    "Installed `{}` from marketplace `{}`.",
+                    escape_review_text(candidate_name),
+                    escape_review_text(catalog_name)
+                )),
+            }
         }
-    };
-    let Some(entry) = lookup_catalog(&state, catalog_name) else {
-        return CommandResult::error(format!(
-            "No marketplace named `{}`. Use /plugin marketplace list.",
-            escape_review_text(catalog_name)
-        ));
-    };
-    let Some(candidate) = entry.catalog.candidate_by_name(candidate_name) else {
-        return CommandResult::error(format!(
-            "No candidate `{}` in marketplace `{}`.",
-            escape_review_text(candidate_name),
-            escape_review_text(catalog_name)
-        ));
-    };
-    if candidate.has_errors() {
-        return CommandResult::error(format!(
-            "Candidate `{}` has parse errors and cannot be installed:\n{}",
-            escape_review_text(candidate_name),
-            render_diagnostics_inline(&candidate.diagnostics)
-        ));
+        Err(error) => CommandResult::error(error),
     }
-    let MarketplaceInstallPlan::Supported { spec, .. } = &candidate.install_plan else {
-        let MarketplaceInstallPlan::Unsupported { reason, .. } = &candidate.install_plan else {
-            unreachable!("is_supported and this match agree");
-        };
-        return CommandResult::error(format!(
-            "Candidate `{}` cannot be installed by Codewhale: {}",
-            escape_review_text(candidate_name),
-            escape_review_text(&localized_marketplace_plan_text(app.ui_locale, reason))
-        ));
-    };
-    let spec = spec.as_str();
-    // Relative local paths resolve against the catalog document's own
-    // directory, not the TUI's working directory.
-    let spec = resolve_spec(&entry.source_path, &candidate.source, spec);
-    super::install_bundle(app, &spec)
 }
 
-fn resolve_spec(source_path: &str, source: &MarketplaceSourceSpec, spec: &str) -> String {
-    if let MarketplaceSourceSpec::LocalPath { path } = source
-        && path.is_relative()
-        && let Some(dir) = Path::new(source_path).parent()
-    {
-        return format!("path:{}", dir.join(path).display());
-    }
-    spec.to_string()
+fn needs_approval_message(host: &str) -> String {
+    format!(
+        "Network policy requires approval for {host}.\n\
+         Add it to your allow list with `/network allow {host}` (or set [network].default = \"allow\" in ~/.codewhale/config.toml), then retry."
+    )
 }
 
-/// Resolve a user-supplied document path to an existing regular file without
-/// following a final symlink (the document is untrusted input).
-fn canonical_document(path: &Path) -> Result<PathBuf, String> {
-    let metadata = std::fs::symlink_metadata(path)
-        .map_err(|e| format!("Cannot read catalog at {}: {e}", path.display()))?;
-    if metadata.is_symlink() {
-        return Err(format!(
-            "Catalog path {} is a symlink; marketplace documents must be regular files",
-            path.display()
-        ));
-    }
-    if !metadata.is_file() {
-        return Err(format!(
-            "Catalog path {} is not a regular file",
-            path.display()
-        ));
-    }
-    Ok(path.to_path_buf())
+fn network_denied_message(host: &str) -> String {
+    format!(
+        "Network policy denied access to {host}.\n\
+         Remove the deny entry from ~/.codewhale/config.toml under [network] or contact your administrator."
+    )
 }
 
-fn read_bounded(path: &Path) -> Result<String, String> {
-    let file = std::fs::File::open(path)
-        .map_err(|e| format!("Cannot read catalog at {}: {e}", path.display()))?;
-    if file.metadata().map_err(|e| e.to_string())?.len() > MAX_CATALOG_BYTES {
-        return Err(format!(
-            "Catalog at {} exceeds the {} byte limit",
-            path.display(),
-            MAX_CATALOG_BYTES
-        ));
-    }
-    let mut text = String::new();
-    let mut limited = file.take(MAX_CATALOG_BYTES + 1);
-    limited
-        .read_to_string(&mut text)
-        .map_err(|e| format!("Cannot read catalog at {}: {e}", path.display()))?;
-    Ok(text)
-}
-
-fn render_catalog_summary(name: &str, catalog: &MarketplaceCatalog) -> String {
+fn render_catalog_summary(name: &str, catalog: &PluginMarketplaceCatalog) -> String {
     let mut out = String::new();
     let display = catalog
         .display_name
@@ -404,8 +237,8 @@ fn render_catalog_summary(name: &str, catalog: &MarketplaceCatalog) -> String {
         "`{}` — {} format, {} candidate(s), tier={} (display only)",
         escape_review_text(name),
         catalog.format,
-        catalog.total_candidates(),
-        catalog.provenance.tier
+        catalog.total_candidates,
+        catalog.tier
     );
     if let Some(display) = display {
         let _ = writeln!(out, "  display name: {}", escape_review_text(display));
@@ -427,21 +260,14 @@ fn render_catalog_summary(name: &str, catalog: &MarketplaceCatalog) -> String {
     out
 }
 
-fn localized_marketplace_plan_text(locale: Locale, value: &str) -> std::borrow::Cow<'_, str> {
-    match value {
-        KIMI_ZIP_UNSUPPORTED_REASON => tr(locale, MessageId::PluginKimiMarketplaceZipUnsupported),
-        KIMI_REMOTE_UNSUPPORTED_REASON => {
-            tr(locale, MessageId::PluginKimiMarketplaceRemoteUnsupported)
-        }
-        KIMI_GZIP_TARBALL_SOURCE_KIND => tr(locale, MessageId::PluginKimiMarketplaceGzipTarball),
-        _ => std::borrow::Cow::Borrowed(value),
-    }
-}
-
-fn render_candidates(locale: Locale, catalog: &MarketplaceCatalog, detailed: bool) -> String {
+fn render_candidates(
+    presentation: &mut dyn CommandPresentationContext,
+    catalog: &PluginMarketplaceCatalog,
+    detailed: bool,
+) -> String {
     let mut out = String::new();
     for candidate in &catalog.candidates {
-        let status = if candidate.has_errors() {
+        let status = if candidate.has_errors {
             "unusable"
         } else {
             "candidate"
@@ -461,26 +287,29 @@ fn render_candidates(locale: Locale, catalog: &MarketplaceCatalog, detailed: boo
         if let Some(version) = &candidate.version {
             let _ = write!(out, " · v{}", escape_review_text(version));
         }
-        let _ = write!(out, " · tier={}", candidate.provenance.tier);
+        let _ = write!(out, " · tier={}", candidate.tier);
         let _ = writeln!(out);
         let compatibility = candidate
             .compatibility
             .as_ref()
-            .map(|c| c.as_str().to_string())
+            .map(|c| c.clone())
             .unwrap_or_else(|| "decided at install review".to_string());
         let _ = writeln!(out, "    compatibility: {compatibility}");
         match &candidate.install_plan {
-            MarketplaceInstallPlan::Supported { source_kind, .. } => {
-                let source_kind = localized_marketplace_plan_text(locale, source_kind);
+            PluginMarketplaceInstallPlan::Supported {
+                spec: _,
+                source_kind,
+            } => {
+                let source_kind = localized_plan_text(presentation, source_kind);
                 let _ = writeln!(
                     out,
                     "    installable via {source_kind}: /plugin marketplace install {} {}",
-                    escape_review_text(catalog.id.as_str()),
+                    escape_review_text(&catalog.id),
                     escape_review_text(&candidate.name)
                 );
             }
-            MarketplaceInstallPlan::Unsupported { reason, .. } => {
-                let reason = localized_marketplace_plan_text(locale, reason);
+            PluginMarketplaceInstallPlan::Unsupported { reason } => {
+                let reason = localized_plan_text(presentation, reason);
                 let _ = writeln!(out, "    not installable: {}", escape_review_text(&reason));
             }
         }
@@ -512,7 +341,7 @@ fn render_candidates(locale: Locale, catalog: &MarketplaceCatalog, detailed: boo
                 );
             }
             if let Some(when) = &candidate.when {
-                let _ = writeln!(out, "    when: {when:?}");
+                let _ = writeln!(out, "    when: {when}");
             }
         }
         if !candidate.diagnostics.is_empty() {
@@ -526,8 +355,16 @@ fn render_candidates(locale: Locale, catalog: &MarketplaceCatalog, detailed: boo
     out
 }
 
+/// Resolve a marketplace plan code through the presentation facet, falling
+/// back to the raw code when unknown (mirrors the legacy localized plan text).
+fn localized_plan_text(presentation: &mut dyn CommandPresentationContext, value: &str) -> String {
+    presentation
+        .translate(value, &[])
+        .unwrap_or_else(|_| value.to_string())
+}
+
 fn render_diagnostics_inline(
-    diagnostics: &[crate::plugins::marketplace::types::MarketplaceDiagnostic],
+    diagnostics: &[codewhale_command_contract::facets::PluginDiagnostic],
 ) -> String {
     diagnostics
         .iter()
@@ -535,8 +372,10 @@ fn render_diagnostics_inline(
             format!(
                 "{} {}: {}",
                 match d.level {
-                    PluginDiagnosticLevel::Error => "error",
-                    PluginDiagnosticLevel::Warning => "warning",
+                    codewhale_command_contract::facets::PluginDiagnosticLevel::Error => "error",
+                    codewhale_command_contract::facets::PluginDiagnosticLevel::Warning => {
+                        "warning"
+                    }
                 },
                 d.code,
                 escape_review_text(&d.message)
@@ -546,17 +385,10 @@ fn render_diagnostics_inline(
         .join("; ")
 }
 
-#[cfg(test)]
-mod localized_plan_tests {
-    use super::*;
+pub(super) fn escape_review_text(value: &str) -> String {
+    super::escape_review_text(value)
+}
 
-    #[test]
-    fn kimi_plan_codes_resolve_at_render_time() {
-        let zip = localized_marketplace_plan_text(Locale::Es419, KIMI_ZIP_UNSUPPORTED_REASON);
-        let remote = localized_marketplace_plan_text(Locale::Es419, KIMI_REMOTE_UNSUPPORTED_REASON);
-        let gzip = localized_marketplace_plan_text(Locale::Es419, KIMI_GZIP_TARBALL_SOURCE_KIND);
-        assert!(zip.contains("no admite paquetes ZIP"), "{zip}");
-        assert!(remote.contains("deben terminar en .tar.gz"), "{remote}");
-        assert_eq!(gzip, "URL de tarball gzip");
-    }
+pub(super) fn escape_review_path(path: &Path) -> String {
+    super::escape_review_path(path)
 }

--- a/crates/tui/src/commands/groups/plugins/marketplace_tests.rs
+++ b/crates/tui/src/commands/groups/plugins/marketplace_tests.rs
@@ -93,13 +93,17 @@ fn marketplace_add_list_show_remove_roundtrip() {
     let catalog_path = write_kimi_catalog(&catalogs);
 
     // Usage errors are honest before anything is touched.
-    assert!(!plugins(&mut app, Some("marketplace")).is_error); // list, empty
-    assert!(plugins(&mut app, Some("marketplace add")).is_error);
-    assert!(plugins(&mut app, Some("marketplace add 'bad name' x")).is_error);
+    assert!(!plugins_with_kimi_home_override(&mut app, Some("marketplace"), None).is_error); // list, empty
+    assert!(plugins_with_kimi_home_override(&mut app, Some("marketplace add"), None).is_error);
+    assert!(
+        plugins_with_kimi_home_override(&mut app, Some("marketplace add 'bad name' x"), None)
+            .is_error
+    );
 
-    let added = plugins(
+    let added = plugins_with_kimi_home_override(
         &mut app,
         Some(&format!("marketplace add kimi {}", catalog_path.display())),
+        None,
     );
     assert!(!added.is_error, "{:?}", added.message);
     let message = added.message.unwrap();
@@ -108,7 +112,10 @@ fn marketplace_add_list_show_remove_roundtrip() {
     assert!(message.contains("display-only"), "{message}");
     assert!(marketplace_state_path(&codewhale_home).exists());
 
-    let list = plugins(&mut app, Some("marketplace list")).message.unwrap();
+    let list = plugins_with_kimi_home_override(&mut app, Some("marketplace list"), None)
+        .message
+        .unwrap();
+    eprintln!("LIST2 >>>{list}<<<");
     assert!(list.contains("`kimi`"), "{list}");
     assert!(list.contains(r"demo\-bundle"), "{list}");
     assert!(list.contains(r"remote\-thing"), "{list}");
@@ -117,7 +124,9 @@ fn marketplace_add_list_show_remove_roundtrip() {
 
     // Stored plans keep stable codes; rendering resolves the current locale.
     app.ui_locale = Locale::Es419;
-    let localized = plugins(&mut app, Some("marketplace list")).message.unwrap();
+    let localized = plugins_with_kimi_home_override(&mut app, Some("marketplace list"), None)
+        .message
+        .unwrap();
     assert!(localized.contains("no admite paquetes ZIP"), "{localized}");
     assert!(!localized.contains("kimi_zip_unsupported"), "{localized}");
     assert!(
@@ -126,7 +135,7 @@ fn marketplace_add_list_show_remove_roundtrip() {
     );
     app.ui_locale = Locale::En;
 
-    let show = plugins(&mut app, Some("marketplace show kimi"))
+    let show = plugins_with_kimi_home_override(&mut app, Some("marketplace show kimi"), None)
         .message
         .unwrap();
     assert!(show.contains("Demo Bundle"), "{show}");
@@ -135,8 +144,8 @@ fn marketplace_add_list_show_remove_roundtrip() {
 
     // read-only verbs never rewrite the store
     let before = fs::read_to_string(marketplace_state_path(&codewhale_home)).unwrap();
-    plugins(&mut app, Some("marketplace list"));
-    plugins(&mut app, Some("marketplace show kimi"));
+    plugins_with_kimi_home_override(&mut app, Some("marketplace list"), None);
+    plugins_with_kimi_home_override(&mut app, Some("marketplace show kimi"), None);
     let after = fs::read_to_string(marketplace_state_path(&codewhale_home)).unwrap();
     assert_eq!(
         before, after,
@@ -144,13 +153,14 @@ fn marketplace_add_list_show_remove_roundtrip() {
     );
 
     // duplicate name is refused
-    let dup = plugins(
+    let dup = plugins_with_kimi_home_override(
         &mut app,
         Some(&format!("marketplace add kimi {}", catalog_path.display())),
+        None,
     );
     assert!(dup.is_error);
 
-    let removed = plugins(&mut app, Some("marketplace remove kimi"));
+    let removed = plugins_with_kimi_home_override(&mut app, Some("marketplace remove kimi"), None);
     assert!(!removed.is_error, "{:?}", removed.message);
     assert!(
         removed
@@ -158,8 +168,12 @@ fn marketplace_add_list_show_remove_roundtrip() {
             .unwrap()
             .contains("Installed plugins and their trust state are unaffected")
     );
-    assert!(plugins(&mut app, Some("marketplace show kimi")).is_error);
-    let empty = plugins(&mut app, Some("marketplace list")).message.unwrap();
+    assert!(
+        plugins_with_kimi_home_override(&mut app, Some("marketplace show kimi"), None).is_error
+    );
+    let empty = plugins_with_kimi_home_override(&mut app, Some("marketplace list"), None)
+        .message
+        .unwrap();
     assert!(empty.contains("No other catalogs"), "{empty}");
 }
 
@@ -175,7 +189,11 @@ fn marketplace_add_rejects_symlinks_and_bad_documents() {
     let catalog_path = write_kimi_catalog(&catalogs);
 
     // missing file
-    let missing = plugins(&mut app, Some("marketplace add nope /nonexistent/x.json"));
+    let missing = plugins_with_kimi_home_override(
+        &mut app,
+        Some("marketplace add nope /nonexistent/x.json"),
+        None,
+    );
     assert!(missing.is_error);
 
     // symlink to a real catalog is refused, not followed
@@ -186,9 +204,10 @@ fn marketplace_add_rejects_symlinks_and_bad_documents() {
     fs::copy(&catalog_path, &link).unwrap();
     #[cfg(unix)]
     {
-        let symlinked = plugins(
+        let symlinked = plugins_with_kimi_home_override(
             &mut app,
             Some(&format!("marketplace add evil {}", link.display())),
+            None,
         );
         assert!(symlinked.is_error);
         assert!(symlinked.message.unwrap().contains("symlink"));
@@ -197,14 +216,15 @@ fn marketplace_add_rejects_symlinks_and_bad_documents() {
     // a document with no documented markers fails honestly and is not stored
     let junk = catalogs.join("junk.json");
     fs::write(&junk, "{\"hello\": \"world\"}").unwrap();
-    let bad = plugins(
+    let bad = plugins_with_kimi_home_override(
         &mut app,
         Some(&format!("marketplace add junk {}", junk.display())),
+        None,
     );
     assert!(bad.is_error);
     assert!(bad.message.unwrap().contains("could not be parsed"));
     assert!(
-        plugins(&mut app, Some("marketplace list"))
+        plugins_with_kimi_home_override(&mut app, Some("marketplace list"), None)
             .message
             .unwrap()
             .contains("No other catalogs")
@@ -214,7 +234,7 @@ fn marketplace_add_rejects_symlinks_and_bad_documents() {
     let store_path = marketplace_state_path(&codewhale_home);
     fs::create_dir_all(store_path.parent().unwrap()).unwrap();
     fs::write(&store_path, "{ not json").unwrap();
-    let corrupt = plugins(&mut app, Some("marketplace list"));
+    let corrupt = plugins_with_kimi_home_override(&mut app, Some("marketplace list"), None);
     assert!(corrupt.is_error);
     assert!(corrupt.message.unwrap().contains("fail-closed"));
     assert_eq!(fs::read_to_string(&store_path).unwrap(), "{ not json");
@@ -232,15 +252,20 @@ fn marketplace_install_routes_through_reviewed_installer() {
     write_kimi_catalog(&catalogs);
     write_demo_bundle(&catalogs);
     assert!(
-        !plugins(
+        !plugins_with_kimi_home_override(
             &mut app,
-            Some("marketplace add kimi catalogs/kimi-marketplace.json")
+            Some("marketplace add kimi catalogs/kimi-marketplace.json"),
+            None
         )
         .is_error
     );
 
     // The unsupported plan is refused before any runtime or network work.
-    let remote = plugins(&mut app, Some("marketplace install kimi remote-thing"));
+    let remote = plugins_with_kimi_home_override(
+        &mut app,
+        Some("marketplace install kimi remote-thing"),
+        None,
+    );
     assert!(remote.is_error);
     assert!(remote.message.unwrap().contains("cannot be installed"));
 
@@ -250,7 +275,11 @@ fn marketplace_install_routes_through_reviewed_installer() {
         .build()
         .unwrap();
     runtime.block_on(async {
-        let installed = plugins(&mut app, Some("marketplace install kimi demo-bundle"));
+        let installed = plugins_with_kimi_home_override(
+            &mut app,
+            Some("marketplace install kimi demo-bundle"),
+            None,
+        );
         assert!(!installed.is_error, "{:?}", installed.message);
         let message = installed.message.unwrap();
         assert!(message.contains("disabled and untrusted"), "{message}");
@@ -298,13 +327,16 @@ fn marketplace_codex_installed_by_default_never_auto_installs() {
     let path = catalogs.join("codex-marketplace.json");
     fs::write(&path, serde_json::to_string_pretty(&codex).unwrap()).unwrap();
 
-    let added = plugins(
+    let added = plugins_with_kimi_home_override(
         &mut app,
         Some(&format!("marketplace add codex {}", path.display())),
+        None,
     );
     assert!(!added.is_error, "{:?}", added.message);
 
-    let list = plugins(&mut app, Some("marketplace list")).message.unwrap();
+    let list = plugins_with_kimi_home_override(&mut app, Some("marketplace list"), None)
+        .message
+        .unwrap();
     assert!(list.contains(r"defaulted\-thing"), "{list}");
     assert!(list.contains("not installable"), "{list}");
     assert!(list.contains("npm"), "{list}");
@@ -325,7 +357,9 @@ fn official_catalog_installs_the_builtin_computer_use_bundle() {
     let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", &codewhale_home);
     let (mut app, _temp) = create_test_app(root.path());
 
-    let list = plugins(&mut app, Some("marketplace list")).message.unwrap();
+    let list = plugins_with_kimi_home_override(&mut app, Some("marketplace list"), None)
+        .message
+        .unwrap();
     assert!(list.contains("`official`"), "{list}");
     assert!(list.contains(r"computer\-use"), "{list}");
     assert!(list.contains("built into this Codewhale"), "{list}");
@@ -335,17 +369,21 @@ fn official_catalog_installs_the_builtin_computer_use_bundle() {
         "listing never writes state"
     );
 
-    let show = plugins(&mut app, Some("marketplace show official"))
+    let show = plugins_with_kimi_home_override(&mut app, Some("marketplace show official"), None)
         .message
         .unwrap();
     assert!(show.contains(r"computer\-use"), "{show}");
 
-    assert!(plugins(&mut app, Some("marketplace remove official")).is_error);
+    assert!(
+        plugins_with_kimi_home_override(&mut app, Some("marketplace remove official"), None)
+            .is_error
+    );
     let bogus = root.path().join("nope.json");
     fs::write(&bogus, "{}").unwrap();
-    let shadow = plugins(
+    let shadow = plugins_with_kimi_home_override(
         &mut app,
         Some(&format!("marketplace add official {}", bogus.display())),
+        None,
     );
     assert!(shadow.is_error);
     assert!(shadow.message.unwrap().contains("built into Codewhale"));
@@ -356,7 +394,11 @@ fn official_catalog_installs_the_builtin_computer_use_bundle() {
         .build()
         .unwrap();
     runtime.block_on(async {
-        let installed = plugins(&mut app, Some("marketplace install official computer-use"));
+        let installed = plugins_with_kimi_home_override(
+            &mut app,
+            Some("marketplace install official computer-use"),
+            None,
+        );
         assert!(!installed.is_error, "{:?}", installed.message);
         let message = installed.message.unwrap();
         assert!(message.contains("disabled and untrusted"), "{message}");
@@ -376,14 +418,15 @@ fn official_catalog_installs_the_builtin_computer_use_bundle() {
         assert!(marker.contains("\"builtin:computer-use\""), "{marker}");
 
         // Same bytes in the binary → nothing to update; never a network error.
-        let update = plugins(&mut app, Some("update computer-use"));
+        let update = plugins_with_kimi_home_override(&mut app, Some("update computer-use"), None);
         assert!(!update.is_error, "{:?}", update.message);
 
         // Installing again is refused like any other duplicate.
-        let again = plugins(&mut app, Some("install builtin:computer-use"));
+        let again =
+            plugins_with_kimi_home_override(&mut app, Some("install builtin:computer-use"), None);
         assert!(again.is_error, "{:?}", again.message);
         // Unknown built-ins name the available ones.
-        let unknown = plugins(&mut app, Some("install builtin:nope"));
+        let unknown = plugins_with_kimi_home_override(&mut app, Some("install builtin:nope"), None);
         assert!(unknown.is_error);
         assert!(unknown.message.unwrap().contains("computer-use"));
     });

--- a/crates/tui/src/commands/groups/plugins/mod.rs
+++ b/crates/tui/src/commands/groups/plugins/mod.rs
@@ -32,13 +32,14 @@ use codewhale_command_contract::facets::{
     CommandPluginContext, CommandPresentationContext, PluginDetail, PluginDiagnosticLevel,
     PluginMutationOutcome, PluginMutationReceipt,
 };
-use codewhale_command_contract::handler::CommandCapabilities;
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
-use crate::commands::traits::{
-    Command, CommandGroup, CommandInfo, FunctionCommand, RegisterCommand,
-};
-use crate::tui::app::{App, AppAction};
+use crate::commands::traits::{CommandGroup, ContextualCommand};
+#[cfg(test)]
+use crate::tui::app::App;
+use crate::tui::app::AppAction;
 
 pub(crate) mod kimi_import;
 pub(crate) mod legacy;
@@ -55,11 +56,10 @@ use legacy::legacy_tools;
 pub struct PluginsCommands;
 
 impl CommandGroup for PluginsCommands {
-    fn commands(&self) -> &'static [Box<dyn Command>] {
-        cached_command_list!(vec![Box::new(FunctionCommand::new(
-            PluginsCmd::info(),
-            PluginsCmd::execute,
-        ))])
+    fn commands(&self) -> &'static [Box<dyn crate::commands::traits::Command>] {
+        cached_command_list!(vec![Box::new(
+            ContextualCommand::from_contract::<PluginsCmd>().expect("plugin registration"),
+        )])
     }
 }
 
@@ -67,21 +67,38 @@ pub(in crate::commands) const PLUGINS_INFO: CommandInfo = CommandInfo {
     name: "plugin",
     aliases: &["plugins", "extensions"],
     usage: "/plugin [list|show|suggest|validate|export|install|import|update|uninstall|trust|enable|disable|revoke|reload|tools|marketplace]",
-    description_id: crate::localization::MessageId::CmdPluginDescription,
+    description_key: "cmd_plugin_description",
 };
 
 pub(in crate::commands) struct PluginsCmd;
 
-impl RegisterCommand for PluginsCmd {
+impl RegisterCommand<CommandResult> for PluginsCmd {
     fn info() -> &'static CommandInfo {
         &PLUGINS_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        // Transitional shell: build the capability bundle and delegate to the
-        // portable dispatch. Phase 6 replaces this with the contract bridge.
-        plugins_with_kimi_home_override(app, arg, None)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual {
+            capabilities: CommandCapabilities::WORKSPACE
+                .union(CommandCapabilities::PRESENTATION)
+                .union(CommandCapabilities::PLUGIN),
+            handler: plugins_contextual,
+        }
     }
+}
+
+fn plugins_contextual(contexts: CommandContexts<'_>, arg: Option<&str>) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let Some(workspace) = parts.workspace.as_deref() else {
+        return CommandResult::error("Command capability unavailable: workspace");
+    };
+    let Some(presentation) = parts.presentation.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: presentation");
+    };
+    let Some(plugin) = parts.plugin.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: plugin");
+    };
+    plugins(&workspace.workspace(), presentation, plugin, arg, None)
 }
 
 #[cfg(test)]
@@ -89,6 +106,7 @@ fn plugins_with_kimi_home(app: &mut App, arg: Option<&str>, home: &Path) -> Comm
     plugins_with_kimi_home_override(app, arg, Some(home))
 }
 
+#[cfg(test)]
 fn plugins_with_kimi_home_override(
     app: &mut App,
     arg: Option<&str>,

--- a/crates/tui/src/commands/groups/plugins/mod.rs
+++ b/crates/tui/src/commands/groups/plugins/mod.rs
@@ -234,10 +234,7 @@ fn suggest_bundles(
     if task.chars().count() < 3 {
         return CommandResult::error("Usage: /plugin suggest <task of at least 3 characters>");
     }
-    let suggestions = match plugin.suggest(task) {
-        Ok(suggestions) => suggestions,
-        Err(_) => Vec::new(),
-    };
+    let suggestions = plugin.suggest(task).unwrap_or_default();
     if suggestions.is_empty() {
         return CommandResult::message(format!(
             "No installed plugin bundles matched `{}`.\n\nInstall a reviewed bundle with /plugin install <source>. Nothing was installed, trusted, or enabled.",

--- a/crates/tui/src/commands/groups/plugins/mod.rs
+++ b/crates/tui/src/commands/groups/plugins/mod.rs
@@ -546,6 +546,7 @@ fn render_install_receipt(
             {
                 return rollback_hash_mismatch(
                     presentation,
+                    plugin,
                     &name,
                     installed_path.as_deref(),
                     expected,
@@ -574,16 +575,24 @@ fn render_install_receipt(
 
 fn rollback_hash_mismatch(
     presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
     name: &str,
     installed_path: Option<&Path>,
     expected: &str,
     actual: Option<&str>,
 ) -> CommandResult {
     let missing_destination = translate(presentation, "plugin_kimi_rollback_destination_missing");
+    // File-level rollback removal crosses the boundary through the plugin
+    // facet (D1); the host adapter owns the `crate::plugins::install::uninstall`
+    // call.
     let rollback = installed_path
         .and_then(Path::parent)
         .ok_or_else(|| anyhow::anyhow!(missing_destination))
-        .and_then(|plugins_dir| crate::plugins::install::uninstall(name, plugins_dir));
+        .and_then(|plugins_dir| {
+            plugin
+                .uninstall_path(name, plugins_dir)
+                .map_err(anyhow::Error::msg)
+        });
     let actual = actual
         .map(escape_review_text)
         .unwrap_or_else(|| translate(presentation, "plugin_kimi_hash_unavailable"));

--- a/crates/tui/src/commands/groups/plugins/mod.rs
+++ b/crates/tui/src/commands/groups/plugins/mod.rs
@@ -16,17 +16,28 @@
 //!   manifest-controlled text from forging review output.
 //! * [`legacy`] — the separate `[tools].plugin_dir` executable inventory,
 //!   which shares no trust state with declarative bundles.
+//!
+//! FEAT-020 converts this group to the portable command contract: every
+//! production handler consumes workspace, presentation, and plugin facets —
+//! never concrete `App`, `PluginRegistry`, or `Config`. The legacy
+//! `RegisterCommand` shell below builds the capability bundle from `App` and
+//! delegates to the portable dispatch; Phase 6 replaces it with
+//! `ContextualCommand::from_contract`. `CommandResult` and `AppAction` remain
+//! temporary TUI-owned references until FEAT-037.
 
-use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
+
+use codewhale_command_contract::facets::{
+    CommandPluginContext, CommandPresentationContext, PluginDetail, PluginDiagnosticLevel,
+    PluginMutationOutcome, PluginMutationReceipt,
+};
+use codewhale_command_contract::handler::CommandCapabilities;
 
 use crate::commands::CommandResult;
 use crate::commands::traits::{
     Command, CommandGroup, CommandInfo, FunctionCommand, RegisterCommand,
 };
-use crate::localization::{MessageId, tr};
-use crate::plugins::types::{LoadedPlugin, PluginDiagnosticLevel};
 use crate::tui::app::{App, AppAction};
 
 pub(crate) mod kimi_import;
@@ -39,10 +50,7 @@ pub(crate) mod render;
 #[cfg(test)]
 mod tests;
 
-use legacy::{legacy_tools, scan_legacy_tools};
-use render::{
-    append_diagnostics, escape_review_path, escape_review_text, render_bundle_detail, review_token,
-};
+use legacy::legacy_tools;
 
 pub struct PluginsCommands;
 
@@ -59,7 +67,7 @@ pub(in crate::commands) const PLUGINS_INFO: CommandInfo = CommandInfo {
     name: "plugin",
     aliases: &["plugins", "extensions"],
     usage: "/plugin [list|show|suggest|validate|export|install|import|update|uninstall|trust|enable|disable|revoke|reload|tools|marketplace]",
-    description_id: MessageId::CmdPluginDescription,
+    description_id: crate::localization::MessageId::CmdPluginDescription,
 };
 
 pub(in crate::commands) struct PluginsCmd;
@@ -70,12 +78,10 @@ impl RegisterCommand for PluginsCmd {
     }
 
     fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        plugins(app, arg)
+        // Transitional shell: build the capability bundle and delegate to the
+        // portable dispatch. Phase 6 replaces this with the contract bridge.
+        plugins_with_kimi_home_override(app, arg, None)
     }
-}
-
-fn plugins(app: &mut App, arg: Option<&str>) -> CommandResult {
-    plugins_with_kimi_home_override(app, arg, None)
 }
 
 #[cfg(test)]
@@ -88,6 +94,35 @@ fn plugins_with_kimi_home_override(
     arg: Option<&str>,
     kimi_home: Option<&Path>,
 ) -> CommandResult {
+    let mut bundle = app.command_contexts();
+    let capabilities = CommandCapabilities::WORKSPACE
+        .union(CommandCapabilities::PRESENTATION)
+        .union(CommandCapabilities::PLUGIN);
+    let mut contexts = bundle.contexts(capabilities).into_parts();
+    let Some(workspace) = contexts.workspace.as_deref() else {
+        return CommandResult::error("Command capability unavailable: workspace");
+    };
+    let Some(presentation) = contexts.presentation.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: presentation");
+    };
+    let Some(plugin) = contexts.plugin.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: plugin");
+    };
+    plugins(&workspace.workspace(), presentation, plugin, arg, kimi_home)
+}
+
+/// Portable `/plugin` dispatch (FEAT-020 Phase 4).
+///
+/// The handler consumes only portable facets; all concrete host access lives
+/// in the TUI adapter. `kimi_home` is a test-only home override for the Kimi
+/// managed-import scan.
+pub(super) fn plugins(
+    workspace: &Path,
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    arg: Option<&str>,
+    kimi_home: Option<&Path>,
+) -> CommandResult {
     let words = arg
         .unwrap_or_default()
         .split_whitespace()
@@ -96,197 +131,180 @@ fn plugins_with_kimi_home_override(
         [] => CommandResult::action(AppAction::OpenExtensions {
             tab: crate::tui::views::extensions::ExtensionsTab::Plugins,
         }),
-        ["list"] => list_bundles_and_legacy_tools(app),
+        ["list"] => list_bundles_and_legacy_tools(presentation, plugin),
         ["help"] => CommandResult::message(format!(
             "{}\n\n/plugin import kimi [list]\n/plugin import kimi approve <name> <content-hash>",
-            tr(app.ui_locale, MessageId::CmdPluginBundleUsage)
+            translate(presentation, "cmd_plugin_bundle_usage")
         )),
-        ["marketplace", rest @ ..] => marketplace::dispatch(app, rest),
-        ["import", "kimi", rest @ ..] => kimi_import::dispatch(app, rest, kimi_home),
-        ["import", ..] => CommandResult::error(kimi_import::usage(app.ui_locale)),
-        ["show", selector] => show_bundle(app, selector),
+        ["marketplace", rest @ ..] => marketplace::dispatch(presentation, plugin, rest),
+        ["import", "kimi", rest @ ..] => {
+            kimi_import::dispatch(presentation, plugin, rest, kimi_home)
+        }
+        ["import", ..] => CommandResult::error(kimi_import::usage(presentation)),
+        ["show", selector] => show_bundle(presentation, plugin, selector),
         ["suggest"] | ["recommend"] => CommandResult::error("Usage: /plugin suggest <task>"),
-        ["suggest", task @ ..] | ["recommend", task @ ..] => suggest_bundles(app, &task.join(" ")),
-        ["validate"] => validate_bundles(app, None),
-        ["validate", selector] => validate_bundles(app, Some(selector)),
+        ["suggest", task @ ..] | ["recommend", task @ ..] => {
+            suggest_bundles(presentation, plugin, &task.join(" "))
+        }
+        ["validate"] => validate_bundles(presentation, plugin, None),
+        ["validate", selector] => validate_bundles(presentation, plugin, Some(selector)),
         ["export"] => CommandResult::error("Usage: /plugin export <name> <target-dir>"),
-        ["export", selector, target @ ..] => export_bundle(app, selector, &target.join(" ")),
-        ["install"] => CommandResult::error(tr(app.ui_locale, MessageId::CmdPluginBundleUsage)),
-        ["install", rest @ ..] => install_bundle(app, &rest.join(" ")),
+        ["export", selector, target @ ..] => {
+            export_bundle(workspace, presentation, plugin, selector, &target.join(" "))
+        }
+        ["install"] => CommandResult::error(translate(presentation, "cmd_plugin_bundle_usage")),
+        ["install", rest @ ..] => install_bundle(presentation, plugin, &rest.join(" ")),
         ["update"] | ["uninstall"] => {
-            CommandResult::error(tr(app.ui_locale, MessageId::CmdPluginBundleUsage))
+            CommandResult::error(translate(presentation, "cmd_plugin_bundle_usage"))
         }
-        ["update", selector] => update_bundle(app, selector),
-        ["uninstall", selector] => uninstall_bundle(app, selector),
-        ["trust", selector] => review_bundle(app, selector),
-        ["trust", selector, token] => mutate_bundle(app, selector, Mutation::Trust(token)),
-        ["enable", selector] => mutate_bundle(app, selector, Mutation::Enable),
-        ["disable", selector] => mutate_bundle(app, selector, Mutation::Disable),
-        ["revoke", selector] => mutate_bundle(app, selector, Mutation::Revoke),
-        ["reload"] => {
-            app.plugin_registry = app.plugin_registry.rediscover_for_workspace(&app.workspace);
-            app.refresh_skill_cache();
-            let count = app.plugin_registry.len();
-            CommandResult::with_message_and_action(
-                tr(app.ui_locale, MessageId::CmdPluginBundleReloaded)
-                    .replace("{count}", &count.to_string())
-                    .replace("{workspace}", &app.workspace.display().to_string()),
-                AppAction::PluginRegistryChanged,
-            )
+        ["update", selector] => update_bundle(presentation, plugin, selector),
+        ["uninstall", selector] => uninstall_bundle(presentation, plugin, selector),
+        ["trust", selector] => review_bundle(presentation, plugin, selector),
+        ["trust", selector, token] => {
+            mutate_bundle(presentation, plugin, selector, Mutation::Trust(token))
         }
-        ["tools"] => legacy_tools(app, None),
-        ["tools", name] => legacy_tools(app, Some(name)),
+        ["enable", selector] => mutate_bundle(presentation, plugin, selector, Mutation::Enable),
+        ["disable", selector] => mutate_bundle(presentation, plugin, selector, Mutation::Disable),
+        ["revoke", selector] => mutate_bundle(presentation, plugin, selector, Mutation::Revoke),
+        ["reload"] => reload(presentation, plugin),
+        ["tools"] => legacy_tools(presentation, plugin, None),
+        ["tools", name] => legacy_tools(presentation, plugin, Some(name)),
         [selector] => {
-            if app.plugin_registry.get(selector).is_some() {
-                show_bundle(app, selector)
+            if plugin.detail(selector).is_ok() {
+                show_bundle(presentation, plugin, selector)
             } else {
                 // Preserve `/plugin <script-tool>` compatibility while making
                 // its distinct execution model explicit in the output.
-                legacy_tools(app, Some(selector))
+                legacy_tools(presentation, plugin, Some(selector))
             }
         }
-        _ => CommandResult::error(tr(app.ui_locale, MessageId::CmdPluginBundleUsage)),
+        _ => CommandResult::error(translate(presentation, "cmd_plugin_bundle_usage")),
+    }
+}
+
+/// Translate one stable plugin key through the presentation facet.
+fn translate(presentation: &mut dyn CommandPresentationContext, key: &str) -> String {
+    presentation.translate(key, &[]).unwrap_or_default()
+}
+
+fn reload(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+) -> CommandResult {
+    match plugin.reload() {
+        Ok(count) => {
+            let message = presentation
+                .translate(
+                    "cmd_plugin_bundle_reloaded",
+                    &[("count", &count.to_string())],
+                )
+                .unwrap_or_default();
+            CommandResult::with_message_and_action(message, AppAction::PluginRegistryChanged)
+        }
+        Err(error) => action_error(presentation, &format!("Plugin reload failed: {error}")),
     }
 }
 
 /// Rank already installed bundle metadata for a task without changing trust,
-/// enablement, disk state, or network state. A full remote plugin marketplace
-/// needs separately curated publisher/provenance policy; the existing plugin
-/// registry is intentionally local-only for this release.
-fn suggest_bundles(app: &App, task: &str) -> CommandResult {
+/// enablement, disk state, or network state.
+fn suggest_bundles(
+    _presentation: &mut dyn CommandPresentationContext,
+    plugin: &dyn CommandPluginContext,
+    task: &str,
+) -> CommandResult {
     let task = task.trim();
     if task.chars().count() < 3 {
         return CommandResult::error("Usage: /plugin suggest <task of at least 3 characters>");
     }
-
-    let mut skills = BTreeMap::new();
-    for plugin in app.plugin_registry.list() {
-        let mut description_parts = plugin
-            .manifest
-            .plugin
-            .description
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
-        let mut keywords = Vec::new();
-        for skill in &plugin.skill_snapshots {
-            description_parts.push(skill.name.clone());
-            description_parts.push(skill.description.clone());
-            keywords.push(skill.name.clone());
-            keywords.extend(skill.aliases.iter().cloned());
-        }
-        skills.insert(
-            plugin.name().to_string(),
-            crate::skills::RegistryEntry {
-                source: plugin.id.as_str().to_string(),
-                description: (!description_parts.is_empty()).then(|| description_parts.join(" ")),
-                keywords,
-                domains: plugin.inventory.network_hosts.clone(),
-            },
-        );
-    }
-
-    let index = crate::skills::RegistryDocument { skills };
-    let recommendations = crate::skills::recommend::recommend_remote_skills(task, &index, 3);
-    if recommendations.is_empty() {
+    let suggestions = match plugin.suggest(task) {
+        Ok(suggestions) => suggestions,
+        Err(_) => Vec::new(),
+    };
+    if suggestions.is_empty() {
         return CommandResult::message(format!(
             "No installed plugin bundles matched `{}`.\n\nInstall a reviewed bundle with /plugin install <source>. Nothing was installed, trusted, or enabled.",
             escape_review_text(task)
         ));
     }
-
     let mut output = format!(
         "Suggested installed plugins for `{}`:\n",
         escape_review_text(task)
     );
     output.push_str("─────────────────────────────\n");
-    for recommendation in recommendations {
-        let Some(plugin) = app.plugin_registry.get(&recommendation.entry.source) else {
-            continue;
-        };
-        let description = plugin
-            .manifest
-            .plugin
-            .description
-            .as_deref()
-            .filter(|description| !description.trim().is_empty())
-            .unwrap_or("No description provided.");
-        let why = recommendation
-            .matched_terms
+    for suggestion in suggestions {
+        let why = suggestion
+            .why
             .iter()
             .map(|term| escape_review_text(term))
             .collect::<Vec<_>>()
             .join(", ");
-        let next_step = if plugin.active() {
-            format!("Already active: /plugin show {}", plugin.name())
-        } else if !plugin.trusted() {
-            format!("Review before enabling: /plugin trust {}", plugin.name())
-        } else if !plugin.enabled {
-            format!(
-                "Enable if that review still applies: /plugin enable {}",
-                plugin.name()
-            )
-        } else {
-            format!("Inspect its inactive state: /plugin show {}", plugin.name())
-        };
         let _ = writeln!(
             output,
             "  {} — {} · {}",
-            escape_review_text(plugin.name()),
-            plugin.state_label(),
-            escape_review_text(description)
+            escape_review_text(&suggestion.name),
+            suggestion.state_label,
+            escape_review_text(&suggestion.description)
         );
         let _ = writeln!(output, "    Why: {why}");
-        let _ = writeln!(output, "    {next_step}");
+        let _ = writeln!(output, "    {}", escape_review_text(&suggestion.next_step));
     }
     output.push_str("\nNothing was installed, trusted, or enabled.");
     CommandResult::message(output)
 }
 
-fn list_bundles_and_legacy_tools(app: &App) -> CommandResult {
-    let mut output = {
-        let registry = app.plugin_registry.as_ref();
-        let plugins = registry.list();
-        let mut output = if plugins.is_empty() {
-            tr(app.ui_locale, MessageId::CmdPluginBundleNoneFound).into_owned()
-        } else {
-            let mut output = tr(app.ui_locale, MessageId::CmdPluginBundleListHeader)
-                .replace("{count}", &plugins.len().to_string());
-            output.push('\n');
-            for plugin in plugins {
-                let _ = writeln!(
-                    output,
-                    "• {} — {}\n  {} · {} · compatibility={} · {}\n  {}",
-                    escape_review_text(plugin.name()),
-                    plugin.state_label(),
-                    plugin.scope,
-                    plugin.trust_status.as_str(),
-                    plugin.compatibility().as_str(),
-                    plugin.inventory.summary(),
-                    escape_review_text(plugin.id.as_str())
-                );
-            }
-            output
-        };
-        append_diagnostics(app, &mut output, registry.diagnostics());
+fn list_bundles_and_legacy_tools(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &dyn CommandPluginContext,
+) -> CommandResult {
+    let summaries = plugin.summaries().unwrap_or_default();
+    let mut output = if summaries.is_empty() {
+        translate(presentation, "cmd_plugin_bundle_none_found")
+    } else {
+        let mut output = presentation
+            .translate(
+                "cmd_plugin_bundle_list_header",
+                &[("count", &summaries.len().to_string())],
+            )
+            .unwrap_or_default();
+        output.push('\n');
+        for summary in &summaries {
+            let _ = writeln!(
+                output,
+                "• {} — {}\n  {} · {} · compatibility={} · {}\n  {}",
+                escape_review_text(&summary.name),
+                summary.state_label,
+                summary.scope,
+                summary.trust_status,
+                summary.compatibility,
+                summary.inventory,
+                escape_review_text(&summary.id)
+            );
+        }
         output
     };
+    append_diagnostics(presentation, &mut output, &plugin.registry_diagnostics());
 
-    if let Some((dir, tools)) = scan_legacy_tools(app) {
+    if let Ok(Some(scan)) = plugin.legacy_scan() {
         output.push('\n');
         output.push_str(
-            &tr(app.ui_locale, MessageId::CmdPluginLegacyListHeader)
-                .replace("{count}", &tools.len().to_string())
-                .replace("{dir}", &dir.display().to_string()),
+            &presentation
+                .translate(
+                    "cmd_plugin_legacy_list_header",
+                    &[
+                        ("count", &scan.tools.len().to_string()),
+                        ("dir", &scan.dir.display().to_string()),
+                    ],
+                )
+                .unwrap_or_default(),
         );
         output.push('\n');
-        for (path, metadata) in tools {
+        for tool in &scan.tools {
             let _ = writeln!(
                 output,
                 "• {} — {}\n  {}",
-                escape_review_text(&metadata.name),
-                escape_review_text(&metadata.description),
-                escape_review_path(&path)
+                escape_review_text(&tool.name),
+                escape_review_text(&tool.description),
+                escape_review_path(&tool.path)
             );
         }
     }
@@ -294,25 +312,40 @@ fn list_bundles_and_legacy_tools(app: &App) -> CommandResult {
     CommandResult::message(output)
 }
 
-fn show_bundle(app: &App, selector: &str) -> CommandResult {
-    let Some(plugin) = app.plugin_registry.get(selector).cloned() else {
-        return CommandResult::error(
-            tr(app.ui_locale, MessageId::CmdPluginBundleNotFound).replace("{name}", selector),
-        );
+fn show_bundle(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &dyn CommandPluginContext,
+    selector: &str,
+) -> CommandResult {
+    let detail = match plugin.detail(selector) {
+        Ok(detail) => detail,
+        Err(_) => {
+            return CommandResult::error(
+                presentation
+                    .translate("cmd_plugin_bundle_not_found", &[("name", selector)])
+                    .unwrap_or_default(),
+            );
+        }
     };
-    CommandResult::message(render_bundle_detail(app, &plugin, true))
+    CommandResult::message(render::render_bundle_detail(presentation, &detail, true))
 }
 
 /// `/plugin export <name> <target-dir>` — publish a loaded bundle as a
-/// spec-valid Agent Plugins v1.0.0 directory (`plugin.json`, `mcp.json` when
-/// servers exist, and the `skills/` tree). The installed bundle is never
-/// modified; a relative target resolves against the workspace.
-fn export_bundle(app: &App, selector: &str, target: &str) -> CommandResult {
-    let Some(plugin) = app.plugin_registry.get(selector).cloned() else {
+/// spec-valid Agent Plugins v1.0.0 directory.
+fn export_bundle(
+    workspace: &Path,
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &dyn CommandPluginContext,
+    selector: &str,
+    target: &str,
+) -> CommandResult {
+    if plugin.detail(selector).is_err() {
         return CommandResult::error(
-            tr(app.ui_locale, MessageId::CmdPluginBundleNotFound).replace("{name}", selector),
+            presentation
+                .translate("cmd_plugin_bundle_not_found", &[("name", selector)])
+                .unwrap_or_default(),
         );
-    };
+    }
     let target = target.trim();
     if target.is_empty() {
         return CommandResult::error("Usage: /plugin export <name> <target-dir>");
@@ -321,16 +354,9 @@ fn export_bundle(app: &App, selector: &str, target: &str) -> CommandResult {
     let target = if target.is_absolute() {
         target
     } else {
-        app.workspace.join(target)
+        workspace.join(target)
     };
-    let existing_names: BTreeSet<String> = app
-        .plugin_registry
-        .list()
-        .iter()
-        .map(|other| other.name().to_string())
-        .filter(|name| name != plugin.name())
-        .collect();
-    match crate::plugins::export::export_plugin_bundle(&plugin, &target, &existing_names) {
+    match plugin.export(selector, &target) {
         Ok(receipt) => {
             let mut output = format!(
                 "Exported `{}` as an Agent Plugins v1.0.0 bundle:\n  {}\n",
@@ -364,281 +390,244 @@ fn export_bundle(app: &App, selector: &str, target: &str) -> CommandResult {
         }
         Err(error) => CommandResult::error(format!(
             "Export of `{}` failed: {}",
-            escape_review_text(plugin.name()),
+            escape_review_text(selector),
             escape_review_text(&error)
         )),
     }
 }
 
-fn review_bundle(app: &App, selector: &str) -> CommandResult {
-    let Some(plugin) = app.plugin_registry.get(selector).cloned() else {
-        return CommandResult::error(
-            tr(app.ui_locale, MessageId::CmdPluginBundleNotFound).replace("{name}", selector),
-        );
+fn review_bundle(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &dyn CommandPluginContext,
+    selector: &str,
+) -> CommandResult {
+    let detail = match plugin.detail(selector) {
+        Ok(detail) => detail,
+        Err(_) => {
+            return CommandResult::error(
+                presentation
+                    .translate("cmd_plugin_bundle_not_found", &[("name", selector)])
+                    .unwrap_or_default(),
+            );
+        }
     };
-    let mut output = render_bundle_detail(app, &plugin, true);
+    let mut output = render::render_bundle_detail(presentation, &detail, true);
     let _ = writeln!(
         output,
         "\n/plugin trust {} {}",
-        plugin.name(),
-        review_token(&plugin)
+        detail.name,
+        review_token(&detail)
     );
     CommandResult::message(output)
 }
 
-fn validate_bundles(app: &App, selector: Option<&str>) -> CommandResult {
-    let (plugins, diagnostics, clean) = {
-        let registry = app.plugin_registry.as_ref();
-        let plugins: Vec<LoadedPlugin> = match selector {
-            Some(selector) => registry.get(selector).cloned().into_iter().collect(),
-            None => registry.list().into_iter().cloned().collect(),
-        };
-        (
-            plugins,
-            registry.diagnostics().to_vec(),
-            registry.validation_is_clean(),
-        )
-    };
-    if app.plugin_registry.is_empty() && selector.is_none() {
-        return CommandResult::error(tr(app.ui_locale, MessageId::CmdPluginBundleNoneFound));
-    };
-    if selector.is_some() && plugins.is_empty() {
-        return CommandResult::error(
-            tr(app.ui_locale, MessageId::CmdPluginBundleNotFound)
-                .replace("{name}", selector.unwrap_or_default()),
-        );
+pub(crate) fn review_token(detail: &PluginDetail) -> String {
+    // This is an explicit user confirmation, not cosmetic display text. Bind
+    // the command to both complete SHA-256 receipts so a same-inventory bundle
+    // cannot collide through the former 48-bit content prefix.
+    format!("{}.{}", detail.content_hash, detail.capability_hash)
+}
+
+fn validate_bundles(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &dyn CommandPluginContext,
+    selector: Option<&str>,
+) -> CommandResult {
+    if plugin.is_empty() && selector.is_none() {
+        return CommandResult::error(translate(presentation, "cmd_plugin_bundle_none_found"));
     }
 
     let mut output = String::new();
-    for plugin in &plugins {
-        let _ = writeln!(
-            output,
-            "{} — {} — {}",
-            plugin.name(),
-            if plugin
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.level == PluginDiagnosticLevel::Error)
-            {
-                "invalid"
-            } else {
-                "valid"
-            },
-            plugin.inventory.summary()
-        );
-        append_diagnostics(app, &mut output, &plugin.diagnostics);
+    if let Some(selector) = selector {
+        match plugin.detail(selector) {
+            Ok(detail) => {
+                let invalid = detail
+                    .diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic.level == PluginDiagnosticLevel::Error);
+                let _ = writeln!(
+                    output,
+                    "{} — {} — {}",
+                    detail.name,
+                    if invalid { "invalid" } else { "valid" },
+                    detail.inventory_summary
+                );
+                append_diagnostics(presentation, &mut output, &detail.diagnostics);
+            }
+            Err(_) => {
+                return CommandResult::error(
+                    presentation
+                        .translate("cmd_plugin_bundle_not_found", &[("name", selector)])
+                        .unwrap_or_default(),
+                );
+            }
+        }
+    } else {
+        for summary in plugin.summaries().unwrap_or_default() {
+            let _ = writeln!(
+                output,
+                "{} — {} — {}",
+                summary.name, summary.state_label, summary.inventory
+            );
+        }
+        append_diagnostics(presentation, &mut output, &plugin.registry_diagnostics());
     }
-    append_diagnostics(app, &mut output, &diagnostics);
     if output.is_empty() {
-        output.push_str(if clean { "valid" } else { "invalid" });
+        output.push_str(if plugin.validation_is_clean() {
+            "valid"
+        } else {
+            "invalid"
+        });
     }
     CommandResult::message(output)
 }
 
 // ─── /plugin install | update | uninstall (#5182) ──────────────────────────
-//
-// The fetch/place on-ramp. All writes go through `plugins::mutation`; after a
-// successful install or update the command rediscovers and drops the user
-// into the existing trust review (`review_bundle`) — installed or replaced
-// bits are always disabled and untrusted until the hash-bound trust flow runs.
 
-fn install_bundle(app: &mut App, spec: &str) -> CommandResult {
-    let source = match crate::plugins::install::PluginInstallSource::parse(spec) {
-        Ok(source) => source,
-        Err(error) => {
-            return CommandResult::error(format!(
-                "Invalid plugin install source `{spec}`: {error:#}\n\
-                 Expected a local path, github:owner/repo, an HTTPS tarball URL, or builtin:<name>."
-            ));
-        }
-    };
-    install_bundle_source(app, source, None)
+fn install_bundle(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    spec: &str,
+) -> CommandResult {
+    match plugin.install(spec, None) {
+        Ok(receipt) => render_install_receipt(presentation, plugin, receipt, None),
+        Err(error) => action_error(presentation, &format!("Plugin install failed: {error}")),
+    }
 }
 
 fn install_bundle_with_expected_hash(
-    app: &mut App,
-    path: &std::path::Path,
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    path: &Path,
     expected_content_hash: &str,
 ) -> CommandResult {
-    install_bundle_source(
-        app,
-        crate::plugins::install::PluginInstallSource::LocalPath(path.to_path_buf()),
+    match plugin.install(
+        path.to_str().unwrap_or_default(),
         Some(expected_content_hash),
-    )
+    ) {
+        Ok(receipt) => {
+            render_install_receipt(presentation, plugin, receipt, Some(expected_content_hash))
+        }
+        Err(error) => action_error(presentation, &format!("Plugin install failed: {error}")),
+    }
 }
 
-fn install_bundle_source(
-    app: &mut App,
-    source: crate::plugins::install::PluginInstallSource,
+fn render_install_receipt(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    receipt: PluginMutationReceipt,
     expected_content_hash: Option<&str>,
 ) -> CommandResult {
-    use crate::plugins::mutation::{
-        PluginMutationContext, PluginMutationOutcome, PluginMutationRequest,
-    };
-
-    let network = plugin_network_policy();
-    let expected_content_hash = expected_content_hash.map(str::to_string);
-    let expected_for_request = expected_content_hash.clone();
-    let registry = std::sync::Arc::make_mut(&mut app.plugin_registry);
-    let outcome = run_async(async move {
-        let ctx = PluginMutationContext {
-            network: &network,
-            max_size: crate::plugins::install::DEFAULT_MAX_SIZE_BYTES,
-        };
-        let request = match expected_for_request {
-            Some(expected_content_hash) => PluginMutationRequest::InstallExact {
-                source,
-                expected_content_hash,
-            },
-            None => PluginMutationRequest::Install { source },
-        };
-        crate::plugins::mutation::execute(request, &ctx, registry).await
-    });
-
-    match outcome {
-        Ok(receipt) => match receipt.outcome {
-            PluginMutationOutcome::Installed => {
-                let name = receipt.name.clone();
-                let installed_path = receipt.path.clone();
-                let installed_content_hash = receipt.installed_content_hash.clone();
-                let path = installed_path
-                    .as_deref()
-                    .map(|path| path.display().to_string())
-                    .unwrap_or_default();
-                if let Some(expected) = expected_content_hash.as_deref()
-                    && receipt.content_hash.as_deref() != Some(expected)
-                {
-                    return rollback_hash_mismatch(
-                        app,
-                        &name,
-                        installed_path.as_deref(),
-                        expected,
-                        receipt.content_hash.as_deref(),
-                    );
-                }
-                app.plugin_registry = app.plugin_registry.rediscover_for_workspace(&app.workspace);
-                app.refresh_skill_cache();
-                if expected_content_hash.is_some() {
-                    let post_copy_hash = app
-                        .plugin_registry
-                        .get(&name)
-                        .map(|plugin| plugin.content_hash.clone());
-                    if installed_content_hash.is_none()
-                        || post_copy_hash.as_deref() != installed_content_hash.as_deref()
-                    {
-                        return rollback_hash_mismatch(
-                            app,
-                            &name,
-                            installed_path.as_deref(),
-                            installed_content_hash.as_deref().unwrap_or("unavailable"),
-                            post_copy_hash.as_deref(),
-                        );
-                    }
-                }
-                let mut output = format!(
-                    "Installed plugin '{name}' to {path}.\n\
-                     It is disabled and untrusted. Review its requested authority below, then trust and enable it.\n"
+    match receipt.outcome {
+        PluginMutationOutcome::Installed => {
+            let name = receipt.name.clone();
+            let installed_path = receipt.path.clone();
+            let path = installed_path
+                .as_deref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_default();
+            if let Some(expected) = expected_content_hash
+                && receipt.content_hash.as_deref() != Some(expected)
+            {
+                return rollback_hash_mismatch(
+                    presentation,
+                    &name,
+                    installed_path.as_deref(),
+                    expected,
+                    receipt.content_hash.as_deref(),
                 );
-                if let Some(review) = review_bundle(app, &name).message {
-                    output.push('\n');
-                    output.push_str(&review);
-                }
-                CommandResult::with_message_and_action(output, AppAction::PluginRegistryChanged)
             }
-            PluginMutationOutcome::NeedsApproval(host) => {
-                CommandResult::error(needs_approval_message(&host))
+            let mut output = format!(
+                "Installed plugin '{name}' to {path}.\n\
+                 It is disabled and untrusted. Review its requested authority below, then trust and enable it.\n"
+            );
+            if let Some(review) = review_bundle(presentation, plugin, &name).message {
+                output.push('\n');
+                output.push_str(&review);
             }
-            PluginMutationOutcome::NetworkDenied(host) => {
-                CommandResult::error(network_denied_message(&host))
-            }
-            other => CommandResult::error(format!("Unexpected install outcome: {other:?}")),
-        },
-        Err(error) => action_error(app, &format!("Plugin install failed: {error:#}")),
+            CommandResult::with_message_and_action(output, AppAction::PluginRegistryChanged)
+        }
+        PluginMutationOutcome::NeedsApproval(host) => {
+            CommandResult::error(needs_approval_message(&host))
+        }
+        PluginMutationOutcome::NetworkDenied(host) => {
+            CommandResult::error(network_denied_message(&host))
+        }
+        other => CommandResult::error(format!("Unexpected install outcome: {other:?}")),
     }
 }
 
 fn rollback_hash_mismatch(
-    app: &mut App,
+    presentation: &mut dyn CommandPresentationContext,
     name: &str,
-    installed_path: Option<&std::path::Path>,
+    installed_path: Option<&Path>,
     expected: &str,
     actual: Option<&str>,
 ) -> CommandResult {
-    let locale = app.ui_locale;
-    let missing_destination =
-        tr(locale, MessageId::PluginKimiRollbackDestinationMissing).into_owned();
+    let missing_destination = translate(presentation, "plugin_kimi_rollback_destination_missing");
     let rollback = installed_path
-        .and_then(std::path::Path::parent)
+        .and_then(Path::parent)
         .ok_or_else(|| anyhow::anyhow!(missing_destination))
         .and_then(|plugins_dir| crate::plugins::install::uninstall(name, plugins_dir));
-    app.plugin_registry = app.plugin_registry.rediscover_for_workspace(&app.workspace);
-    app.refresh_skill_cache();
     let actual = actual
         .map(escape_review_text)
-        .unwrap_or_else(|| tr(locale, MessageId::PluginKimiHashUnavailable).into_owned());
+        .unwrap_or_else(|| translate(presentation, "plugin_kimi_hash_unavailable"));
     let name = escape_review_text(name);
     let expected = escape_review_text(expected);
     match rollback {
         Ok(()) => CommandResult::error(
-            tr(locale, MessageId::PluginKimiMismatchRemoved)
-                .replace("{name}", &name)
-                .replace("{expected}", &expected)
-                .replace("{actual}", &actual),
+            presentation
+                .translate(
+                    "plugin_kimi_mismatch_removed",
+                    &[
+                        ("name", &name),
+                        ("expected", &expected),
+                        ("actual", &actual),
+                    ],
+                )
+                .unwrap_or_default(),
         ),
-        Err(error) => CommandResult {
-            message: Some(
-                tr(locale, MessageId::PluginKimiMismatchRollbackFailed)
-                    .replace("{name}", &name)
-                    .replace("{expected}", &expected)
-                    .replace("{actual}", &actual)
-                    .replace("{error}", &escape_review_text(&format!("{error:#}")))
-                    .replace(
-                        "{path}",
-                        &installed_path.map(escape_review_path).unwrap_or_else(|| {
-                            tr(locale, MessageId::PluginKimiUserPluginDirectory).into_owned()
-                        }),
-                    ),
-            ),
-            action: Some(AppAction::PluginRegistryChanged),
-            is_error: true,
-        },
+        Err(error) => {
+            let error_text = escape_review_text(&format!("{error:#}"));
+            let path_text = installed_path
+                .map(escape_review_path)
+                .unwrap_or_else(|| translate(presentation, "plugin_kimi_user_plugin_directory"));
+            CommandResult {
+                message: Some(
+                    presentation
+                        .translate(
+                            "plugin_kimi_mismatch_rollback_failed",
+                            &[
+                                ("name", &name),
+                                ("expected", &expected),
+                                ("actual", &actual),
+                                ("error", &error_text),
+                                ("path", &path_text),
+                            ],
+                        )
+                        .unwrap_or_default(),
+                ),
+                action: Some(AppAction::PluginRegistryChanged),
+                is_error: true,
+            }
+        }
     }
 }
 
-fn update_bundle(app: &mut App, selector: &str) -> CommandResult {
-    use crate::plugins::mutation::{
-        PluginMutationContext, PluginMutationOutcome, PluginMutationRequest,
-    };
-
-    let network = plugin_network_policy();
-    let selector_owned = selector.to_string();
-    let registry = std::sync::Arc::make_mut(&mut app.plugin_registry);
-    let outcome = run_async(async move {
-        let ctx = PluginMutationContext {
-            network: &network,
-            max_size: crate::plugins::install::DEFAULT_MAX_SIZE_BYTES,
-        };
-        crate::plugins::mutation::execute(
-            PluginMutationRequest::Update {
-                selector: selector_owned,
-            },
-            &ctx,
-            registry,
-        )
-        .await
-    });
-
-    match outcome {
+fn update_bundle(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    selector: &str,
+) -> CommandResult {
+    match plugin.update(selector) {
         Ok(receipt) => match receipt.outcome {
             PluginMutationOutcome::Updated => {
                 let name = receipt.name.clone();
-                app.plugin_registry = app.plugin_registry.rediscover_for_workspace(&app.workspace);
-                app.refresh_skill_cache();
                 let mut output = format!(
                     "Updated plugin '{name}'. Its content changed, so the previous trust receipt no \
                      longer matches — review and trust it again before enabling.\n"
                 );
-                if let Some(review) = review_bundle(app, &name).message {
+                if let Some(review) = review_bundle(presentation, plugin, &name).message {
                     output.push('\n');
                     output.push_str(&review);
                 }
@@ -655,56 +644,25 @@ fn update_bundle(app: &mut App, selector: &str) -> CommandResult {
             }
             other => CommandResult::error(format!("Unexpected update outcome: {other:?}")),
         },
-        Err(error) => action_error(app, &format!("Plugin update failed: {error:#}")),
+        Err(error) => action_error(presentation, &format!("Plugin update failed: {error}")),
     }
 }
 
-fn uninstall_bundle(app: &mut App, selector: &str) -> CommandResult {
-    use crate::plugins::mutation::{
-        PluginMutationContext, PluginMutationOutcome, PluginMutationRequest,
-    };
-
-    let network = plugin_network_policy();
-    let selector_owned = selector.to_string();
-    let registry = std::sync::Arc::make_mut(&mut app.plugin_registry);
-    let outcome = run_async(async move {
-        let ctx = PluginMutationContext {
-            network: &network,
-            max_size: crate::plugins::install::DEFAULT_MAX_SIZE_BYTES,
-        };
-        crate::plugins::mutation::execute(
-            PluginMutationRequest::Uninstall {
-                selector: selector_owned,
-            },
-            &ctx,
-            registry,
-        )
-        .await
-    });
-
-    match outcome {
-        Ok(receipt) => {
-            debug_assert!(matches!(
-                receipt.outcome,
-                PluginMutationOutcome::Uninstalled
-            ));
-            app.plugin_registry = app.plugin_registry.rediscover_for_workspace(&app.workspace);
-            app.refresh_skill_cache();
-            app.active_skill = None;
-            app.active_skill_provenance = None;
-            CommandResult::with_message_and_action(
-                format!("Uninstalled plugin '{}'.", receipt.name),
-                AppAction::PluginRegistryChanged,
-            )
-        }
-        Err(error) => action_error(app, &format!("Plugin uninstall failed: {error:#}")),
+fn uninstall_bundle(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    selector: &str,
+) -> CommandResult {
+    match plugin.uninstall(selector) {
+        Ok(receipt) => CommandResult::with_message_and_action(
+            format!("Uninstalled plugin '{}'.", receipt.name),
+            AppAction::PluginRegistryChanged,
+        ),
+        Err(error) => action_error(presentation, &format!("Plugin uninstall failed: {error}")),
     }
 }
 
-/// Read the active network policy for plugin downloads. Mirrors the skill
-/// installer's on-demand `Config::load` (`App` carries no `Config` field);
-/// a parse failure falls back to the prompt-default policy so the download
-/// stays gated rather than crashing.
+/// Read the active network policy for plugin downloads (host-side, D11).
 pub(crate) fn plugin_network_policy() -> crate::network_policy::NetworkPolicy {
     crate::config::Config::load(None, None)
         .unwrap_or_default()
@@ -717,9 +675,6 @@ pub(crate) fn run_async<F, T>(future: F) -> T
 where
     F: std::future::Future<Output = T>,
 {
-    // Same bridge as the skill commands: the TUI thread is part of the
-    // multi-threaded runtime, so `block_in_place` + `block_on` brings the
-    // sync slash-command handler back into the async ecosystem.
     tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
 }
 
@@ -745,77 +700,108 @@ enum Mutation<'a> {
     Revoke,
 }
 
-fn mutate_bundle(app: &mut App, selector: &str, mutation: Mutation<'_>) -> CommandResult {
+fn mutate_bundle(
+    presentation: &mut dyn CommandPresentationContext,
+    plugin: &mut dyn CommandPluginContext,
+    selector: &str,
+    mutation: Mutation<'_>,
+) -> CommandResult {
     if matches!(mutation, Mutation::Enable) {
-        let needs_review = app
-            .plugin_registry
-            .get(selector)
-            .is_some_and(|plugin| !plugin.trusted());
+        let needs_review = plugin
+            .detail(selector)
+            .map(|detail| !detail.trusted)
+            .unwrap_or(false);
         if needs_review {
             // Enabling is the natural entry point. Open the exact capability
             // review instead of leaving the user at an opaque denial.
-            return review_bundle(app, selector);
-        }
-    }
-    if let Mutation::Trust(token) = mutation {
-        let Some(expected) = app.plugin_registry.get(selector).map(review_token) else {
-            return CommandResult::error(
-                tr(app.ui_locale, MessageId::CmdPluginBundleNotFound).replace("{name}", selector),
-            );
-        };
-        if token != expected {
-            return action_error(
-                app,
-                "Review token does not match this bundle content and capability set; run `/plugin trust <name>` again",
-            );
+            return review_bundle(presentation, plugin, selector);
         }
     }
 
     let result = match mutation {
-        Mutation::Trust(_) => std::sync::Arc::make_mut(&mut app.plugin_registry)
-            .trust(selector)
-            .map(|()| "trusted"),
-        Mutation::Enable => std::sync::Arc::make_mut(&mut app.plugin_registry)
-            .enable(selector)
-            .map(|()| "enabled"),
-        Mutation::Disable => std::sync::Arc::make_mut(&mut app.plugin_registry)
-            .disable(selector)
-            .map(|()| "disabled"),
-        Mutation::Revoke => std::sync::Arc::make_mut(&mut app.plugin_registry)
-            .revoke_trust(selector)
-            .map(|()| "trust-revoked"),
+        Mutation::Trust(token) => plugin.trust(selector, token).map(|()| "trusted"),
+        Mutation::Enable => plugin.enable(selector).map(|()| "enabled"),
+        Mutation::Disable => plugin.disable(selector).map(|()| "disabled"),
+        Mutation::Revoke => plugin.revoke_trust(selector).map(|()| "trust-revoked"),
     };
     match result {
         Ok(action) => {
-            app.refresh_skill_cache();
-            if matches!(mutation, Mutation::Disable | Mutation::Revoke) {
-                app.active_skill = None;
-                app.active_skill_provenance = None;
-            }
-            let mut message = tr(app.ui_locale, MessageId::CmdPluginBundleMutationSuccess)
-                .replace("{name}", selector)
-                .replace("{action}", action);
+            let mut message = presentation
+                .translate(
+                    "cmd_plugin_bundle_mutation_success",
+                    &[("name", selector), ("action", action)],
+                )
+                .unwrap_or_default();
             if matches!(mutation, Mutation::Enable)
-                && let Some(plugin) = app.plugin_registry.get(selector)
+                && let Ok(detail) = plugin.detail(selector)
             {
-                let inactive = plugin.inventory.unsupported_labels();
+                let inactive = detail.unsupported_labels;
                 if !inactive.is_empty() {
                     message.push(' ');
                     message.push_str(&format!(
                         "Compatibility: {}. Supported declarative components are active; inactive: {}.",
-                        plugin.compatibility().as_str(),
+                        detail.compatibility,
                         inactive.join(", ")
                     ));
                 }
             }
             CommandResult::with_message_and_action(message, AppAction::PluginRegistryChanged)
         }
-        Err(error) => action_error(app, &error),
+        Err(error) => action_error(presentation, &error),
     }
 }
 
-fn action_error(app: &App, error: &str) -> CommandResult {
+fn action_error(presentation: &mut dyn CommandPresentationContext, error: &str) -> CommandResult {
     CommandResult::error(
-        tr(app.ui_locale, MessageId::CmdPluginActionFailed).replace("{error}", error),
+        presentation
+            .translate("cmd_plugin_action_failed", &[("error", error)])
+            .unwrap_or_default(),
     )
+}
+
+pub(super) fn append_diagnostics(
+    presentation: &mut dyn CommandPresentationContext,
+    output: &mut String,
+    diagnostics: &[codewhale_command_contract::facets::PluginDiagnostic],
+) {
+    if diagnostics.is_empty() {
+        return;
+    }
+    if !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output.push_str(
+        &presentation
+            .translate(
+                "cmd_plugin_bundle_diagnostics_header",
+                &[("count", &diagnostics.len().to_string())],
+            )
+            .unwrap_or_default(),
+    );
+    output.push('\n');
+    for diagnostic in diagnostics {
+        let level = match diagnostic.level {
+            PluginDiagnosticLevel::Warning => "warning",
+            PluginDiagnosticLevel::Error => "error",
+        };
+        let path = diagnostic
+            .path
+            .as_deref()
+            .map(|path| format!(" ({})", escape_review_path(path)))
+            .unwrap_or_default();
+        let _ = writeln!(
+            output,
+            "• {level} [{}]: {}{path}",
+            diagnostic.code,
+            escape_review_text(&diagnostic.message)
+        );
+    }
+}
+
+pub(super) fn escape_review_path(path: &Path) -> String {
+    render::escape_review_path(path)
+}
+
+pub(super) fn escape_review_text(value: &str) -> String {
+    render::escape_review_text(value)
 }

--- a/crates/tui/src/commands/groups/plugins/mod.rs
+++ b/crates/tui/src/commands/groups/plugins/mod.rs
@@ -29,12 +29,12 @@ use crate::localization::{MessageId, tr};
 use crate::plugins::types::{LoadedPlugin, PluginDiagnosticLevel};
 use crate::tui::app::{App, AppAction};
 
-mod kimi_import;
-mod legacy;
-mod marketplace;
+pub(crate) mod kimi_import;
+pub(crate) mod legacy;
+pub(crate) mod marketplace;
 #[cfg(test)]
 mod marketplace_tests;
-mod render;
+pub(crate) mod render;
 
 #[cfg(test)]
 mod tests;
@@ -705,7 +705,7 @@ fn uninstall_bundle(app: &mut App, selector: &str) -> CommandResult {
 /// installer's on-demand `Config::load` (`App` carries no `Config` field);
 /// a parse failure falls back to the prompt-default policy so the download
 /// stays gated rather than crashing.
-fn plugin_network_policy() -> crate::network_policy::NetworkPolicy {
+pub(crate) fn plugin_network_policy() -> crate::network_policy::NetworkPolicy {
     crate::config::Config::load(None, None)
         .unwrap_or_default()
         .network
@@ -713,7 +713,7 @@ fn plugin_network_policy() -> crate::network_policy::NetworkPolicy {
         .unwrap_or_default()
 }
 
-fn run_async<F, T>(future: F) -> T
+pub(crate) fn run_async<F, T>(future: F) -> T
 where
     F: std::future::Future<Output = T>,
 {

--- a/crates/tui/src/commands/groups/plugins/render.rs
+++ b/crates/tui/src/commands/groups/plugins/render.rs
@@ -72,7 +72,7 @@ pub(super) fn render_bundle_detail(
     let skills = detail
         .skills
         .iter()
-        .map(|skill| escape_review_text(&format!("{skill}")))
+        .map(|skill| escape_review_text(skill))
         .collect::<Vec<_>>();
     let _ = write!(
         output,
@@ -130,7 +130,7 @@ fn render_mcp_inventory(detail: &PluginDetail) -> String {
     detail
         .mcp_servers
         .iter()
-        .map(|server| render_mcp_server(server))
+        .map(render_mcp_server)
         .collect::<Vec<_>>()
         .join("; ")
 }

--- a/crates/tui/src/commands/groups/plugins/render.rs
+++ b/crates/tui/src/commands/groups/plugins/render.rs
@@ -1,31 +1,37 @@
 //! Presentation for `/plugin`: bundle detail, the capability review body,
 //! and diagnostics.
 //!
-//! Everything here is a pure `&LoadedPlugin -> String` transform — no
-//! registry mutation, no disk access. [`escape_review_text`] is the
-//! security-relevant part: manifest fields are attacker-controlled, so they
-//! are escaped before they reach a review the user is about to approve.
+//! Everything here is a pure portable transform — no registry mutation, no
+//! disk access. [`escape_review_text`] is the security-relevant part:
+//! manifest fields are attacker-controlled, so they are escaped before they
+//! reach a review the user is about to approve.
+//!
+//! FEAT-020: render helpers consume portable `PluginDetail` values and the
+//! presentation facet; the concrete `LoadedPlugin` never crosses the
+//! boundary.
 
 use std::fmt::Write as _;
 use std::path::Path;
 
-use crate::localization::{MessageId, tr};
-use crate::plugins::types::{LoadedPlugin, PluginDiagnosticLevel};
-use crate::tui::app::App;
+use codewhale_command_contract::facets::{
+    CommandPresentationContext, PluginDetail, PluginDiagnostic, PluginDiagnosticLevel,
+    PluginMcpServerDetail,
+};
+
+use super::append_diagnostics;
 
 pub(super) fn render_bundle_detail(
-    app: &App,
-    plugin: &LoadedPlugin,
+    presentation: &mut dyn CommandPresentationContext,
+    detail: &PluginDetail,
     include_hashes: bool,
 ) -> String {
-    let unsupported = plugin.inventory.unsupported_labels();
-    let unsupported = if unsupported.is_empty() {
+    let unsupported = if detail.unsupported_labels.is_empty() {
         "none".to_string()
     } else {
-        unsupported.join(", ")
+        detail.unsupported_labels.join(", ")
     };
-    let active_components = if plugin.active() {
-        let labels = plugin.inventory.supported_labels();
+    let active_components = if detail.active {
+        let labels = &detail.supported_labels;
         if labels.is_empty() {
             "none".to_string()
         } else {
@@ -36,190 +42,212 @@ pub(super) fn render_bundle_detail(
     };
     let (content_hash, capability_hash) = if include_hashes {
         (
-            plugin.content_hash.as_str(),
-            plugin.capability_hash.as_str(),
+            detail.content_hash.as_str(),
+            detail.capability_hash.as_str(),
         )
     } else {
         ("hidden", "hidden")
     };
-    let mut output = tr(app.ui_locale, MessageId::CmdPluginBundleDetail)
-        .replace("{name}", &escape_review_text(plugin.name()))
-        .replace("{id}", &escape_review_text(plugin.id.as_str()))
-        .replace(
-            "{version}",
-            &escape_review_text(&plugin.manifest.plugin.version),
+    let mut output = presentation
+        .translate(
+            "cmd_plugin_bundle_detail",
+            &[
+                ("name", &escape_review_text(&detail.name)),
+                ("id", &escape_review_text(&detail.id)),
+                ("version", &escape_review_text(&detail.version)),
+                ("origin", &detail.origin),
+                ("scope", &detail.scope),
+                ("state", &detail.state_label),
+                ("trust", &detail.trust_status),
+                ("inventory", &detail.inventory_summary),
+                ("permissions", &render_permissions(detail)),
+                ("mcp", &render_mcp_inventory(detail)),
+                ("unsupported", &unsupported),
+                ("content_hash", content_hash),
+                ("capability_hash", capability_hash),
+                ("path", &escape_review_path(&detail.canonical_root)),
+            ],
         )
-        .replace("{origin}", plugin.origin.as_str())
-        .replace("{scope}", plugin.scope.as_str())
-        .replace("{state}", plugin.state_label())
-        .replace("{trust}", plugin.trust_status.as_str())
-        .replace("{inventory}", &plugin.inventory.summary())
-        .replace("{permissions}", &render_permissions(plugin))
-        .replace("{mcp}", &render_mcp_inventory(plugin))
-        .replace("{unsupported}", &unsupported)
-        .replace("{content_hash}", content_hash)
-        .replace("{capability_hash}", capability_hash)
-        .replace("{path}", &escape_review_path(&plugin.canonical_root));
-    let skills = plugin
-        .skill_snapshots
+        .unwrap_or_default();
+    let skills = detail
+        .skills
         .iter()
-        .map(|skill| escape_review_text(&format!("{}:{}", plugin.name(), skill.name)))
+        .map(|skill| escape_review_text(&format!("{skill}")))
         .collect::<Vec<_>>();
     let _ = write!(
         output,
         "\nCompatibility: {}\nActive components: [{active_components}]\nInactive components: [{unsupported}]\nQualified skills: [{}]\nActivation boundary: trust stages the exact reviewed content but does not activate it; enable rebuilds this workspace's Skills, MCP, Commands, Agents, and Hooks immediately. Every plugin command dispatch, Agent spawn, Hook process start, Skill use, and MCP call rechecks current authority. LSP, native, filesystem-roots, and lifecycle-mutation stay inventoried and inactive.",
-        plugin.compatibility().as_str(),
+        detail.compatibility,
         if skills.is_empty() {
             "none".to_string()
         } else {
             skills.join(", ")
         }
     );
-    append_diagnostics(app, &mut output, &plugin.diagnostics);
+    append_diagnostics(presentation, &mut output, &detail.diagnostics);
     output
 }
 
-fn render_permissions(plugin: &LoadedPlugin) -> String {
-    let filesystem = if plugin.inventory.filesystem_roots.is_empty() {
+fn render_permissions(detail: &PluginDetail) -> String {
+    let filesystem = if detail.filesystem_roots.is_empty() {
         "none".to_string()
     } else {
-        plugin
-            .inventory
+        detail
             .filesystem_roots
             .iter()
             .map(|value| escape_review_text(value))
             .collect::<Vec<_>>()
             .join(", ")
     };
-    let network = if plugin.inventory.network_hosts.is_empty() {
+    let network = if detail.network_hosts.is_empty() {
         "none".to_string()
     } else {
-        plugin
-            .inventory
+        detail
             .network_hosts
             .iter()
             .map(|value| escape_review_text(value))
             .collect::<Vec<_>>()
             .join(", ")
     };
-    let stdio_authority = if plugin.inventory.stdio_mcp_servers == 0 {
+    let stdio_authority = if detail.stdio_mcp_servers == 0 {
         "none".to_string()
     } else {
         format!(
             "{} local child process(es) with host-user filesystem/network authority; MCP tool approvals still apply",
-            plugin.inventory.stdio_mcp_servers
+            detail.stdio_mcp_servers
         )
     };
     format!(
         "filesystem_roots=[{filesystem}] network_hosts=[{network}] (exact allowlist for Codewhale-managed remote requests; redirects stay same-origin) lifecycle_mutation={} stdio_runtime=[{stdio_authority}]",
-        plugin.inventory.lifecycle_mutation
+        detail.lifecycle_mutation
     )
 }
 
-fn render_mcp_inventory(plugin: &LoadedPlugin) -> String {
-    let Some(servers) = plugin.manifest.mcp_servers.as_ref() else {
+fn render_mcp_inventory(detail: &PluginDetail) -> String {
+    if detail.mcp_servers.is_empty() {
         return "none".to_string();
-    };
-    let mut servers = servers.iter().collect::<Vec<_>>();
-    servers.sort_by_key(|(name, _)| *name);
-    servers
-        .into_iter()
-        .map(|(name, server)| {
-            let enabled = if server.is_enabled() {
-                "configured-on"
-            } else {
-                "configured-off"
-            };
-            if let Some(command) = server.command.as_deref() {
-                let mut env_provenance = server
-                    .env
-                    .iter()
-                    .map(|(destination, source)| {
-                        let source = source
-                            .strip_prefix("${")
-                            .and_then(|source| source.strip_suffix('}'))
-                            .unwrap_or("invalid");
-                        format!(
-                            "{} <- {}",
-                            escape_review_text(destination),
-                            escape_review_text(source)
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                env_provenance.sort_unstable();
-                let cwd = server
-                    .cwd
-                    .as_deref()
-                    .map(escape_review_path)
-                    .unwrap_or_else(|| "plugin-root".to_string());
-                let argv = render_review_argv(plugin, &server.args);
-                format!(
-                    "{}: transport=stdio command={} argv=[{}] cwd={cwd} env=[{}] timeouts={} required={} enabled_tools=[{}] disabled_tools=[{}] host-user-filesystem/network-authority {enabled}",
-                    escape_review_text(name),
-                    escape_review_text(command),
-                    argv.join(", "),
-                    if env_provenance.is_empty() { "none".to_string() } else { env_provenance.join(", ") },
-                    render_mcp_timeouts(server),
-                    server.required,
-                    render_review_values(&server.enabled_tools),
-                    render_review_values(&server.disabled_tools),
-                )
-            } else if let Some(url) = server.url.as_deref() {
-                let endpoint = reqwest::Url::parse(url)
-                    .ok()
-                    .map(|url| escape_review_text(url.as_str()))
-                    .unwrap_or_else(|| "invalid-url".to_string());
-                let mut env_headers = server
-                    .env_headers
-                    .iter()
-                    .map(|(header, source)| {
-                        format!(
-                            "{} <- {}",
-                            escape_review_text(header),
-                            escape_review_text(source)
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                env_headers.sort_unstable();
-                let bearer = server
-                    .bearer_token_env_var
-                    .as_deref()
-                    .map(escape_review_text)
-                    .unwrap_or_else(|| "none".to_string());
-                let transport = server.transport.as_deref().unwrap_or(
-                    "streamable-http with same-origin SSE fallback",
-                );
-                format!(
-                    "{}: transport={} endpoint={} redirects=same-origin-only env_headers=[{}] bearer_env={} oauth=disabled timeouts={} required={} enabled_tools=[{}] disabled_tools=[{}] {enabled}",
-                    escape_review_text(name),
-                    escape_review_text(transport),
-                    endpoint,
-                    if env_headers.is_empty() { "none".to_string() } else { env_headers.join(", ") },
-                    bearer,
-                    render_mcp_timeouts(server),
-                    server.required,
-                    render_review_values(&server.enabled_tools),
-                    render_review_values(&server.disabled_tools),
-                )
-            } else {
-                format!("{name}: invalid")
-            }
-        })
+    }
+    detail
+        .mcp_servers
+        .iter()
+        .map(|server| render_mcp_server(server))
         .collect::<Vec<_>>()
         .join("; ")
 }
 
-fn render_review_argv(plugin: &LoadedPlugin, arguments: &[String]) -> Vec<String> {
+fn render_mcp_server(server: &PluginMcpServerDetail) -> String {
+    let enabled = if server.enabled {
+        "configured-on"
+    } else {
+        "configured-off"
+    };
+    if let Some(command) = server.command.as_deref() {
+        let mut env_provenance = server
+            .env
+            .iter()
+            .map(|(destination, source)| {
+                let source = source
+                    .strip_prefix("${")
+                    .and_then(|source| source.strip_suffix('}'))
+                    .unwrap_or("invalid");
+                format!(
+                    "{} <- {}",
+                    escape_review_text(destination),
+                    escape_review_text(source)
+                )
+            })
+            .collect::<Vec<_>>();
+        env_provenance.sort_unstable();
+        let cwd = server
+            .cwd
+            .as_deref()
+            .map(escape_review_path)
+            .unwrap_or_else(|| "plugin-root".to_string());
+        let argv = render_review_argv(server, &server.argv);
+        format!(
+            "{}: transport=stdio command={} argv=[{}] cwd={cwd} env=[{}] timeouts={} required={} enabled_tools=[{}] disabled_tools=[{}] host-user-filesystem/network-authority {enabled}",
+            escape_review_text(&server.name),
+            escape_review_text(command),
+            argv.join(", "),
+            if env_provenance.is_empty() {
+                "none".to_string()
+            } else {
+                env_provenance.join(", ")
+            },
+            render_mcp_timeouts(server),
+            server.required,
+            render_review_values(&server.enabled_tools),
+            render_review_values(&server.disabled_tools),
+        )
+    } else if let Some(url) = server.url.as_deref() {
+        let endpoint = reqwest::Url::parse(url)
+            .ok()
+            .map(|url| escape_review_text(url.as_str()))
+            .unwrap_or_else(|| "invalid-url".to_string());
+        let mut env_headers = server
+            .env_headers
+            .iter()
+            .map(|(header, source)| {
+                format!(
+                    "{} <- {}",
+                    escape_review_text(header),
+                    escape_review_text(source)
+                )
+            })
+            .collect::<Vec<_>>();
+        env_headers.sort_unstable();
+        let bearer = server
+            .bearer_token_env_var
+            .as_deref()
+            .map(escape_review_text)
+            .unwrap_or_else(|| "none".to_string());
+        let transport = transport_label(&server.transport);
+        format!(
+            "{}: transport={} endpoint={} redirects=same-origin-only env_headers=[{}] bearer_env={} oauth=disabled timeouts={} required={} enabled_tools=[{}] disabled_tools=[{}] {enabled}",
+            escape_review_text(&server.name),
+            escape_review_text(transport),
+            endpoint,
+            if env_headers.is_empty() {
+                "none".to_string()
+            } else {
+                env_headers.join(", ")
+            },
+            bearer,
+            render_mcp_timeouts(server),
+            server.required,
+            render_review_values(&server.enabled_tools),
+            render_review_values(&server.disabled_tools),
+        )
+    } else {
+        format!("{}: invalid", server.name)
+    }
+}
+
+fn transport_label(
+    transport: &codewhale_command_contract::facets::PluginMcpTransport,
+) -> &'static str {
+    match transport {
+        codewhale_command_contract::facets::PluginMcpTransport::Stdio => "stdio",
+        codewhale_command_contract::facets::PluginMcpTransport::Http => "http",
+        codewhale_command_contract::facets::PluginMcpTransport::Invalid => "invalid",
+    }
+}
+
+fn render_review_argv(server: &PluginMcpServerDetail, arguments: &[String]) -> Vec<String> {
+    // Portable argv rendering: plugin-path classification requires the
+    // canonical root, which is carried in the detail. Keep the exact
+    // semantics of the legacy renderer.
+    let root = &server.cwd.clone().unwrap_or_default();
     arguments
         .iter()
         .enumerate()
         .map(|(index, argument)| {
             let position = index + 1;
-            let candidate = plugin.canonical_root.join(argument);
+            let candidate = root.join(argument);
             if candidate.exists()
                 && candidate
                     .canonicalize()
-                    .is_ok_and(|path| path.starts_with(&plugin.canonical_root))
+                    .is_ok_and(|path| path.starts_with(root))
             {
                 return format!(
                     "#{position} plugin-path={}",
@@ -249,26 +277,26 @@ fn render_review_values(values: &[String]) -> String {
         .join(", ")
 }
 
-fn render_mcp_timeouts(server: &crate::mcp::McpServerConfig) -> String {
+fn render_mcp_timeouts(server: &PluginMcpServerDetail) -> String {
     format!(
         "connect={}/execute={}/read={}",
         server
-            .connect_timeout
+            .connect_timeout_secs
             .map_or_else(|| "default".to_string(), |value| format!("{value}s")),
         server
-            .execute_timeout
+            .execute_timeout_secs
             .map_or_else(|| "default".to_string(), |value| format!("{value}s")),
         server
-            .read_timeout
+            .read_timeout_secs
             .map_or_else(|| "default".to_string(), |value| format!("{value}s")),
     )
 }
 
-pub(super) fn escape_review_path(path: &Path) -> String {
+pub(crate) fn escape_review_path(path: &Path) -> String {
     escape_review_text(&path.to_string_lossy())
 }
 
-pub(super) fn escape_review_text(value: &str) -> String {
+pub(crate) fn escape_review_text(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len());
     for ch in value.chars() {
         if ch.is_control()
@@ -311,44 +339,18 @@ pub(super) fn escape_review_text(value: &str) -> String {
     escaped
 }
 
-pub(crate) fn review_token(plugin: &LoadedPlugin) -> String {
-    // This is an explicit user confirmation, not cosmetic display text. Bind
-    // the command to both complete SHA-256 receipts so a same-inventory bundle
-    // cannot collide through the former 48-bit content prefix.
-    format!("{}.{}", plugin.content_hash, plugin.capability_hash)
+#[allow(dead_code)]
+fn _diagnostic_level_label(level: PluginDiagnosticLevel) -> &'static str {
+    match level {
+        PluginDiagnosticLevel::Warning => "warning",
+        PluginDiagnosticLevel::Error => "error",
+    }
 }
 
-pub(super) fn append_diagnostics(
-    app: &App,
-    output: &mut String,
-    diagnostics: &[crate::plugins::types::PluginDiagnostic],
-) {
-    if diagnostics.is_empty() {
-        return;
-    }
-    if !output.ends_with('\n') {
-        output.push('\n');
-    }
-    output.push_str(
-        &tr(app.ui_locale, MessageId::CmdPluginBundleDiagnosticsHeader)
-            .replace("{count}", &diagnostics.len().to_string()),
-    );
-    output.push('\n');
-    for diagnostic in diagnostics {
-        let level = match diagnostic.level {
-            PluginDiagnosticLevel::Warning => "warning",
-            PluginDiagnosticLevel::Error => "error",
-        };
-        let path = diagnostic
-            .path
-            .as_deref()
-            .map(|path| format!(" ({})", escape_review_path(path)))
-            .unwrap_or_default();
-        let _ = writeln!(
-            output,
-            "• {level} [{}]: {}{path}",
-            diagnostic.code,
-            escape_review_text(&diagnostic.message)
-        );
-    }
+#[allow(dead_code)]
+fn _diagnostic_path(diagnostic: &PluginDiagnostic) -> Option<String> {
+    diagnostic
+        .path
+        .as_ref()
+        .map(|path| path.display().to_string())
 }

--- a/crates/tui/src/commands/groups/plugins/render.rs
+++ b/crates/tui/src/commands/groups/plugins/render.rs
@@ -311,7 +311,7 @@ pub(super) fn escape_review_text(value: &str) -> String {
     escaped
 }
 
-pub(super) fn review_token(plugin: &LoadedPlugin) -> String {
+pub(crate) fn review_token(plugin: &LoadedPlugin) -> String {
     // This is an explicit user confirmation, not cosmetic display text. Bind
     // the command to both complete SHA-256 receipts so a same-inventory bundle
     // cannot collide through the former 48-bit content prefix.

--- a/crates/tui/src/commands/groups/plugins/tests.rs
+++ b/crates/tui/src/commands/groups/plugins/tests.rs
@@ -97,7 +97,7 @@ fn bare_plugin_command_opens_unified_extensions_modal() {
     let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", root.path().join("home"));
     let (mut app, _temp) = create_test_app(root.path());
 
-    let result = plugins(&mut app, None);
+    let result = plugins_with_kimi_home_override(&mut app, None, None);
 
     assert!(matches!(
         result.action,
@@ -132,11 +132,13 @@ fn list_show_validate_are_read_only_and_label_legacy_tools() {
     let state_path = codewhale_home.join("plugins/state.json");
 
     for arg in [Some("list"), Some("show demo"), Some("validate")] {
-        let result = plugins(&mut app, arg);
+        let result = plugins_with_kimi_home_override(&mut app, arg, None);
         assert!(!result.is_error, "{:?}", result.message);
         assert!(!state_path.exists(), "read-only command wrote plugin state");
     }
-    let list = plugins(&mut app, Some("list")).message.unwrap();
+    let list = plugins_with_kimi_home_override(&mut app, Some("list"), None)
+        .message
+        .unwrap();
     assert!(list.contains("Plugin bundles (1)"));
     assert!(list.contains("disabled"));
     assert!(list.contains("Legacy executable plugin tools (1)"));
@@ -152,14 +154,15 @@ fn suggest_ranks_installed_plugins_without_trusting_or_enabling_them() {
     let (mut app, _temp) = create_test_app(root.path());
 
     for arg in ["suggest", "suggest go"] {
-        let result = plugins(&mut app, Some(arg));
+        let result = plugins_with_kimi_home_override(&mut app, Some(arg), None);
         assert!(
             result.is_error,
             "expected usage error for {arg}: {result:?}"
         );
     }
 
-    let result = plugins(&mut app, Some("suggest spreadsheet import"));
+    let result =
+        plugins_with_kimi_home_override(&mut app, Some("suggest spreadsheet import"), None);
     assert!(!result.is_error, "{result:?}");
     let message = result.message.expect("suggestion message");
     assert!(message.contains("Suggested installed plugins"), "{message}");
@@ -179,7 +182,7 @@ fn trust_requires_content_and_capability_bound_review_token() {
     let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", root.path().join("home"));
     write_bundle(root.path());
     let (mut app, _temp) = create_test_app(root.path());
-    let enable_review = plugins(&mut app, Some("enable demo"));
+    let enable_review = plugins_with_kimi_home_override(&mut app, Some("enable demo"), None);
     assert!(!enable_review.is_error);
     assert!(
         enable_review
@@ -189,7 +192,9 @@ fn trust_requires_content_and_capability_bound_review_token() {
     );
     assert!(!app.plugin_registry.get("demo").unwrap().trusted());
 
-    let review = plugins(&mut app, Some("trust demo")).message.unwrap();
+    let review = plugins_with_kimi_home_override(&mut app, Some("trust demo"), None)
+        .message
+        .unwrap();
     let confirmation = review
         .lines()
         .find(|line| line.starts_with("/plugin trust demo "))
@@ -211,21 +216,21 @@ fn trust_requires_content_and_capability_bound_review_token() {
     );
     assert!(!app.plugin_registry.get("demo").unwrap().trusted());
 
-    assert!(plugins(&mut app, Some("trust demo wrong")).is_error);
+    assert!(plugins_with_kimi_home_override(&mut app, Some("trust demo wrong"), None).is_error);
     let shortened = format!(
         "trust demo {}.{}",
         &content_digest[..12],
         &capability_digest[..12]
     );
     assert!(
-        plugins(&mut app, Some(&shortened)).is_error,
+        plugins_with_kimi_home_override(&mut app, Some(&shortened), None).is_error,
         "the legacy 48-bit content prefix must not authorize trust"
     );
     let arg = confirmation.trim_start_matches("/plugin ");
-    assert!(!plugins(&mut app, Some(arg)).is_error);
-    assert!(!plugins(&mut app, Some("enable demo")).is_error);
+    assert!(!plugins_with_kimi_home_override(&mut app, Some(arg), None).is_error);
+    assert!(!plugins_with_kimi_home_override(&mut app, Some("enable demo"), None).is_error);
     assert!(app.plugin_registry.is_active("demo"));
-    assert!(!plugins(&mut app, Some("disable demo")).is_error);
+    assert!(!plugins_with_kimi_home_override(&mut app, Some("disable demo"), None).is_error);
     assert!(!app.plugin_registry.is_active("demo"));
 }
 
@@ -255,24 +260,30 @@ fn mixed_bundle_review_and_enable_keep_supported_components_active() {
     write_mixed_bundle(root.path());
     let (mut app, _temp) = create_test_app(root.path());
 
-    let list = plugins(&mut app, Some("list")).message.unwrap();
+    let list = plugins_with_kimi_home_override(&mut app, Some("list"), None)
+        .message
+        .unwrap();
     assert!(list.contains("compatibility=partial"), "{list}");
     assert!(list.contains("commands=1"), "{list}");
     assert!(list.contains("hooks=1"), "{list}");
 
-    let show = plugins(&mut app, Some("show mixed")).message.unwrap();
+    let show = plugins_with_kimi_home_override(&mut app, Some("show mixed"), None)
+        .message
+        .unwrap();
     assert!(show.contains("Compatibility: partial"), "{show}");
     assert!(show.contains("Inactive components: [lsp]"), "{show}");
     assert!(show.contains("Active components: [none]"), "{show}");
 
-    let review = plugins(&mut app, Some("trust mixed")).message.unwrap();
+    let review = plugins_with_kimi_home_override(&mut app, Some("trust mixed"), None)
+        .message
+        .unwrap();
     let confirmation = review
         .lines()
         .find(|line| line.starts_with("/plugin trust mixed "))
         .unwrap();
     let arg = confirmation.trim_start_matches("/plugin ");
-    assert!(!plugins(&mut app, Some(arg)).is_error);
-    let enabled = plugins(&mut app, Some("enable mixed"));
+    assert!(!plugins_with_kimi_home_override(&mut app, Some(arg), None).is_error);
+    let enabled = plugins_with_kimi_home_override(&mut app, Some("enable mixed"), None);
     assert!(!enabled.is_error, "{:?}", enabled.message);
     let message = enabled.message.unwrap();
     assert!(message.contains("Compatibility: partial"), "{message}");
@@ -287,7 +298,9 @@ fn mixed_bundle_review_and_enable_keep_supported_components_active() {
         "partial"
     );
 
-    let show = plugins(&mut app, Some("show mixed")).message.unwrap();
+    let show = plugins_with_kimi_home_override(&mut app, Some("show mixed"), None)
+        .message
+        .unwrap();
     assert!(show.contains("State: active"), "{show}");
     assert!(show.contains("Inactive components: [lsp]"), "{show}");
     assert!(
@@ -304,7 +317,7 @@ fn mcp_review_discloses_host_authority_and_names_without_secret_values() {
     let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", root.path().join("home"));
     write_mcp_review_bundle(root.path());
     let (mut app, _temp) = create_test_app(root.path());
-    let review = plugins(&mut app, Some("trust review-mcp"))
+    let review = plugins_with_kimi_home_override(&mut app, Some("trust review-mcp"), None)
         .message
         .expect("review output");
     assert!(review.contains("mcp=2 (stdio=1 remote=1)"));
@@ -331,7 +344,7 @@ fn legacy_tool_detail_remains_available_under_tools_namespace() {
         "# name: greet\n# description: Say hello\n# approval: required\n",
     )
     .unwrap();
-    let result = plugins(&mut app, Some("tools greet"));
+    let result = plugins_with_kimi_home_override(&mut app, Some("tools greet"), None);
     assert!(!result.is_error);
     let message = result.message.unwrap();
     assert!(message.contains("Say hello"));
@@ -345,10 +358,10 @@ fn install_update_uninstall_verbs_validate_arguments() {
     let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", root.path().join("home"));
     let (mut app, _temp) = create_test_app(root.path());
     for arg in ["install", "update", "uninstall"] {
-        let result = plugins(&mut app, Some(arg));
+        let result = plugins_with_kimi_home_override(&mut app, Some(arg), None);
         assert!(result.is_error, "bare `{arg}` must print usage");
     }
-    let invalid = plugins(&mut app, Some("install github:"));
+    let invalid = plugins_with_kimi_home_override(&mut app, Some("install github:"), None);
     assert!(invalid.is_error);
     assert!(
         invalid
@@ -381,7 +394,11 @@ fn install_update_uninstall_verbs_drive_the_guided_trust_flow() {
         .build()
         .unwrap();
     runtime.block_on(async {
-        let installed = plugins(&mut app, Some(&format!("install {}", source.display())));
+        let installed = plugins_with_kimi_home_override(
+            &mut app,
+            Some(&format!("install {}", source.display())),
+            None,
+        );
         assert!(!installed.is_error, "{:?}", installed.message);
         let message = installed.message.unwrap();
         assert!(message.contains("disabled and untrusted"), "{message}");
@@ -399,21 +416,29 @@ fn install_update_uninstall_verbs_drive_the_guided_trust_flow() {
         );
 
         // Local-path installs cannot be updated from the network.
-        let update = plugins(&mut app, Some("update installed-demo"));
+        let update = plugins_with_kimi_home_override(&mut app, Some("update installed-demo"), None);
         assert!(update.is_error);
         assert!(update.message.unwrap().contains("local path"));
 
         let arg = confirmation.trim_start_matches("/plugin ").to_string();
-        assert!(!plugins(&mut app, Some(&arg)).is_error);
-        assert!(!plugins(&mut app, Some("enable installed-demo")).is_error);
+        assert!(!plugins_with_kimi_home_override(&mut app, Some(&arg), None).is_error);
+        assert!(
+            !plugins_with_kimi_home_override(&mut app, Some("enable installed-demo"), None)
+                .is_error
+        );
         assert!(app.plugin_registry.is_active("installed-demo"));
 
         // Uninstall requires disabled, then removes bits and prunes state.
-        let refused = plugins(&mut app, Some("uninstall installed-demo"));
+        let refused =
+            plugins_with_kimi_home_override(&mut app, Some("uninstall installed-demo"), None);
         assert!(refused.is_error);
         assert!(codewhale_home.join("plugins/installed-demo").exists());
-        assert!(!plugins(&mut app, Some("disable installed-demo")).is_error);
-        let removed = plugins(&mut app, Some("uninstall installed-demo"));
+        assert!(
+            !plugins_with_kimi_home_override(&mut app, Some("disable installed-demo"), None)
+                .is_error
+        );
+        let removed =
+            plugins_with_kimi_home_override(&mut app, Some("uninstall installed-demo"), None);
         assert!(!removed.is_error, "{:?}", removed.message);
         assert!(!codewhale_home.join("plugins/installed-demo").exists());
         assert!(app.plugin_registry.get("installed-demo").is_none());
@@ -456,7 +481,9 @@ fn kimi_managed_import_is_read_only_until_hash_bound_approval() {
     .unwrap();
 
     let (mut app, _temp) = create_test_app(root.path());
-    let help = plugins(&mut app, Some("help")).message.unwrap();
+    let help = plugins_with_kimi_home_override(&mut app, Some("help"), None)
+        .message
+        .unwrap();
     assert!(help.contains("/plugin import kimi [list]"), "{help}");
     let listed = plugins_with_kimi_home(&mut app, Some("import kimi"), root.path());
     assert!(!listed.is_error, "{:?}", listed.message);
@@ -573,12 +600,12 @@ fn export_verb_writes_agent_plugins_bundle() {
     write_bundle(root.path());
     let (mut app, _temp) = create_test_app(root.path());
 
-    let usage = plugins(&mut app, Some("export"));
+    let usage = plugins_with_kimi_home_override(&mut app, Some("export"), None);
     assert!(usage.is_error, "export without arguments is a usage error");
-    let missing = plugins(&mut app, Some("export nope out"));
+    let missing = plugins_with_kimi_home_override(&mut app, Some("export nope out"), None);
     assert!(missing.is_error, "exporting an unknown plugin fails");
 
-    let result = plugins(&mut app, Some("export demo exported/demo"));
+    let result = plugins_with_kimi_home_override(&mut app, Some("export demo exported/demo"), None);
     assert!(!result.is_error, "{result:?}");
     let message = result.message.expect("export message");
     assert!(message.contains("Exported `demo`"), "{message}");

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -1888,6 +1888,8 @@ mod tests {
             // FEAT-019 memory group.
             "note",
             "memory",
+            // FEAT-020 plugins group.
+            "plugin",
         ];
         for info in command_infos() {
             if info.name == "feat015ctx" || MIGRATED.contains(&info.name) {
@@ -2143,6 +2145,117 @@ mod tests {
             let result = execute(command, &mut app);
             // Every path returns a result; none may panic.
             assert!(result.message.is_some(), "{command}: {result:?}");
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // FEAT-020 plugins group public dispatch (Phase 6)
+    // ---------------------------------------------------------------------
+
+    /// App with an isolated temp workspace and a discovered plugin bundle.
+    fn plugin_test_app(tmpdir: &tempfile::TempDir) -> App {
+        // Write a minimal plugin bundle so the registry discovers real data.
+        let bundle = tmpdir.path().join(".codewhale/plugins/demo");
+        std::fs::create_dir_all(bundle.join("skills/hello")).unwrap();
+        std::fs::write(
+            bundle.join("plugin.toml"),
+            "schema_version = 1\n[plugin]\nname = \"demo\"\nversion = \"1.0.0\"\ndescription = \"Import spreadsheet data safely\"\n[skills]\npath = \"skills\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            bundle.join("skills/hello/SKILL.md"),
+            "---\nname: hello\ndescription: hello\n---\nbody\n",
+        )
+        .unwrap();
+        let options = TuiOptions {
+            ..crate::test_support::test_tui_options(tmpdir.path())
+        };
+        let mut app = App::new(options, &Config::default());
+        let discovery = crate::plugins::PluginDiscoveryContext::capture_pre_dotenv();
+        app.plugin_registry = discovery.registry_for_workspace(tmpdir.path());
+        app
+    }
+
+    #[test]
+    fn feat020_plugin_entry_is_registered_with_exact_capabilities() {
+        let name = "plugin";
+        assert!(
+            registry().has_contextual_handler(name),
+            "/{name} must register through the portable bridge"
+        );
+        let handler = registry()
+            .get(name)
+            .expect("entry")
+            .contextual_handler()
+            .expect("contextual handler");
+        let codewhale_command_contract::handler::CommandHandler::Contextual {
+            capabilities, ..
+        } = handler
+        else {
+            panic!("/{name} must be contextual");
+        };
+        let expected = codewhale_command_contract::handler::CommandCapabilities::WORKSPACE
+            .union(codewhale_command_contract::handler::CommandCapabilities::PRESENTATION)
+            .union(codewhale_command_contract::handler::CommandCapabilities::PLUGIN);
+        assert_eq!(capabilities, expected, "/{name} exact capability set");
+        // Undeclared facets stay absent.
+        assert!(
+            !capabilities.contains(codewhale_command_contract::handler::CommandCapabilities::MEDIA)
+        );
+        assert!(
+            !capabilities
+                .contains(codewhale_command_contract::handler::CommandCapabilities::MEMORY)
+        );
+        assert!(
+            !capabilities
+                .contains(codewhale_command_contract::handler::CommandCapabilities::SKILLS)
+        );
+    }
+
+    #[test]
+    fn feat020_plugin_dispatches_through_public_seam() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let mut app = plugin_test_app(&tmpdir);
+
+        // Bare action opens the extensions view (no panic).
+        let bare = execute("/plugin", &mut app);
+        assert!(bare.action.is_some(), "{bare:?}");
+
+        // List reaches the real adapter through the public seam.
+        let list = execute("/plugin list", &mut app);
+        assert!(!list.is_error, "{list:?}");
+        let msg = list.message.expect("list message");
+        assert!(msg.contains("demo"), "{msg}");
+
+        // Metadata bridges to the TUI localization id.
+        let info = registry().get_info("plugin").expect("plugin info");
+        assert_eq!(
+            info.description_id,
+            crate::localization::MessageId::CmdPluginDescription
+        );
+    }
+
+    #[test]
+    fn feat020_public_dispatch_never_panics_on_plugin_commands() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let mut app = plugin_test_app(&tmpdir);
+        for command in [
+            "/plugin",
+            "/plugin ",
+            "/plugin list",
+            "/plugin show nope",
+            "/plugin validate",
+            "/plugin tools",
+            "/plugin marketplace",
+            "/plugin import kimi",
+            "/plugin suggest",
+        ] {
+            let result = execute(command, &mut app);
+            // Every path returns a result; none may panic.
+            assert!(
+                result.message.is_some() || result.action.is_some(),
+                "{command}: {result:?}"
+            );
         }
     }
 }

--- a/scripts/command-migration-topology.json
+++ b/scripts/command-migration-topology.json
@@ -282,7 +282,6 @@
     "config",
     "core",
     "debug",
-    "plugins",
     "project",
     "session",
     "skills"

--- a/scripts/test_check_command_migration_manifest.py
+++ b/scripts/test_check_command_migration_manifest.py
@@ -362,12 +362,12 @@ class LiveGateTests(unittest.TestCase):
         frontier = doc["frontier"]
         self.assertEqual(frontier, sorted(frontier))
         self.assertEqual(len(frontier), len(set(frontier)))
-        # FEAT-018 removed the utility group and FEAT-019 removed the memory
-        # group from the frontier (Stage B slices); the remaining seven groups
-        # stay pending.
+        # FEAT-018 removed the utility group, FEAT-019 removed the memory
+        # group, and FEAT-020 removed the plugins group from the frontier
+        # (Stage B slices); the remaining six groups stay pending.
         self.assertEqual(
             set(frontier),
-            {"plugins", "project", "skills", "session", "config", "debug", "core"},
+            {"project", "skills", "session", "config", "debug", "core"},
         )
 
 


### PR DESCRIPTION
## Summary

FEAT-020 converts the TUI plugins command group (`/plugin`, alias `plugins`) to the external command shapes introduced by FEAT-014 and hosted by FEAT-015, following the pattern FEAT-018 (utility) and FEAT-019 (memory) established. The command files remain under `codewhale-tui`; this PR changes their execution boundary without physically moving them.

**Baseline:** the implementation is built on the v0.9.12 integration branch (`codex/v0912-integration-20260823`, `96bc9e79c`), where FEAT-019 landed and the plugins group gained the marketplace and Kimi managed-import verbs. Those verbs joined the FEAT-020 scope per the migration rule ("every production command then present in that group joins the FEAT-020 scope").

This PR:

- adds the contract-owned `CommandPluginContext` facet with **exact-minimum typed delegates**: registry reads (`summaries`, `detail`, `registry_diagnostics`, `validation_is_clean`, `len`, `is_empty`, `state_path`, `suggest`), registry mutations (`reload`/rediscover + skill-cache, `trust`/`enable`/`disable`/`revoke_trust`), async-bridged bundle mutations returning synchronous portable receipts (`install`, `update`, `uninstall`, `uninstall_path` rollback, `export`, `legacy_scan`, Kimi `managed_scan`/`managed_install`, marketplace `marketplace_state`/`marketplace_add`/`marketplace_remove`/`marketplace_install`) and the `PLUGIN = 1 << 10` capability bit with one envelope slot;
- converts the complete `/plugin` dispatch, `render` helpers, legacy-tools scan, Kimi managed import, and marketplace operations to portable contract values — 19 structured DTOs, byte-identical output preserved;
- registers `/plugin` via `ContextualCommand::from_contract` with the exact `WORKSPACE | PRESENTATION | PLUGIN` capability set (no `SKILLS`: skill-cache refresh and active-skill resets happen host-side in the adapter);
- maps all plugin catalog messages to stable keys through the presentation facet (`key_to_plugin_message_id`), with `description_key: "cmd_plugin_description"` and authoritative English fallback;
- removes `plugins` from **both** migration-frontier representations atomically;
- preserves names, aliases, usage strings, registry order, messages, diagnostics, review tokens, network approval/denial text, and safety checks byte-for-byte.

Tracking: EPIC-006 / FEAT-020 in umbrella [Hmbown/CodeWhale#5316](https://github.com/Hmbown/CodeWhale/issues/5316).

## Dependency boundary

The intended dependency direction remains acyclic:

```text
future codewhale-commands plugins group
                 |
                 v
codewhale-command-contract ---> codewhale-core / other acyclic leaf crates
                 ^
                 |
codewhale-tui implements the host facets
```

`/plugin` handlers no longer name or call concrete `App`, `PluginRegistry`, `crate::plugins`, or `Config`; the plugin facet delegates to the TUI-owned services through the adapter. The capability-driven dispatcher populates only declared slots.

## Review hardening (PR #5525 lessons + post-completion audit)

- Missing required facets return `Command capability unavailable: <facet>` — zero `.expect()` in production handlers.
- **D1 fix:** the Kimi content-hash-mismatch rollback previously called `crate::plugins::install::uninstall` directly from the portable handler; it now crosses the boundary through the new `CommandPluginContext::uninstall_path` facet method, and the host adapter owns the `crate::plugins` call.
- Facet-count doc comments refreshed to eleven slots; preservation proven by parity tests with exact-string evidence.

## Scope and behavior

- Only `groups/plugins` is migrated (one production command: `/plugin`).
- No command file moves out of `codewhale-tui`; no shared result/action ownership moves (FEAT-037); `CommandResult` and `AppAction` remain bounded temporary data references.
- No localization system extraction occurs (FEAT-036); the presentation facet maps existing `MessageId`s.
- Names, aliases, usage strings, registry order, help/palette discovery, messages, parsing, review-token semantics, marketplace/Kimi behavior, and safety checks remain unchanged.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-command-contract --lib --locked` — 23 passed
- [x] `cargo test -p codewhale-tui --lib --locked` plugins-scoped — 205 passed; full TUI lib 11,394 passed / 0 failed at completion
- [x] `python3 scripts/test_check_command_crate_boundaries.py` — 8 passed
- [x] `python3 scripts/check-command-migration-manifest.py --baseline-ref origin/codex/v0912-integration-20260823` — PASS (`plugins` absent from both frontier representations)
- [x] `python3 scripts/test_check_command_migration_manifest.py` — 54 passed
- [x] Strict workspace Clippy with `-D warnings` — 0 warnings
- [x] `git diff --check`

## Checklist

- [x] Only `/plugin` migrated; zero concrete-`App` / `PluginRegistry` / `crate::plugins` / `Config` handler dependencies
- [x] `CommandPluginContext` is the only new plugin-specific host facet; `PLUGIN` = `1 << 10`
- [x] `/plugin` declares exactly `WORKSPACE | PRESENTATION | PLUGIN`; no other facets
- [x] Typed signatures and contract-owned result shapes for every operation
- [x] Existing user-facing output byte-identical (parity tests with exact-string evidence)
- [x] `plugins` removed from both migration-frontier representations
- [x] Rollback routed through the facet (D1); host-helper extraction tracked for the FEAT-040 move
- [x] Dispatcher exposes only declared facets; missing facets fail safely
- [x] No manual UI verification required for this structural change

## CI status

The base is the `codex/v0912-integration-20260823` branch (where FEAT-019 landed and the plugins
group's marketplace/Kimi verbs live); the repo's `ci.yml` triggers only on `master`/`main`-targeted
PRs, so the full Actions matrix does not run here. Lightweight cross-repo checks (DCO, link,
GitGuardian, contribution gate) are green, and the full matrix was verified locally with the exact
configured gates: TUI lib 11,394/0, contract 23/23, boundary 8/8 + live, migration 54/54 + live
scan, strict workspace Clippy `-D warnings` 0, `cargo fmt --check`. The matrix will run on this
branch when the v0.9.12 integration branch reaches `main`.

No-Issue: FEAT-020 is tracked in umbrella #5316, which must remain open for the remaining decomposition FEATs.

Paulo Aboim Pinto