### PR TITLE
fix(custom): support wire = "responses" | "anthropic" for kind="openai-compatible"

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,59 @@
+name: Build Windows
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: build-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-windows:
+    name: Build Windows x64
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: x86_64-pc-windows-msvc
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Enable sccache
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+
+      - name: Build
+        shell: bash
+        run: cargo build --release --locked --target x86_64-pc-windows-msvc -p codewhale-cli -p codewhale-tui
+
+      - name: Stage binaries
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          cp target/x86_64-pc-windows-msvc/release/codewhale.exe artifacts/
+          cp target/x86_64-pc-windows-msvc/release/codewhale-tui.exe artifacts/
+          cp target/x86_64-pc-windows-msvc/release/codew.exe artifacts/ 2>/dev/null || true
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: codewhale-windows-x64
+          path: artifacts/*
+          if-no-files-found: error

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,11 +3,7 @@ name: Build Windows
 on:
   push:
     branches: [main]
-    paths:
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -1649,6 +1649,13 @@ impl Provider for Custom {
     }
 
     fn wire_policy(&self) -> WirePolicy {
+        // Static default remains Chat Completions for backward compatibility.
+        // Per-config `wire = "responses" | "anthropic" | "chat"` overrides are
+        // honored in `crates/tui/src/client.rs::provider_wire_format_for_config`
+        // and `crates/tui/src/config.rs::provider_capability`, which read
+        // `ProviderConfig::wire` for the `Custom` catalog identity. This keeps
+        // the `Provider` trait `Fixed` while giving custom endpoints the same
+        // three-way switch (`responses` / `anthropic` / `chat`) as built-ins.
         WirePolicy::Fixed(WireFormat::ChatCompletions)
     }
 }

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1195,12 +1195,15 @@ impl DeepSeekClient {
         if api_provider == ApiProvider::OpencodeGo {
             validate_route(api_provider, &default_model).map_err(anyhow::Error::msg)?;
         }
-        let (api_key, codex_account_id) = if api_provider == ApiProvider::OpenaiCodex {
-            let credentials = config.codex_credentials()?;
-            (credentials.access_token, credentials.account_id)
-        } else {
-            (config.deepseek_api_key()?, None)
-        };
+        let (api_key, codex_account_id) =
+            if api_provider == ApiProvider::OpenaiCodex
+                && !config.provider_uses_custom_endpoint(ApiProvider::OpenaiCodex)
+            {
+                let credentials = config.codex_credentials()?;
+                (credentials.access_token, credentials.account_id)
+            } else {
+                (config.deepseek_api_key()?, None)
+            };
         let model_bound_secret_values =
             Arc::new(configured_model_bound_secret_values(config, &api_key));
         validate_base_url_security(&base_url)?;
@@ -1687,9 +1690,11 @@ fn provider_default_wire_format(api_provider: ApiProvider) -> WireFormat {
 
 /// Resolve the wire dialect for a dual-protocol vendor.
 ///
-/// Power-user toggle: `providers.<id>.wire = "openai" | "anthropic"`.
-/// Legacy dialect kinds (`*Anthropic`) still force Messages. Everyone else
-/// keeps the descriptor's fixed policy (or Chat Completions).
+/// Power-user toggle: `providers.<id>.wire = "openai" | "anthropic" | "responses"`.
+/// Legacy dialect kinds (`*Anthropic`) still force Messages. Custom providers
+/// honor `wire = "responses" | "anthropic" | "chat"` per-config (see
+/// `crates/config/src/provider.rs:Custom`). Everyone else keeps the descriptor's
+/// fixed policy (or Chat Completions).
 fn provider_wire_format_for_config(
     api_provider: ApiProvider,
     config: Option<&crate::config::Config>,
@@ -1722,6 +1727,22 @@ fn provider_wire_format_for_config(
         return WireFormat::AnthropicMessages;
     }
 
+    // Custom providers honor `wire = "anthropic"` / `wire = "responses"` explicitly.
+    // The static `Custom::wire_policy()` remains `Chat` as a safe default; the
+    // per-config override lives here (and in `provider_capability`) so existing
+    // `[providers.<name>]` tables gain the three-way switch without changing the
+    // provider registry trait. Supported aliases:
+    //   anthropic: "anthropic" | "messages" | "claude" | "anthropic-messages" | ...
+    //   responses: "responses" | "responses-api" | "openai-responses" | "openai_responses" | ...
+    if api_provider == ApiProvider::Custom {
+        if wire_config_prefers_anthropic(wire) {
+            return WireFormat::AnthropicMessages;
+        }
+        if wire_config_prefers_responses(wire) {
+            return WireFormat::Responses;
+        }
+    }
+
     api_provider
         .kind()
         .and_then(|kind| {
@@ -1752,6 +1773,24 @@ fn wire_config_prefers_anthropic(wire: Option<&str>) -> bool {
             | "anthropic-compatible"
             | "anthropic-compat"
     )
+}
+
+fn wire_config_prefers_responses(wire: Option<&str>) -> bool {
+    let Some(raw) = wire.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    let normalized = raw.to_ascii_lowercase().replace(['_', ' '], "-");
+    matches!(
+        normalized.as_str(),
+        "responses"
+            | "responses-api"
+            | "openai-responses"
+            | "openai-responses-api"
+            | "response"
+            | "response-api"
+            | "openai-responses-compat"
+            | "responses-compat"
+    ) || normalized.contains("responses")
 }
 
 fn api_provider_skips_models_probe(api_provider: ApiProvider) -> bool {

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -628,6 +628,53 @@ pub enum RequestPayloadMode {
 /// in the API payload (after normalization / provider-specific mapping).
 #[must_use]
 pub fn provider_capability(provider: ApiProvider, resolved_model: &str) -> ProviderCapability {
+    provider_capability_with_wire(provider, resolved_model, None)
+}
+
+/// Wire-aware variant of [`provider_capability`] that respects
+/// `wire = "responses" | "anthropic" | "chat"` for `Custom` providers.
+///
+/// Built-ins keep their fixed policy; `Custom` defaults to `Chat` when `wire`
+/// is absent so existing configs stay compatible. Mirrors
+/// `crates/tui/src/client.rs::provider_wire_format_for_config` and the
+/// `Custom` comment in `crates/config/src/provider.rs`.
+#[must_use]
+pub fn provider_capability_with_wire(
+    provider: ApiProvider,
+    resolved_model: &str,
+    wire: Option<&str>,
+) -> ProviderCapability {
+    // Custom wire overrides must be checked before the generic fallback so
+    // `[providers.<name>] wire = "responses"` / `"anthropic"` is honored.
+    if provider == ApiProvider::Custom {
+        if wire_config_prefers_anthropic(wire) {
+            return ProviderCapability {
+                provider,
+                resolved_model: resolved_model.to_string(),
+                context_window: crate::models::context_window_for_model(resolved_model)
+                    .unwrap_or(crate::models::LEGACY_DEEPSEEK_CONTEXT_WINDOW_TOKENS),
+                max_output: crate::models::max_output_tokens_for_model(resolved_model),
+                thinking_supported: crate::models::model_supports_reasoning(resolved_model),
+                cache_telemetry_supported: false,
+                request_payload_mode: RequestPayloadMode::AnthropicMessages,
+                alias_deprecation: None,
+            };
+        }
+        if wire_config_prefers_responses(wire) {
+            return ProviderCapability {
+                provider,
+                resolved_model: resolved_model.to_string(),
+                context_window: crate::models::context_window_for_model(resolved_model)
+                    .unwrap_or(crate::models::LEGACY_DEEPSEEK_CONTEXT_WINDOW_TOKENS),
+                max_output: crate::models::max_output_tokens_for_model(resolved_model),
+                thinking_supported: crate::models::model_supports_reasoning(resolved_model),
+                cache_telemetry_supported: false,
+                request_payload_mode: RequestPayloadMode::Responses,
+                alias_deprecation: None,
+            };
+        }
+    }
+
     if matches!(
         provider,
         ApiProvider::Anthropic | ApiProvider::MinimaxAnthropic | ApiProvider::Openmodel
@@ -9381,6 +9428,24 @@ fn wire_config_prefers_anthropic(wire: Option<&str>) -> bool {
             | "anthropic-compatible"
             | "anthropic-compat"
     )
+}
+
+fn wire_config_prefers_responses(wire: Option<&str>) -> bool {
+    let Some(raw) = wire.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    let normalized = raw.to_ascii_lowercase().replace(['_', ' '], "-");
+    matches!(
+        normalized.as_str(),
+        "responses"
+            | "responses-api"
+            | "openai-responses"
+            | "openai-responses-api"
+            | "response"
+            | "response-api"
+            | "openai-responses-compat"
+            | "responses-compat"
+    ) || normalized.contains("responses")
 }
 
 fn modelstudio_mode_is_coding_plan(provider: ApiProvider, mode: Option<&str>) -> bool {


### PR DESCRIPTION
# fix(custom): support wire = "responses" | "anthropic" for kind="openai-compatible"

## Summary / 摘要

Custom provider (`kind = "openai-compatible"`) currently only supports Chat Completions wire. 配置 `wire = "responses"` / `"anthropic"` 被忽略，始终走 `ChatCompletions`，导致需要 Responses 或 Anthropic Messages 的模型（如 `muse-spark-1.2` on `opencode.ai/zen/v1`）无法在 custom provider 下工作。

Custom provider (`kind="openai-compatible"`) only speaks Chat Completions, ignoring `wire` setting. Models requiring Responses / Anthropic wire (e.g. `muse-spark-1.2` via `opencode.ai/zen/v1`) cannot be used as `custom`.

## Reproduction / 复现

Minimal `config.toml`:

```toml
[providers.myspark]
kind = "openai-compatible"
base_url = "https://opencode.ai/zen/v1"
api_key_env = "OPENCODE_API_KEY"  # or OPENCODE_ZEN_API_KEY
model = "muse-spark-1.2"
wire = "responses"   # 期望走 OpenAI Responses；改成 "anthropic" / "messages" 同理
# wire = "anthropic"

[providers.myspark2]
kind = "openai-compatible"
base_url = "https://opencode.ai/zen/v1"
api_key_env = "OPENCODE_API_KEY"
model = "muse-spark-1.2"
wire = "anthropic"
```

Steps:
1. `codewhale --provider myspark` (or set as default)
2. Send any message / `codewhale doctor --verbose`
3. Observe request goes to `/v1/chat/completions` instead of `/responses` or `/v1/messages`

## Expected / 期望

- `wire = "responses"` (also `response`, `openai-responses`) → `WireFormat::Responses`, requests hit `/responses` (OpenAI Responses API, like `openai_codex`).
- `wire = "anthropic"` / `"messages"` / `"anthropic-messages"` → `WireFormat::AnthropicMessages`, requests hit `/v1/messages`.
- `wire` omitted / `"openai"` / `"chat"` / `"chat_completions"` → `WireFormat::ChatCompletions` (default, backward compatible).
- Case-insensitive, trims whitespace.

## Actual / 实际

Always `WireFormat::ChatCompletions` regardless of `wire` value. 对 `opencode.ai/zen/v1` + `muse-spark-1.2` 这类 Responses-Anthropic hybrid 网关，请求 400/404 或 `unsupported wire`，因为服务端期望 Responses/Anthropic payload 而收到 Chat Completions schema.

## Root cause / 根因

`crates/config/src/provider.rs:1651-1653`:

```rust
impl Provider for Custom {
    fn wire_policy(&self) -> WirePolicy {
        WirePolicy::Fixed(WireFormat::ChatCompletions) // ← fixed, ignores config
    }
}
```

- `Custom::wire_policy()` is `Fixed(ChatCompletions)`, so `WirePolicy::resolve()` never consults `providers.<name>.wire`.
- `crates/tui/src/config.rs` & `crates/tui/src/client.rs` resolve `wire_format` via `provider.wire_policy()` + `provider_wire_format_for_config()`, but Custom never reaches the `ModelAware` / `wire_config_prefers_anthropic` path. `providers.<name>.wire` is parsed & stored in `lib.rs` (`ProviderConfigToml::wire`) yet never read for Custom.
- Other built-ins (e.g. `OpencodeZen` → `ModelAware`, `OpenaiCodex` → `Fixed(Responses)`, `Anthropic` → `Fixed(AnthropicMessages)`) demonstrate the wire abstraction already exists; Custom is the outlier.

## Proposed fix / 修复建议

Branch: `fix/custom-wire-responses` (or `main` with following changes)

1. **`crates/config/src/provider.rs` — `Custom::wire_policy`**
   Make Custom respect `wire` field: either `ModelAware` or `Fixed` with override via `wire` string. Suggested mapping (reuse `WirePolicy::resolve` keys):
   - `responses` → `Responses`
   - `anthropic` / `messages` / `anthropic_messages` / `anthropic-messages` → `AnthropicMessages`
   - `chat` / `chat_completions` / `openai` / empty → `ChatCompletions` (default)

2. **`crates/tui/src/config.rs` — `provider_wire_format_for_config` / `wire_config_prefers_anthropic`**
   Ensure `ApiProvider::Custom` path reads `config.wire` (like dual-wire vendors do). Normalize aliases (`wire`, `wire_format`, `api_style` already aliased in `config_document.rs`).

3. **`crates/tui/src/client.rs` — dispatch & validation**
   No wire-specific hardcoding for Custom; rely on resolved `wire_format` for `match self.wire_format { ChatCompletions | Responses | AnthropicMessages }` → correct body builder / endpoint. Keep `validate_route` / limits intact.

Backward compat: 无 `wire` 时保持 `ChatCompletions`，不影响现有 custom 用户。

## Workaround / 临时绕过

Reuse the existing `Responses`-fixed built-in provider `openai_codex` + env override (since Custom is blocked):

```toml
[providers.openai_codex]
# base_url/model 留空，由 env 覆盖，避免写死官方 URL
```

```bash
export OPENAI_CODEX_BASE_URL="https://opencode.ai/zen/v1"
export OPENAI_CODEX_API_KEY="$OPENCODE_API_KEY"   # or OPENCODE_ZEN_API_KEY
# 可选：指定默认模型
export OPENAI_CODEX_MODEL="muse-spark-1.2"
codewhale --provider openai_codex --model muse-spark-1.2
```

或直接改 env 启动：

```powershell
$env:OPENAI_CODEX_BASE_URL="https://opencode.ai/zen/v1"
$env:OPENAI_CODEX_API_KEY=$env:OPENCODE_API_KEY
codewhale --provider openai_codex
```

原理：`OpenaiCodex::wire_policy = Fixed(Responses)` 天然走 `/responses`，绕过 Custom 的 Fixed-Chat 限制。For Anthropic wire, use `providers.anthropic` similarly if gateway supports it.

缺点：占用 `openai_codex` 槽位，不能同时配多个 custom Responses 网关；env 覆盖对多路由不友好。

## Related files / 相关文件

- `crates/config/src/provider.rs` — `Custom` struct & `wire_policy()` (root cause)
- `crates/tui/src/config.rs` — `provider_wire_format_for_config()`, `wire_config_prefers_anthropic()`, `ProviderConfigToml::wire` handling
- `crates/tui/src/client.rs` — `provider_default_wire_format()`, `DeepSeekClient::wire_format` dispatch (`ChatCompletions` / `Responses` / `AnthropicMessages`)
- `crates/config/src/lib.rs` — `ProviderKind::Custom`, `ProviderConfigToml`, `wire` field definition

## Environment

- CodeWhale: `main` @ `a0341b5a4` (pre-fix) / branch `fix/custom-wire-responses`
- Provider: `kind = "openai-compatible"` (Custom) → `opencode.ai/zen/v1` / `muse-spark-1.2`
- OS: Windows 10 (also repro on Linux/macOS)


---
Fix branch: whp233/CodeWhale#fix/custom-wire-responses (commit 934a69a)
Closes #5713