### PR TITLE
chore: remove verified-dead code and unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
- "tokio-util",
  "tracing",
  "uuid",
 ]
@@ -1084,7 +1083,6 @@ dependencies = [
  "pretty_assertions",
  "qrcode",
  "ratatui",
- "ratatui-core",
  "regex",
  "reqwest 0.13.4",
  "rio-vt",
@@ -2235,12 +2233,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hashbrown"
@@ -5707,13 +5699,9 @@ checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
- "futures-util",
- "hashbrown 0.15.5",
  "libc",
  "pin-project-lite",
- "slab",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ tower-http = { version = "0.7", features = ["cors"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-tokio-util = { version = "0.7.16", features = ["io", "full"] }
 uuid = { version = "1.11", features = ["v4"] }
 mimalloc = { version = "0.1", default-features = false }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,7 +15,6 @@ anyhow.workspace = true
 chrono.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-tokio-util.workspace = true
 codewhale-agent = { path = "../agent", version = "0.9.11" }
 codewhale-config = { path = "../config", version = "0.9.11" }
 codewhale-execpolicy = { path = "../execpolicy", version = "0.9.11" }

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -59,13 +59,11 @@ fd-lock = "4.0.4"
 dirs.workspace = true
 futures-util = "0.3.31"
 oauth2 = "5"
-# ratatui-core >= 0.1.1 queries cursor position inside `Terminal::clear()`
-# and races our input loop at startup (ratatui/ratatui#2483/#2640).
-# ColorCompatBackend answers `get_cursor_position()` from tracked state
-# (#2640's recommended workaround), so the pin is no longer needed and lru
-# can resolve to >= 0.18.2 (RUSTSEC-2026-0253).
+# No ratatui-core pin: ColorCompatBackend answers `get_cursor_position()`
+# from tracked state (ratatui#2640's recommended workaround), so the CPR query
+# inside `Terminal::clear()` no longer races the input loop. See
+# `tui/color_compat.rs`.
 ratatui = { version = "=0.30.2", features = ["unstable-rendered-line-info"] }
-ratatui-core = "0.1"
 regex = "1.11"
 reqwest = { workspace = true, features = ["blocking", "stream", "form", "http2"] }
 rusqlite.workspace = true

--- a/crates/tui/src/commands/groups/core/voice.rs
+++ b/crates/tui/src/commands/groups/core/voice.rs
@@ -546,33 +546,6 @@ fn resolve_asr_choice(_config: &Config) -> (String, String) {
     }
 }
 
-/// Available ASR providers (for `voice --list` / settings UI).
-#[allow(dead_code)]
-pub fn available_asr_providers() -> Vec<(&'static str, &'static str, &'static str)> {
-    vec![
-        (
-            "local-whisper",
-            "Local Whisper.cpp",
-            "free, offline, mac/win/linux/harmony — brew install whisper-cpp",
-        ),
-        (
-            "groq",
-            "Groq Whisper large-v3-turbo",
-            "free tier, fast, needs GROQ_API_KEY",
-        ),
-        (
-            "xiaomi",
-            "Xiaomi MiMo ASR (mimo-v2.5-asr)",
-            "needs XIAOMI_API_KEY, streaming, high quality",
-        ),
-        (
-            "openai",
-            "OpenAI whisper-1",
-            "needs OPENAI_API_KEY, compatible",
-        ),
-    ]
-}
-
 pub async fn capture_and_transcribe(
     app: &mut App,
     config: &Config,

--- a/crates/tui/src/features.rs
+++ b/crates/tui/src/features.rs
@@ -140,10 +140,6 @@ pub fn feature_from_key(key: &str) -> Option<Feature> {
         .map(|spec| spec.id)
 }
 
-pub fn feature_spec_by_key(key: &str) -> Option<&'static FeatureSpec> {
-    FEATURES.iter().find(|spec| spec.key == key)
-}
-
 pub fn render_feature_table(features: &Features) -> String {
     let mut output = String::from("feature\tstage\tenabled\n");
     for spec in FEATURES {

--- a/crates/tui/src/fleet/profile.rs
+++ b/crates/tui/src/fleet/profile.rs
@@ -183,10 +183,6 @@ pub fn load_workspace_agent_profiles_tolerant(
     load_agent_profiles_from_dir_tolerant(dir, ProfileOrigin::Workspace)
 }
 
-pub fn load_personal_agent_profiles_tolerant() -> Result<(Vec<AgentProfile>, Vec<String>)> {
-    load_agent_profiles_from_dir_tolerant(personal_agent_profile_dir()?, ProfileOrigin::Personal)
-}
-
 pub fn load_agent_profiles_from_dir_tolerant(
     dir: impl AsRef<Path>,
     origin: ProfileOrigin,

--- a/crates/tui/src/plugins/discovery.rs
+++ b/crates/tui/src/plugins/discovery.rs
@@ -499,22 +499,6 @@ pub(crate) fn load_staged_skill_snapshots(
     Ok(snapshots)
 }
 
-#[cfg(test)]
-pub(crate) fn load_plugin_for_test(manifest_path: &Path) -> Result<LoadedPlugin, String> {
-    let discovery_root = manifest_path
-        .parent()
-        .and_then(Path::parent)
-        .ok_or_else(|| "test plugin manifest needs a bundle and discovery root".to_string())?
-        .canonicalize()
-        .map_err(|error| format!("failed to canonicalize test discovery root: {error}"))?;
-    load_plugin(
-        manifest_path,
-        &discovery_root,
-        PluginScope::User,
-        PluginOrigin::CodeWhaleHome,
-    )
-}
-
 fn plugin_id(scope: PluginScope, name: &str, canonical_root: &Path) -> PluginId {
     let mut hasher = Sha256::new();
     // v2 intentionally invalidates receipts produced by the former lossy

--- a/crates/tui/src/provider_lake.rs
+++ b/crates/tui/src/provider_lake.rs
@@ -484,21 +484,6 @@ pub fn models_for_provider(
     }
 }
 
-/// Every built-in provider that carries at least one merged-catalog row.
-#[must_use]
-#[allow(dead_code)]
-pub fn all_catalog_providers() -> Vec<ApiProvider> {
-    let mut seen = Vec::new();
-    for offering in &merged_snapshot().offerings {
-        if let Some(provider) = ApiProvider::parse(&offering.provider)
-            && !seen.contains(&provider)
-        {
-            seen.push(provider);
-        }
-    }
-    seen
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -1187,13 +1187,6 @@ impl ToolContext {
         self
     }
 
-    /// Set the sandbox policy.
-    #[allow(dead_code)]
-    pub fn with_sandbox_policy(mut self, policy: SandboxPolicy) -> Self {
-        self.sandbox_policy = policy;
-        self
-    }
-
     /// Set feature flags for tool execution.
     pub fn with_features(mut self, features: Features) -> Self {
         self.features = features;

--- a/crates/tui/src/tui/git_status.rs
+++ b/crates/tui/src/tui/git_status.rs
@@ -294,13 +294,6 @@ pub fn create_worktree(
     Ok(())
 }
 
-/// List worktrees from the cache (refresh first if needed).
-#[must_use]
-pub fn list_worktrees(workspace: &Path) -> Vec<WorktreeEntry> {
-    refresh_if_stale(workspace);
-    cached_status().worktrees
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tui/src/work_graph/liveness.rs
+++ b/crates/tui/src/work_graph/liveness.rs
@@ -40,12 +40,6 @@ impl OperationIntent {
             acceptance: Vec::new(),
         }
     }
-
-    #[must_use]
-    pub fn with_acceptance(mut self, acceptance: Vec<AcceptanceRequirement>) -> Self {
-        self.acceptance = acceptance;
-        self
-    }
 }
 
 /// One authoritative owner snapshot. `seq` must be monotonic within the

--- a/crates/tui/src/work_graph/runtime.rs
+++ b/crates/tui/src/work_graph/runtime.rs
@@ -720,43 +720,6 @@ impl WorkRuntime {
         }
     }
 
-    /// Reconcile restored Fleet and Lane bindings from their durable owners.
-    /// Missing records fail toward `Stale`; process probes never override the
-    /// replayed ledger/registry state.
-    pub fn reconcile_workspace_owner_bindings(
-        &self,
-        session_id: &str,
-        workspace: &Path,
-    ) -> Result<usize, String> {
-        let (base, revision) = {
-            let active = lock_unpoisoned(&self.graph);
-            if active.session_id.as_deref() != Some(session_id) {
-                return Err(format!(
-                    "workspace owner reconciliation does not match active session {session_id}"
-                ));
-            }
-            let base = active
-                .snapshot
-                .clone()
-                .ok_or_else(|| "workspace owner reconciliation has no active graph".to_string())?;
-            let revision = base.revision;
-            (base, revision)
-        };
-        let (next, changed) = reconcile_workspace_snapshot(base, session_id, workspace)?;
-        if changed == 0 {
-            return Ok(0);
-        }
-        let mut active = lock_unpoisoned(&self.graph);
-        if active.session_id.as_deref() != Some(session_id)
-            || active.snapshot.as_ref().map(|graph| graph.revision) != Some(revision)
-        {
-            return Err("Work Graph changed during workspace owner reconciliation".to_string());
-        }
-        active.snapshot = Some(next);
-        active.pending_publish = true;
-        Ok(changed)
-    }
-
     pub fn clear(&self, session_id: Option<&str>) -> bool {
         let Some(mut todos) = retry_lock(&self.todos, 100) else {
             return false;


### PR DESCRIPTION
## What

Dead-code sweep over `main`: 2 unused dependencies and 9 dead functions removed — **+4 / −143 lines** across 13 files, plus a slimmer `Cargo.lock`.

## How every removal was verified

Because all member crates deny warnings, dead code here hides behind `allow(dead_code)` / `expect(dead_code)`. Candidates came from a `rustc --force-warn dead_code` pass over a full `--workspace --all-targets` build, then each name was re-vetted with whole-word textual searches across Rust sources, scripts, docs, `web/`, `npm/`, and `integrations/` — so nothing consumed by non-Rust tooling was touched. Only items with **zero references anywhere and no documented reservation** were removed.

## Unused dependencies (cargo-machete)

- **codewhale-core: `tokio-util`** — zero references in the crate; its workspace-level `full` feature set was pulling `futures-io`/`futures-util` edges into every core build.
- **codewhale-tui: `ratatui-core`** — only ever a transitive-version pin; its own comment recorded the pin was obsolete once `ColorCompatBackend` answered `get_cursor_position()` from tracked state (ratatui#2640 workaround). The surviving note now lives on the `ratatui` entry. Lockfile drops `hashbrown 0.15.5` as a result.

## Dead functions removed

| Item | Why it was safe |
| --- | --- |
| `provider_lake::all_catalog_providers` | no callers |
| `voice::available_asr_providers` | doc cited a `voice --list` surface that does not exist |
| `features::feature_spec_by_key` | no callers; sibling accessors cover the surface |
| `tui/git_status::list_worktrees` | no callers |
| `fleet/profile::load_personal_agent_profiles_tolerant` | no callers; workspace variant remains |
| `plugins/discovery::load_plugin_for_test` | `#[cfg(test)]` helper with zero test callers |
| `work_graph::Runtime::reconcile_workspace_owner_bindings` | no callers |
| `work_graph::ExternalBinding::with_acceptance` | builder never chained |
| `ToolContextBuilder::with_sandbox_policy` | builder never chained |

## Deliberately kept

- `PUBLIC_SANDBOX_BACKENDS` — parsed out of the source text by the web facts-drift gate (`web/scripts/facts-lib.mjs`).
- Palette token constants — curated design inventory marked `#[expect(dead_code)]` on purpose.
- Seams reserved for tracked follow-ups (TUI-DOG-008..011, #2186, #4651, #4407, #3217, #97).

## Evidence (local)

- `cargo check --workspace --all-targets` — clean, zero warnings
- `cargo fmt --all -- --check` — clean
- `cargo-machete` — clean (was: 2 hits)
- 261 focused nextest cases across every touched module — all pass
- force-warn `dead_code` re-inventory — the nine items are gone and **zero** items became newly dead

No-Issue: verified dead-code sweep — no tracking issue; every removal is compiler- and search-verified as described above.
