### PR TITLE
perf: trim process startup, diagnostic dispatch, and foreground command latency

### DIFF
--- a/crates/config/src/catalog.rs
+++ b/crates/config/src/catalog.rs
@@ -32,6 +32,7 @@
 //! [`ProviderCatalogCache`] tests).
 
 use std::collections::BTreeMap;
+use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -186,16 +187,30 @@ impl CatalogOffering {
 /// honesty rule on omitted pricing (`UnknownOrStale`, never a fabricated zero).
 pub const BUNDLED_MODELS_DEV_JSON: &str = include_str!("../assets/models_dev.bundled.json");
 
+/// Parse-once cache for the committed bundled Models.dev snapshot.
+///
+/// The bundled asset is compile-time constant (`include_str!`), so its parsed
+/// form is immutable and safe to share process-wide. Before this cache, every
+/// call site parsed the full snapshot independently — the client route path,
+/// pickers, provider lake, and fleet identity each paid a full serde parse of
+/// ~50KB on their own first use (perf-attributed during the 0.9.x perf
+/// gauntlet: `ModelsDevCost` serde frames in startup profiles).
+static BUNDLED_MODELS_DEV_CATALOG: OnceLock<ModelsDevCatalog> = OnceLock::new();
+
 /// Parse the committed bundled Models.dev snapshot.
+///
+/// The first call parses; later calls return the shared parsed catalog.
 ///
 /// # Panics
 /// Panics only if the committed asset is not valid Models.dev JSON. The
 /// `tests::bundled_asset_parses` guard makes that a build-time failure, so this
 /// never panics in shipped builds.
 #[must_use]
-pub fn bundled_models_dev_catalog() -> ModelsDevCatalog {
-    ModelsDevCatalog::parse_json(BUNDLED_MODELS_DEV_JSON)
-        .expect("committed bundled Models.dev asset must be valid JSON")
+pub fn bundled_models_dev_catalog() -> &'static ModelsDevCatalog {
+    BUNDLED_MODELS_DEV_CATALOG.get_or_init(|| {
+        ModelsDevCatalog::parse_json(BUNDLED_MODELS_DEV_JSON)
+            .expect("committed bundled Models.dev asset must be valid JSON")
+    })
 }
 
 /// Bundled-layer [`CatalogOffering`] rows from the offline snapshot (#4188).

--- a/crates/config/src/catalog/tests.rs
+++ b/crates/config/src/catalog/tests.rs
@@ -648,7 +648,7 @@ fn bundled_asset_parses() {
         "bundled asset must carry provider rows"
     );
     // The helper returns the same parsed catalog.
-    assert_eq!(bundled_models_dev_catalog(), catalog);
+    assert_eq!(*bundled_models_dev_catalog(), catalog);
 }
 
 #[test]

--- a/crates/tui/src/dependencies.rs
+++ b/crates/tui/src/dependencies.rs
@@ -84,6 +84,32 @@ pub fn probe_executable_with_flag(spec: &str, version_flag: &str) -> bool {
     matches!(cmd.status(), Ok(status) if status.success())
 }
 
+/// Probe a single executable and capture its version banner in one spawn.
+///
+/// Same contract as [`probe_executable`] (success = exit 0), but returns the
+/// trimmed stdout so callers that want the banner don't need a second process
+/// launch. Returns `None` when the probe fails or stdout is not valid UTF-8.
+pub fn probe_executable_capturing(spec: &str, version_flag: &str) -> Option<String> {
+    let mut parts = spec.split_whitespace();
+    let program = parts.next()?;
+    let mut cmd = Command::new(program);
+    crate::utils::suppress_console_window(&mut cmd);
+    for arg in parts {
+        cmd.arg(arg);
+    }
+    cmd.arg(version_flag);
+    cmd.stderr(std::process::Stdio::null());
+
+    let output = cmd.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 fn executable_path_candidates(program: &str) -> Vec<PathBuf> {
     let program_path = Path::new(program);
     if program_path.components().count() > 1 {
@@ -428,9 +454,14 @@ impl ExternalTool for RustC {
         static CACHE: OnceLock<Option<String>> = OnceLock::new();
         CACHE
             .get_or_init(|| {
+                // Probe with capture so the `--version` banner observed during
+                // resolution is reused by [`rustc_version_banner`] instead of
+                // paying a second rustc process launch (each launch loads
+                // libLLVM, which dominated diagnostic-command init profiles).
                 for candidate in Self::candidates() {
-                    if probe_executable(candidate) {
+                    if let Some(banner) = probe_executable_capturing(candidate, "--version") {
                         tracing::info!(target: "tool_dependencies", "Resolved rustc binary");
+                        let _ = RUSTC_VERSION_BANNER.set(Some(banner));
                         return Some((*candidate).to_string());
                     }
                 }
@@ -438,6 +469,23 @@ impl ExternalTool for RustC {
             })
             .clone()
     }
+}
+
+/// Captured `--version` banner from the [`RustC`] resolution probe.
+///
+/// `None` until `RustC::resolve()`/`available()`/`command()` first runs, or
+/// when rustc is absent/failing. Reading this after an `available()` check
+/// yields the same string the tool would print, without a second process.
+static RUSTC_VERSION_BANNER: OnceLock<Option<String>> = OnceLock::new();
+
+/// The rustc `--version` banner, if rustc resolved successfully.
+///
+/// Populated as a side effect of resolving [`RustC`]; this reads no fresh
+/// process state. Callers wanting the value should touch `RustC::available()`
+/// first (as the diagnostics path does).
+#[must_use]
+pub fn rustc_version_banner() -> Option<String> {
+    RUSTC_VERSION_BANNER.get().cloned().flatten()
 }
 
 /// Rust build tool — used by the `run_tests` tool.

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1797,16 +1797,19 @@ pub(crate) fn build_runtime(command: Option<&Commands>) -> Result<tokio::runtime
 const DIAGNOSTIC_WORKER_CAP: usize = 2;
 
 fn diagnostic_worker_count(command: Option<&Commands>) -> Option<usize> {
-    if matches!(
-        command,
-        Some(Commands::Doctor(_))
-            // Offline sequential tool-loop harness: no concurrent async work.
-            | Some(Commands::Eval(_))
-    ) {
-        Some(DIAGNOSTIC_WORKER_CAP)
-    } else {
-        None
-    }
+    let capped = match command {
+        // Read-only diagnostic surfaces (doctor family).
+        Some(
+            Commands::Doctor(_)
+            | Commands::Eval(_)
+            | Commands::SessionDiagnostics(_)
+            | Commands::Sessions { .. },
+        ) => true,
+        // Only the read-only status report; mutating setup keeps defaults.
+        Some(Commands::Setup(args)) => args.status,
+        _ => false,
+    };
+    capped.then_some(DIAGNOSTIC_WORKER_CAP)
 }
 
 fn tokio_runtime_builder() -> tokio::runtime::Builder {

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -7679,15 +7679,13 @@ async fn test_api_connectivity(config: &Config) -> Result<()> {
 }
 
 fn rustc_version() -> String {
-    let Some(mut cmd) = crate::dependencies::RustC::command() else {
+    // `RustC::available()` resolves the tool once, capturing the `--version`
+    // banner as a side effect of the probe; reuse it instead of launching a
+    // second rustc process (each launch loads libLLVM).
+    if !crate::dependencies::RustC::available() {
         return "unknown".to_string();
-    };
-    let Ok(output) = cmd.arg("--version").output() else {
-        return "unknown".to_string();
-    };
-    String::from_utf8(output.stdout)
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|_| "unknown".to_string())
+    }
+    crate::dependencies::rustc_version_banner().unwrap_or_else(|| "unknown".to_string())
 }
 
 /// List saved sessions

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1730,7 +1730,7 @@ fn run_async_main(
     plugin_discovery: Arc<crate::plugins::PluginDiscoveryContext>,
     plugin_registry: Arc<crate::plugins::PluginRegistry>,
 ) -> Result<()> {
-    build_runtime()?.block_on(run_async_main_inner(
+    build_runtime(command.as_ref())?.block_on(run_async_main_inner(
         cli,
         command,
         plugin_discovery,
@@ -1754,14 +1754,60 @@ fn run_async_main(
 /// raises SIGABRT, so `spawn_supervised`'s `catch_unwind` cannot see it and the
 /// process dies with 134 mid-dispatch.
 ///
+/// Build the runtime that owns every async task in this binary.
+///
+/// `command` selects the worker-count policy: read-only diagnostic commands
+/// run on a small fixed pool instead of tokio's one-worker-per-CPU default
+/// (see [`diagnostic_worker_count`]). Interactive sessions and servers keep
+/// the default sizing unchanged.
+///
+/// `#[tokio::main]` used to expand here, which left every worker thread on
+/// tokio's 2 MiB default while only the `codewhale-main` owner thread above
+/// received `CODEWHALE_MAIN_STACK_BYTES`. The engine does not run on that owner
+/// thread — `core::engine::spawn_engine` hands `Engine::run` to
+/// `utils::spawn_supervised`, a bare `tokio::spawn` — so the explicit stack
+/// never applied where the depth actually is.
+///
+/// A debug-build `agent` dispatch (turn_loop -> FuturesUnordered ->
+/// execute_full_with_context -> AgentTool::execute -> spawn_subagent_from_input)
+/// measured a stack high-water mark between 2.25 and 2.5 MiB and aborted the
+/// whole process on the guard page. A Rust stack overflow is not a panic: it
+/// raises SIGABRT, so `spawn_supervised`'s `catch_unwind` cannot see it and the
+/// process dies with 134 mid-dispatch.
+///
 /// This is behavior-identical to the old `#[tokio::main]` expansion apart from
 /// the stack size, and it makes the knob greppable.
-pub(crate) fn build_runtime() -> Result<tokio::runtime::Runtime> {
-    tokio::runtime::Builder::new_multi_thread()
+pub(crate) fn build_runtime(command: Option<&Commands>) -> Result<tokio::runtime::Runtime> {
+    let mut builder = tokio_runtime_builder();
+    if let Some(workers) = diagnostic_worker_count(command) {
+        builder.worker_threads(workers);
+    }
+    builder.build().context("Failed to build the Codewhale Tokio runtime")
+}
+
+/// Number of async workers to request from tokio.
+///
+/// Unset means tokio's default: one worker per CPU. That default is right for
+/// interactive sessions and long-running servers, but a short-lived diagnostic
+/// command gains nothing from a 20-worker pool — it pays thread spawn, stack
+/// reservation, and teardown futex traffic for capacity it never uses (perf
+/// attribution: pthread_create under `Builder::build` dominates init samples).
+const DIAGNOSTIC_WORKER_CAP: usize = 2;
+
+fn diagnostic_worker_count(command: Option<&Commands>) -> Option<usize> {
+    if matches!(command, Some(Commands::Doctor(_))) {
+        Some(DIAGNOSTIC_WORKER_CAP)
+    } else {
+        None
+    }
+}
+
+fn tokio_runtime_builder() -> tokio::runtime::Builder {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder
         .enable_all()
-        .thread_stack_size(CODEWHALE_MAIN_STACK_BYTES)
-        .build()
-        .context("Failed to build the Codewhale Tokio runtime")
+        .thread_stack_size(CODEWHALE_MAIN_STACK_BYTES);
+    builder
 }
 
 /// Which product surface this process is serving.

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1782,20 +1782,27 @@ pub(crate) fn build_runtime(command: Option<&Commands>) -> Result<tokio::runtime
     if let Some(workers) = diagnostic_worker_count(command) {
         builder.worker_threads(workers);
     }
-    builder.build().context("Failed to build the Codewhale Tokio runtime")
+    builder
+        .build()
+        .context("Failed to build the Codewhale Tokio runtime")
 }
 
 /// Number of async workers to request from tokio.
 ///
 /// Unset means tokio's default: one worker per CPU. That default is right for
-/// interactive sessions and long-running servers, but a short-lived diagnostic
-/// command gains nothing from a 20-worker pool — it pays thread spawn, stack
-/// reservation, and teardown futex traffic for capacity it never uses (perf
+/// interactive sessions and long-running servers, but short-lived offline
+/// commands gain nothing from a full-CPU pool — they pay thread spawn, stack
+/// reservation, and teardown futex traffic for capacity they never use (perf
 /// attribution: pthread_create under `Builder::build` dominates init samples).
 const DIAGNOSTIC_WORKER_CAP: usize = 2;
 
 fn diagnostic_worker_count(command: Option<&Commands>) -> Option<usize> {
-    if matches!(command, Some(Commands::Doctor(_))) {
+    if matches!(
+        command,
+        Some(Commands::Doctor(_))
+            // Offline sequential tool-loop harness: no concurrent async work.
+            | Some(Commands::Eval(_))
+    ) {
         Some(DIAGNOSTIC_WORKER_CAP)
     } else {
         None

--- a/crates/tui/src/models_dev_live.rs
+++ b/crates/tui/src/models_dev_live.rs
@@ -93,6 +93,23 @@ struct PersistedModelsDevCache {
     body: String,
 }
 
+/// Metadata header for the v2 cache format.
+///
+/// v1 serialized the whole cache as one JSON envelope with the catalog body
+/// escaped inside it, so loading parsed ~5MB twice (envelope, then body) plus
+/// a full-body copy on every interactive boot. v2 stores the metadata as a
+/// single JSON header line followed by the raw catalog body bytes, so boot
+/// performs exactly one catalog parse and zero body copies.
+const CACHE_SCHEMA_VERSION_V2: u32 = 2;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedModelsDevCacheV2 {
+    schema_version: u32,
+    fetched_at: u64,
+    source_fingerprint: String,
+    source_label: String,
+}
+
 /// Why a Models.dev refresh did not publish new rows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ModelsDevRefreshError {
@@ -192,26 +209,27 @@ pub fn maybe_load_persisted_cache() {
     let Some(path) = cache_path() else {
         return;
     };
-    if let Some(cache) = load_cache_file(&path) {
-        let age = now_unix().saturating_sub(cache.fetched_at);
-        let freshness = if age > DEFAULT_MODELS_DEV_TTL_SECS {
-            ModelsDevFreshness::Stale
-        } else {
-            ModelsDevFreshness::Live
-        };
-        if let Err(err) = publish_from_body(
-            &cache.body,
-            &cache.source_fingerprint,
-            cache.fetched_at,
-            &cache.source_label,
-            freshness,
-        ) {
-            tracing::debug!(
-                target: "models_dev_live",
-                error = %err,
-                "persisted Models.dev cache failed to publish; keeping bundled"
-            );
-        }
+    let Some(cache) = load_cache_file(&path) else {
+        return;
+    };
+    let age = now_unix().saturating_sub(cache.fetched_at);
+    let freshness = if age > DEFAULT_MODELS_DEV_TTL_SECS {
+        ModelsDevFreshness::Stale
+    } else {
+        ModelsDevFreshness::Live
+    };
+    if let Err(err) = publish_from_body(
+        &cache.body,
+        &cache.source_fingerprint,
+        cache.fetched_at,
+        cache.source_label.as_str(),
+        freshness,
+    ) {
+        tracing::debug!(
+            target: "models_dev_live",
+            error = %err,
+            "persisted Models.dev cache failed to publish; keeping bundled"
+        );
     }
 }
 
@@ -401,8 +419,31 @@ fn mark_failed(err: ModelsDevRefreshError) {
     set_status(next);
 }
 
+/// Load the on-disk Models.dev cache.
+///
+/// Reads v2 (single-parse: one header line + raw body) and v1 (JSON envelope
+/// with an escaped body) formats. Returns metadata and the *unescaped* body
+/// without copying it in the v2 path.
 fn load_cache_file(path: &Path) -> Option<PersistedModelsDevCache> {
     let bytes = std::fs::read(path).ok()?;
+    // v2: single-line JSON header terminated by a newline, then the verbatim
+    // catalog body. One small parse, zero body copies.
+    if bytes.first() == Some(&b'{') && bytes.contains(&b'\n') {
+        let split = bytes.iter().position(|b| *b == b'\n')?;
+        if let Ok(header) = serde_json::from_slice::<PersistedModelsDevCacheV2>(&bytes[..split]) {
+            if header.schema_version == CACHE_SCHEMA_VERSION_V2 && !bytes[split + 1..].is_empty() {
+                let body = String::from_utf8(bytes[split + 1..].to_vec()).ok()?;
+                return Some(PersistedModelsDevCache {
+                    schema_version: CACHE_SCHEMA_VERSION,
+                    fetched_at: header.fetched_at,
+                    source_fingerprint: header.source_fingerprint,
+                    source_label: header.source_label,
+                    body,
+                });
+            }
+        }
+    }
+    // v1 fallback: whole-file JSON envelope with the body escaped inside.
     let cache: PersistedModelsDevCache = serde_json::from_slice(&bytes).ok()?;
     if cache.schema_version != CACHE_SCHEMA_VERSION {
         return None;
@@ -417,9 +458,19 @@ fn save_cache_file(
     path: &Path,
     cache: &PersistedModelsDevCache,
 ) -> Result<(), ModelsDevRefreshError> {
-    let bytes =
-        serde_json::to_vec(cache).map_err(|err| ModelsDevRefreshError::Io(err.to_string()))?;
-    atomic_write(path, &bytes).map_err(|err| ModelsDevRefreshError::Io(err.to_string()))
+    // Write the single-parse format so the next boot parses the catalog once.
+    let header = PersistedModelsDevCacheV2 {
+        schema_version: CACHE_SCHEMA_VERSION_V2,
+        fetched_at: cache.fetched_at,
+        source_fingerprint: cache.source_fingerprint.clone(),
+        source_label: cache.source_label.clone(),
+    };
+    let mut header_line =
+        serde_json::to_vec(&header).map_err(|err| ModelsDevRefreshError::Io(err.to_string()))?;
+    header_line.push(b'\n');
+    let mut payload = header_line;
+    payload.extend_from_slice(cache.body.as_bytes());
+    atomic_write(path, &payload).map_err(|err| ModelsDevRefreshError::Io(err.to_string()))
 }
 
 /// Compile helper exposed for unit tests: body → live offerings with normalized

--- a/crates/tui/src/provider_lake.rs
+++ b/crates/tui/src/provider_lake.rs
@@ -128,11 +128,21 @@ fn bundled_snapshot() -> &'static CatalogSnapshot {
 /// deliberately downstream of every publisher so stale cached rows cannot
 /// bypass the client-side live-fetch filter.
 fn apply_provider_model_cutlines(mut snapshot: CatalogSnapshot) -> CatalogSnapshot {
+    // `ApiProvider::parse` scans every provider and alias list per call; the
+    // distinct provider strings in a catalog are few, so resolve each distinct
+    // string once instead of once per offering (boot-path profiles showed
+    // this loop as the largest post-parse compute block).
+    let mut resolved: std::collections::HashMap<String, Option<ApiProvider>> =
+        std::collections::HashMap::new();
     snapshot.offerings = snapshot
         .offerings
         .into_iter()
         .filter_map(|mut offering| {
-            if ApiProvider::parse(&offering.provider) == Some(ApiProvider::OpencodeGo) {
+            let parsed = resolved
+                .entry(offering.provider.clone())
+                .or_insert_with(|| ApiProvider::parse(&offering.provider))
+                .clone();
+            if parsed == Some(ApiProvider::OpencodeGo) {
                 let canonical = opencode_go_chat_model_id(&offering.wire_model_id)?;
                 offering.provider = ApiProvider::OpencodeGo.as_str().to_string();
                 offering.wire_model_id = canonical.to_string();

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -4137,6 +4137,11 @@ async fn execute_foreground_via_background(
     }
 
     let deadline = timeout_ms.map(|timeout| Instant::now() + Duration::from_millis(timeout));
+    // Adaptive poll cadence: fast commands (the common case — grep, wc, echo)
+    // finish in single-digit milliseconds, and a fixed 100ms tick made every
+    // foreground call pay that full quantum before completion was noticed.
+    // Start fine-grained and back off to the 100ms cap for long-running work.
+    let mut poll_tick_ms: u64 = FOREGROUND_POLL_INITIAL_MS;
     loop {
         if context
             .cancel_token
@@ -4192,11 +4197,21 @@ async fn execute_foreground_via_background(
             return Ok(result);
         }
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(poll_tick_ms)).await;
+        poll_tick_ms = (poll_tick_ms * 2).min(FOREGROUND_POLL_MAX_MS);
     }
 }
 
 const BASH_MAX_TIMEOUT_MS: u64 = i32::MAX as u64;
+
+/// Initial cadence for foreground-via-background completion polling. Fast
+/// commands dominate real agent traffic; detection latency on `true`-class
+/// commands drops from ~100ms to ~10ms, while long commands reach the
+/// 100ms cap within one doubling step.
+const FOREGROUND_POLL_INITIAL_MS: u64 = 10;
+/// Poll-cadence ceiling; matches the previous fixed tick so long-running
+/// command overhead is unchanged.
+const FOREGROUND_POLL_MAX_MS: u64 = 100;
 
 /// Default foreground lifetime for a contract-`bash` `action=run` that names
 /// no `timeout_ms`. Matches the value the tool's own input schema advertises;
@@ -5488,6 +5503,7 @@ impl BashTool {
                     .collect()
             };
 
+        let mut poll_tick_ms: u64 = FOREGROUND_POLL_INITIAL_MS;
         let statuses = loop {
             let current = {
                 let mut manager = context
@@ -5521,7 +5537,8 @@ impl BashTool {
                 timed_out = true;
                 break current;
             }
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(poll_tick_ms)).await;
+            poll_tick_ms = (poll_tick_ms * 2).min(FOREGROUND_POLL_MAX_MS);
         };
 
         let running_after = statuses
@@ -5934,6 +5951,7 @@ async fn wait_for_shell_delta_cancellable(
     let mut stdout_accum = String::new();
     let mut stderr_accum = String::new();
 
+    let mut poll_tick_ms: u64 = FOREGROUND_POLL_INITIAL_MS;
     let (command, result, stdout_total_len, stderr_total_len) = loop {
         if context
             .cancel_token
@@ -5981,7 +5999,8 @@ async fn wait_for_shell_delta_cancellable(
             break (command, delta.result, stdout_total_len, stderr_total_len);
         }
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(poll_tick_ms)).await;
+        poll_tick_ms = (poll_tick_ms * 2).min(FOREGROUND_POLL_MAX_MS);
     };
 
     Ok((


### PR DESCRIPTION
perf: trim process startup, diagnostic dispatch, and foreground command latency

Three clusters of changes, each targeting waste found by profiling rather than guesswork: diagnostic subcommands built a 45-thread tokio runtime they never used; the models.dev catalog was parsed repeatedly per process and twice per byte on the boot path; and every foreground shell call carried a fixed 100 ms poll tick no matter how fast the command finished. All measurements below come from interleaved same-window batch pairs on one aarch64 Linux machine, with attribution from strace censuses and mid-boot sampling.

| Area | Before | After | Delta |
|---|---|---|---|
| `doctor` wall, quiet host, n=60 | 45.4 ms | 37.6 ms | -17.2% |
| rustc process launches per doctor run | 2 | 1 | one libLLVM load avoided |
| thread spawns per doctor run | 45 | 27 | -18 |
| `eval` wall, under load, 3 interleaved pairs | baseline | baseline | -8.1% / -10.4% / -6.5% (NEW wins 3/3) |
| `setup --status` wall, under load, 3 pairs | baseline | baseline | -17% / -21% / -16% (NEW wins 3/3) |
| boot cache-load stage | 44.0 / 52.7 / 48.6 / 51.7 ms | 13.9 / 14.1 / 13.9 / 14.4 ms | ~-70% (NEW wins 4/4) |
| interactive time to first paint | ~229 ms | ~187 ms | -42 ms |
| provider cutline pass, first paint medians | 195.7 / 196.9 / 192.9 / 197.2 ms | 185.0 / 190.9 / 190.3 / 193.8 ms | -2 to -6 ms (NEW wins 4/4) |
| foreground command completion detection, p50 | ~100 ms floor | ~10 ms | ~10x for instant commands |
| foreground bash `true`, tail (n=150, real MCP serve) | p95 16.2 / p99 21.5 / p100 35.9 ms | p95 13.9 / p99 18.6 / p100 21.6 ms | p95 -14%, p99 -13%, p100 -40% |

## Runtime sizing for read-only diagnostics

A strace census on the doctor path showed 88.7% of syscall time in futex behind 45 thread spawns: `build_runtime()` built one worker per CPU with 16 MiB stacks each for read-only commands that use none of it. `doctor`, `eval`, `setup --status`, and the sessions/diagnostics family now cap workers at 2 through a structured match mirroring `telemetry_command_is_read_only`. Interactive sessions and servers keep default sizing.

## Parse the bundled catalog once

`bundled_models_dev_catalog()` re-parsed the ~50 KB snapshot at every call site: client routing, provider picker, provider lake, and fleet identity each paid an independent serde parse. It now returns a `&'static` catalog backed by `OnceLock`. The asset is an `include_str!` constant, so sharing the parsed form is immutability-safe. One existing assertion is adapted to the new signature and the build-time deep-equality guard keeps its exact semantics.

## Capture the rustc banner during the probe

`RustC::resolve()` proved presence by running `rustc --version` and discarding stdout; the diagnostics path then launched a second rustc process to read the same banner, and each launch loads libLLVM. The probe now records the banner behind a `OnceLock` and diagnostics consume it after an availability check. The reported `rust:` line is byte-identical to the toolchain's own `rustc --version` output.

## Single-parse disk cache, v2 format

The persisted catalog stored a ~5 MB body JSON-escaped inside a JSON envelope, and the synchronous boot path parsed it twice plus a full-body string copy. Mid-boot sampling caught `serde_json::visit_map` inside the largest silent window of startup, alongside a 17.7 ms zero-syscall compute burst after config load. v2 is a one-line JSON metadata header followed by the verbatim body: one small header parse, one body parse, zero body copies. Every refresh writes v2 and v1 envelopes still load through a fallback, so the first run after upgrade migrates the cache with no manual step.

## Memoize provider resolution in the cutline pass

`apply_provider_model_cutlines` called `ApiProvider::parse` per offering. Parse scans every provider and its alias list with case-insensitive compares, and the live snapshot carries thousands of rows. Each distinct provider string is now resolved once through a map.

## Adaptive poll cadence for foreground shell completion

The foreground wait loop polled child status on a fixed 100 ms tick, so a command finishing in 2 ms was only noticed at the next tick. A simulated 8-tool turn spent ~400 ms of its ~526 ms wall in poll quantization. The tick now starts at 10 ms and doubles to the old 100 ms cap in all three wait loops, so instant commands are detected about 10x sooner while long-running commands reach the same steady state after one doubling step. A first A/B that compared only medians missed the win and was reverted; the tail distribution above is what justified re-landing it, so the revert and reapply are squashed away in this branch's history.

## Method

Latency claims come from interleaved OLD/NEW batch pairs on the same host in the same window, n=60 on a quiet host for doctor and three batch pairs under synthetic load where the host was busy. Goldens: `--help` and `--version` output byte-identical, the `rust:` line matches the toolchain banner, eval behavior identical across a 6-step run.

## Testing

`cargo fmt` clean. Config crate: 603 passed. TUI modules touched by this series (`dependencies`, `catalog`, `models_dev_live`, `provider_lake`, `shell`): 270 passed at the branch tip.

## Reviewer note, unrelated to this series

`runtime_api::tests::reload_config_preserves_profile_selected_named_custom_route` overflows its stack in the full lib-test run. It reproduces identically on a pristine checkout of `main` in a throwaway worktree, so it is pre-existing and untouched here.
