### PR TITLE
fix(tui): nudge /plugin reload when on-disk bundles change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `/plugin reload` is now discoverable when on-disk plugin bundles change: the
+  next send and `/plugin list` nudge once with `Run /plugin reload to apply`
+  instead of silently keeping the stale catalog (#5579). Trust is unchanged;
+  this does not auto-reload.
 - Context-pressure warnings and critical alerts now remain visible in sticky UI
   status until compaction or explicit dismissal, instead of disappearing into
   scrolling turn metadata (#5620).

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -72,6 +72,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `/plugin reload` is now discoverable when on-disk plugin bundles change: the
+  next send and `/plugin list` nudge once with `Run /plugin reload to apply`
+  instead of silently keeping the stale catalog (#5579). Trust is unchanged;
+  this does not auto-reload.
 - Context-pressure warnings and critical alerts now remain visible in sticky UI
   status until compaction or explicit dismissal, instead of disappearing into
   scrolling turn metadata (#5620).

--- a/crates/tui/src/commands/groups/plugins/mod.rs
+++ b/crates/tui/src/commands/groups/plugins/mod.rs
@@ -243,7 +243,7 @@ fn suggest_bundles(app: &App, task: &str) -> CommandResult {
     CommandResult::message(output)
 }
 
-fn list_bundles_and_legacy_tools(app: &App) -> CommandResult {
+fn list_bundles_and_legacy_tools(app: &mut App) -> CommandResult {
     let mut output = {
         let registry = app.plugin_registry.as_ref();
         let plugins = registry.list();
@@ -289,6 +289,14 @@ fn list_bundles_and_legacy_tools(app: &App) -> CommandResult {
                 escape_review_path(&path)
             );
         }
+    }
+
+    if let Some(nudge) = crate::plugins::plugin_reload_nudge(
+        app.plugin_registry.as_ref(),
+        &mut app.plugin_reload_nudge_stamp,
+    ) {
+        output.push('\n');
+        output.push_str(nudge);
     }
 
     CommandResult::message(output)

--- a/crates/tui/src/plugins/context.rs
+++ b/crates/tui/src/plugins/context.rs
@@ -129,6 +129,19 @@ impl PluginDiscoveryContext {
     pub fn user_plugins_dir(&self) -> &Path {
         &self.user_plugins_dir
     }
+
+    #[must_use]
+    pub fn catalog_stamp_for_workspace(
+        &self,
+        workspace: &Path,
+    ) -> super::discovery::PluginCatalogStamp {
+        let mut roots = vec![
+            self.user_plugins_dir.clone(),
+            super::discovery::default_workspace_plugins_dir(workspace),
+        ];
+        roots.extend(self.builtin_plugin_dirs.iter().cloned());
+        super::discovery::PluginCatalogStamp::capture(roots)
+    }
 }
 
 #[cfg(test)]

--- a/crates/tui/src/plugins/discovery.rs
+++ b/crates/tui/src/plugins/discovery.rs
@@ -1,6 +1,7 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use sha2::{Digest, Sha256};
 
@@ -20,6 +21,40 @@ pub struct DiscoveryConfig {
     pub workspace_plugins_dir: PathBuf,
     pub builtin_plugin_dirs: Vec<PathBuf>,
     pub state_path: PathBuf,
+}
+
+/// Cheap on-disk catalog fingerprint: plugin-bundle directories only.
+///
+/// Used to nudge `/plugin reload` when a bundle appears, disappears, or is
+/// rewritten without consulting process environment or auto-applying trust.
+/// `state.json` writes are ignored so enable/trust does not look like a
+/// catalog change.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PluginCatalogStamp {
+    entries: BTreeMap<PathBuf, Option<SystemTime>>,
+}
+
+impl PluginCatalogStamp {
+    #[must_use]
+    pub fn capture(roots: impl IntoIterator<Item = PathBuf>) -> Self {
+        let mut entries = BTreeMap::new();
+        for root in roots {
+            let Ok(read) = fs::read_dir(&root) else {
+                continue;
+            };
+            for entry in read.flatten() {
+                let path = entry.path();
+                let Ok(metadata) = fs::symlink_metadata(&path) else {
+                    continue;
+                };
+                if metadata_is_link_or_reparse(&metadata) || !metadata.is_dir() {
+                    continue;
+                }
+                entries.insert(path, metadata.modified().ok());
+            }
+        }
+        Self { entries }
+    }
 }
 
 #[must_use]

--- a/crates/tui/src/plugins/mod.rs
+++ b/crates/tui/src/plugins/mod.rs
@@ -20,5 +20,25 @@ pub(crate) mod test_fixture;
 mod tests;
 
 pub use context::{HostEnvironment, PluginDiscoveryContext};
+pub use discovery::PluginCatalogStamp;
 pub(crate) use path_identity::metadata_is_link_or_reparse;
 pub use registry::PluginRegistry;
+
+pub const PLUGIN_RELOAD_NUDGE: &str = "Plugins changed on disk. Run /plugin reload to apply.";
+
+/// Returns the reload nudge once per distinct on-disk catalog stamp.
+#[must_use]
+pub fn plugin_reload_nudge(
+    registry: &PluginRegistry,
+    last_nudged: &mut Option<PluginCatalogStamp>,
+) -> Option<&'static str> {
+    if !registry.on_disk_catalog_changed() {
+        return None;
+    }
+    let live = registry.live_catalog_stamp();
+    if last_nudged.as_ref() == Some(&live) {
+        return None;
+    }
+    *last_nudged = Some(live);
+    Some(PLUGIN_RELOAD_NUDGE)
+}

--- a/crates/tui/src/plugins/registry.rs
+++ b/crates/tui/src/plugins/registry.rs
@@ -68,6 +68,7 @@ pub struct PluginRegistry {
     state_error: Option<String>,
     workspace: PathBuf,
     discovery_context: Option<std::sync::Arc<super::context::PluginDiscoveryContext>>,
+    catalog_stamp: super::discovery::PluginCatalogStamp,
 }
 
 impl PluginRegistry {
@@ -104,6 +105,10 @@ impl PluginRegistry {
                 (PluginStateFile::default(), Some(error))
             }
         };
+        let catalog_stamp = discovery_context
+            .as_ref()
+            .map(|context| context.catalog_stamp_for_workspace(&workspace))
+            .unwrap_or_default();
         let mut registry = Self {
             plugins: BTreeMap::new(),
             names: BTreeMap::new(),
@@ -113,6 +118,7 @@ impl PluginRegistry {
             state_error,
             workspace,
             discovery_context,
+            catalog_stamp,
         };
         for plugin in plugins {
             registry.register_loaded(plugin);
@@ -181,6 +187,27 @@ impl PluginRegistry {
     /// Re-discover for a new workspace using the immutable pre-dotenv roots
     /// and environment. Registries without a context are test/ad-hoc values
     /// and remain fail-closed instead of consulting ambient process state.
+    #[must_use]
+    pub fn catalog_stamp(&self) -> &super::discovery::PluginCatalogStamp {
+        &self.catalog_stamp
+    }
+
+    #[must_use]
+    pub fn live_catalog_stamp(&self) -> super::discovery::PluginCatalogStamp {
+        self.discovery_context
+            .as_ref()
+            .map_or_else(super::discovery::PluginCatalogStamp::default, |context| {
+                context.catalog_stamp_for_workspace(&self.workspace)
+            })
+    }
+
+    /// True when a plugin bundle directory has appeared, vanished, or been
+    /// rewritten since this registry was last discovered. Does not auto-reload.
+    #[must_use]
+    pub fn on_disk_catalog_changed(&self) -> bool {
+        self.discovery_context.is_some() && self.live_catalog_stamp() != self.catalog_stamp
+    }
+
     #[must_use]
     pub fn rediscover_for_workspace(&self, workspace: &Path) -> std::sync::Arc<Self> {
         self.discovery_context.as_ref().map_or_else(

--- a/crates/tui/src/plugins/tests.rs
+++ b/crates/tui/src/plugins/tests.rs
@@ -32,6 +32,43 @@ fn write_named_plugin(config: &DiscoveryConfig, name: &str, extra: &str) -> Path
 }
 
 #[test]
+fn on_disk_catalog_change_nudges_reload_once_until_rediscover() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = config(tmp.path());
+    write_plugin(&config, "");
+
+    let registry = discover_with_config(&config);
+    assert!(
+        !registry.on_disk_catalog_changed(),
+        "fresh discovery must match the on-disk stamp"
+    );
+
+    let mut last_nudged = None;
+    assert!(
+        crate::plugins::plugin_reload_nudge(&registry, &mut last_nudged).is_none(),
+        "unchanged catalog must not nudge"
+    );
+
+    write_named_plugin(&config, "extra", "");
+    assert!(
+        registry.on_disk_catalog_changed(),
+        "a new bundle directory is a catalog change"
+    );
+    assert_eq!(
+        crate::plugins::plugin_reload_nudge(&registry, &mut last_nudged),
+        Some(crate::plugins::PLUGIN_RELOAD_NUDGE)
+    );
+    assert!(
+        crate::plugins::plugin_reload_nudge(&registry, &mut last_nudged).is_none(),
+        "the same unseen catalog must nudge only once"
+    );
+
+    let reloaded = registry.rediscover_for_workspace(&config.workspace);
+    assert!(!reloaded.on_disk_catalog_changed());
+    assert!(crate::plugins::plugin_reload_nudge(&reloaded, &mut last_nudged).is_none());
+}
+
+#[test]
 fn trust_and_enablement_are_separate_atomic_state_transitions() {
     let tmp = tempfile::tempdir().unwrap();
     let config = config(tmp.path());

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1290,6 +1290,8 @@ pub struct App {
     /// the operator explicitly dismisses its sticky warning. Reset when the
     /// pressure falls below the warning threshold or compaction starts.
     pub context_pressure_warning_dismissed: Option<crate::context_budget::PressureLevel>,
+    /// Last on-disk plugin catalog stamp we already nudged `/plugin reload` for.
+    pub plugin_reload_nudge_stamp: Option<crate::plugins::PluginCatalogStamp>,
     pub model: String,
     /// Persisted model selections by provider name. Loaded from settings so
     /// `/model` and the picker can surface saved provider-specific choices.

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -754,6 +754,7 @@ impl App {
             sticky_status: None,
             last_status_message_seen: None,
             context_pressure_warning_dismissed: None,
+            plugin_reload_nudge_stamp: None,
             model,
             provider_models,
             enabled_provider_models,

--- a/crates/tui/src/tui/ui/dispatch.rs
+++ b/crates/tui/src/tui/ui/dispatch.rs
@@ -848,6 +848,12 @@ pub(crate) fn build_dispatch_success_closure(
             ));
 
             maybe_warn_context_pressure_for_config(app, &outcome.turn_compaction);
+            if let Some(message) = crate::plugins::plugin_reload_nudge(
+                app.plugin_registry.as_ref(),
+                &mut app.plugin_reload_nudge_stamp,
+            ) {
+                app.push_status_toast(message, StatusToastLevel::Warning, Some(8_000));
+            }
             app.session.last_prompt_tokens = None;
             app.session.last_completion_tokens = None;
             app.session.last_output_throughput = None;


### PR DESCRIPTION
## Summary

First slice of #5579 (reload discoverability). `/plugin reload` already existed; nothing told the operator when a bundle appeared, vanished, or was rewritten on disk.

This PR:

- fingerprints plugin-bundle directories (user, workspace, builtin) at discovery time;
- ignores `state.json` writes so trust/enable does not look like a catalog change;
- does **not** auto-reload — trust stays review-gated;
- toasts once per unseen catalog stamp on the next send, and appends the same nudge to `/plugin list`.

Out of scope: proactive in-context recommendations, ranking quality, file-watch, and skill-invocation parity. Those remain on #5579.

Does not close #5579.

## Testing

- [x] `cargo fmt` on the touched files
- [x] `git diff --check`
- [x] `scripts/dev-test.sh tui on_disk_catalog_change_nudges_reload_once_until_rediscover` — 1 passed

No provider credentials or network access.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address