### PR TITLE
fix(tui): first-class shells on the work strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Background shells are first-class work-strip rows (`▾ Shells N`) you can
+  open, watch, and cancel by the `shell_*` id on the row. `/jobs cancel all`
+  cancels running shells; it no longer looks up a task named `all`. The
+  composer hourglass crumb no longer stands in for a shell surface.
 - Account sessions no longer read the macOS Keychain. Unsigned or rebuilt
   `codewhale` binaries were a new Keychain ACL principal every time, so
   `codewhale web` and the TUI popped a password dialog on start. Sessions

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -154,6 +154,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Background shells are first-class work-strip rows (`▾ Shells N`) you can
+  open, watch, and cancel by the `shell_*` id on the row. `/jobs cancel all`
+  cancels running shells; it no longer looks up a task named `all`. The
+  composer hourglass crumb no longer stands in for a shell surface.
 - Account sessions no longer read the macOS Keychain. Unsigned or rebuilt
   `codewhale` binaries were a new Keychain ACL principal every time, so
   `codewhale web` and the TUI popped a password dialog on start. Sessions

--- a/crates/tui/src/commands/groups/utility/jobs.rs
+++ b/crates/tui/src/commands/groups/utility/jobs.rs
@@ -9,7 +9,7 @@ use crate::tui::app::{AppAction, ShellJobAction};
 pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "jobs",
     aliases: &["job", "zuoye"],
-    usage: "/jobs [list|show <id>|poll <id>|wait <id>|stdin <id> <input>|cancel <id>]",
+    usage: "/jobs [list|show <id>|poll <id>|wait <id>|stdin <id> <input>|cancel <id|all>]",
     description_key: "cmd_jobs_description",
 };
 
@@ -23,6 +23,10 @@ impl RegisterCommand<CommandResult> for JobsCmd {
     fn handler() -> CommandHandler<CommandResult> {
         CommandHandler::Pure(jobs)
     }
+}
+
+fn is_cancel_all_token(id: &str) -> bool {
+    id.eq_ignore_ascii_case("all")
 }
 
 fn jobs(args: Option<&str>) -> CommandResult {
@@ -70,16 +74,21 @@ fn jobs(args: Option<&str>) -> CommandResult {
             None => CommandResult::error("Usage: /jobs close-stdin <id>"),
         },
         "cancel" | "kill" | "stop" => match id {
+            Some(id) if is_cancel_all_token(id) => {
+                CommandResult::action(AppAction::ShellJob(ShellJobAction::CancelAll))
+            }
             Some(id) => CommandResult::action(AppAction::ShellJob(ShellJobAction::Cancel {
                 id: id.to_string(),
             })),
-            None => CommandResult::error("Usage: /jobs cancel <id>"),
+            None => CommandResult::error(
+                "Usage: /jobs cancel <id|all> — id is the shell_* shown on the Shells work-strip row",
+            ),
         },
         "cancel-all" | "kill-all" | "stop-all" => {
             CommandResult::action(AppAction::ShellJob(ShellJobAction::CancelAll))
         }
         _ => CommandResult::error(
-            "Usage: /jobs [list|show <id>|poll <id>|wait <id>|stdin <id> <input>|close-stdin <id>|cancel <id>|cancel-all]",
+            "Usage: /jobs [list|show <id>|poll <id>|wait <id>|stdin <id> <input>|close-stdin <id>|cancel <id|all>]",
         ),
     }
 }
@@ -108,6 +117,37 @@ mod tests {
             cancel_all.action,
             Some(AppAction::ShellJob(ShellJobAction::CancelAll))
         ));
+
+        let cancel_all_spaced = jobs(Some("cancel all"));
+        assert!(matches!(
+            cancel_all_spaced.action,
+            Some(AppAction::ShellJob(ShellJobAction::CancelAll))
+        ));
+
+        let cancel_id = jobs(Some("cancel shell_abcd"));
+        assert!(matches!(
+            cancel_id.action,
+            Some(AppAction::ShellJob(ShellJobAction::Cancel { id })) if id == "shell_abcd"
+        ));
+
+        let bare_cancel = jobs(Some("cancel"));
+        assert!(bare_cancel.action.is_none());
+        assert!(
+            bare_cancel
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("shell_*") && message.contains("<id|all>")),
+            "bare cancel must name the work-strip id space, not a task: {:?}",
+            bare_cancel.message
+        );
+        assert!(
+            !bare_cancel
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("Task")),
+            "bare cancel must not mention Task: {:?}",
+            bare_cancel.message
+        );
     }
 
     #[test]

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -1742,7 +1742,7 @@ impl ShellManager {
             Ok(())
         } else {
             // Do not disclose whether the id exists in another session.
-            Err(anyhow!("Task {task_id} not found"))
+            Err(anyhow!("Job {task_id} not found"))
         }
     }
 
@@ -3039,7 +3039,7 @@ impl ShellManager {
                 stderr: snapshot.stderr_tail.clone(),
             });
         }
-        Err(anyhow!("Task {task_id} not found"))
+        Err(anyhow!("Job {task_id} not found"))
     }
 
     pub fn inspect_job_for_session(

--- a/crates/tui/src/tui/background_indicator.rs
+++ b/crates/tui/src/tui/background_indicator.rs
@@ -12,11 +12,9 @@
 //! The indicator mirrors state the Work strip and the `/jobs` surface already
 //! read — it introduces no new registry and takes no lock in the render path:
 //!
-//! - **Background shells + durable tasks**: `App::task_panel`, the merged
-//!   snapshot `refresh_active_task_panel` builds from the shell manager's
-//!   `list_jobs()` and the TaskManager (`/jobs` surface). The event loop
-//!   refreshes it every ~2.5s, so the chip follows shell/task lifecycle with
-//!   the same cadence as the Work panel.
+//! - **Durable tasks**: `App::task_panel` entries that are not live shells.
+//!   Background shells are first-class work-strip rows (`▾ Shells N`) and
+//!   are not mirrored here.
 //! - **Sub-agents**: the union of `App::subagent_cache` entries still in
 //!   `Running` state and `App::agent_progress` keys — the same live projection
 //!   `running_agent_count` uses, so spawn/completion events update the chip
@@ -167,10 +165,12 @@ pub fn pending_work_from_app(app: &App) -> PendingWork {
         if !matches!(entry.status.as_str(), "running" | "queued") {
             continue;
         }
-        let (kind, raw_label) = match entry.prompt_summary.strip_prefix("shell: ") {
-            Some(command) => (PendingItemKind::Shell, command),
-            None => (PendingItemKind::Task, entry.id.as_str()),
-        };
+        // Live shells belong on the work strip (`▾ Shells N`), not this
+        // composer crumb. A dual surface hid the PTY behind hourglasses.
+        if entry.prompt_summary.starts_with("shell: ") || entry.id.starts_with("shell_") {
+            continue;
+        }
+        let (kind, raw_label) = (PendingItemKind::Task, entry.id.as_str());
         items.push(PendingItem {
             kind,
             label: truncate_label(raw_label),
@@ -414,7 +414,11 @@ mod tests {
             .insert("agent_live".to_string(), "Agent 1".to_string());
 
         let work = pending_work_from_app(&app);
-        assert_eq!(work.count(PendingItemKind::Shell), 1, "shell job counted");
+        assert_eq!(
+            work.count(PendingItemKind::Shell),
+            0,
+            "shells are work-strip rows, not crumb items"
+        );
         assert_eq!(work.count(PendingItemKind::Task), 1, "durable task counted");
         assert_eq!(
             work.count(PendingItemKind::Agent),
@@ -422,7 +426,10 @@ mod tests {
             "running agent counted"
         );
         let line = work.render_line(400).unwrap();
-        assert!(line.contains("cargo test"), "shell command labeled: {line}");
+        assert!(
+            !line.contains("cargo test"),
+            "shell command must not occupy the crumb: {line}"
+        );
         assert!(line.contains("run"), "task id labeled: {line}");
         assert!(line.contains("Agent 1"), "agent label shown: {line}");
 

--- a/crates/tui/src/tui/shell_job_routing.rs
+++ b/crates/tui/src/tui/shell_job_routing.rs
@@ -53,7 +53,7 @@ pub(super) fn format_shell_job_list(jobs: &[ShellJobSnapshot]) -> String {
         }
     }
     lines.push(
-        "Controls: /jobs show <id>, /jobs poll <id>, /jobs wait <id>, /jobs stdin <id> <input>, /jobs cancel <id>, /jobs cancel-all."
+        "Controls: /jobs show <id>, /jobs poll <id>, /jobs wait <id>, /jobs stdin <id> <input>, /jobs cancel <id|all>."
             .to_string(),
     );
     lines.join("\n")
@@ -177,6 +177,8 @@ mod tests {
         assert!(formatted.contains("shell_dead"));
         assert!(formatted.contains("stale"));
         assert!(formatted.contains("/jobs poll <id>"));
+        assert!(formatted.contains("/jobs cancel <id|all>"));
+        assert!(!formatted.contains("cancel-all"));
         assert!(formatted.contains("task=task_1"));
     }
 }

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -8,7 +8,10 @@ use ratatui::layout::Rect;
 use crate::settings::InlineDiffMode;
 use crate::tools::canonical_action::canonical_action_alias;
 use crate::tools::subagent::{AgentWorkerStatus, SubAgentResult, SubAgentStatus};
-use crate::tui::app::{AgentCurrentActivityStatus, AgentProgressMeta, App, SidebarRowAction};
+use crate::tui::app::{
+    AgentCurrentActivityStatus, AgentProgressMeta, App, SidebarRowAction, TaskPanelEntry,
+    TaskPanelEntryKind,
+};
 use crate::tui::history::{
     FileActivityKind, FileActivitySummary, FileMutationReceipt, HistoryCell, ToolCell,
 };
@@ -495,7 +498,7 @@ pub(super) fn project(app: &mut App) -> Vec<WorkRow> {
 
     update_session_instance_scope(app);
 
-    let rows = match graph {
+    let mut rows = match graph {
         Some(graph) => graph_rows(
             &mut app.work_surface,
             &graph,
@@ -522,6 +525,7 @@ pub(super) fn project(app: &mut App) -> Vec<WorkRow> {
             )]
         }),
     };
+    rows = with_live_shell_rows(app, rows);
     app.work_surface.latest_rows = rows.clone();
     if let Some(opened) = app.work_surface.opened.as_ref()
         && !rows.iter().any(|row| &row.id == opened)
@@ -538,8 +542,8 @@ pub(super) fn project(app: &mut App) -> Vec<WorkRow> {
 
 /// Projection used by the live surface. The full Work catalog remains intact
 /// for explicit inspectors, while persistent chrome stays literal: current
-/// sub-agents, then plan-step to-dos. Tool operations, coordination receipts,
-/// file activity, and generic graph headings never enter this list.
+/// sub-agents, live shells, then plan-step to-dos. Tool operations, coordination
+/// receipts, file activity, and generic graph headings never enter this list.
 ///
 /// On Top, the strip is actionable work only: running / queued / needs-input
 /// agents, plus plan-step to-dos. Quietly completed or cancelled workers
@@ -573,6 +577,7 @@ pub(super) fn project_visible(app: &mut App) -> Vec<WorkRow> {
     let mut todos = Vec::new();
     let mut live_agents = Vec::new();
     let mut settled_agents = 0usize;
+    let mut shells = Vec::new();
     for row in rows {
         if todo_ids.contains(&row.id.0) {
             todos.push(row);
@@ -582,10 +587,12 @@ pub(super) fn project_visible(app: &mut App) -> Vec<WorkRow> {
             } else {
                 live_agents.push(row);
             }
+        } else if row.id.0.starts_with("shell:") {
+            shells.push(row);
         }
     }
 
-    let mut out = Vec::with_capacity(todos.len() + live_agents.len() + 1);
+    let mut out = Vec::with_capacity(todos.len() + live_agents.len() + shells.len() + 2);
     if !live_agents.is_empty() || settled_agents > 0 {
         // Honest live/settled split — failed/interrupted stay as strip rows
         // (needs attention) and are never counted as "running".
@@ -610,6 +617,7 @@ pub(super) fn project_visible(app: &mut App) -> Vec<WorkRow> {
         out.push(agents_section_heading(&header));
         out.extend(live_agents);
     }
+    push_shell_group(&mut out, shells);
     out.extend(todos);
     app.work_surface.latest_rows = out.clone();
     out
@@ -655,8 +663,8 @@ fn plan_step_row_ids(app: &App) -> HashSet<String> {
 ///
 /// - `Tasks` — the full live projection ([`project_visible`]).
 /// - `Agents` — the full sub-agent register under the `▾ Subagents N` header,
-///   followed by the durable to-do checklist: opening the register never hides
-///   the list.
+///   then live shells, then the durable to-do checklist: opening the register
+///   never hides the list.
 /// - `Pinned` — the goal, the sub-agent group, then the plan-step to-dos.
 /// - `Context` — empty: session facts are a line list, not work rows, and
 ///   render outside the row machinery.
@@ -681,14 +689,17 @@ pub(super) fn visible_rows_for_panel(app: &mut App) -> Vec<WorkRow> {
             let todo_ids = plan_step_row_ids(app);
             let mut agents = Vec::new();
             let mut todos = Vec::new();
+            let mut shells = Vec::new();
             for row in rows {
                 if row.id.0.starts_with("worker:") {
                     agents.push(row);
+                } else if row.id.0.starts_with("shell:") {
+                    shells.push(row);
                 } else if todo_ids.contains(&row.id.0) {
                     todos.push(row);
                 }
             }
-            let mut out = Vec::with_capacity(agents.len() + todos.len() + 2);
+            let mut out = Vec::with_capacity(agents.len() + todos.len() + shells.len() + 3);
             if !agents.is_empty() {
                 out.push(agents_section_heading(&format!(
                     "Subagents {}",
@@ -696,6 +707,7 @@ pub(super) fn visible_rows_for_panel(app: &mut App) -> Vec<WorkRow> {
                 )));
                 out.extend(agents);
             }
+            push_shell_group(&mut out, shells);
             if !todos.is_empty() {
                 out.push(section_heading("tasks", "Tasks", "Durable to-do checklist"));
                 out.extend(todos);
@@ -708,14 +720,17 @@ pub(super) fn visible_rows_for_panel(app: &mut App) -> Vec<WorkRow> {
             let todo_ids = plan_step_row_ids(app);
             let mut todos = Vec::new();
             let mut agents = Vec::new();
+            let mut shells = Vec::new();
             for row in rows {
                 if todo_ids.contains(&row.id.0) {
                     todos.push(row);
                 } else if row.id.0.starts_with("worker:") {
                     agents.push(row);
+                } else if row.id.0.starts_with("shell:") {
+                    shells.push(row);
                 }
             }
-            let mut out = Vec::with_capacity(todos.len() + agents.len() + 2);
+            let mut out = Vec::with_capacity(todos.len() + agents.len() + shells.len() + 3);
             // On Top the goal is already the strip title; a side column
             // repeats it as its first row so the durable goal home survives
             // in every placement.
@@ -743,6 +758,7 @@ pub(super) fn visible_rows_for_panel(app: &mut App) -> Vec<WorkRow> {
                 )));
                 out.extend(agents);
             }
+            push_shell_group(&mut out, shells);
             out.extend(todos);
             app.work_surface.latest_rows = out.clone();
             out
@@ -2018,6 +2034,150 @@ fn agents_section_heading(label: &str) -> WorkRow {
     }
 }
 
+fn with_live_shell_rows(app: &App, mut rows: Vec<WorkRow>) -> Vec<WorkRow> {
+    rows.retain(|row| !row.id.0.starts_with("shell:") && row.id.0 != "section:shells");
+    let shells = shell_work_rows(app);
+    if shells.is_empty() {
+        return rows;
+    }
+    let mut out = Vec::with_capacity(rows.len() + shells.len() + 1);
+    push_shell_group(&mut out, shells);
+    out.extend(rows);
+    out
+}
+
+fn push_shell_group(out: &mut Vec<WorkRow>, shells: Vec<WorkRow>) {
+    if shells.is_empty() {
+        return;
+    }
+    out.push(shells_section_heading(&shells));
+    out.extend(shells);
+}
+
+fn is_live_shell_entry(entry: &TaskPanelEntry) -> bool {
+    if entry.kind != TaskPanelEntryKind::Background {
+        return false;
+    }
+    if !matches!(entry.status.as_str(), "running" | "queued") {
+        return false;
+    }
+    entry.prompt_summary.starts_with("shell: ") || entry.id.starts_with("shell_")
+}
+
+fn shell_work_rows(app: &App) -> Vec<WorkRow> {
+    app.task_panel
+        .iter()
+        .filter(|entry| is_live_shell_entry(entry))
+        .map(|entry| {
+            let command = entry
+                .prompt_summary
+                .strip_prefix("shell: ")
+                .unwrap_or(entry.prompt_summary.as_str())
+                .trim();
+            let status = if entry.stale {
+                "stale"
+            } else {
+                entry.status.as_str()
+            };
+            let elapsed_secs = entry.duration_ms.map(|ms| ms / 1_000);
+            let objective = if command.is_empty() {
+                entry.id.clone()
+            } else {
+                command.to_string()
+            };
+            WorkRow {
+                id: WorkRowId(format!("shell:{}", entry.id)),
+                mark: agent_mark(WorkBucket::Active),
+                label: entry.id.clone(),
+                detail: format!("{status} · {}", entry.id),
+                tone: WorkTone::Live,
+                selectable: true,
+                primary_action: Some(SidebarRowAction::InspectWork {
+                    title: format!("Shell {}", entry.id),
+                    body: shell_inspector_body(app, entry, command, status),
+                    stop_action: Some(Box::new(SidebarRowAction::Command(format!(
+                        "/jobs cancel {}",
+                        entry.id
+                    )))),
+                }),
+                agent: Some(AgentRowFacts {
+                    role_label: "shell".to_string(),
+                    status: status.to_string(),
+                    objective,
+                    elapsed_secs,
+                    model: None,
+                    tokens: None,
+                    todos_remaining: None,
+                }),
+            }
+        })
+        .collect()
+}
+
+fn shells_section_heading(shells: &[WorkRow]) -> WorkRow {
+    let ids: Vec<&str> = shells
+        .iter()
+        .filter_map(|row| row.id.0.strip_prefix("shell:"))
+        .collect();
+    let listing = if ids.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "{}\n\n",
+            ids.iter()
+                .map(|id| format!("- {id}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    };
+    WorkRow {
+        id: WorkRowId("section:shells".to_string()),
+        mark: "▾",
+        label: format!("Shells {}", shells.len()),
+        detail: "Watch live output · cancel by the id on the row".to_string(),
+        tone: WorkTone::Heading,
+        selectable: true,
+        primary_action: Some(SidebarRowAction::InspectWork {
+            title: format!("Shells {}", shells.len()),
+            body: format!(
+                "Running shells ({})\n\n{listing}Open a row to watch output. Cancel with /jobs cancel <id> or /jobs cancel all.",
+                shells.len()
+            ),
+            stop_action: Some(Box::new(SidebarRowAction::Command(
+                "/jobs cancel all".to_string(),
+            ))),
+        }),
+        agent: None,
+    }
+}
+
+fn shell_inspector_body(app: &App, entry: &TaskPanelEntry, command: &str, status: &str) -> String {
+    let mut body = format!(
+        "Job: {}\nStatus: {status}\nCommand: {command}\n\nCancel: /jobs cancel {}\n",
+        entry.id, entry.id
+    );
+    let session = app.current_session_id.as_deref().unwrap_or("");
+    if let Some(manager) = app.runtime_services.shell_manager.as_ref()
+        && let Ok(mut manager) = manager.try_lock()
+        && let Ok(detail) = manager.inspect_job_for_session(session, &entry.id)
+    {
+        if !detail.stdout.is_empty() {
+            body.push_str("\nSTDOUT:\n");
+            body.push_str(&detail.stdout);
+        }
+        if !detail.stderr.is_empty() {
+            body.push_str("\nSTDERR:\n");
+            body.push_str(&detail.stderr);
+        }
+        if detail.stdout.is_empty() && detail.stderr.is_empty() {
+            body.push_str("\n(no output yet — reopen this row to watch the shell)");
+        }
+    } else {
+        body.push_str("\nOpen this row to watch live output.");
+    }
+    body
+}
+
 fn graph_node_row(snapshot: &WorkGraphSnapshot, node: &WorkNode) -> WorkRow {
     let (mark, tone) = match node.state {
         NodeState::Ready => (crate::tui::glyphs::READY, WorkTone::Muted),
@@ -3169,6 +3329,110 @@ mod tests {
         assert_eq!(
             rows[0].label,
             "Work · Needs input: operation choose a release target · 1 blocked"
+        );
+    }
+
+    fn running_shell_entry(id: &str, command: &str) -> crate::tui::app::TaskPanelEntry {
+        crate::tui::app::TaskPanelEntry {
+            id: id.to_string(),
+            status: "running".to_string(),
+            prompt_summary: format!("shell: {command}"),
+            duration_ms: Some(42_000),
+            kind: crate::tui::app::TaskPanelEntryKind::Background,
+            stale: false,
+            elapsed_since_output_ms: None,
+            owner_agent_id: None,
+            owner_agent_name: None,
+            current_tool: None,
+            role: None,
+            files_touched: 0,
+        }
+    }
+
+    #[test]
+    fn live_shells_are_first_class_work_strip_rows() {
+        let mut app = test_app();
+        app.work_surface.placement = WorkSurfacePlacement::Top;
+        app.work_surface.effective_placement = WorkSurfacePlacement::Top;
+        app.task_panel.push(running_shell_entry(
+            "shell_a1b2c3d4",
+            "cd /Volumes/VIXinSSD/ShannonNet",
+        ));
+        app.subagent_cache
+            .push(running_agent("doc-scout-spec-arch"));
+
+        let rows = project_visible(&mut app);
+        assert!(
+            rows.iter()
+                .any(|row| row.id.0 == "section:agents" && row.label.contains("Subagents")),
+            "subagent visibility must not regress: {rows:?}"
+        );
+        let heading = rows
+            .iter()
+            .find(|row| row.id.0 == "section:shells")
+            .expect("Shells group heading");
+        assert_eq!(heading.label, "Shells 1");
+        assert!(heading.selectable);
+        let shell = rows
+            .iter()
+            .find(|row| row.id.0 == "shell:shell_a1b2c3d4")
+            .expect("navigable shell row");
+        assert_eq!(shell.label, "shell_a1b2c3d4");
+        let Some(SidebarRowAction::InspectWork {
+            title,
+            body,
+            stop_action,
+        }) = shell.primary_action.as_ref()
+        else {
+            panic!(
+                "shell row must open live output, got {:?}",
+                shell.primary_action
+            );
+        };
+        assert!(title.contains("shell_a1b2c3d4"), "{title}");
+        assert!(body.contains("Job: shell_a1b2c3d4"), "{body}");
+        assert!(body.contains("/jobs cancel shell_a1b2c3d4"), "{body}");
+        assert!(matches!(
+            stop_action.as_deref(),
+            Some(SidebarRowAction::Command(command)) if command == "/jobs cancel shell_a1b2c3d4"
+        ));
+        let facts = shell
+            .agent
+            .as_ref()
+            .expect("shell uses the same row columns");
+        assert_eq!(facts.role_label, "shell");
+        assert_eq!(facts.status, "running");
+        assert!(
+            facts.objective.contains("ShannonNet"),
+            "{}",
+            facts.objective
+        );
+    }
+
+    #[test]
+    fn durable_tasks_are_not_promoted_as_shell_rows() {
+        let mut app = test_app();
+        app.work_surface.placement = WorkSurfacePlacement::Top;
+        app.work_surface.effective_placement = WorkSurfacePlacement::Top;
+        app.task_panel.push(crate::tui::app::TaskPanelEntry {
+            id: "run".to_string(),
+            status: "running".to_string(),
+            prompt_summary: "background confirmation test".to_string(),
+            duration_ms: Some(99_000),
+            kind: crate::tui::app::TaskPanelEntryKind::Background,
+            stale: false,
+            elapsed_since_output_ms: None,
+            owner_agent_id: None,
+            owner_agent_name: None,
+            current_tool: None,
+            role: None,
+            files_touched: 0,
+        });
+        let rows = project_visible(&mut app);
+        assert!(
+            rows.iter()
+                .all(|row| !row.id.0.starts_with("shell:") && row.id.0 != "section:shells"),
+            "non-shell task_panel entries must not become Shells rows: {rows:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Background shells are now the same class of work as subagents: a navigable `▾ Shells N` group on the work strip. Open a row to watch output; the `shell_*` id on the row is the cancel target (`/jobs cancel <id>`).
- `/jobs cancel all` (space) and `/jobs cancel-all` both cancel running shells. The old parse treated `all` as a task id and printed `Command cancel failed: Task all not found`.
- The composer hourglass crumb no longer stands in for a shell surface. Subagent visibility is unchanged.

This is a **new PR**, not a ride on #5698. The #5698 startup-hero lane was left alone (no `underwater.rs`, composer, or `prompts/text.rs` edits).

## What was ripped
- Shells as a footer/status crumb (`⏳ 1 shell — cd …`) as the only operator surface
- `/jobs cancel all` looking up a TaskManager/shell-owner id named `all`
- Session-scoped `/jobs` misses saying `Task {id} not found` (now `Job {id} not found`)

## Test plan
- [x] Local: jobs parse + shell-strip + crumb exclusion **8/8** (`parses_job_actions`, `handler_is_pure_and_argument_only` ×3 filter hits, `list_shows_controls_and_stale_state`, `pending_work_from_app_picks_up_shell_and_agent_entries`, `live_shells_are_first_class_work_strip_rows`, `durable_tasks_are_not_promoted_as_shell_rows`)
- [x] Local: `tui::` suite **3140 passed / 8184 skipped / 0 failed** (includes work-strip subagent regression tests)
- [ ] Hosted exact-head CI at this SHA before merge (`b1b7fda40eedcff2251bcf862d458c7f9cea5b91`)
- [ ] In `cw operate` with a live background shell: strip shows `▾ Shells 1` + the `shell_*` id; Enter opens output; `/jobs cancel all` cancels that job; subagents group still works


Made with [Cursor](https://cursor.com)

No-Issue: founder operate fix for first-class shells and /jobs cancel all; tracked in the 0.9.12 ledger, not a standalone GitHub issue.
