### PR TITLE
fix(web): enforce native search constraints before fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Provider-native web search now applies domain constraints before accepting an
+  attempt, discards generated answers when returned citations violate those
+  constraints, and preserves the caller's configured/local timeout as an
+  independent fallback budget (#5681).
 - Idle session metrics omit zero facts (`0 turns`, `LLM 0s`) until the
   runtime has evidence. Working chrome says `in the current` instead of a
   generic `working`.

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -86,6 +86,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Provider-native web search now applies domain constraints before accepting an
+  attempt, discards generated answers when returned citations violate those
+  constraints, and preserves the caller's configured/local timeout as an
+  independent fallback budget (#5681).
 - Idle session metrics omit zero facts (`0 turns`, `LLM 0s`) until the
   runtime has evidence. Working chrome says `in the current` instead of a
   generic `working`.

--- a/crates/tui/src/client/provider_native_search.rs
+++ b/crates/tui/src/client/provider_native_search.rs
@@ -61,6 +61,11 @@ impl ProviderNativeSearchClient {
     }
 
     #[must_use]
+    pub(crate) fn base_url(&self) -> &str {
+        &self.inner.base_url
+    }
+
+    #[must_use]
     pub(crate) fn host(&self) -> Option<String> {
         reqwest::Url::parse(&self.inner.base_url)
             .ok()

--- a/crates/tui/src/tools/web/backend.rs
+++ b/crates/tui/src/tools/web/backend.rs
@@ -138,13 +138,21 @@ impl<'a> SearchBackendChain<'a> {
         query: &SearchQuery,
         deadline: Instant,
         first_attempt_budget: Option<Duration>,
+        fallback_budget_after_first: Option<Duration>,
     ) -> Result<ChainedSearch, ToolError> {
         let backends = self
             .backends
             .iter()
             .map(|backend| backend.as_ref())
             .collect::<Vec<_>>();
-        run_backend_chain(&backends, query, deadline, first_attempt_budget).await
+        run_backend_chain(
+            &backends,
+            query,
+            deadline,
+            first_attempt_budget,
+            fallback_budget_after_first,
+        )
+        .await
     }
 }
 
@@ -165,14 +173,20 @@ const fn provider_native_is_available(capability_supported: bool, client_present
 async fn run_backend_chain(
     backends: &[&dyn SearchBackend],
     query: &SearchQuery,
-    deadline: Instant,
+    mut deadline: Instant,
     first_attempt_budget: Option<Duration>,
+    fallback_budget_after_first: Option<Duration>,
 ) -> Result<ChainedSearch, ToolError> {
     let mut degraded = Vec::new();
     let mut last_empty = None;
     let mut attempted = Vec::new();
 
     for (index, backend) in backends.iter().enumerate() {
+        if index == 1
+            && let Some(fallback_budget) = fallback_budget_after_first
+        {
+            deadline = Instant::now() + fallback_budget.max(Duration::from_millis(1));
+        }
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             break;
@@ -208,20 +222,19 @@ async fn run_backend_chain(
             .and_then(std::convert::identity);
 
         match result {
-            Ok(mut raw) if !raw.results.is_empty() => {
-                degraded.append(&mut raw.degraded);
-                raw.degraded = degraded;
-                return Ok(ChainedSearch {
-                    raw,
-                    capabilities: backend.capabilities(),
-                });
-            }
             Ok(mut raw) => {
+                let capabilities = backend.capabilities();
+                crate::tools::web_search::apply_domain_constraints(query, capabilities, &mut raw);
+                if !raw.results.is_empty() {
+                    degraded.append(&mut raw.degraded);
+                    raw.degraded = degraded;
+                    return Ok(ChainedSearch { raw, capabilities });
+                }
                 degraded.push(DegradedReason::NoUsableResults {
                     backend: backend_id,
                 });
                 degraded.append(&mut raw.degraded);
-                last_empty = Some((raw, backend.capabilities()));
+                last_empty = Some((raw, capabilities));
             }
             Err(error) if is_fail_closed(&error) => return Err(error),
             Err(error) if backends.len() == 1 => return Err(error),
@@ -403,6 +416,12 @@ mod tests {
         result: Result<Vec<super::super::contract::SearchResult>, ToolError>,
     }
 
+    struct DeadlineBackend {
+        id: BackendId,
+        observed_budget: Arc<Mutex<Option<Duration>>>,
+        delay: Duration,
+    }
+
     #[async_trait]
     impl SearchBackend for FakeBackend {
         fn id(&self) -> BackendId {
@@ -423,6 +442,35 @@ mod tests {
                 source: self.id.as_str().to_string(),
                 backend_detail: None,
                 results: self.result.clone()?,
+                degraded: Vec::new(),
+                note: None,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl SearchBackend for DeadlineBackend {
+        fn id(&self) -> BackendId {
+            self.id
+        }
+
+        fn capabilities(&self) -> QueryCapabilities {
+            QueryCapabilities::count_only()
+        }
+
+        async fn search(
+            &self,
+            _query: &SearchQuery,
+            deadline: Instant,
+        ) -> Result<BackendSearch, ToolError> {
+            *self.observed_budget.lock().expect("budget lock") =
+                Some(deadline.saturating_duration_since(Instant::now()));
+            tokio::time::sleep(self.delay).await;
+            Ok(BackendSearch {
+                backend: self.id,
+                source: self.id.as_str().to_string(),
+                backend_detail: None,
+                results: vec![result()],
                 degraded: Vec::new(),
                 note: None,
             })
@@ -495,6 +543,7 @@ mod tests {
             &query(),
             Instant::now() + Duration::from_secs(1),
             None,
+            None,
         )
         .await
         .expect("fallback should succeed");
@@ -534,6 +583,7 @@ mod tests {
             &query(),
             Instant::now() + Duration::from_secs(1),
             None,
+            None,
         )
         .await
         .expect("final scrape fallback should succeed");
@@ -562,41 +612,11 @@ mod tests {
 
     #[tokio::test]
     async fn first_attempt_budget_overrides_the_default_fair_share() {
-        struct DeadlineBackend {
-            observed_budget: Arc<Mutex<Option<Duration>>>,
-        }
-
-        #[async_trait]
-        impl SearchBackend for DeadlineBackend {
-            fn id(&self) -> BackendId {
-                BackendId::Volcengine
-            }
-
-            fn capabilities(&self) -> QueryCapabilities {
-                QueryCapabilities::count_only()
-            }
-
-            async fn search(
-                &self,
-                _query: &SearchQuery,
-                deadline: Instant,
-            ) -> Result<BackendSearch, ToolError> {
-                *self.observed_budget.lock().expect("budget lock") =
-                    Some(deadline.saturating_duration_since(Instant::now()));
-                Ok(BackendSearch {
-                    backend: BackendId::Volcengine,
-                    source: "volcengine".to_string(),
-                    backend_detail: None,
-                    results: vec![result()],
-                    degraded: Vec::new(),
-                    note: None,
-                })
-            }
-        }
-
         let observed_budget = Arc::new(Mutex::new(None));
         let volcengine = DeadlineBackend {
+            id: BackendId::Volcengine,
             observed_budget: Arc::clone(&observed_budget),
+            delay: Duration::ZERO,
         };
         let fallback = FakeBackend {
             id: BackendId::DuckDuckGo,
@@ -608,6 +628,7 @@ mod tests {
             &query(),
             Instant::now() + Duration::from_secs(2),
             Some(first_attempt_budget),
+            None,
         )
         .await
         .expect("the first backend should complete inside its dedicated budget");
@@ -625,6 +646,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn provider_native_unused_budget_does_not_extend_fallback_deadline() {
+        let native = FakeBackend {
+            id: BackendId::ProviderNative,
+            result: Err(ToolError::execution_failed("native unavailable")),
+        };
+        let observed_budget = Arc::new(Mutex::new(None));
+        let fallback = DeadlineBackend {
+            id: BackendId::DuckDuckGo,
+            observed_budget: Arc::clone(&observed_budget),
+            delay: Duration::from_millis(200),
+        };
+        let fallback_budget = Duration::from_millis(30);
+        let error = run_backend_chain(
+            &[&native, &fallback],
+            &query(),
+            Instant::now() + Duration::from_millis(500),
+            Some(Duration::from_millis(500)),
+            Some(fallback_budget),
+        )
+        .await
+        .expect_err("blocking fallback must stop at its own budget");
+
+        assert!(matches!(error, ToolError::NotAvailable { .. }));
+        let observed = observed_budget
+            .lock()
+            .expect("budget lock")
+            .expect("fallback must observe a deadline");
+        assert!(observed <= fallback_budget);
+    }
+
+    #[tokio::test]
     async fn all_unavailable_returns_typed_error_with_backend_ids_only() {
         let private_error = "secret provider response";
         let api = FakeBackend {
@@ -639,6 +691,7 @@ mod tests {
             &[&api, &scrape],
             &query(),
             Instant::now() + Duration::from_secs(1),
+            None,
             None,
         )
         .await
@@ -689,6 +742,7 @@ mod tests {
             &query(),
             Instant::now() + Duration::from_secs(1),
             None,
+            None,
         )
         .await
         .expect_err("policy error must fail closed");
@@ -712,6 +766,7 @@ mod tests {
             &query(),
             Instant::now() + Duration::from_secs(1),
             None,
+            None,
         )
         .await
         .expect("empty API response should fall back");
@@ -728,5 +783,62 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn domain_filtered_results_fall_back_before_chain_success() {
+        let native = FakeBackend {
+            id: BackendId::ProviderNative,
+            result: Ok(vec![SearchResult::new(
+                1,
+                "Outside source".to_string(),
+                "https://outside.test/result".to_string(),
+                None,
+                None,
+            )]),
+        };
+        let configured = FakeBackend {
+            id: BackendId::Searxng,
+            result: Ok(vec![SearchResult::new(
+                1,
+                "Matching source".to_string(),
+                "https://docs.rs/example/latest/example/".to_string(),
+                None,
+                None,
+            )]),
+        };
+        let constrained = SearchQuery::new(
+            "example docs".to_string(),
+            5,
+            None,
+            vec!["docs.rs".to_string()],
+            None,
+        );
+
+        let response = run_backend_chain(
+            &[&native, &configured],
+            &constrained,
+            Instant::now() + Duration::from_secs(1),
+            None,
+            None,
+        )
+        .await
+        .expect("configured backend should satisfy the domain constraint");
+
+        assert_eq!(response.raw.backend, BackendId::Searxng);
+        assert_eq!(response.raw.results.len(), 1);
+        assert!(response.raw.degraded.iter().any(|reason| matches!(
+            reason,
+            DegradedReason::NoUsableResults {
+                backend: BackendId::ProviderNative
+            }
+        )));
+        assert!(response.raw.degraded.iter().any(|reason| matches!(
+            reason,
+            DegradedReason::BackendFallback {
+                from: BackendId::ProviderNative,
+                to: BackendId::Searxng
+            }
+        )));
     }
 }

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -41,6 +41,7 @@ const BAIDU_ENDPOINT: &str = "https://qianfan.baidubce.com/v2/ai_search/web_sear
 const VOLCENGINE_RESPONSES_ENDPOINT: &str = "https://ark.cn-beijing.volces.com/api/v3/responses";
 const SOFYA_ENDPOINT: &str = "https://sofya.co/v1/search";
 const ERROR_BODY_PREVIEW_BYTES: usize = 512;
+const PROVIDER_NATIVE_MIN_TIMEOUT_MS: u64 = 45_000;
 const VOLCENGINE_MIN_TIMEOUT_MS: u64 = 90_000;
 
 /// Credential-free endpoint selected for an explicit doctor reachability
@@ -217,7 +218,7 @@ impl ToolSpec for WebSearchTool {
                 },
                 "timeout_ms": {
                     "type": "integer",
-                    "description": "Timeout in milliseconds (default: 15000, max: 60000)"
+                    "description": "Configured/local search timeout in milliseconds (default: 15000, max: 60000). Model-backed provider-native search has a separate bounded minimum before fallback."
                 },
                 "recency": {
                     "oneOf": [
@@ -908,14 +909,17 @@ pub(crate) async fn execute_search(
 
     let started = Instant::now();
     let requested_timeout = Duration::from_millis(timeout_ms.max(1));
-    let (total_timeout, first_attempt_budget) = if initial_backend == BackendId::Volcengine {
-        let provider_budget = Duration::from_millis(VOLCENGINE_MIN_TIMEOUT_MS);
-        (provider_budget + requested_timeout, Some(provider_budget))
-    } else {
-        (requested_timeout, None)
-    };
+    let (total_timeout, first_attempt_budget, fallback_budget_after_first) =
+        search_timeout_budgets(initial_backend, requested_timeout);
     let deadline = started + total_timeout;
-    let chained = chain.search(&query, deadline, first_attempt_budget).await?;
+    let chained = chain
+        .search(
+            &query,
+            deadline,
+            first_attempt_budget,
+            fallback_budget_after_first,
+        )
+        .await?;
     let mut response =
         finalize_search_response(query.clone(), chained.capabilities, chained.raw, started);
     register_search_citations(&mut response, context);
@@ -927,6 +931,35 @@ pub(crate) async fn execute_search(
         response.clone(),
     );
     Ok(response)
+}
+
+fn search_timeout_budgets(
+    initial_backend: BackendId,
+    requested_timeout: Duration,
+) -> (Duration, Option<Duration>, Option<Duration>) {
+    match initial_backend {
+        BackendId::Volcengine => {
+            let provider_budget = Duration::from_millis(VOLCENGINE_MIN_TIMEOUT_MS);
+            (
+                provider_budget + requested_timeout,
+                Some(provider_budget),
+                None,
+            )
+        }
+        BackendId::ProviderNative => {
+            // Provider-native search performs a model-backed request. Give it
+            // a dedicated minimum without donating unused time to the
+            // configured/local fallback selected by the caller.
+            let provider_budget =
+                requested_timeout.max(Duration::from_millis(PROVIDER_NATIVE_MIN_TIMEOUT_MS));
+            (
+                provider_budget.saturating_add(requested_timeout),
+                Some(provider_budget),
+                Some(requested_timeout),
+            )
+        }
+        _ => (requested_timeout, None, None),
+    }
 }
 
 fn register_search_citations(response: &mut SearchResponse, context: &ToolContext) {
@@ -1069,20 +1102,11 @@ fn finalize_search_response(
         }
     }
     if !query.domains.is_empty() {
-        let before = raw.results.len();
-        raw.results
-            .retain(|result| domain_matches(&result.url, &query.domains));
-        rerank(&mut raw.results);
+        // The backend chain applies this before deciding whether an attempt
+        // produced usable results. Keep finalization defensive for cached or
+        // directly constructed responses; the helper is idempotent.
+        apply_domain_constraints(&query, capabilities, &mut raw);
         honored.domains = true;
-        let provider_honored = matches!(
-            capabilities.domains,
-            super::web::contract::CapabilityState::Supported
-        );
-        if !provider_honored || raw.results.len() != before {
-            raw.degraded.push(DegradedReason::PostFiltered {
-                knob: QueryKnob::Domains,
-            });
-        }
     }
     if query.locale.is_some() {
         if matches!(
@@ -1125,6 +1149,44 @@ fn finalize_search_response(
         message,
         results: raw.results,
         receipt,
+    }
+}
+
+pub(crate) fn apply_domain_constraints(
+    query: &SearchQuery,
+    capabilities: super::web::contract::QueryCapabilities,
+    raw: &mut BackendSearch,
+) {
+    if query.domains.is_empty() {
+        return;
+    }
+
+    let before = raw.results.len();
+    raw.results
+        .retain(|result| domain_matches(&result.url, &query.domains));
+    rerank(&mut raw.results);
+    let provider_honored = matches!(
+        capabilities.domains,
+        super::web::contract::CapabilityState::Supported
+    );
+    let filtered_any = raw.results.len() != before;
+    if raw.backend == BackendId::ProviderNative && (!provider_honored || filtered_any) {
+        // Post-filtering constrains returned citations but cannot prove that a
+        // provider-generated answer did not rely on a removed source.
+        raw.note = None;
+    }
+    let already_recorded = raw.degraded.iter().any(|reason| {
+        matches!(
+            reason,
+            DegradedReason::PostFiltered {
+                knob: QueryKnob::Domains
+            }
+        )
+    });
+    if (!provider_honored || filtered_any) && !already_recorded {
+        raw.degraded.push(DegradedReason::PostFiltered {
+            knob: QueryKnob::Domains,
+        });
     }
 }
 
@@ -2079,7 +2141,7 @@ mod tests {
         parse_bocha_results, parse_metaso_results, parse_searxng_results, parse_sofya_results,
         parse_tavily_results, parse_volcengine_results, register_search_citations, rerank,
         run_scrape_search_with_endpoints, sanitize_error_body, search_probe_target,
-        searxng_search_url, truncate_error_body, volcengine_extract_text,
+        search_timeout_budgets, searxng_search_url, truncate_error_body, volcengine_extract_text,
     };
     use crate::config::SearchProvider;
     use crate::tools::web::contract::{
@@ -2088,7 +2150,17 @@ mod tests {
     };
     use crate::tools::web::scrape::{decode_html_entities, normalize_bing_url};
     use serde_json::json;
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn provider_native_receives_dedicated_budget_without_extending_fallback() {
+        let requested = Duration::from_millis(15_000);
+        let (total, first, fallback) = search_timeout_budgets(BackendId::ProviderNative, requested);
+
+        assert_eq!(total, Duration::from_millis(60_000));
+        assert_eq!(first, Some(Duration::from_millis(45_000)));
+        assert_eq!(fallback, Some(requested));
+    }
 
     #[test]
     fn doctor_search_probe_targets_cover_every_builtin_provider() {
@@ -3127,6 +3199,63 @@ mod tests {
             }
         )));
         assert!(!response.receipt.degraded.iter().any(|reason| matches!(
+            reason,
+            DegradedReason::PostFiltered {
+                knob: QueryKnob::Domains
+            }
+        )));
+        assert!(response.message.contains("Grounded answer."));
+    }
+
+    #[test]
+    fn provider_native_discards_answer_when_domain_filter_removes_a_source() {
+        let query = SearchQuery::new(
+            "current release".to_string(),
+            3,
+            None,
+            vec!["example.com".to_string()],
+            None,
+        );
+        let raw = BackendSearch {
+            backend: BackendId::ProviderNative,
+            source: "provider-native/xai/grok-4.5".to_string(),
+            backend_detail: Some("api.x.ai".to_string()),
+            results: vec![
+                SearchResult::new(
+                    1,
+                    "Allowed source".to_string(),
+                    "https://docs.example.com/release".to_string(),
+                    None,
+                    None,
+                ),
+                SearchResult::new(
+                    2,
+                    "Leaked source".to_string(),
+                    "https://outside.test/release".to_string(),
+                    None,
+                    None,
+                ),
+            ],
+            degraded: Vec::new(),
+            note: Some("Answer synthesized from both sources.".to_string()),
+        };
+        let response = finalize_search_response(
+            query,
+            QueryCapabilities {
+                max_results: CapabilityState::Supported,
+                recency: CapabilityState::Unsupported,
+                domains: CapabilityState::Supported,
+                locale: CapabilityState::Unsupported,
+                published_date: CapabilityState::Unknown,
+            },
+            raw,
+            Instant::now(),
+        );
+
+        assert_eq!(response.count, 1);
+        assert_eq!(response.results[0].domain, "docs.example.com");
+        assert_eq!(response.message, "Found 1 result(s)");
+        assert!(response.receipt.degraded.iter().any(|reason| matches!(
             reason,
             DegradedReason::PostFiltered {
                 knob: QueryKnob::Domains

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -42,6 +42,7 @@ const VOLCENGINE_RESPONSES_ENDPOINT: &str = "https://ark.cn-beijing.volces.com/a
 const SOFYA_ENDPOINT: &str = "https://sofya.co/v1/search";
 const ERROR_BODY_PREVIEW_BYTES: usize = 512;
 const PROVIDER_NATIVE_MIN_TIMEOUT_MS: u64 = 45_000;
+const KIMI_K3_FORMULA_MIN_TIMEOUT_MS: u64 = 180_000;
 const VOLCENGINE_MIN_TIMEOUT_MS: u64 = 90_000;
 
 /// Credential-free endpoint selected for an explicit doctor reachability
@@ -909,8 +910,15 @@ pub(crate) async fn execute_search(
 
     let started = Instant::now();
     let requested_timeout = Duration::from_millis(timeout_ms.max(1));
-    let (total_timeout, first_attempt_budget, fallback_budget_after_first) =
-        search_timeout_budgets(initial_backend, requested_timeout);
+    let provider_native_timeout_floor = context
+        .provider_native_search
+        .as_ref()
+        .and_then(provider_native_timeout_floor);
+    let (total_timeout, first_attempt_budget, fallback_budget_after_first) = search_timeout_budgets(
+        initial_backend,
+        requested_timeout,
+        provider_native_timeout_floor,
+    );
     let deadline = started + total_timeout;
     let chained = chain
         .search(
@@ -936,6 +944,7 @@ pub(crate) async fn execute_search(
 fn search_timeout_budgets(
     initial_backend: BackendId,
     requested_timeout: Duration,
+    provider_native_timeout_floor: Option<Duration>,
 ) -> (Duration, Option<Duration>, Option<Duration>) {
     match initial_backend {
         BackendId::Volcengine => {
@@ -950,8 +959,10 @@ fn search_timeout_budgets(
             // Provider-native search performs a model-backed request. Give it
             // a dedicated minimum without donating unused time to the
             // configured/local fallback selected by the caller.
-            let provider_budget =
-                requested_timeout.max(Duration::from_millis(PROVIDER_NATIVE_MIN_TIMEOUT_MS));
+            let provider_budget = requested_timeout.max(
+                provider_native_timeout_floor
+                    .unwrap_or(Duration::from_millis(PROVIDER_NATIVE_MIN_TIMEOUT_MS)),
+            );
             (
                 provider_budget.saturating_add(requested_timeout),
                 Some(provider_budget),
@@ -960,6 +971,17 @@ fn search_timeout_budgets(
         }
         _ => (requested_timeout, None, None),
     }
+}
+
+fn provider_native_timeout_floor(
+    client: &crate::client::ProviderNativeSearchClient,
+) -> Option<Duration> {
+    crate::config::is_exact_direct_moonshot_k3_route(
+        client.provider(),
+        client.base_url(),
+        client.model(),
+    )
+    .then_some(Duration::from_millis(KIMI_K3_FORMULA_MIN_TIMEOUT_MS))
 }
 
 fn register_search_citations(response: &mut SearchResponse, context: &ToolContext) {
@@ -2134,14 +2156,15 @@ fn duckduckgo_allows_bing_fallback(base_url: Option<&str>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        ERROR_BODY_PREVIEW_BYTES, ScrapeEndpoints, SearchProbeTargetError, WebSearchTool,
-        acquire_model_backed_search_inference_participant, baidu_search_payload,
-        bocha_error_message, domain_matches, duckduckgo_search_url, extract_search_query,
-        finalize_search_response, optional_search_max_results, parse_baidu_results,
-        parse_bocha_results, parse_metaso_results, parse_searxng_results, parse_sofya_results,
-        parse_tavily_results, parse_volcengine_results, register_search_citations, rerank,
-        run_scrape_search_with_endpoints, sanitize_error_body, search_probe_target,
-        search_timeout_budgets, searxng_search_url, truncate_error_body, volcengine_extract_text,
+        ERROR_BODY_PREVIEW_BYTES, KIMI_K3_FORMULA_MIN_TIMEOUT_MS, ScrapeEndpoints,
+        SearchProbeTargetError, WebSearchTool, acquire_model_backed_search_inference_participant,
+        baidu_search_payload, bocha_error_message, domain_matches, duckduckgo_search_url,
+        extract_search_query, finalize_search_response, optional_search_max_results,
+        parse_baidu_results, parse_bocha_results, parse_metaso_results, parse_searxng_results,
+        parse_sofya_results, parse_tavily_results, parse_volcengine_results,
+        register_search_citations, rerank, run_scrape_search_with_endpoints, sanitize_error_body,
+        search_probe_target, search_timeout_budgets, searxng_search_url, truncate_error_body,
+        volcengine_extract_text,
     };
     use crate::config::SearchProvider;
     use crate::tools::web::contract::{
@@ -2155,10 +2178,20 @@ mod tests {
     #[test]
     fn provider_native_receives_dedicated_budget_without_extending_fallback() {
         let requested = Duration::from_millis(15_000);
-        let (total, first, fallback) = search_timeout_budgets(BackendId::ProviderNative, requested);
+        let (total, first, fallback) =
+            search_timeout_budgets(BackendId::ProviderNative, requested, None);
 
         assert_eq!(total, Duration::from_millis(60_000));
         assert_eq!(first, Some(Duration::from_millis(45_000)));
+        assert_eq!(fallback, Some(requested));
+
+        let (total, first, fallback) = search_timeout_budgets(
+            BackendId::ProviderNative,
+            requested,
+            Some(Duration::from_millis(KIMI_K3_FORMULA_MIN_TIMEOUT_MS)),
+        );
+        assert_eq!(total, Duration::from_millis(195_000));
+        assert_eq!(first, Some(Duration::from_millis(180_000)));
         assert_eq!(fallback, Some(requested));
     }
 


### PR DESCRIPTION
## Summary

- Apply requested domain constraints inside the backend chain before deciding
  that a provider-native attempt produced usable results. A native attempt that
  becomes empty now falls through to the configured backend with explicit
  `no_usable_results` and fallback receipts.
- Drop a provider-generated answer whenever post-filtering removes a citation,
  even when the provider claims server-side domain support. Surviving citations
  remain available without presenting synthesis that may depend on a removed
  source.
- Give model-backed provider-native search a dedicated 45-second minimum while
  keeping the caller's `timeout_ms` as an independent configured/local fallback
  budget. Unused native time no longer leaks into fallback execution.
- Raise only the exact direct Moonshot `kimi-k3` Formula route to a 180-second
  native-stage floor; Kimi Code, K2.6, and every other route retain 45 seconds,
  while configured/local fallback still receives only the caller timeout.

Refs #5681 (partial).

No-Issue: partial delivery tracked by #5681; this slice must not close the umbrella issue.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-tui tools::web::backend::tests --lib --locked` — 10 passed
- [x] `cargo test -p codewhale-tui tools::web_search::tests --lib --locked` — 69 passed
- [x] `cargo test -p codewhale-tui provider_native_receives_dedicated_budget_without_extending_fallback -- --nocapture`
- [x] `cargo check -p codewhale-tui --locked`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked -- <CI allow list>` — blocked by pre-existing `clippy::collapsible_match` findings in unchanged files including `commands/groups/session/structcopy.rs`, `runtime_threads.rs`, `settings.rs`, and `core/engine/tests.rs`. The same command with `-A clippy::collapsible_match` completed successfully.
- [ ] `cargo test --workspace --all-features --locked` — progressed through the workspace and then aborted in the unchanged `runtime_api::tests::reload_config_preserves_profile_selected_named_custom_route` with a stack overflow. An exact single-threaded isolated rerun reproduces the same stack overflow. The affected search test slices above pass.

## Checklist

- [x] This PR does not add a new layer or abstraction
- [x] Updated docs or comments as needed
- [x] Added or updated tests for each changed behavior boundary
- [x] No UI change
- [x] No harvested or co-authored code

## Honesty boundary

All tests are offline and deterministic. No provider credentials, live traffic,
release, tag, deployment, or publication action is part of this PR.
