### PR TITLE
chore(tui): gate audited test-only helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The first #5587 dead-code sweep converts audited test-only helpers to
+  `#[cfg(test)]`, keeping production builds free of test-only APIs without
+  changing runtime behavior.
 - `/plugin reload` is now discoverable when on-disk plugin bundles change: the
   next send and `/plugin list` nudge once with `Run /plugin reload to apply`
   instead of silently keeping the stale catalog (#5579). Trust is unchanged;

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -72,6 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The first #5587 dead-code sweep converts audited test-only helpers to
+  `#[cfg(test)]`, keeping production builds free of test-only APIs without
+  changing runtime behavior.
 - `/plugin reload` is now discoverable when on-disk plugin bundles change: the
   next send and `/plugin list` nudge once with `Run /plugin reload to apply`
   instead of silently keeping the stale catalog (#5579). Trust is unchanged;

--- a/crates/tui/src/tui/ambient_life.rs
+++ b/crates/tui/src/tui/ambient_life.rs
@@ -191,7 +191,7 @@ pub struct AmbientFrameStats {
 /// [`AmbientFrameStats::marks_built`], not a runtime clamp: the population is
 /// bounded by construction, and this constant is what fails the build if a
 /// future change makes it unbounded.
-#[allow(dead_code)]
+#[cfg(test)]
 pub const MAX_FRAME_MARKS: u32 = 24;
 
 /// Optional pointer reaction for fish dart / bubble rise.

--- a/crates/tui/src/tui/file_tree.rs
+++ b/crates/tui/src/tui/file_tree.rs
@@ -348,7 +348,7 @@ impl FileTreeState {
     }
 
     /// Adjust scroll for a given visible height.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn adjust_scroll(&mut self, visible: usize) {
         if self.cursor < self.scroll_offset {
             self.scroll_offset = self.cursor;
@@ -661,6 +661,19 @@ mod tests {
             "re-expanding the parent restores the expanded child subtree: {:?}",
             entry_names(&state)
         );
+    }
+
+    #[test]
+    fn adjust_scroll_keeps_the_cursor_inside_the_visible_window() {
+        let ws = fixture_workspace();
+        let mut state = FileTreeState::new(ws.path());
+        state.cursor = state.entries.len().saturating_sub(1);
+        state.adjust_scroll(3);
+        assert!(state.cursor < state.scroll_offset + 3);
+
+        state.cursor = 0;
+        state.adjust_scroll(3);
+        assert_eq!(state.scroll_offset, 0);
     }
 
     #[test]

--- a/crates/tui/src/tui/focus_texture.rs
+++ b/crates/tui/src/tui/focus_texture.rs
@@ -114,7 +114,7 @@ pub struct FocusTextureStats {
 impl FocusTextureStats {
     /// The accounting identity asserted by the unit tests. This type's only
     /// consumer is the test gate below, hence the `dead_code` allowance.
-    #[allow(dead_code)]
+    #[cfg(test)]
     #[must_use]
     pub fn accounted(&self) -> bool {
         self.cells_examined

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1167,7 +1167,7 @@ pub struct ExploringCell {
 
 impl ExploringCell {
     /// Render the exploring cell into lines.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn lines_with_motion(&self, width: u16, low_motion: bool) -> Vec<Line<'static>> {
         self.lines_with_motion_and_locale(width, low_motion, Locale::En)
     }
@@ -1691,7 +1691,7 @@ impl GenericToolCell {
     /// `mode` controls multi-line output handling: `Live` caps at
     /// `TOOL_OUTPUT_LINE_LIMIT` rows with a "+N more" affordance;
     /// `Transcript` emits the full output.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn lines_with_mode(
         &self,
         width: u16,

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -1175,7 +1175,7 @@ fn a_card_verb_agrees_with_its_own_label_in_every_locale() {
             }],
         };
 
-        let header_en = line_text(&cell.lines_with_motion_and_locale(80, true, Locale::En)[0]);
+        let header_en = line_text(&cell.lines_with_motion(80, true)[0]);
         assert!(
             header_en.contains(expected_en),
             "{label:?} should read {expected_en:?}: {header_en:?}"

--- a/crates/tui/src/tui/history/thinking.rs
+++ b/crates/tui/src/tui/history/thinking.rs
@@ -30,7 +30,7 @@ enum ThinkingVisualState {
     Idle,
 }
 
-#[allow(dead_code)] // Kept for compatibility/tests; live view uses explicit summaries only.
+#[cfg(test)]
 #[must_use]
 pub fn extract_reasoning_summary(text: &str) -> Option<String> {
     extract_explicit_reasoning_summary(text).or_else(|| {

--- a/crates/tui/src/tui/whales.rs
+++ b/crates/tui/src/tui/whales.rs
@@ -73,7 +73,7 @@ pub enum WhaleSpecies {
 
 impl WhaleSpecies {
     /// Every species, for exhaustive checks and the test gallery.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub const ALL: [WhaleSpecies; 7] = [
         Self::Scout,
         Self::Patch,
@@ -190,7 +190,7 @@ pub enum WhaleState {
 
 impl WhaleState {
     /// Every state, for exhaustive checks and the test gallery.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub const ALL: [WhaleState; 6] = [
         Self::Resting,
         Self::Thinking,
@@ -202,7 +202,7 @@ impl WhaleState {
 
     /// CWC state priority; higher wins when several facts apply. Public
     /// contract for surfaces that fold several children into one whale.
-    #[allow(dead_code)]
+    #[cfg(test)]
     #[must_use]
     pub const fn priority(self) -> u8 {
         match self {
@@ -633,7 +633,7 @@ pub fn portrait(
 /// The portrait narrowed through the glyph charter's ASCII fallback — what an
 /// `CODEWHALE_ASCII_SAFE=1` terminal draws. Pure text, for tests and
 /// text-only surfaces.
-#[allow(dead_code)] // test/text-surface API; the draw path narrows per cell
+#[cfg(test)]
 #[must_use]
 pub fn portrait_ascii(
     species: WhaleSpecies,
@@ -656,7 +656,7 @@ pub fn portrait_ascii(
 }
 
 /// The portrait as plain Unicode rows (no color), for tests and snapshots.
-#[allow(dead_code)] // test/snapshot API
+#[cfg(test)]
 #[must_use]
 pub fn portrait_text(
     species: WhaleSpecies,
@@ -695,7 +695,7 @@ pub fn badge(species: WhaleSpecies, theme: &UiTheme) -> Vec<Span<'static>> {
 
 /// Badge followed by the state word (glyph + word: never color alone). The
 /// word takes the state's tone; when `state` is `None` only the badge renders.
-#[allow(dead_code)] // frame-less convenience for static surfaces
+#[cfg(test)]
 #[must_use]
 pub fn badge_with_state(
     species: WhaleSpecies,
@@ -753,7 +753,7 @@ fn state_cue(
 }
 
 /// The badge as ASCII text (`<#`, `#]`, ...), for tests and text surfaces.
-#[allow(dead_code)] // test/text-surface API
+#[cfg(test)]
 #[must_use]
 pub fn badge_ascii(species: WhaleSpecies) -> String {
     let (feature, body, feature_first) = species.badge_glyphs();
@@ -857,6 +857,14 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn state_priority_orders_attention_before_work() {
+        assert!(
+            WhaleState::Waiting.priority() > WhaleState::Working.priority()
+                && WhaleState::Working.priority() > WhaleState::Resting.priority()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Addresses the approved bounded first slice of #5587.

This PR converts 13 audited test-only helper surfaces from `#[allow(dead_code)]` to `#[cfg(test)]` across TUI rendering/text fixtures:

- whale gallery constants and text/ASCII render helpers;
- focus-texture accounting assertion;
- file-tree scroll test helper;
- ambient frame-budget assertion constant;
- history exploration/generic render convenience wrappers;
- reasoning-summary test helper.

Where a gated helper had no existing direct consumer, a small property test now exercises the helper (`FileTreeState::adjust_scroll`, `ExploringCell::lines_with_motion`, and whale state priority). Production consumers were verified with `cargo check -p codewhale-tui --lib`; no runtime behavior or production code path changes are intended.

Stale production-use allowances, blanket conversions, and Tier C intent-check items remain out of scope.

## Tests

Passed locally:

- `cargo fmt --all -- --check`
- `git diff --check`
- affected module suites: whales (14), focus texture (9), file tree (8), history (41), ambient life (29)
- `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib --locked` — 11,228 passed, 0 failed, 13 ignored
- `cargo check -p codewhale-tui --lib --locked`

The default-stack full TUI test run is blocked by the known #5585 baseline stack overflow in `runtime_api::tests::reload_config_preserves_profile_selected_named_custom_route`; the documented 16 MiB stack setting passes the full suite.

Strict Clippy is currently blocked on the untouched `runtime_threads.rs:2562` baseline function `accumulate_runtime_cost_coverage` (`clippy::too_many_arguments`, 9/7), which is outside this cleanup slice and already present on `origin/main`.

No provider credentials or network access are required.

No-Issue: This PR addresses the approved first #5587 test-only-marker slice without automatically closing the broader audit issue.
