### PR TITLE
Add GET /v1/fleet/profiles runtime API endpoint

### DIFF
--- a/crates/tui/src/fleet/manager.rs
+++ b/crates/tui/src/fleet/manager.rs
@@ -285,7 +285,8 @@ impl FleetManager {
     /// Effective session roster used everywhere a task references an
     /// `agent_profile` id. A selected v2 Fleet is authoritative; the merged
     /// legacy profile layers remain the fallback only when no Fleet is selected.
-    fn agent_roster(&self) -> crate::fleet::roster::FleetRoster {
+    /// Also exposed over `GET /v1/fleet/profiles` for GUI clients.
+    pub fn agent_roster(&self) -> crate::fleet::roster::FleetRoster {
         crate::fleet::identity::load_effective_roster(&self.fleet_config, &self.workspace, None)
     }
 

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1025,6 +1025,7 @@ pub fn build_router(state: RuntimeApiState) -> Router {
         .route("/v1/workspace/status", get(workspace_status))
         .route("/v1/agent-runs", get(list_agent_runs))
         .route("/v1/agent-runs/{run_id}", get(get_agent_run))
+        .route("/v1/fleet/profiles", get(list_fleet_profiles))
         .route(
             "/v1/fleet/runs",
             get(list_fleet_runs).post(create_fleet_run),
@@ -1480,6 +1481,32 @@ async fn get_agent_run(
         })
         .ok_or_else(|| ApiError::not_found(format!("agent run '{run_id}' not found")))?;
     Ok(Json(run))
+}
+
+async fn list_fleet_profiles(
+    State(state): State<RuntimeApiState>,
+) -> Result<Json<Value>, ApiError> {
+    let manager = open_fleet_manager(&state)?;
+    // Same roster path the manager uses to validate `agent_profile` ids on
+    // run creation, so GUI pickers can never offer a profile the runtime
+    // would reject.
+    let roster = manager.agent_roster();
+    let profiles = roster
+        .members()
+        .iter()
+        .map(|member| {
+            json!({
+                "id": member.id.clone(),
+                "display_name": member.display_name.clone(),
+                "description": member.description.clone(),
+                "origin": member.origin.to_string(),
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(Json(json!({
+        "profiles": profiles,
+        "load_error": roster.load_error().map(str::to_string),
+    })))
 }
 
 async fn create_fleet_run(

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -2037,6 +2037,32 @@ async fn fleet_status_runtime_api_exposes_state_and_actions() -> Result<()> {
     assert_eq!(runs["status"]["running"], 1);
     assert_eq!(runs["runs"][0]["id"], report.run_id.0);
 
+    let profiles: serde_json::Value = client
+        .get(format!("http://{addr}/v1/fleet/profiles"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let profile_ids: Vec<&str> = profiles["profiles"]
+        .as_array()
+        .expect("profiles array")
+        .iter()
+        .map(|member| member["id"].as_str().expect("profile id"))
+        .collect();
+    assert!(
+        profile_ids.contains(&"manager"),
+        "built-in roster member 'manager' missing from /v1/fleet/profiles: {profile_ids:?}"
+    );
+    assert!(
+        profiles["profiles"]
+            .as_array()
+            .expect("profiles array")
+            .iter()
+            .all(|member| member["origin"].is_string()),
+        "every profile must carry its roster origin"
+    );
+
     let worker: serde_json::Value = client
         .get(format!("http://{addr}/v1/fleet/workers/{worker_id}"))
         .send()


### PR DESCRIPTION
## Summary

- Add `GET /v1/fleet/profiles` to the runtime API, exposing the effective agent roster (id, display name, description, origin, plus roster load error) so GUI clients can build profile pickers.
- Reuses the same roster path the `FleetManager` uses to validate `agent_profile` ids on run creation (`agent_roster` made `pub`), so a picker can never offer a profile the runtime would reject.
- Extend the existing `fleet_status_runtime_api_exposes_state_and_actions` test to cover the new endpoint.

## Testing

<!-- Exact gate commands (including the clippy allow list) are in
     CONTRIBUTING.md → "Pre-push verification". -->

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [ ] `cargo test --workspace --all-features --locked`

Focused check run locally: `cargo test -p codewhale-tui --lib runtime_api::tests::fleet_status_runtime_api_exposes_state_and_actions` (passed).

## Checklist

- [ ] This PR adds a new layer/module/abstraction — it names or deletes the layer it replaces
- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address

No-Issue: additive runtime API surface (GET /v1/fleet/profiles) with no open tracking issue; roster reuse follows the FleetManager validation path.
