### PR TITLE
fix(tui): durable completion commit preserves the crash-recovery checkpoint

### DIFF
--- a/crates/tui/src/tui/persistence_actor.rs
+++ b/crates/tui/src/tui/persistence_actor.rs
@@ -45,6 +45,16 @@ pub enum PersistRequest {
     SaveCheckpoint { session: SavedSession },
     /// Write a full session snapshot (completed turn, durable save).
     SessionSnapshot(SavedSession),
+    /// Compound completion commit: write the completed session snapshot,
+    /// and only if that write succeeds, clear that same session's
+    /// crash-recovery checkpoint. A failed snapshot write RETAINS the
+    /// checkpoint as the only surviving recovery record, and the clear is
+    /// scoped to the committed session's id — it can never remove another
+    /// session's checkpoint. Turn completion must send this instead of a
+    /// `SessionSnapshot` + `ClearCheckpoint` pair, which the actor could
+    /// otherwise apply with the clear first, erasing the recovery record
+    /// before the snapshot safely landed.
+    CompletedCommit { session: SavedSession },
     /// Write queued/draft offline input for crash recovery.
     OfflineQueue {
         state: OfflineQueueState,
@@ -126,7 +136,8 @@ impl PersistActorHandle {
     pub fn try_send(&self, mut request: PersistRequest) -> bool {
         match &mut request {
             PersistRequest::SaveCheckpoint { session }
-            | PersistRequest::SessionSnapshot(session) => {
+            | PersistRequest::SessionSnapshot(session)
+            | PersistRequest::CompletedCommit { session } => {
                 session.compact_for_persistence_queue();
             }
             _ => {}
@@ -173,6 +184,7 @@ fn request_label(request: &PersistRequest) -> &'static str {
     match request {
         PersistRequest::SaveCheckpoint { .. } => "SaveCheckpoint",
         PersistRequest::SessionSnapshot(_) => "SessionSnapshot",
+        PersistRequest::CompletedCommit { .. } => "CompletedCommit",
         PersistRequest::OfflineQueue { .. } => "OfflineQueue",
         PersistRequest::ClearOfflineQueue => "ClearOfflineQueue",
         PersistRequest::ClearCheckpoint { .. } => "ClearCheckpoint",
@@ -283,6 +295,13 @@ struct PendingState {
     /// drop session A when an immediate `/new` queues session B before
     /// the actor drains.
     sessions: BTreeMap<String, SavedSession>,
+    /// Compound completion commits, latest-wins per session id: the
+    /// completed snapshot body to write, followed by that session's own
+    /// checkpoint clear — the clear only if the write succeeded. Kept
+    /// separate from `sessions` so a plain snapshot can never be drained
+    /// as a completion (or vice versa) and the clear intent stays bound to
+    /// exactly the session that completed.
+    completed_commits: BTreeMap<String, SavedSession>,
     offline_queue: Option<PendingOfflineQueue>,
 }
 
@@ -303,10 +322,42 @@ impl PendingState {
                 // the stale checkpoint, undoing the clear).
                 let id = session.metadata.id.clone();
                 self.checkpoint_clears.remove(&id);
+                // A new in-flight checkpoint means newer turn work started
+                // after the completion it would have cleared: the compound's
+                // clear-on-success intent is stale now (it would erase the
+                // fresher recovery record), so drop the pending compound and
+                // keep only the newer checkpoint body.
+                if self.completed_commits.remove(&id).is_some() {
+                    tracing::debug!(
+                        session_id = %id,
+                        "pending completed commit superseded by a newer in-flight checkpoint"
+                    );
+                }
                 self.checkpoints.insert(id, session);
             }
             PersistRequest::SessionSnapshot(session) => {
-                self.sessions.insert(session.metadata.id.clone(), session);
+                // A newer full snapshot of a session with a pending
+                // completed commit refreshes the commit's body (and keeps
+                // its clear-on-success intent): the in-flight checkpoint it
+                // guards is already captured by the newer completed state.
+                let id = session.metadata.id.clone();
+                if let Some(pending) = self.completed_commits.get_mut(&id) {
+                    *pending = session;
+                } else {
+                    self.sessions.insert(id, session);
+                }
+            }
+            PersistRequest::CompletedCommit { session } => {
+                let id = session.metadata.id.clone();
+                // The compound owns this session's snapshot and clear: a
+                // pending plain snapshot is superseded, a pending standalone
+                // clear would erase the recovery record even when the save
+                // fails, and a pending checkpoint write would re-create the
+                // record after the compound cleared it.
+                self.sessions.remove(&id);
+                self.checkpoint_clears.remove(&id);
+                self.checkpoints.remove(&id);
+                self.completed_commits.insert(id, session);
             }
             PersistRequest::OfflineQueue { state, session_id } => {
                 self.offline_queue = Some(PendingOfflineQueue::Save {
@@ -320,7 +371,11 @@ impl PendingState {
             PersistRequest::ClearCheckpoint { session_id } => {
                 // A clear supersedes a pending checkpoint write for the same
                 // session only — other sessions' pending work is untouched.
+                // An explicit clear is also a user-owned boundary (e.g.
+                // `/new`): it supersedes a pending compound for the same
+                // session so the discarded session is not re-written.
                 self.checkpoints.remove(&session_id);
+                self.completed_commits.remove(&session_id);
                 self.checkpoint_clears.insert(session_id);
             }
             PersistRequest::FlushAndReport { reply } => return Control::Flush(reply),
@@ -333,6 +388,12 @@ impl PendingState {
 /// Write all pending work to disk, draining `pending`. Every write and
 /// removal result is collected into the returned [`FlushReport`] — failures
 /// are reported, never silently discarded.
+///
+/// Ordering is durability-critical: every session snapshot write (plain or
+/// completion commit) happens BEFORE any checkpoint clear. A completion
+/// commit clears its session's checkpoint only after that session's own
+/// write succeeded, so a failed save always leaves the crash-recovery
+/// checkpoint in place.
 fn flush_inner(manager: &SessionManager, pending: &mut PendingState) -> FlushReport {
     let mut report = FlushReport::default();
     let mut record = |what: String, result: std::io::Result<()>| match result {
@@ -340,6 +401,29 @@ fn flush_inner(manager: &SessionManager, pending: &mut PendingState) -> FlushRep
         Err(err) => report.failures.push((what, err.kind())),
     };
 
+    for (session_id, session) in std::mem::take(&mut pending.sessions) {
+        record(
+            format!("session:{session_id}"),
+            manager.save_session(&session).map(|_| ()),
+        );
+    }
+    for (session_id, session) in std::mem::take(&mut pending.completed_commits) {
+        let commit_result = manager.save_session(&session);
+        let save_succeeded = commit_result.is_ok();
+        record(
+            format!("completed-commit:{session_id}"),
+            commit_result.map(|_| ()),
+        );
+        if save_succeeded {
+            // Only the committed session's own checkpoint is cleared, and
+            // only because its snapshot safely landed. A failure above
+            // retains the checkpoint as the sole recovery record.
+            record(
+                format!("clear-checkpoint:{session_id}"),
+                manager.clear_session_checkpoint(&session_id),
+            );
+        }
+    }
     for session_id in std::mem::take(&mut pending.checkpoint_clears) {
         record(
             format!("clear-checkpoint:{session_id}"),
@@ -350,12 +434,6 @@ fn flush_inner(manager: &SessionManager, pending: &mut PendingState) -> FlushRep
         record(
             format!("checkpoint:{session_id}"),
             manager.save_checkpoint(&session).map(|_| ()),
-        );
-    }
-    for (session_id, session) in std::mem::take(&mut pending.sessions) {
-        record(
-            format!("session:{session_id}"),
-            manager.save_session(&session).map(|_| ()),
         );
     }
     if let Some(request) = pending.offline_queue.take() {
@@ -633,6 +711,259 @@ mod tests {
                 .any(|(what, _)| what == &format!("checkpoint:{session_id}")),
             "failed checkpoint write must be reported, got: {:?}",
             report.failures
+        );
+        handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
+    }
+
+    /// Pre-write a crash-recovery checkpoint file for `session_id` directly,
+    /// so completion-commit tests can assert on its survival without needing
+    /// a prior in-flight turn.
+    fn seed_checkpoint_file(
+        sessions_dir: &std::path::Path,
+        session_id: &str,
+    ) -> std::path::PathBuf {
+        let path = sessions_dir
+            .join("checkpoints")
+            .join(format!("{session_id}.json"));
+        std::fs::create_dir_all(path.parent().expect("checkpoints parent")).expect("mkdir");
+        std::fs::write(&path, "{}").expect("seed checkpoint file");
+        path
+    }
+
+    /// Deterministically fail session-file saves only: a directory at the
+    /// session's own `<id>.json` path makes `save_session` fail while the
+    /// checkpoints directory stays fully usable.
+    fn block_session_file(sessions_dir: &std::path::Path, session_id: &str) {
+        std::fs::create_dir_all(sessions_dir.join(format!("{session_id}.json")))
+            .expect("block session file path");
+    }
+
+    #[tokio::test]
+    async fn completed_commit_preserves_checkpoint_when_session_save_fails() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        let session = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let session_id = session.metadata.id.clone();
+        let checkpoint_path = seed_checkpoint_file(&sessions_dir, &session_id);
+        block_session_file(&sessions_dir, &session_id);
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        handle.try_send(PersistRequest::CompletedCommit { session });
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        handle.try_send(PersistRequest::FlushAndReport { reply: reply_tx });
+        let report = reply_rx.await.expect("flush report reply");
+
+        assert!(
+            report
+                .failures
+                .iter()
+                .any(|(what, _)| what == &format!("completed-commit:{session_id}")),
+            "failed session save must be reported, got: {:?}",
+            report.failures
+        );
+        assert!(
+            !report
+                .failures
+                .iter()
+                .any(|(what, _)| what == &format!("clear-checkpoint:{session_id}")),
+            "the checkpoint clear must not be attempted after a failed save"
+        );
+        assert!(
+            checkpoint_path.exists(),
+            "a failed session save must retain the crash-recovery checkpoint"
+        );
+        handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
+    }
+
+    #[tokio::test]
+    async fn completed_commit_clears_only_after_session_save() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        let verification_manager = SessionManager::new(sessions_dir.clone()).expect("verify");
+        let session = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let session_id = session.metadata.id.clone();
+        let checkpoint_path = seed_checkpoint_file(&sessions_dir, &session_id);
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        handle.try_send(PersistRequest::CompletedCommit { session });
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        handle.try_send(PersistRequest::FlushAndReport { reply: reply_tx });
+        let report = reply_rx.await.expect("flush report reply");
+
+        assert!(
+            report.failures.is_empty(),
+            "commit save and its clear must both succeed, got: {:?}",
+            report.failures
+        );
+        let saved = verification_manager
+            .load_session(&session_id)
+            .expect("completed session must be saved before its checkpoint is cleared");
+        assert_eq!(saved.metadata.id, session_id);
+        assert!(
+            !checkpoint_path.exists(),
+            "the checkpoint is cleared only after the session save succeeded"
+        );
+        handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
+    }
+
+    #[tokio::test]
+    async fn completed_commit_never_clears_another_sessions_checkpoint() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        let verification_manager = SessionManager::new(sessions_dir.clone()).expect("verify");
+        let committed = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let inflight = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let committed_id = committed.metadata.id.clone();
+        let inflight_id = inflight.metadata.id.clone();
+        let committed_checkpoint = seed_checkpoint_file(&sessions_dir, &committed_id);
+        // The concurrent session's checkpoint must carry a loadable body, so
+        // seed it through the real manager instead of a placeholder file.
+        let inflight_checkpoint = verification_manager
+            .save_checkpoint(&inflight)
+            .expect("seed the concurrent session's checkpoint");
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        handle.try_send(PersistRequest::CompletedCommit { session: committed });
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        handle.try_send(PersistRequest::FlushAndReport { reply: reply_tx });
+        let report = reply_rx.await.expect("flush report reply");
+        assert!(report.failures.is_empty(), "{:?}", report.failures);
+
+        assert!(
+            !committed_checkpoint.exists(),
+            "the committed session's own checkpoint must be cleared"
+        );
+        let survivor = verification_manager
+            .load_session_checkpoint(&inflight_id)
+            .expect("load the concurrent session's checkpoint")
+            .expect("another session's checkpoint must never be cleared");
+        assert_eq!(survivor.metadata.id, inflight_id);
+        assert!(inflight_checkpoint.exists());
+        handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
+    }
+
+    #[tokio::test]
+    async fn shutdown_preserves_inflight_checkpoint() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        let verification_manager = SessionManager::new(sessions_dir.clone()).expect("verify");
+        let session = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let session_id = session.metadata.id.clone();
+        let checkpoint_path = seed_checkpoint_file(&sessions_dir, &session_id);
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        handle.try_send(PersistRequest::SaveCheckpoint { session });
+        handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
+
+        assert!(
+            checkpoint_path.exists(),
+            "shutdown must never unconditionally clear an in-flight checkpoint"
+        );
+        let recovered = verification_manager
+            .load_session_checkpoint(&session_id)
+            .expect("load checkpoint after shutdown")
+            .expect("in-flight work must survive shutdown for recovery review");
+        assert_eq!(recovered.metadata.id, session_id);
+    }
+
+    #[tokio::test]
+    async fn newer_inflight_checkpoint_supersedes_pending_completed_commit() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        let completed = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let mut inflight = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        // The new turn reuses the same session id: a fresh in-flight
+        // checkpoint arrives while the previous completion is still queued.
+        inflight.metadata.id = completed.metadata.id.clone();
+        let session_id = completed.metadata.id.clone();
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        handle.try_send(PersistRequest::CompletedCommit { session: completed });
+        handle.try_send(PersistRequest::SaveCheckpoint { session: inflight });
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        handle.try_send(PersistRequest::FlushAndReport { reply: reply_tx });
+        let report = reply_rx.await.expect("flush report reply");
+
+        assert!(
+            !report
+                .failures
+                .iter()
+                .any(|(what, _)| what.starts_with("clear-checkpoint:")),
+            "the newer in-flight checkpoint must not be cleared, got: {:?}",
+            report.failures
+        );
+        let checkpoint = std::fs::read_to_string(
+            sessions_dir
+                .join("checkpoints")
+                .join(format!("{session_id}.json")),
+        )
+        .expect("the newer checkpoint must survive the drain");
+        assert!(
+            !checkpoint.is_empty(),
+            "the newer checkpoint body must be on disk"
+        );
+        assert!(
+            report.completed >= 1,
+            "the newer checkpoint write must be counted, got: {report:?}"
         );
         handle.try_send(PersistRequest::Shutdown);
         task.await.expect("persistence actor join");

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -687,12 +687,23 @@ pub async fn run_tui(
         });
     }
 
-    // Flush the persistence actor: clear this session's checkpoint, collect
-    // the durability report (write failures are surfaced, not discarded),
-    // then shut down gracefully.
+    // Flush the persistence actor, collect the durability report (write
+    // failures are surfaced, not discarded), then shut down gracefully.
+    //
+    // The session's crash-recovery checkpoint is cleared only for a settled
+    // session. While a turn is in flight (or a spawned dispatch has not yet
+    // applied), the checkpoint is the only durable record of that work:
+    // clearing it here unconditionally could erase in-flight progress that
+    // never reached a snapshot, so it survives for startup recovery review.
     if let Some((handle, task)) = persistence_runtime {
-        if let Some(session_id) = app.current_session_id.clone() {
+        let turn_in_flight = app.is_loading || app.dispatch_in_flight;
+        if !turn_in_flight && let Some(session_id) = app.current_session_id.clone() {
             handle.try_send(PersistRequest::ClearCheckpoint { session_id });
+        } else if turn_in_flight {
+            tracing::info!(
+                target: "persistence",
+                "shutdown preserves the in-flight checkpoint for recovery review"
+            );
         }
         let (report_tx, report_rx) = tokio::sync::oneshot::channel();
         handle.try_send(PersistRequest::FlushAndReport { reply: report_tx });
@@ -2011,15 +2022,19 @@ pub(crate) async fn run_event_loop(
                         // Auto-save completed turn and clear crash checkpoint.
                         // Offloaded to the persistence actor so the UI
                         // stays responsive.
-                        let mut completed_snapshot_id: Option<String> = None;
                         if let Ok(manager) = SessionManager::default_location()
                             && let Ok(session) = build_session_snapshot(app, &manager)
                         {
                             app.current_session_id = Some(session.metadata.id.clone());
-                            completed_snapshot_id = Some(session.metadata.id.clone());
-                            let queued = persistence_actor::try_persist(
-                                PersistRequest::SessionSnapshot(session),
-                            );
+                            // Compound completion commit: the actor writes the
+                            // completed snapshot and clears this session's
+                            // crash checkpoint only after that write succeeds.
+                            // A failed save now retains the checkpoint as the
+                            // sole recovery record instead of erasing it.
+                            let queued =
+                                persistence_actor::try_persist(PersistRequest::CompletedCommit {
+                                    session,
+                                });
                             if queued {
                                 if let Err(err) = publish_pending_work_projection(app).await {
                                     tracing::warn!(
@@ -2042,11 +2057,11 @@ pub(crate) async fn run_event_loop(
                                 );
                             }
                         }
-                        if let Some(session_id) = completed_snapshot_id {
-                            persistence_actor::persist(PersistRequest::ClearCheckpoint {
-                                session_id,
-                            });
-                        }
+                        // The checkpoint clear is owned by the compound
+                        // `CompletedCommit` above: it applies only after this
+                        // session's snapshot safely landed. When the snapshot
+                        // could not be built or queued, the in-flight
+                        // checkpoint survives for startup recovery review.
 
                         // Refresh DeepSeek account balance after each completed
                         // turn so the footer balance chip stays current without


### PR DESCRIPTION
Runtime P0 #1 from the 0.9.12 ledger: durable completion commit.

**Defect.** Turn completion persisted `ClearCheckpoint` before the completed session snapshot had safely landed (the actor drained clears before session writes), and shutdown cleared the current session's checkpoint unconditionally — even mid-turn. A failed session save or a mid-turn exit could erase the only recovery record of accepted work.

**Fix.**
- New compound `PersistRequest::CompletedCommit { session }`: the actor writes the completed snapshot and clears only that session's checkpoint after the write succeeds; a failed save retains the checkpoint as the sole recovery record. The clear is scoped to the committed session's id.
- Coalescing stays safe both ways: a newer in-flight checkpoint supersedes a pending compound (cancelling its clear intent); a newer plain snapshot refreshes the compound's body keeping its clear intent; an explicit `ClearCheckpoint` boundary supersedes a pending compound for the same session.
- `flush_inner` ordering inverted to durability-first: all session snapshot writes now happen before any checkpoint clear.
- Turn completion sends the single compound request; the unconditional clear after queueing is gone.
- Shutdown clears the current session's checkpoint only when no turn is in flight (`!is_loading && !dispatch_in_flight`); in-flight checkpoints survive shutdown for startup recovery review.

**Tests (local, exact).** Required regressions: `completed_commit_preserves_checkpoint_when_session_save_fails`, `completed_commit_clears_only_after_session_save`, `completed_commit_never_clears_another_sessions_checkpoint`, `shutdown_preserves_inflight_checkpoint` — plus `newer_inflight_checkpoint_supersedes_pending_completed_commit`. persistence_actor 13/13; full TUI library suite 11,298 passed / 0 failed / 13 ignored (rebased head: persistence_actor 13/13 re-verified). Failure injection is deterministic: a directory at the session's `<id>.json` path fails session saves while checkpoints stay writable.

No deployment, billing, tag, release, or publish state is touched by this PR.

No-Issue: owner runtime P0 durability repair tracked in the 0.9.12 control ledger, not a standalone GitHub issue.
