### PR TITLE
test(config): retire published fingerprint note gate

### DIFF
--- a/crates/config/src/catalog/tests.rs
+++ b/crates/config/src/catalog/tests.rs
@@ -338,42 +338,6 @@ fn fingerprint_of_an_empty_base_url_is_the_redacted_constant() {
 }
 
 #[test]
-fn changelog_declares_fingerprint_persisted_key_change() {
-    // `base_url_fingerprint` is serde-serialized (catalog cache, LiveOffering,
-    // pricing receipts, TurnRecord.routed_usage_source_ids). Empty input and
-    // scheme-less URLs with `@` hash differently than they did before
-    // 388125491. Before a release cut, Unreleased must say so; after the
-    // coordinated version bump, the current-version section owns the same
-    // declaration. An older release cannot satisfy this check, because stale
-    // caches would then look like corruption without a note for this build.
-    let changelog = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../CHANGELOG.md"));
-    let unreleased = changelog
-        .split_once("## [Unreleased]")
-        .expect("CHANGELOG has an Unreleased section")
-        .1
-        .split_once("\n## [")
-        .expect("Unreleased is followed by a released section")
-        .0;
-    let current_heading = format!("## [{}]", env!("CARGO_PKG_VERSION"));
-    let current_release = changelog
-        .split_once(&current_heading)
-        .map(|(_, tail)| tail.split("\n## [").next().unwrap_or(tail))
-        .unwrap_or_default();
-    let declared_change = format!("{unreleased}\n{current_release}");
-    for needle in [
-        "base_url_fingerprint",
-        "persisted-key",
-        "scheme-less",
-        "routed_usage_source_ids",
-    ] {
-        assert!(
-            declared_change.contains(needle),
-            "Unreleased or the current release section must declare the {needle} persisted-key change:\n{declared_change}"
-        );
-    }
-}
-
-#[test]
 fn ttl_marks_entries_stale_and_excludes_them_from_fresh() {
     let fp = base_url_fingerprint("https://api.example.com");
     let mut cache = ProviderCatalogCache::new();


### PR DESCRIPTION
No-Issue: removes a stale release-note contract that was forcing a migration already published in v0.9.11 into every later current-version section.

## Summary
- removes only `changelog_declares_fingerprint_persisted_key_change`
- keeps all behavioral `base_url_fingerprint` tests
- confirms implementation commit `388125491...` is an ancestor of tag `v0.9.11` and the full persisted-key note is already in the tagged changelog
- makes no runtime, changelog, version, generated-file, dependency, or release-automation change

## Verification
- `cargo test -p codewhale-config --lib --locked`: 605 passed
- `cargo test -p codewhale-config fingerprint_ --locked`: 5 passed
- `bash scripts/release/prepare-release.test.sh`
- `bash scripts/release/check-feature-release-notes.test.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- exact-range contributor-credit check

This is a prerequisite for re-cutting the v0.9.12 release-prep PR. No tag, publication, artifact, deployment, or provider action is included.