### PR TITLE
fix(tui): make context pressure an agent directive

### DIFF
--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -26,6 +26,7 @@ Mr-Moon121 = Jeffrey Luna <56358802+Mr-Moon121@users.noreply.github.com>
 lerugray = Ray Weiss <15095329+lerugray@users.noreply.github.com>
 lerugray@gmail.com = Ray Weiss <15095329+lerugray@users.noreply.github.com>
 reidliu41 = reidliu41 <61492567+reidliu41@users.noreply.github.com>
+ronohara = ronohara <4027321+ronohara@users.noreply.github.com>
 reid201711@gmail.com = reidliu41 <61492567+reidliu41@users.noreply.github.com>
 ousamabenyounes = Ben Younes <2910651+ousamabenyounes@users.noreply.github.com>
 benyounes.ousama@gmail.com = Ben Younes <2910651+ousamabenyounes@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Context-pressure warnings and critical alerts now remain visible in sticky UI
   status until compaction or explicit dismissal, instead of disappearing into
   scrolling turn metadata (#5620).
+- Context-pressure turn metadata is now an explicit agent directive: tell the
+  user immediately, recommend `/compact`, and reduce scope. The constitution
+  names that standing reaction; the live line stays byte-stable within each
+  pressure band so ordinary turns do not bust the prefix cache (#5620).
 - The Runtime thread store defaults to a per-session root
   (`$CODEWHALE_HOME/sessions/<id>/runtime`) so multiple Codewhale processes on
   one machine no longer share one owner lock (#5630). The exclusive lock is

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -75,6 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Context-pressure warnings and critical alerts now remain visible in sticky UI
   status until compaction or explicit dismissal, instead of disappearing into
   scrolling turn metadata (#5620).
+- Context-pressure turn metadata is now an explicit agent directive: tell the
+  user immediately, recommend `/compact`, and reduce scope. The constitution
+  names that standing reaction; the live line stays byte-stable within each
+  pressure band so ordinary turns do not bust the prefix cache (#5620).
 - The Runtime thread store defaults to a per-session root
   (`$CODEWHALE_HOME/sessions/<id>/runtime`) so multiple Codewhale processes on
   one machine no longer share one owner lock (#5630). The exclusive lock is

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -89,13 +89,16 @@ const GOAL_CONTINUATION_FAILURE_DETAIL_MAX_BYTES: usize = 512;
 const PLAN_SHELL_NETWORK_DENIED_HINT: &str = "Shell command blocked: Plan mode runs shell commands in a read-only sandbox — no writes, no network. Use Act mode (`/mode act`) for any command that creates or modifies files, or that needs network access.";
 
 fn context_pressure_message(usage_percent: f64) -> Option<&'static str> {
+    // Byte-stable within each pressure band so ordinary turns do not bust the
+    // prefix cache. The constitution names the standing reaction; this line is
+    // the live, append-only signal that the band is active (#5620).
     if usage_percent >= crate::tui::context_inspector::CONTEXT_CRITICAL_THRESHOLD_PERCENT {
         Some(
-            "Context pressure: critical — CRITICAL: stop expanding scope; run /compact immediately or finish the current task",
+            "Context pressure: critical — ACTIONABLE: tell the user now; run /compact immediately or finish the current task; stop expanding scope",
         )
     } else if usage_percent >= crate::tui::context_inspector::CONTEXT_WARNING_THRESHOLD_PERCENT {
         Some(
-            "Context pressure: warning — ESCALATED: prefer /compact, narrow scope, or finish the current task",
+            "Context pressure: warning — ACTIONABLE: tell the user now; recommend /compact; then narrow scope or finish the current task",
         )
     } else {
         None

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -16126,8 +16126,8 @@ fn turn_metadata_surfaces_goal_budget_only_while_goal_active() {
 
 #[test]
 fn context_pressure_message_emits_only_at_warning_and_critical_thresholds() {
-    const WARNING: &str = "Context pressure: warning — ESCALATED: prefer /compact, narrow scope, or finish the current task";
-    const CRITICAL: &str = "Context pressure: critical — CRITICAL: stop expanding scope; run /compact immediately or finish the current task";
+    const WARNING: &str = "Context pressure: warning — ACTIONABLE: tell the user now; recommend /compact; then narrow scope or finish the current task";
+    const CRITICAL: &str = "Context pressure: critical — ACTIONABLE: tell the user now; run /compact immediately or finish the current task; stop expanding scope";
 
     assert_eq!(context_pressure_message(84.99), None);
     assert_eq!(context_pressure_message(85.0), Some(WARNING));
@@ -16138,6 +16138,8 @@ fn context_pressure_message_emits_only_at_warning_and_critical_thresholds() {
     // Threshold labels steer a decision without exposing a continuously
     // changing percentage, token count, or headroom value.
     for line in [WARNING, CRITICAL] {
+        assert!(line.contains("tell the user now"), "{line}");
+        assert!(line.contains("/compact"), "{line}");
         assert!(!line.contains('%'), "{line}");
         assert!(!line.contains("tokens"), "{line}");
         assert!(!line.contains("headroom"), "{line}");

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -1610,6 +1610,9 @@ mod tests {
             "### Truthful completion",
             "### Put guarantees in mechanism",
             "### Whose word wins",
+            "When turn metadata includes a Context pressure warning or critical line",
+            "tell the user immediately, recommend",
+            "`/compact`",
         ] {
             assert!(
                 BASE_PROMPT.contains(phrase),

--- a/crates/tui/src/prompts/text.rs
+++ b/crates/tui/src/prompts/text.rs
@@ -68,6 +68,11 @@ prohibitions stay binding; convenience creates no exception. If a gate blocks
 the request, name it and ask; never route around it or claim prose granted
 authority the runtime withheld.
 
+When turn metadata includes a Context pressure warning or critical line, treat
+it as an actionable runtime signal: tell the user immediately, recommend
+`/compact` (or finish the current task), and reduce output scope. Do not wait
+to be asked.
+
 ### Truthful completion
 Nothing is done until checked. Read test output, not only exit status; confirm
 the change landed and say what was not verified. External actions are not complete until


### PR DESCRIPTION
## Summary

Second slice of #5620. Isabel's display-only sticky warning is already on `main` (#5629). The remaining failure was that the model-facing line still read like decorative turn metadata, so the agent kept working until the user asked whether the warning existed.

This PR:

- names the standing reaction in `BASE_PROMPT` (frozen KV-cache prefix): when turn metadata includes a Context pressure warning or critical line, tell the user immediately, recommend `/compact`, and reduce scope;
- makes the live `turn_meta` line an explicit `ACTIONABLE: tell the user now` directive;
- keeps the line byte-stable within each pressure band (no percentages, token counts, or headroom), so ordinary turns do not bust the prefix cache.

Does not close #5620: structured `context_pressure` fields and prompt-injection economisation remain follow-up.

Credit: report and recovery notes from @ronohara; display slice already landed as #5629 by @wuisabel-gif.

## Testing

- [x] `cargo fmt` on the touched files
- [x] `git diff --check`
- [x] `scripts/dev-test.sh tui context_pressure_message_emits base_prompt_carries_constitutional_core` — 2 passed

No provider credentials or network access.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address