### PR TITLE
refactor(tui): adopt command shapes in project group (FEAT-021)

### DIFF
--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -111,3 +111,97 @@ pub trait CommandMediaContext {
     /// Validate and insert a resolved media path atomically.
     fn attach_media(&mut self, resolved_path: &Path) -> Result<MediaAttachmentReceipt, String>;
 }
+
+// Project (FEAT-021 D1/D2/D3/D4)
+// ---------------------------------------------------------------------------
+
+/// Portable goal status for the project facet (FEAT-021 D1).
+///
+/// Mirrors the four TUI-owned `tools::goal::GoalStatus` variants without
+/// naming the TUI type. The adapter maps host state onto this enum; handlers
+/// compare and render it directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProjectGoalStatus {
+    #[default]
+    Active,
+    Paused,
+    Complete,
+    Blocked,
+}
+
+/// Portable session-share projection (FEAT-021 D1).
+///
+/// Carries only the emptiness/length and the model/mode labels the live
+/// `/share` handler consumes. The session history itself, exporter I/O, and
+/// all `App` state stay host-side.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectShareProjection {
+    /// Whether the session history is empty (drives the empty-share error).
+    pub history_is_empty: bool,
+    /// Session history length used in the export message and action.
+    pub history_len: usize,
+    /// Current model label.
+    pub model: String,
+    /// Current operating-mode label.
+    pub mode_label: String,
+}
+
+/// Portable goal projection (FEAT-021 D1).
+///
+/// Carries the visible goal state, the effective pending-control view, and the
+/// session-derived token fallback the live `/goal` handler consumes. Concrete
+/// goal-service, session-manager, and `App` types never cross the boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectGoalState {
+    /// Visible goal objective.
+    pub objective: Option<String>,
+    /// Visible goal status.
+    pub status: ProjectGoalStatus,
+    /// Pause reason label when the goal is paused (already rendered).
+    pub pause_reason: Option<String>,
+    /// Elapsed seconds from `started_at` when present (host-computed).
+    pub started_at_elapsed_seconds: Option<u64>,
+    /// Seconds of goal time used (stable budget/elapsed source).
+    pub time_used_seconds: u64,
+    /// Optional token budget.
+    pub token_budget: Option<u32>,
+    /// Tokens used by the goal engine.
+    pub tokens_used: u64,
+    /// Session conversation-token total (fallback when tokens_used == 0).
+    pub session_total_tokens: u32,
+    /// Goal continuation count.
+    pub continuation_count: u32,
+    /// Whether pending goal controls are queued (effective-state gate).
+    pub pending_controls: bool,
+    /// Last-known durable objective (session-derived effective source).
+    pub last_known_objective: Option<String>,
+    /// Last-known durable status (session-derived effective source).
+    pub last_known_status: Option<ProjectGoalStatus>,
+    /// Whether the conversation has API messages (bare `/goal` context gate).
+    pub conversation_present: bool,
+    /// Whether the host is currently loading (idle-hint gate).
+    pub is_loading: bool,
+    /// Whether the goal continuation loop is waiting (idle-hint gate).
+    pub goal_continuation_waiting: bool,
+}
+
+/// Host project data for the project command group (FEAT-021 D1).
+///
+/// Exposes the typed, exact-minimum operations the live project handlers
+/// consume: `/lsp` status/set state, `/share` session payload data, and
+/// `/goal` goal state including the session-derived effective values.
+/// `/init` host data flows through the existing `WORKSPACE` facet (D2), so it
+/// declares `PROJECT | WORKSPACE` (D4) without consuming a project-facet
+/// method. All results are contract-owned portable values; implementation
+/// errors cross as safe text. The TUI adapter is the only place that touches
+/// `App`, `config::config`, the goal service, or the session manager.
+pub trait CommandProjectContext {
+    /// `/lsp` status: whether LSP diagnostics are enabled.
+    fn lsp_enabled(&self) -> bool;
+    /// `/lsp` set: enable or disable LSP diagnostics.
+    fn lsp_set(&mut self, enabled: bool) -> Result<(), String>;
+    /// `/share` projection: session emptiness, length, model, and mode label.
+    fn share_projection(&self) -> ProjectShareProjection;
+    /// `/goal` projection: visible and effective goal state.
+    fn goal_state(&self) -> ProjectGoalState;
+}

--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -190,9 +190,9 @@ pub struct ProjectGoalState {
 /// Exposes the typed, exact-minimum operations the live project handlers
 /// consume: `/lsp` status/set state, `/share` session payload data, and
 /// `/goal` goal state including the session-derived effective values.
-/// `/init` host data flows through the existing `WORKSPACE` facet (D2), so it
-/// declares `PROJECT | WORKSPACE` (D4) without consuming a project-facet
-/// method. All results are contract-owned portable values; implementation
+/// `/init` host data flows through the existing `WORKSPACE` facet (D2), so
+/// `/init` destructures exactly `WORKSPACE` (D4) and consumes no
+/// project-facet method. All results are contract-owned portable values; implementation
 /// errors cross as safe text. The TUI adapter is the only place that touches
 /// `App`, `config::config`, the goal service, or the session manager.
 pub trait CommandProjectContext {

--- a/crates/command-contract/src/handler.rs
+++ b/crates/command-contract/src/handler.rs
@@ -6,10 +6,9 @@
 
 use crate::facets::{
     CommandCostContext, CommandMediaContext, CommandModePolicyContext, CommandModelContext,
-    CommandPresentationContext, CommandSessionContext, CommandSkillsContext,
+    CommandPresentationContext, CommandProjectContext, CommandSessionContext, CommandSkillsContext,
     CommandSystemPromptContext, CommandWorkspaceContext,
 };
-
 /// A command handler that is either argument-only or capability-scoped.
 #[derive(Clone, Copy)]
 pub enum CommandHandler<R> {
@@ -28,6 +27,7 @@ pub struct CommandContexts<'a> {
     workspace: Option<&'a mut dyn CommandWorkspaceContext>,
     presentation: Option<&'a mut dyn CommandPresentationContext>,
     media: Option<&'a mut dyn CommandMediaContext>,
+    project: Option<&'a mut dyn CommandProjectContext>,
 }
 
 /// Consumed envelope used when one handler needs several independent facets.
@@ -41,6 +41,7 @@ pub struct ContextParts<'a> {
     pub workspace: Option<&'a mut dyn CommandWorkspaceContext>,
     pub presentation: Option<&'a mut dyn CommandPresentationContext>,
     pub media: Option<&'a mut dyn CommandMediaContext>,
+    pub project: Option<&'a mut dyn CommandProjectContext>,
 }
 
 impl<'a> CommandContexts<'a> {
@@ -55,6 +56,7 @@ impl<'a> CommandContexts<'a> {
             workspace: None,
             presentation: None,
             media: None,
+            project: None,
         }
     }
 
@@ -69,6 +71,7 @@ impl<'a> CommandContexts<'a> {
             workspace: self.workspace,
             presentation: self.presentation,
             media: self.media,
+            project: self.project,
         }
     }
 
@@ -137,6 +140,14 @@ impl<'a> CommandContexts<'a> {
         assert!(
             self.media.replace(value).is_none(),
             "media facet already set"
+        );
+        self
+    }
+
+    pub fn with_project(mut self, value: &'a mut dyn CommandProjectContext) -> Self {
+        assert!(
+            self.project.replace(value).is_none(),
+            "project facet already set"
         );
         self
     }

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -344,3 +344,162 @@ fn envelope_rejects_duplicate_new_slots_deterministically() {
     }));
     assert!(result.is_err(), "duplicate media slot must assert");
 }
+
+// Project facet (FEAT-021 D1/D4)
+// ---------------------------------------------------------------------------
+
+/// Deterministic fake project facet over portable values only.
+struct FakeProject {
+    lsp_enabled: bool,
+    share: ProjectShareProjection,
+    goal: ProjectGoalState,
+}
+
+impl FakeProject {
+    fn new() -> Self {
+        Self {
+            lsp_enabled: false,
+            share: ProjectShareProjection {
+                history_is_empty: true,
+                history_len: 0,
+                model: "deepseek-chat".to_string(),
+                mode_label: "ACT".to_string(),
+            },
+            goal: ProjectGoalState {
+                objective: Some("Ship FEAT-021".to_string()),
+                status: ProjectGoalStatus::Active,
+                pause_reason: None,
+                started_at_elapsed_seconds: Some(42),
+                time_used_seconds: 42,
+                token_budget: Some(50_000),
+                tokens_used: 1_000,
+                session_total_tokens: 2_000,
+                continuation_count: 3,
+                pending_controls: false,
+                last_known_objective: None,
+                last_known_status: None,
+                conversation_present: true,
+                is_loading: false,
+                goal_continuation_waiting: false,
+            },
+        }
+    }
+}
+
+impl CommandProjectContext for FakeProject {
+    fn lsp_enabled(&self) -> bool {
+        self.lsp_enabled
+    }
+
+    fn lsp_set(&mut self, enabled: bool) -> Result<(), String> {
+        self.lsp_enabled = enabled;
+        Ok(())
+    }
+
+    fn share_projection(&self) -> ProjectShareProjection {
+        self.share.clone()
+    }
+
+    fn goal_state(&self) -> ProjectGoalState {
+        self.goal.clone()
+    }
+}
+
+#[test]
+fn project_facet_is_object_safe_and_typed() {
+    fn project(_: &dyn CommandProjectContext) {}
+    project(&FakeProject::new());
+
+    let mut project = FakeProject::new();
+    assert!(!project.lsp_enabled());
+    project.lsp_set(true).unwrap();
+    assert!(project.lsp_enabled());
+    project.lsp_set(false).unwrap();
+    assert!(!project.lsp_enabled());
+}
+
+#[test]
+fn project_share_projection_preserves_semantic_values() {
+    let project = FakeProject::new();
+    let share = project.share_projection();
+    assert!(share.history_is_empty);
+    assert_eq!(share.history_len, 0);
+    assert_eq!(share.model, "deepseek-chat");
+    assert_eq!(share.mode_label, "ACT");
+}
+
+#[test]
+fn project_goal_state_preserves_semantic_values() {
+    let project = FakeProject::new();
+    let goal = project.goal_state();
+    assert_eq!(goal.objective.as_deref(), Some("Ship FEAT-021"));
+    assert_eq!(goal.status, ProjectGoalStatus::Active);
+    assert_eq!(goal.pause_reason, None);
+    assert_eq!(goal.started_at_elapsed_seconds, Some(42));
+    assert_eq!(goal.time_used_seconds, 42);
+    assert_eq!(goal.token_budget, Some(50_000));
+    assert_eq!(goal.tokens_used, 1_000);
+    assert_eq!(goal.session_total_tokens, 2_000);
+    assert_eq!(goal.continuation_count, 3);
+    assert!(!goal.pending_controls);
+    assert_eq!(goal.last_known_objective, None);
+    assert_eq!(goal.last_known_status, None);
+    assert!(goal.conversation_present);
+    assert!(!goal.is_loading);
+    assert!(!goal.goal_continuation_waiting);
+}
+
+#[test]
+fn project_goal_status_variants_are_distinguishable() {
+    let paused = ProjectGoalState {
+        status: ProjectGoalStatus::Paused,
+        pause_reason: Some("user".to_string()),
+        ..FakeProject::new().goal
+    };
+    assert_eq!(paused.status, ProjectGoalStatus::Paused);
+    assert_eq!(paused.pause_reason.as_deref(), Some("user"));
+
+    let complete = ProjectGoalState {
+        status: ProjectGoalStatus::Complete,
+        ..paused
+    };
+    assert_eq!(complete.status, ProjectGoalStatus::Complete);
+    assert_ne!(complete.status, ProjectGoalStatus::Blocked);
+}
+
+#[test]
+fn project_facet_transports_through_envelope_when_declared() {
+    let mut project = FakeProject::new();
+    let parts = CommandContexts::empty()
+        .with_project(&mut project)
+        .into_parts();
+    assert!(parts.project.is_some());
+    assert!(parts.plugin.is_none());
+    assert!(parts.memory.is_none());
+    assert!(parts.session.is_none());
+
+    // PROJECT combined with WORKSPACE (init) and PRESENTATION (goal).
+    let mut workspace = Workspace;
+    let parts = CommandContexts::empty()
+        .with_project(&mut project)
+        .with_workspace(&mut workspace)
+        .into_parts();
+    assert!(parts.project.is_some());
+    assert!(parts.workspace.is_some());
+    assert!(parts.presentation.is_none());
+    assert!(parts.plugin.is_none());
+}
+
+#[test]
+fn envelope_rejects_duplicate_project_slot_deterministically() {
+    let mut a = FakeProject::new();
+    let mut b = FakeProject::new();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        CommandContexts::empty()
+            .with_project(&mut a)
+            .with_project(&mut b);
+    }));
+    assert!(result.is_err(), "duplicate project slot must assert");
+}
+
+#[test]

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -501,5 +501,3 @@ fn envelope_rejects_duplicate_project_slot_deterministically() {
     }));
     assert!(result.is_err(), "duplicate project slot must assert");
 }
-
-#[test]

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -474,8 +474,6 @@ fn project_facet_transports_through_envelope_when_declared() {
         .with_project(&mut project)
         .into_parts();
     assert!(parts.project.is_some());
-    assert!(parts.plugin.is_none());
-    assert!(parts.memory.is_none());
     assert!(parts.session.is_none());
 
     // PROJECT combined with WORKSPACE (init) and PRESENTATION (goal).
@@ -487,7 +485,6 @@ fn project_facet_transports_through_envelope_when_declared() {
     assert!(parts.project.is_some());
     assert!(parts.workspace.is_some());
     assert!(parts.presentation.is_none());
-    assert!(parts.plugin.is_none());
 }
 
 #[test]

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -33,9 +33,9 @@ use std::rc::Rc;
 
 use codewhale_command_contract::facets::{
     CommandCostContext, CommandMediaContext, CommandModePolicyContext, CommandModelContext,
-    CommandPresentationContext, CommandProjectContext, CommandSessionContext,
-    CommandSkillsContext, CommandSystemPromptContext, CommandWorkspaceContext,
-    MediaAttachmentReceipt, ProjectGoalState, ProjectGoalStatus, ProjectShareProjection,
+    CommandPresentationContext, CommandProjectContext, CommandSessionContext, CommandSkillsContext,
+    CommandSystemPromptContext, CommandWorkspaceContext, MediaAttachmentReceipt, ProjectGoalState,
+    ProjectGoalStatus, ProjectShareProjection,
 };
 use codewhale_command_contract::handler::CommandContexts;
 #[cfg(test)]

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -897,6 +897,47 @@ mod tests {
     }
 
     #[test]
+    fn key_to_project_message_id_resolves_goal_runtime_keys_and_rejects_unknown() {
+        // FEAT-021 D5: only /goal uses runtime translations via the project
+        // key map; unknown keys fail safely.
+        assert_eq!(
+            key_to_project_message_id("goal_control_accepted"),
+            Some(MessageId::GoalControlAccepted)
+        );
+        assert_eq!(
+            key_to_project_message_id("goal_status_idle_hint"),
+            Some(MessageId::GoalStatusIdleHint)
+        );
+        assert_eq!(key_to_project_message_id("goal_bogus_key"), None);
+        assert_eq!(key_to_project_message_id(""), None);
+    }
+
+    #[test]
+    fn presentation_translate_resolves_project_keys_with_locale_and_fallback() {
+        // The presentation facet resolves the project runtime keys through the
+        // current catalog (authoritative English fallback preserved).
+        let mut app = test_app();
+        let mut bundle = app.command_contexts();
+        let mut parts = bundle.parts();
+        let presentation = parts.presentation.as_mut().expect("presentation facet");
+        let accepted = presentation
+            .translate("goal_control_accepted", &[])
+            .expect("goal_control_accepted must resolve");
+        assert!(
+            accepted.contains("Goal control saved"),
+            "English fallback text expected: {accepted}"
+        );
+        let hint = presentation
+            .translate("goal_status_idle_hint", &[])
+            .expect("goal_status_idle_hint must resolve");
+        assert!(hint.contains("not running now"), "hint: {hint}");
+        assert!(
+            presentation.translate("goal_bogus", &[]).is_err(),
+            "unknown key must fail safely"
+        );
+    }
+
+    #[test]
     fn cost_adapter_delegates_totals_high_water_and_route_receipt_to_app() {
         let mut app = test_app();
         app.cost_currency = CostCurrency::Usd;

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -897,47 +897,6 @@ mod tests {
     }
 
     #[test]
-    fn key_to_project_message_id_resolves_goal_runtime_keys_and_rejects_unknown() {
-        // FEAT-021 D5: only /goal uses runtime translations via the project
-        // key map; unknown keys fail safely.
-        assert_eq!(
-            key_to_project_message_id("goal_control_accepted"),
-            Some(MessageId::GoalControlAccepted)
-        );
-        assert_eq!(
-            key_to_project_message_id("goal_status_idle_hint"),
-            Some(MessageId::GoalStatusIdleHint)
-        );
-        assert_eq!(key_to_project_message_id("goal_bogus_key"), None);
-        assert_eq!(key_to_project_message_id(""), None);
-    }
-
-    #[test]
-    fn presentation_translate_resolves_project_keys_with_locale_and_fallback() {
-        // The presentation facet resolves the project runtime keys through the
-        // current catalog (authoritative English fallback preserved).
-        let mut app = test_app();
-        let mut bundle = app.command_contexts();
-        let mut parts = bundle.parts();
-        let presentation = parts.presentation.as_mut().expect("presentation facet");
-        let accepted = presentation
-            .translate("goal_control_accepted", &[])
-            .expect("goal_control_accepted must resolve");
-        assert!(
-            accepted.contains("Goal control saved"),
-            "English fallback text expected: {accepted}"
-        );
-        let hint = presentation
-            .translate("goal_status_idle_hint", &[])
-            .expect("goal_status_idle_hint must resolve");
-        assert!(hint.contains("not running now"), "hint: {hint}");
-        assert!(
-            presentation.translate("goal_bogus", &[]).is_err(),
-            "unknown key must fail safely"
-        );
-    }
-
-    #[test]
     fn cost_adapter_delegates_totals_high_water_and_route_receipt_to_app() {
         let mut app = test_app();
         app.cost_currency = CostCurrency::Usd;

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -33,8 +33,9 @@ use std::rc::Rc;
 
 use codewhale_command_contract::facets::{
     CommandCostContext, CommandMediaContext, CommandModePolicyContext, CommandModelContext,
-    CommandPresentationContext, CommandSessionContext, CommandSkillsContext,
-    CommandSystemPromptContext, CommandWorkspaceContext, MediaAttachmentReceipt,
+    CommandPresentationContext, CommandProjectContext, CommandSessionContext,
+    CommandSkillsContext, CommandSystemPromptContext, CommandWorkspaceContext,
+    MediaAttachmentReceipt, ProjectGoalState, ProjectGoalStatus, ProjectShareProjection,
 };
 use codewhale_command_contract::handler::CommandContexts;
 #[cfg(test)]
@@ -518,7 +519,9 @@ pub(crate) struct PresentationAdapter<'a> {
 
 impl CommandPresentationContext for PresentationAdapter<'_> {
     fn translate(&self, key: &str, replacements: &[(&str, &str)]) -> Result<String, String> {
-        let Some(message_id) = key_to_utility_message_id(key) else {
+        let Some(message_id) =
+            key_to_utility_message_id(key).or_else(|| key_to_project_message_id(key))
+        else {
             return Err("unknown translation key".to_string());
         };
         let locale = self.host.app.borrow().ui_locale;
@@ -540,6 +543,20 @@ fn key_to_utility_message_id(key: &str) -> Option<MessageId> {
         "mcp_recommendation_playwright" => MessageId::McpRecommendationPlaywright,
         "mcp_recommendation_cua" => MessageId::McpRecommendationCua,
         "mcp_recommendation_container_use" => MessageId::McpRecommendationContainerUse,
+        _ => return None,
+    })
+}
+
+/// Resolve a stable project message key to the current catalog id (FEAT-021 D5).
+///
+/// Only `/goal` uses runtime translations (`GoalControlAccepted`,
+/// `GoalStatusIdleHint`); all four description keys resolve through the
+/// metadata bridge (`key_to_message_id`) and do not require the presentation
+/// facet.
+pub(crate) fn key_to_project_message_id(key: &str) -> Option<MessageId> {
+    Some(match key {
+        "goal_control_accepted" => MessageId::GoalControlAccepted,
+        "goal_status_idle_hint" => MessageId::GoalStatusIdleHint,
         _ => return None,
     })
 }
@@ -625,10 +642,100 @@ fn media_kind(path: &Path) -> Option<&'static str> {
 }
 
 // ---------------------------------------------------------------------------
+// Project host adapter (FEAT-021 D1/D3)
+// ---------------------------------------------------------------------------
+
+/// Concrete TUI host mapping for the project command group (FEAT-021 D1/D3).
+///
+/// The only place that touches `App` goal/share/LSP state, `config::config`
+/// (cross-group LSP bridge), and the session manager. Every method borrows
+/// `App` for one call and converts host values to portable contract values
+/// before returning; the `/init` workspace path flows through the existing
+/// `WORKSPACE` facet (D2), so no init-specific method exists here.
+pub(crate) struct ProjectAdapter<'a> {
+    host: SharedCommandHost<'a>,
+}
+
+/// Map the TUI-owned goal status onto the portable project status.
+fn portable_goal_status(status: crate::tools::goal::GoalStatus) -> ProjectGoalStatus {
+    match status {
+        crate::tools::goal::GoalStatus::Active => ProjectGoalStatus::Active,
+        crate::tools::goal::GoalStatus::Paused => ProjectGoalStatus::Paused,
+        crate::tools::goal::GoalStatus::Complete => ProjectGoalStatus::Complete,
+        crate::tools::goal::GoalStatus::Blocked => ProjectGoalStatus::Blocked,
+    }
+}
+
+/// Map the durable session goal status onto the portable project status.
+fn portable_session_goal_status(
+    status: crate::session_manager::SessionGoalStatus,
+) -> ProjectGoalStatus {
+    match status {
+        crate::session_manager::SessionGoalStatus::Active => ProjectGoalStatus::Active,
+        crate::session_manager::SessionGoalStatus::Paused => ProjectGoalStatus::Paused,
+        crate::session_manager::SessionGoalStatus::Complete => ProjectGoalStatus::Complete,
+        crate::session_manager::SessionGoalStatus::Blocked => ProjectGoalStatus::Blocked,
+    }
+}
+
+impl CommandProjectContext for ProjectAdapter<'_> {
+    fn lsp_enabled(&self) -> bool {
+        self.host.app.borrow().lsp_enabled
+    }
+
+    fn lsp_set(&mut self, enabled: bool) -> Result<(), String> {
+        // Cross-group LSP behavior stays host-side (D3): the adapter owns the
+        // `config::config::lsp_command` invocation. The portable handler
+        // composes the byte-identical user-facing message from the typed
+        // state, so the formatted result is intentionally not forwarded.
+        let mut app = self.host.app.borrow_mut();
+        let arg = if enabled { "on" } else { "off" };
+        let _ = crate::commands::groups::config::config::lsp_command(&mut app, Some(arg));
+        Ok(())
+    }
+
+    fn share_projection(&self) -> ProjectShareProjection {
+        let app = self.host.app.borrow();
+        ProjectShareProjection {
+            history_is_empty: app.history.is_empty(),
+            history_len: app.history.len(),
+            model: app.model.clone(),
+            mode_label: app.mode.label().to_string(),
+        }
+    }
+
+    fn goal_state(&self) -> ProjectGoalState {
+        let app = self.host.app.borrow();
+        let pending_controls = !app.pending_goal_controls.is_empty();
+        let last_known = app.last_known_goal_state.as_ref();
+        ProjectGoalState {
+            objective: app.goal.objective.clone(),
+            status: portable_goal_status(app.goal.status),
+            pause_reason: app
+                .goal
+                .pause_reason
+                .map(|reason| reason.label().to_string()),
+            started_at_elapsed_seconds: app.goal.started_at.map(|t| t.elapsed().as_secs()),
+            time_used_seconds: app.goal.time_used_seconds,
+            token_budget: app.goal.token_budget,
+            tokens_used: app.goal.tokens_used,
+            session_total_tokens: app.session.total_conversation_tokens,
+            continuation_count: app.goal.continuation_count,
+            pending_controls,
+            last_known_objective: last_known.map(|goal| goal.objective.clone()),
+            last_known_status: last_known.map(|goal| portable_session_goal_status(goal.status)),
+            conversation_present: !app.api_messages.is_empty(),
+            is_loading: app.is_loading,
+            goal_continuation_waiting: app.goal_continuation_waiting,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Envelope construction (D1)
 // ---------------------------------------------------------------------------
 
-/// Owns seven facet objects sharing one synchronous TUI host proxy.
+/// Owns ten facet objects sharing one synchronous TUI host proxy.
 ///
 /// Handlers borrow only these adapters. Every method delegates to the real App
 /// authority and releases its `RefCell` borrow before returning, so facets can
@@ -643,6 +750,7 @@ pub(crate) struct CommandContextBundle<'a> {
     workspace: WorkspaceAdapter<'a>,
     presentation: PresentationAdapter<'a>,
     media: MediaAdapter<'a>,
+    project: ProjectAdapter<'a>,
 }
 
 impl<'a> CommandContextBundle<'a> {
@@ -657,6 +765,7 @@ impl<'a> CommandContextBundle<'a> {
             .with_workspace(&mut self.workspace)
             .with_presentation(&mut self.presentation)
             .with_media(&mut self.media)
+            .with_project(&mut self.project)
     }
 
     /// Test-only: consume the bundle into independent facet parts.
@@ -682,6 +791,7 @@ impl App {
             skills: SkillsAdapter { host: host.clone() },
             workspace: WorkspaceAdapter { host: host.clone() },
             presentation: PresentationAdapter { host: host.clone() },
+            project: ProjectAdapter { host: host.clone() },
             media: MediaAdapter { host },
         }
     }
@@ -1152,5 +1262,192 @@ mod tests {
             let _ = parts.presentation.is_some();
         }
         assert_eq!(app.input, input_before, "no eager composer mutation");
+    }
+
+    // ---------------------------------------------------------------------
+    // FEAT-021 project adapter tests
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn key_to_project_message_id_resolves_goal_runtime_keys_and_rejects_unknown() {
+        // FEAT-021 D5: only /goal uses runtime translations via the project
+        // key map; unknown keys fail safely.
+        assert_eq!(
+            key_to_project_message_id("goal_control_accepted"),
+            Some(MessageId::GoalControlAccepted)
+        );
+        assert_eq!(
+            key_to_project_message_id("goal_status_idle_hint"),
+            Some(MessageId::GoalStatusIdleHint)
+        );
+        assert_eq!(key_to_project_message_id("goal_bogus_key"), None);
+        assert_eq!(key_to_project_message_id(""), None);
+    }
+
+    #[test]
+    fn presentation_translate_resolves_project_keys_with_locale_and_fallback() {
+        // The presentation facet resolves the project runtime keys through the
+        // current catalog (authoritative English fallback preserved).
+        let mut app = test_app();
+        let mut bundle = app.command_contexts();
+        let mut parts = bundle.parts();
+        let presentation = parts.presentation.as_mut().expect("presentation facet");
+        let accepted = presentation
+            .translate("goal_control_accepted", &[])
+            .expect("goal_control_accepted must resolve");
+        assert!(
+            accepted.contains("Goal control saved"),
+            "English fallback text expected: {accepted}"
+        );
+        let hint = presentation
+            .translate("goal_status_idle_hint", &[])
+            .expect("goal_status_idle_hint must resolve");
+        assert!(hint.contains("not running now"), "hint: {hint}");
+        assert!(
+            presentation.translate("goal_bogus", &[]).is_err(),
+            "unknown key must fail safely"
+        );
+    }
+
+    #[test]
+    fn project_adapter_maps_lsp_state() {
+        let mut app = test_app();
+        app.lsp_enabled = false;
+        assert!(!app.lsp_enabled);
+        {
+            let mut bundle = app.command_contexts();
+            let project = bundle
+                .parts()
+                .project
+                .expect("project facet must be present");
+            assert!(!project.lsp_enabled());
+
+            project.lsp_set(true).unwrap();
+            assert!(project.lsp_enabled());
+            project.lsp_set(false).unwrap();
+            assert!(!project.lsp_enabled());
+        }
+        assert!(!app.lsp_enabled);
+    }
+
+    #[test]
+    fn project_adapter_share_projection_maps_history_model_and_mode() {
+        let mut app = test_app();
+        app.model = "deepseek-v4-pro".to_string();
+        app.mode = crate::tui::app::AppMode::Agent;
+        let mut bundle = app.command_contexts();
+        let project = bundle
+            .parts()
+            .project
+            .expect("project facet must be present");
+
+        // Empty history → empty share branch.
+        let share = project.share_projection();
+        assert!(share.history_is_empty);
+        assert_eq!(share.history_len, 0);
+
+        // Populated history → length and labels match host exactly.
+        app.history.push(crate::tui::history::HistoryCell::User {
+            content: "hello".to_string(),
+        });
+        app.history
+            .push(crate::tui::history::HistoryCell::Assistant {
+                content: "world".to_string(),
+                streaming: false,
+            });
+        let mut bundle = app.command_contexts();
+        let project = bundle
+            .parts()
+            .project
+            .expect("project facet must be present");
+        let share = project.share_projection();
+        assert!(!share.history_is_empty);
+        assert_eq!(share.history_len, 2);
+        assert_eq!(share.model, "deepseek-v4-pro");
+        assert_eq!(share.mode_label, crate::tui::app::AppMode::Agent.label());
+    }
+
+    #[test]
+    fn project_adapter_goal_projection_preserves_visible_and_effective_state() {
+        let mut app = test_app();
+        app.goal.objective = Some("Ship FEAT-021".to_string());
+        app.goal.status = crate::tools::goal::GoalStatus::Active;
+        app.goal.time_used_seconds = 42;
+        app.goal.token_budget = Some(50_000);
+        app.goal.tokens_used = 1_000;
+        app.goal.continuation_count = 3;
+        app.session.total_conversation_tokens = 2_000;
+        app.goal_continuation_waiting = true;
+        app.is_loading = false;
+        app.api_messages.push(crate::models::Message {
+            role: crate::models::Role::User,
+            content: vec![crate::models::ContentBlock::Text {
+                text: "work".to_string(),
+                cache_control: None,
+            }],
+        });
+
+        let mut bundle = app.command_contexts();
+        let project = bundle
+            .parts()
+            .project
+            .expect("project facet must be present");
+        let goal = project.goal_state();
+        assert_eq!(goal.objective.as_deref(), Some("Ship FEAT-021"));
+        assert_eq!(goal.status, ProjectGoalStatus::Active);
+        assert_eq!(goal.time_used_seconds, 42);
+        assert_eq!(goal.token_budget, Some(50_000));
+        assert_eq!(goal.tokens_used, 1_000);
+        assert_eq!(goal.session_total_tokens, 2_000);
+        assert_eq!(goal.continuation_count, 3);
+        assert!(!goal.pending_controls);
+        assert!(goal.goal_continuation_waiting);
+        assert!(goal.conversation_present);
+
+        // Pending controls flip the effective source to the durable state.
+        app.pending_goal_controls
+            .push_back(crate::tui::app::PendingGoalControl {
+                intent: crate::tui::app::GoalControlIntent::SetStatus {
+                    status: crate::tools::goal::GoalStatus::Paused,
+                    clear: false,
+                },
+                dispatched: false,
+            });
+        app.last_known_goal_state = Some(crate::session_manager::SessionGoalState {
+            schema_version: 1,
+            objective: "Durable objective".to_string(),
+            status: crate::session_manager::SessionGoalStatus::Paused,
+            token_budget: None,
+            tokens_used: 0,
+            time_used_seconds: 0,
+            continuation_count: 0,
+            elapsed_seconds: 0,
+            pause_reason: None,
+        });
+        let mut bundle = app.command_contexts();
+        let project = bundle
+            .parts()
+            .project
+            .expect("project facet must be present");
+        let goal = project.goal_state();
+        assert!(goal.pending_controls);
+        assert_eq!(
+            goal.last_known_objective.as_deref(),
+            Some("Durable objective")
+        );
+        assert_eq!(goal.last_known_status, Some(ProjectGoalStatus::Paused));
+    }
+
+    #[test]
+    fn project_adapter_exposure_matches_main_envelope_model() {
+        // main's envelope always populates every adapter (no capability
+        // bitmask yet); the project facet is present and usable, and the
+        // handlers destructure only the facets they need.
+        let mut app = test_app();
+        let mut bundle = app.command_contexts();
+        let parts = bundle.parts();
+        assert!(parts.project.is_some());
+        assert!(parts.workspace.is_some());
+        assert!(parts.presentation.is_some());
     }
 }

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -65,7 +65,7 @@ use crate::tui::app::{App, ReasoningEffort};
 /// declaration by source regex and the Rust frontier tests assert it.
 #[allow(dead_code)]
 pub(crate) const PENDING_GROUPS: &[&str] = &[
-    "config", "core", "debug", "memory", "plugins", "project", "session", "skills",
+    "config", "core", "debug", "memory", "plugins", "session", "skills",
 ];
 
 // ---------------------------------------------------------------------------

--- a/crates/tui/src/commands/groups/project/goal.rs
+++ b/crates/tui/src/commands/groups/project/goal.rs
@@ -580,4 +580,81 @@ mod tests {
                 .contains("Command capability unavailable: presentation")
         );
     }
+
+    #[test]
+    fn format_elapsed_matches_tui_leaf_helper() {
+        // The portable replica must stay byte-identical to the TUI elapsed
+        // helper (Phase 4 review recommendation).
+        for secs in [0, 1, 59, 60, 61, 125, 3599, 3600, 3601] {
+            assert_eq!(
+                format_elapsed(secs),
+                crate::elapsed::format_elapsed_secs(secs),
+                "format_elapsed({secs}) must equal the TUI helper"
+            );
+        }
+    }
+
+    #[test]
+    fn goal_control_accepted_translates_through_fake_presentation() {
+        // Pending controls route to the translated message, not the raw key.
+        let mut goal = goal_state();
+        goal.objective = Some("Keep the build green".to_string());
+        goal.status = ProjectGoalStatus::Active;
+        goal.pending_controls = true;
+        goal.last_known_objective = Some("Keep the build green".to_string());
+        goal.last_known_status = Some(ProjectGoalStatus::Paused);
+        let result = run(&goal, Some("pause"));
+        assert!(!result.is_error);
+        let msg = result.message.expect("pending-control message");
+        assert!(msg.contains("Goal control saved"));
+        assert!(
+            !msg.contains("goal_control_accepted"),
+            "raw key must not leak"
+        );
+    }
+
+    #[test]
+    fn idle_hint_translates_through_fake_presentation() {
+        // Active goal not being driven: the idle hint is the translated text.
+        let mut goal = goal_state();
+        goal.objective = Some("Ship it".to_string());
+        goal.status = ProjectGoalStatus::Active;
+        goal.is_loading = false;
+        goal.goal_continuation_waiting = false;
+        let result = run(&goal, Some("status"));
+        let line = result.message.unwrap();
+        assert!(
+            line.contains("not running now"),
+            "idle hint must be translated: {line}"
+        );
+        assert!(
+            !line.contains("goal_status_idle_hint"),
+            "raw key must not leak"
+        );
+    }
+
+    #[test]
+    fn goal_token_fallback_uses_session_total() {
+        // tokens_used == 0 falls back to the session conversation-token total.
+        let mut goal = goal_state();
+        goal.objective = Some("Ship it".to_string());
+        goal.token_budget = Some(100);
+        goal.tokens_used = 0;
+        goal.session_total_tokens = 42;
+        let result = run(&goal, Some("status"));
+        let line = result.message.unwrap();
+        assert!(line.contains("tokens 42/100 (42%)"), "line: {line}");
+    }
+
+    #[test]
+    fn goal_token_uses_engine_count_when_nonzero() {
+        let mut goal = goal_state();
+        goal.objective = Some("Ship it".to_string());
+        goal.token_budget = Some(100);
+        goal.tokens_used = 10;
+        goal.session_total_tokens = 42;
+        let result = run(&goal, Some("status"));
+        let line = result.message.unwrap();
+        assert!(line.contains("tokens 10/100 (10%)"), "line: {line}");
+    }
 }

--- a/crates/tui/src/commands/groups/project/goal.rs
+++ b/crates/tui/src/commands/groups/project/goal.rs
@@ -12,10 +12,9 @@
 use codewhale_command_contract::facets::{
     CommandPresentationContext, ProjectGoalState, ProjectGoalStatus,
 };
-use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts};
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
 use crate::tui::app::AppAction;
 
 use crate::commands::CommandResult;
@@ -275,26 +274,25 @@ fn parse_goal_budget(text: &str) -> (String, Option<u32>) {
     (text.trim().to_string(), None)
 }
 
-pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
+pub(in crate::commands) const GOAL_INFO: CommandInfo = CommandInfo {
     name: "goal",
     aliases: &[],
     usage: "/goal [objective|status|pause|resume|done|blocked|clear] [budget: N]",
-    description_id: MessageId::CmdGoalDescription,
+    description_key: "cmd_goal_description",
 };
 
 pub(in crate::commands) struct GoalCmd;
 
-impl RegisterCommand for GoalCmd {
+impl RegisterCommand<CommandResult> for GoalCmd {
     fn info() -> &'static CommandInfo {
-        &COMMAND_INFO
+        &GOAL_INFO
     }
 
-    fn execute(app: &mut crate::tui::app::App, arg: Option<&str>) -> CommandResult {
-        // Transitional shell: build the capability bundle and delegate to the
-        // contextual dispatch. Phase 6 replaces this with the contract bridge.
-        let mut bundle = app.command_contexts();
-        let capabilities = CommandCapabilities::PROJECT.union(CommandCapabilities::PRESENTATION);
-        goal_contextual(bundle.contexts(capabilities), arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual {
+            capabilities: CommandCapabilities::PROJECT.union(CommandCapabilities::PRESENTATION),
+            handler: goal_contextual,
+        }
     }
 }
 

--- a/crates/tui/src/commands/groups/project/goal.rs
+++ b/crates/tui/src/commands/groups/project/goal.rs
@@ -2,27 +2,64 @@
 //! a durable objective. The engine owns the goal: setting or resuming one
 //! starts work through the runtime's continuation steering, never by echoing
 //! the objective back as a user message.
+//!
+//! FEAT-021 converts this handler to the portable command contract: it
+//! consumes the typed project goal projection and the presentation facet only.
+//! `CommandResult` and the emitted `AppAction` variants (`SetGoalStatus`,
+//! `SetGoalObjective`, `SendMessage`) remain temporary TUI-owned data-only
+//! references until FEAT-037.
+
+use codewhale_command_contract::facets::{
+    CommandPresentationContext, ProjectGoalState, ProjectGoalStatus,
+};
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts};
 
 use crate::commands::traits::{CommandInfo, RegisterCommand};
 use crate::localization::MessageId;
-use crate::tools::goal::GoalStatus;
-use crate::tui::app::{App, AppAction};
+use crate::tui::app::AppAction;
 
 use crate::commands::CommandResult;
 
+/// Translate one stable project key through the presentation facet.
+fn translate(presentation: &mut dyn CommandPresentationContext, key: &str) -> String {
+    presentation.translate(key, &[]).unwrap_or_default()
+}
+
+/// Map the portable goal status onto the TUI-owned action payload status.
+///
+/// This is the bounded FEAT-037 temporary action reference: the handler only
+/// constructs data-only `AppAction` payloads and never touches the goal
+/// service, config, or session manager.
+fn to_action_status(status: ProjectGoalStatus) -> crate::tools::goal::GoalStatus {
+    match status {
+        ProjectGoalStatus::Active => crate::tools::goal::GoalStatus::Active,
+        ProjectGoalStatus::Paused => crate::tools::goal::GoalStatus::Paused,
+        ProjectGoalStatus::Complete => crate::tools::goal::GoalStatus::Complete,
+        ProjectGoalStatus::Blocked => crate::tools::goal::GoalStatus::Blocked,
+    }
+}
+
 /// Declare, show, pause, resume, or close a goal.
-fn goal_command(app: &mut App, arg: Option<&str>) -> CommandResult {
+fn goal_command(
+    goal: &ProjectGoalState,
+    presentation: &mut dyn CommandPresentationContext,
+    arg: Option<&str>,
+) -> CommandResult {
     match arg {
         Some("clear") | Some("reset") => CommandResult::action(AppAction::SetGoalStatus {
-            status: GoalStatus::Active,
+            status: crate::tools::goal::GoalStatus::Active,
             clear: true,
         }),
-        Some("done") | Some("complete") => close_goal(app, GoalStatus::Complete),
-        Some("pause") | Some("paused") => close_goal(app, GoalStatus::Paused),
-        Some("resume") | Some("continue") => resume_goal(app),
+        Some("done") | Some("complete") => {
+            close_goal(goal, presentation, ProjectGoalStatus::Complete)
+        }
+        Some("pause") | Some("paused") => close_goal(goal, presentation, ProjectGoalStatus::Paused),
+        Some("resume") | Some("continue") => resume_goal(goal, presentation),
         Some("help") | Some("?") | Some("usage") => CommandResult::message(goal_usage()),
-        Some("status") | Some("show") => goal_status(app),
-        Some("block") | Some("blocked") => close_goal(app, GoalStatus::Blocked),
+        Some("status") | Some("show") => goal_status(goal, presentation),
+        Some("block") | Some("blocked") => {
+            close_goal(goal, presentation, ProjectGoalStatus::Blocked)
+        }
         Some(text) if !text.is_empty() => {
             let (objective, budget) = parse_goal_budget(text);
             if objective.is_empty() || objective.chars().all(|c| c == '|') {
@@ -37,11 +74,11 @@ fn goal_command(app: &mut App, arg: Option<&str>) -> CommandResult {
             })
         }
         _ => {
-            if !app.pending_goal_controls.is_empty() {
-                CommandResult::message(app.tr(MessageId::GoalControlAccepted))
-            } else if app.goal.objective.is_some() {
-                goal_status(app)
-            } else if app.api_messages.is_empty() {
+            if goal.pending_controls {
+                CommandResult::message(translate(presentation, "goal_control_accepted"))
+            } else if goal.objective.is_some() {
+                goal_status(goal, presentation)
+            } else if !goal.conversation_present {
                 // Nothing has happened yet: there is no context to derive an
                 // objective from, so answer with usage instead of spending a
                 // model turn on a question we already know the answer to.
@@ -70,29 +107,27 @@ fn goal_command(app: &mut App, arg: Option<&str>) -> CommandResult {
 
 /// Plain status line: objective, state, elapsed, budget, continuations, and
 /// — for an active goal that no turn is driving right now — how to continue.
-fn goal_status(app: &App) -> CommandResult {
-    let Some(obj) = app.goal.objective.as_deref() else {
+fn goal_status(
+    goal: &ProjectGoalState,
+    presentation: &mut dyn CommandPresentationContext,
+) -> CommandResult {
+    let Some(obj) = goal.objective.as_deref() else {
         return CommandResult::message(goal_usage());
     };
-    let elapsed = app
-        .goal
-        .time_used_seconds
-        .gt(&0)
-        .then(|| crate::elapsed::format_elapsed_secs(app.goal.time_used_seconds))
-        .or_else(|| {
-            app.goal
-                .started_at
-                .map(|t| crate::elapsed::format_elapsed_secs(t.elapsed().as_secs()))
-        })
-        .unwrap_or_else(|| "unknown".to_string());
-    let budget_str = app
-        .goal
+    let elapsed = if goal.time_used_seconds > 0 {
+        format_elapsed(goal.time_used_seconds)
+    } else if let Some(secs) = goal.started_at_elapsed_seconds {
+        format_elapsed(secs)
+    } else {
+        "unknown".to_string()
+    };
+    let budget_str = goal
         .token_budget
         .map(|b| {
-            let used = if app.goal.tokens_used > 0 {
-                app.goal.tokens_used
+            let used = if goal.tokens_used > 0 {
+                goal.tokens_used
             } else {
-                u64::from(app.session.total_conversation_tokens)
+                u64::from(goal.session_total_tokens)
             };
             let pct = if b > 0 {
                 (used as f64 / f64::from(b) * 100.0).min(100.0)
@@ -102,17 +137,20 @@ fn goal_status(app: &App) -> CommandResult {
             format!(" · tokens {used}/{b} ({pct:.0}%)")
         })
         .unwrap_or_default();
-    let mut state = goal_status_label(app.goal.status).to_string();
-    if let (GoalStatus::Paused, Some(reason)) = (app.goal.status, app.goal.pause_reason) {
-        state = format!("{state} ({})", reason.label());
+    let mut state = goal_status_label(goal.status).to_string();
+    if let (ProjectGoalStatus::Paused, Some(reason)) = (goal.status, goal.pause_reason.as_deref()) {
+        state = format!("{state} ({reason})");
     }
     let mut line = format!(
         "Goal {state}: \"{obj}\" · elapsed {elapsed}{budget_str} · continuations {}",
-        app.goal.continuation_count
+        goal.continuation_count
     );
-    if app.goal.status == GoalStatus::Active && !app.is_loading && !app.goal_continuation_waiting {
+    if goal.status == ProjectGoalStatus::Active
+        && !goal.is_loading
+        && !goal.goal_continuation_waiting
+    {
         line.push_str(" · ");
-        line.push_str(&app.tr(MessageId::GoalStatusIdleHint));
+        line.push_str(&translate(presentation, "goal_status_idle_hint"));
     }
     CommandResult::message(line)
 }
@@ -120,19 +158,23 @@ fn goal_status(app: &App) -> CommandResult {
 /// Close out the goal at `status`. Pure control plane: the engine stops (or
 /// re-arms) the continuation loop from the `SetGoalStatus` op; no model turn
 /// is dispatched.
-fn close_goal(app: &mut App, status: GoalStatus) -> CommandResult {
-    if effective_goal_objective(app).is_none_or(str::is_empty) {
+fn close_goal(
+    goal: &ProjectGoalState,
+    presentation: &mut dyn CommandPresentationContext,
+    status: ProjectGoalStatus,
+) -> CommandResult {
+    if effective_goal_objective(goal).is_none_or(str::is_empty) {
         return CommandResult::error("No goal set. Use /goal <objective> [budget: N] first.");
     }
-    if effective_goal_status(app) == status {
-        if !app.pending_goal_controls.is_empty() {
-            return CommandResult::message(app.tr(MessageId::GoalControlAccepted));
+    if effective_goal_status(goal) == status {
+        if goal.pending_controls {
+            return CommandResult::message(translate(presentation, "goal_control_accepted"));
         }
-        return goal_status(app);
+        return goal_status(goal, presentation);
     }
 
     CommandResult::action(AppAction::SetGoalStatus {
-        status,
+        status: to_action_status(status),
         clear: false,
     })
 }
@@ -140,8 +182,11 @@ fn close_goal(app: &mut App, status: GoalStatus) -> CommandResult {
 /// Resume a paused goal. The engine restarts the continuation loop itself
 /// (`SetGoalStatus` → schedule kickoff); the objective is never re-sent as a
 /// user message.
-fn resume_goal(app: &mut App) -> CommandResult {
-    if effective_goal_objective(app)
+fn resume_goal(
+    goal: &ProjectGoalState,
+    presentation: &mut dyn CommandPresentationContext,
+) -> CommandResult {
+    if effective_goal_objective(goal)
         .map(str::trim)
         .is_none_or(str::is_empty)
     {
@@ -151,38 +196,32 @@ fn resume_goal(app: &mut App) -> CommandResult {
     // Resuming an already-active goal is a no-op: the continuation loop is
     // already running, and re-asserting Active could stack a second
     // autonomous turn. Report progress instead.
-    if effective_goal_status(app) == GoalStatus::Active {
-        if !app.pending_goal_controls.is_empty() {
-            return CommandResult::message(app.tr(MessageId::GoalControlAccepted));
+    if effective_goal_status(goal) == ProjectGoalStatus::Active {
+        if goal.pending_controls {
+            return CommandResult::message(translate(presentation, "goal_control_accepted"));
         }
-        return goal_status(app);
+        return goal_status(goal, presentation);
     }
 
     CommandResult::action(AppAction::SetGoalStatus {
-        status: GoalStatus::Active,
+        status: crate::tools::goal::GoalStatus::Active,
         clear: false,
     })
 }
 
-fn effective_goal_objective(app: &App) -> Option<&str> {
-    if app.pending_goal_controls.is_empty() {
-        app.goal.objective.as_deref()
+fn effective_goal_objective(goal: &ProjectGoalState) -> Option<&str> {
+    if goal.pending_controls {
+        goal.last_known_objective.as_deref()
     } else {
-        app.last_known_goal_state
-            .as_ref()
-            .map(|goal| goal.objective.as_str())
+        goal.objective.as_deref()
     }
 }
 
-fn effective_goal_status(app: &App) -> GoalStatus {
-    if app.pending_goal_controls.is_empty() {
-        return app.goal.status;
-    }
-    match app.last_known_goal_state.as_ref().map(|goal| goal.status) {
-        Some(crate::session_manager::SessionGoalStatus::Paused) => GoalStatus::Paused,
-        Some(crate::session_manager::SessionGoalStatus::Complete) => GoalStatus::Complete,
-        Some(crate::session_manager::SessionGoalStatus::Blocked) => GoalStatus::Blocked,
-        Some(crate::session_manager::SessionGoalStatus::Active) | None => GoalStatus::Active,
+fn effective_goal_status(goal: &ProjectGoalState) -> ProjectGoalStatus {
+    if goal.pending_controls {
+        goal.last_known_status.unwrap_or(ProjectGoalStatus::Active)
+    } else {
+        goal.status
     }
 }
 
@@ -197,12 +236,22 @@ fn goal_usage() -> &'static str {
      /goal clear — remove the current goal."
 }
 
-fn goal_status_label(status: GoalStatus) -> &'static str {
+fn goal_status_label(status: ProjectGoalStatus) -> &'static str {
     match status {
-        GoalStatus::Active => "active",
-        GoalStatus::Complete => "complete",
-        GoalStatus::Paused => "paused",
-        GoalStatus::Blocked => "blocked",
+        ProjectGoalStatus::Active => "active",
+        ProjectGoalStatus::Complete => "complete",
+        ProjectGoalStatus::Paused => "paused",
+        ProjectGoalStatus::Blocked => "blocked",
+    }
+}
+
+/// Format a whole-seconds duration (portable replica of the TUI leaf helper,
+/// byte-identical output; the contract never ships preformatted strings).
+fn format_elapsed(secs: u64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else {
+        format!("{}m {:02}s", secs / 60, secs % 60)
     }
 }
 
@@ -240,31 +289,116 @@ impl RegisterCommand for GoalCmd {
         &COMMAND_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        goal_command(app, arg)
+    fn execute(app: &mut crate::tui::app::App, arg: Option<&str>) -> CommandResult {
+        // Transitional shell: build the capability bundle and delegate to the
+        // contextual dispatch. Phase 6 replaces this with the contract bridge.
+        let mut bundle = app.command_contexts();
+        let capabilities = CommandCapabilities::PROJECT.union(CommandCapabilities::PRESENTATION);
+        goal_contextual(bundle.contexts(capabilities), arg)
     }
+}
+
+/// Contextual `/goal` dispatch (FEAT-021 Phase 4).
+///
+/// Destructures the declared `PROJECT | PRESENTATION` facets with safe
+/// missing-facet errors; the portable handler never panics on absent
+/// capabilities and never emits a partial action.
+fn goal_contextual(contexts: CommandContexts<'_>, arg: Option<&str>) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let Some(project) = parts.project.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: project");
+    };
+    let Some(presentation) = parts.presentation.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: presentation");
+    };
+    let goal = project.goal_state();
+    goal_command(&goal, presentation, arg)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::Role;
+    use codewhale_command_contract::facets::{CommandProjectContext, ProjectShareProjection};
 
-    fn create_test_app() -> App {
-        let options = crate::tui::app::TuiOptions {
-            skills_dir: std::path::PathBuf::from("/tmp/test-skills"),
-            ..crate::test_support::test_tui_options(std::path::PathBuf::from("/tmp/test-workspace"))
-        };
-        let config = crate::config::Config::default();
-        App::new(options, &config)
+    /// Deterministic fake project facet over portable values only.
+    struct FakeProject;
+
+    impl FakeProject {
+        fn new() -> Self {
+            Self
+        }
+    }
+
+    impl CommandProjectContext for FakeProject {
+        fn lsp_enabled(&self) -> bool {
+            false
+        }
+
+        fn lsp_set(&mut self, _enabled: bool) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn share_projection(&self) -> ProjectShareProjection {
+            ProjectShareProjection {
+                history_is_empty: true,
+                history_len: 0,
+                model: String::new(),
+                mode_label: String::new(),
+            }
+        }
+
+        fn goal_state(&self) -> ProjectGoalState {
+            goal_state()
+        }
+    }
+
+    /// Deterministic fake presentation facet over portable values only.
+    struct FakePresentation;
+
+    impl CommandPresentationContext for FakePresentation {
+        fn translate(&self, key: &str, _replacements: &[(&str, &str)]) -> Result<String, String> {
+            match key {
+                "goal_control_accepted" => {
+                    Ok("Goal control saved; applying at the next safe boundary.".to_string())
+                }
+                "goal_status_idle_hint" => {
+                    Ok("not running now — send a message or /goal resume to continue".to_string())
+                }
+                other => Err(format!("unknown key {other}")),
+            }
+        }
+    }
+
+    fn goal_state() -> ProjectGoalState {
+        ProjectGoalState {
+            objective: None,
+            status: ProjectGoalStatus::Active,
+            pause_reason: None,
+            started_at_elapsed_seconds: None,
+            time_used_seconds: 0,
+            token_budget: None,
+            tokens_used: 0,
+            session_total_tokens: 0,
+            continuation_count: 0,
+            pending_controls: false,
+            last_known_objective: None,
+            last_known_status: None,
+            conversation_present: false,
+            is_loading: false,
+            goal_continuation_waiting: false,
+        }
+    }
+
+    fn run(goal: &ProjectGoalState, arg: Option<&str>) -> CommandResult {
+        let mut presentation = FakePresentation;
+        goal_command(goal, &mut presentation, arg)
     }
 
     #[test]
     fn test_set_goal_dispatches_control_plane_not_user_echo() {
-        let mut app = create_test_app();
-        let result = goal_command(&mut app, Some("Fix the login bug"));
+        let goal = goal_state();
+        let result = run(&goal, Some("Fix the login bug"));
         assert!(result.message.is_none());
-        assert_eq!(app.goal.objective, None);
         // The engine owns the kickoff: the objective must reach it as a
         // SetGoalObjective control op, never as a SendMessage user echo.
         assert!(matches!(
@@ -276,10 +410,8 @@ mod tests {
 
     #[test]
     fn test_goal_budget_parsing_reaches_the_op() {
-        let mut app = create_test_app();
-        let result = goal_command(&mut app, Some("Ship 0.9.10 | budget: 5000"));
-        assert_eq!(app.goal.objective, None);
-        assert_eq!(app.goal.token_budget, None);
+        let goal = goal_state();
+        let result = run(&goal, Some("Ship 0.9.10 | budget: 5000"));
         assert!(matches!(
             result.action,
             Some(AppAction::SetGoalObjective { ref objective, token_budget: Some(5000) })
@@ -289,28 +421,25 @@ mod tests {
 
     #[test]
     fn pause_and_clear_are_control_ops_without_optimistic_state() {
-        let mut app = create_test_app();
-        app.goal.objective = Some("Keep the build green".to_string());
-        app.goal.status = GoalStatus::Active;
-        let paused = goal_command(&mut app, Some("pause"));
+        let mut goal = goal_state();
+        goal.objective = Some("Keep the build green".to_string());
+        goal.status = ProjectGoalStatus::Active;
+        let paused = run(&goal, Some("pause"));
         assert!(paused.message.is_none());
-        assert_eq!(app.goal.status, GoalStatus::Active);
         assert!(matches!(
             paused.action,
             Some(AppAction::SetGoalStatus {
-                status: GoalStatus::Paused,
+                status: crate::tools::goal::GoalStatus::Paused,
                 clear: false
             })
         ));
-        assert!(app.goal.finished_at.is_none());
 
-        let cleared = goal_command(&mut app, Some("clear"));
+        let cleared = run(&goal, Some("clear"));
         assert!(cleared.message.is_none());
-        assert_eq!(app.goal.objective.as_deref(), Some("Keep the build green"));
         assert!(matches!(
             cleared.action,
             Some(AppAction::SetGoalStatus {
-                status: GoalStatus::Active,
+                status: crate::tools::goal::GoalStatus::Active,
                 clear: true
             })
         ));
@@ -321,15 +450,9 @@ mod tests {
         // Bare /goal with no active goal is context-dependent: the model
         // derives the objective from the conversation and sets it via
         // create_goal — it must not error with a usage demand.
-        let mut app = create_test_app();
-        app.api_messages.push(crate::models::Message {
-            role: Role::User,
-            content: vec![crate::models::ContentBlock::Text {
-                text: "make the tests pass".to_string(),
-                cache_control: None,
-            }],
-        });
-        let result = goal_command(&mut app, None);
+        let mut goal = goal_state();
+        goal.conversation_present = true;
+        let result = run(&goal, None);
         assert!(!result.is_error);
         let Some(AppAction::SendMessage(message)) = result.action else {
             panic!("expected SendMessage action");
@@ -342,8 +465,8 @@ mod tests {
     fn bare_goal_on_an_empty_session_prints_usage_without_a_model_turn() {
         // No conversation yet: there is nothing to derive an objective from,
         // so the answer is usage — free, and not a question to the model.
-        let mut app = create_test_app();
-        let result = goal_command(&mut app, None);
+        let goal = goal_state();
+        let result = run(&goal, None);
         assert!(!result.is_error);
         assert!(result.action.is_none());
         assert!(result.message.unwrap().contains("/goal <objective>"));
@@ -351,11 +474,11 @@ mod tests {
 
     #[test]
     fn goal_status_reports_objective_and_state() {
-        let mut app = create_test_app();
-        app.goal.objective = Some("Make the suite green".to_string());
-        app.goal.token_budget = Some(100);
-        app.goal.status = GoalStatus::Active;
-        let result = goal_command(&mut app, Some("status"));
+        let mut goal = goal_state();
+        goal.objective = Some("Make the suite green".to_string());
+        goal.token_budget = Some(100);
+        goal.status = ProjectGoalStatus::Active;
+        let result = run(&goal, Some("status"));
         let line = result.message.unwrap();
         assert!(line.contains("Make the suite green"));
         assert!(line.contains("active"));
@@ -363,13 +486,36 @@ mod tests {
     }
 
     #[test]
+    fn goal_status_includes_elapsed_and_continuations() {
+        let mut goal = goal_state();
+        goal.objective = Some("Ship it".to_string());
+        goal.status = ProjectGoalStatus::Active;
+        goal.time_used_seconds = 125;
+        goal.continuation_count = 3;
+        let result = run(&goal, Some("status"));
+        let line = result.message.unwrap();
+        assert!(line.contains("elapsed 2m 05s"), "line: {line}");
+        assert!(line.contains("continuations 3"), "line: {line}");
+    }
+
+    #[test]
+    fn paused_goal_status_shows_reason() {
+        let mut goal = goal_state();
+        goal.objective = Some("Ship it".to_string());
+        goal.status = ProjectGoalStatus::Paused;
+        goal.pause_reason = Some("usage limit".to_string());
+        let result = run(&goal, Some("status"));
+        assert!(result.message.unwrap().contains("paused (usage limit)"));
+    }
+
+    #[test]
     fn resume_on_an_active_goal_is_a_no_op_report() {
         // Re-asserting Active while the loop is already running must not
         // schedule a second autonomous turn.
-        let mut app = create_test_app();
-        app.goal.objective = Some("Keep the build green".to_string());
-        app.goal.status = GoalStatus::Active;
-        let resumed = goal_command(&mut app, Some("resume"));
+        let mut goal = goal_state();
+        goal.objective = Some("Keep the build green".to_string());
+        goal.status = ProjectGoalStatus::Active;
+        let resumed = run(&goal, Some("resume"));
         assert!(!resumed.is_error);
         assert!(
             resumed.action.is_none(),
@@ -380,10 +526,8 @@ mod tests {
 
     #[test]
     fn invalid_budget_suffix_stays_part_of_the_objective() {
-        let mut app = create_test_app();
-        let result = goal_command(&mut app, Some("Fix budget: handling in settings"));
-        assert_eq!(app.goal.objective, None);
-        assert_eq!(app.goal.token_budget, None);
+        let goal = goal_state();
+        let result = run(&goal, Some("Fix budget: handling in settings"));
         assert!(matches!(
             result.action,
             Some(AppAction::SetGoalObjective { ref objective, token_budget: None })
@@ -393,8 +537,49 @@ mod tests {
 
     #[test]
     fn completing_a_goal_without_one_is_an_error() {
-        let mut app = create_test_app();
-        let result = goal_command(&mut app, Some("done"));
+        let goal = goal_state();
+        let result = run(&goal, Some("done"));
         assert!(result.is_error);
+    }
+
+    #[test]
+    fn goal_help_route_returns_usage() {
+        let goal = goal_state();
+        for arg in ["help", "?", "usage"] {
+            let result = run(&goal, Some(arg));
+            assert!(!result.is_error);
+            assert!(result.message.unwrap().contains("/goal <objective>"));
+        }
+    }
+
+    #[test]
+    fn missing_project_facet_fails_safely() {
+        let result = goal_contextual(CommandContexts::empty(), Some("status"));
+        assert!(result.is_error);
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("Command capability unavailable: project")
+        );
+    }
+
+    #[test]
+    fn missing_presentation_facet_fails_safely() {
+        // PROJECT present but PRESENTATION absent: safe error, no partial action.
+        let mut project = FakeProject::new();
+        let contexts = CommandContexts::empty().with_project(&mut project);
+        let result = goal_contextual(contexts, Some("status"));
+        assert!(result.is_error);
+        assert!(
+            result.action.is_none(),
+            "no partial action on missing facet"
+        );
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("Command capability unavailable: presentation")
+        );
     }
 }

--- a/crates/tui/src/commands/groups/project/goal.rs
+++ b/crates/tui/src/commands/groups/project/goal.rs
@@ -12,7 +12,7 @@
 use codewhale_command_contract::facets::{
     CommandPresentationContext, ProjectGoalState, ProjectGoalStatus,
 };
-use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
 use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::tui::app::AppAction;
@@ -289,10 +289,7 @@ impl RegisterCommand<CommandResult> for GoalCmd {
     }
 
     fn handler() -> CommandHandler<CommandResult> {
-        CommandHandler::Contextual {
-            capabilities: CommandCapabilities::PROJECT.union(CommandCapabilities::PRESENTATION),
-            handler: goal_contextual,
-        }
+        CommandHandler::Contextual(goal_contextual)
     }
 }
 

--- a/crates/tui/src/commands/groups/project/init.rs
+++ b/crates/tui/src/commands/groups/project/init.rs
@@ -10,16 +10,21 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts};
+
 use crate::project_context;
-use crate::tui::app::{App, AppAction};
+use crate::tui::app::AppAction;
 
 use crate::commands::CommandResult;
 
 /// Generate an AGENTS.md file for the current project by gathering context and
 /// delegating content generation to the LLM agent.
-fn init(app: &mut App) -> CommandResult {
-    let workspace = &app.workspace;
-
+///
+/// FEAT-021 portable dispatch: consumes only the workspace path (supplied
+/// through the `WORKSPACE` facet); the workspace scan and prompt composition
+/// stay handler-owned (D2). `crate::utils`/`crate::project_context` are leaf,
+/// path-parameterized helpers (no App/service state), consistent with D8.
+fn init(workspace: &Path) -> CommandResult {
     // Ensure .deepseek/ is gitignored if we're inside a git repo.
     ensure_deepseek_gitignored(workspace);
 
@@ -816,8 +821,26 @@ impl crate::commands::traits::RegisterCommand for InitCmd {
         app: &mut crate::tui::app::App,
         _arg: Option<&str>,
     ) -> crate::commands::CommandResult {
-        init(app)
+        // Transitional shell: build the capability bundle and delegate to the
+        // contextual dispatch. Phase 6 replaces this with the contract bridge.
+        let mut bundle = app.command_contexts();
+        let capabilities = CommandCapabilities::PROJECT.union(CommandCapabilities::WORKSPACE);
+        init_contextual(bundle.contexts(capabilities))
     }
+}
+
+/// Contextual `/init` dispatch (FEAT-021 Phase 4).
+///
+/// Destructures the declared `PROJECT | WORKSPACE` facets with a safe
+/// missing-facet error. The workspace path is consumed via the `WORKSPACE`
+/// facet (D2); the `PROJECT` capability is declared per D4 even though init
+/// consumes no project-facet method.
+fn init_contextual(contexts: CommandContexts<'_>) -> CommandResult {
+    let parts = contexts.into_parts();
+    let Some(workspace) = parts.workspace.as_deref() else {
+        return crate::commands::CommandResult::error("Command capability unavailable: workspace");
+    };
+    init(&workspace.workspace())
 }
 
 // ---------------------------------------------------------------------------
@@ -827,28 +850,14 @@ impl crate::commands::traits::RegisterCommand for InitCmd {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
-    use crate::tui::app::{App, TuiOptions};
     use tempfile::TempDir;
-
-    fn create_test_app_with_tmpdir(tmpdir: &TempDir) -> App {
-        let options = TuiOptions {
-            skills_dir: tmpdir.path().join("skills"),
-            memory_path: tmpdir.path().join("memory.md"),
-            notes_path: tmpdir.path().join("notes.txt"),
-            mcp_config_path: tmpdir.path().join("mcp.json"),
-            ..crate::test_support::test_tui_options(tmpdir.path())
-        };
-        App::new(options, &Config::default())
-    }
 
     // --- init() integration tests ---
 
     #[test]
     fn init_returns_send_message_action() {
         let tmpdir = TempDir::new().unwrap();
-        let mut app = create_test_app_with_tmpdir(&tmpdir);
-        let result = init(&mut app);
+        let result = init(tmpdir.path());
         assert!(result.message.is_some());
         let msg = result.message.unwrap();
         assert!(msg.contains("Creating AGENTS.md"));
@@ -861,9 +870,8 @@ mod tests {
     #[test]
     fn init_says_updating_when_agents_md_exists() {
         let tmpdir = TempDir::new().unwrap();
-        let mut app = create_test_app_with_tmpdir(&tmpdir);
         std::fs::write(tmpdir.path().join("AGENTS.md"), "existing content").unwrap();
-        let result = init(&mut app);
+        let result = init(tmpdir.path());
         assert!(result.message.unwrap().contains("Updating AGENTS.md"));
         assert!(matches!(result.action, Some(AppAction::SendMessage(_))));
     }
@@ -871,9 +879,8 @@ mod tests {
     #[test]
     fn init_includes_gitignore_handling() {
         let tmpdir = TempDir::new().unwrap();
-        let mut app = create_test_app_with_tmpdir(&tmpdir);
         std::fs::create_dir_all(tmpdir.path().join(".git")).unwrap();
-        let result = init(&mut app);
+        let result = init(tmpdir.path());
         assert!(!result.is_error);
         // Should have added .deepseek/ to .gitignore.
         let gi = std::fs::read_to_string(tmpdir.path().join(".gitignore")).unwrap();
@@ -883,13 +890,12 @@ mod tests {
     #[test]
     fn init_prompt_includes_context_for_rust_project() {
         let tmpdir = TempDir::new().unwrap();
-        let mut app = create_test_app_with_tmpdir(&tmpdir);
         std::fs::write(
             tmpdir.path().join("Cargo.toml"),
             "[package]\nname = \"test-crate\"\nversion = \"0.1.0\"\n",
         )
         .unwrap();
-        let result = init(&mut app);
+        let result = init(tmpdir.path());
         let Some(AppAction::SendMessage(prompt)) = result.action else {
             panic!("expected SendMessage action");
         };
@@ -910,18 +916,32 @@ mod tests {
     #[test]
     fn init_prompt_includes_existing_content() {
         let tmpdir = TempDir::new().unwrap();
-        let mut app = create_test_app_with_tmpdir(&tmpdir);
         std::fs::write(
             tmpdir.path().join("AGENTS.md"),
             "# My Project\n\nCustom instructions here.",
         )
         .unwrap();
-        let result = init(&mut app);
+        let result = init(tmpdir.path());
         let Some(AppAction::SendMessage(prompt)) = result.action else {
             panic!("expected SendMessage action");
         };
         assert!(prompt.contains("Custom instructions here"));
         assert!(prompt.contains("update it in place"));
+    }
+
+    #[test]
+    fn missing_workspace_facet_fails_safely() {
+        // An empty envelope must fail safely — never panic and never perform a
+        // partial workspace mutation.
+        let result = init_contextual(CommandContexts::empty());
+        assert!(result.is_error);
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("Command capability unavailable: workspace"),
+            "missing workspace facet must fail safely"
+        );
     }
 
     // --- parse_cargo_toml tests ---

--- a/crates/tui/src/commands/groups/project/init.rs
+++ b/crates/tui/src/commands/groups/project/init.rs
@@ -821,20 +821,18 @@ impl codewhale_command_contract::metadata::RegisterCommand<crate::commands::Comm
 
     fn handler()
     -> codewhale_command_contract::handler::CommandHandler<crate::commands::CommandResult> {
-        codewhale_command_contract::handler::CommandHandler::Contextual {
-            capabilities: codewhale_command_contract::handler::CommandCapabilities::PROJECT
-                .union(codewhale_command_contract::handler::CommandCapabilities::WORKSPACE),
-            handler: init_contextual,
-        }
+        codewhale_command_contract::handler::CommandHandler::Contextual(init_contextual)
     }
 }
 
 /// Contextual `/init` dispatch (FEAT-021 Phase 4).
 ///
-/// Destructures the declared `PROJECT | WORKSPACE` facets with a safe
-/// missing-facet error. The workspace path is consumed via the `WORKSPACE`
-/// facet (D2); the `PROJECT` capability is declared per D4 even though init
-/// consumes no project-facet method.
+/// Destructures the declared `WORKSPACE` facet with a safe missing-facet
+/// error. The workspace path is consumed via the `WORKSPACE` facet (D2);
+/// `/init` consumes no project-facet method, so it destructures exactly
+/// `WORKSPACE` (D4, least-capability — the initial PROJECT|WORKSPACE
+/// declaration was amended after the critical audit; main's model expresses
+/// the declaration as exact facet destructuring rather than a bitmask).
 fn init_contextual(contexts: CommandContexts<'_>, _arg: Option<&str>) -> CommandResult {
     let parts = contexts.into_parts();
     let Some(workspace) = parts.workspace.as_deref() else {

--- a/crates/tui/src/commands/groups/project/init.rs
+++ b/crates/tui/src/commands/groups/project/init.rs
@@ -10,7 +10,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts};
+use codewhale_command_contract::handler::CommandContexts;
 
 use crate::project_context;
 use crate::tui::app::AppAction;
@@ -802,30 +802,30 @@ fn build_init_prompt(
     prompt
 }
 
-pub(in crate::commands) const COMMAND_INFO: crate::commands::traits::CommandInfo =
-    crate::commands::traits::CommandInfo {
+pub(in crate::commands) const INIT_INFO: codewhale_command_contract::metadata::CommandInfo =
+    codewhale_command_contract::metadata::CommandInfo {
         name: "init",
         aliases: &[],
         usage: "/init",
-        description_id: crate::localization::MessageId::CmdInitDescription,
+        description_key: "cmd_init_description",
     };
 
 pub(in crate::commands) struct InitCmd;
 
-impl crate::commands::traits::RegisterCommand for InitCmd {
-    fn info() -> &'static crate::commands::traits::CommandInfo {
-        &COMMAND_INFO
+impl codewhale_command_contract::metadata::RegisterCommand<crate::commands::CommandResult>
+    for InitCmd
+{
+    fn info() -> &'static codewhale_command_contract::metadata::CommandInfo {
+        &INIT_INFO
     }
 
-    fn execute(
-        app: &mut crate::tui::app::App,
-        _arg: Option<&str>,
-    ) -> crate::commands::CommandResult {
-        // Transitional shell: build the capability bundle and delegate to the
-        // contextual dispatch. Phase 6 replaces this with the contract bridge.
-        let mut bundle = app.command_contexts();
-        let capabilities = CommandCapabilities::PROJECT.union(CommandCapabilities::WORKSPACE);
-        init_contextual(bundle.contexts(capabilities))
+    fn handler()
+    -> codewhale_command_contract::handler::CommandHandler<crate::commands::CommandResult> {
+        codewhale_command_contract::handler::CommandHandler::Contextual {
+            capabilities: codewhale_command_contract::handler::CommandCapabilities::PROJECT
+                .union(codewhale_command_contract::handler::CommandCapabilities::WORKSPACE),
+            handler: init_contextual,
+        }
     }
 }
 
@@ -835,7 +835,7 @@ impl crate::commands::traits::RegisterCommand for InitCmd {
 /// missing-facet error. The workspace path is consumed via the `WORKSPACE`
 /// facet (D2); the `PROJECT` capability is declared per D4 even though init
 /// consumes no project-facet method.
-fn init_contextual(contexts: CommandContexts<'_>) -> CommandResult {
+fn init_contextual(contexts: CommandContexts<'_>, _arg: Option<&str>) -> CommandResult {
     let parts = contexts.into_parts();
     let Some(workspace) = parts.workspace.as_deref() else {
         return crate::commands::CommandResult::error("Command capability unavailable: workspace");
@@ -933,7 +933,7 @@ mod tests {
     fn missing_workspace_facet_fails_safely() {
         // An empty envelope must fail safely — never panic and never perform a
         // partial workspace mutation.
-        let result = init_contextual(CommandContexts::empty());
+        let result = init_contextual(CommandContexts::empty(), None);
         assert!(result.is_error);
         assert!(
             result

--- a/crates/tui/src/commands/groups/project/lsp.rs
+++ b/crates/tui/src/commands/groups/project/lsp.rs
@@ -1,10 +1,14 @@
 //! `/lsp` command — enable/disable LSP integration.
 //!
-//! Bridges to config::config::lsp_command for actual execution.
+//! Bridges to the host LSP state through the portable project facet
+//! (FEAT-021 D3): the handler composes byte-identical output from typed
+//! status/set delegates; the TUI adapter owns all host-side LSP behavior.
+
+use codewhale_command_contract::facets::CommandProjectContext;
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts};
 
 use crate::commands::traits::{CommandInfo, RegisterCommand};
 use crate::localization::MessageId;
-use crate::tui::app::App;
 
 use crate::commands::CommandResult;
 
@@ -22,7 +26,186 @@ impl RegisterCommand for LspCmd {
         &COMMAND_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        super::super::config::config::lsp_command(app, arg)
+    fn execute(app: &mut crate::tui::app::App, arg: Option<&str>) -> CommandResult {
+        // Transitional shell: build the capability bundle and delegate to the
+        // contextual dispatch. Phase 6 replaces this with the contract bridge.
+        let mut bundle = app.command_contexts();
+        lsp_contextual(bundle.contexts(CommandCapabilities::PROJECT), arg)
+    }
+}
+
+/// Contextual `/lsp` dispatch (FEAT-021 Phase 4).
+///
+/// Destructures the declared `PROJECT` facet with a safe missing-facet error;
+/// the portable [`lsp`] handler never panics on absent capabilities.
+fn lsp_contextual(contexts: CommandContexts<'_>, arg: Option<&str>) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let Some(project) = parts.project.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: project");
+    };
+    lsp(project, arg)
+}
+
+/// Portable `/lsp` dispatch (FEAT-021 Phase 4).
+///
+/// The handler consumes only the typed project facet; all concrete host LSP
+/// behavior lives in the TUI adapter (D3). Messages are byte-identical to the
+/// baseline `config::config::lsp_command` output.
+fn lsp(project: &mut dyn CommandProjectContext, arg: Option<&str>) -> CommandResult {
+    let raw = arg.map(str::trim).unwrap_or("");
+
+    match raw {
+        "" | "status" => {
+            let enabled = project.lsp_enabled();
+            let status = if enabled { "on" } else { "off" };
+            CommandResult::message(format!(
+                "LSP diagnostics are currently **{status}**.\n\n\
+                 Use `/lsp on` to enable or `/lsp off` to disable inline diagnostics after file edits."
+            ))
+        }
+        "on" | "enable" | "1" | "true" => {
+            if let Err(error) = project.lsp_set(true) {
+                return CommandResult::error(format!("Failed to enable LSP diagnostics: {error}"));
+            }
+            CommandResult::message(
+                "LSP diagnostics enabled — file edit results will include compiler errors and warnings when available.",
+            )
+        }
+        "off" | "disable" | "0" | "false" => {
+            if let Err(error) = project.lsp_set(false) {
+                return CommandResult::error(format!("Failed to disable LSP diagnostics: {error}"));
+            }
+            CommandResult::message("LSP diagnostics disabled.")
+        }
+        other => CommandResult::error(format!(
+            "Unknown /lsp argument `{other}`. Use `/lsp on`, `/lsp off`, or `/lsp status`."
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codewhale_command_contract::facets::{
+        ProjectGoalState, ProjectGoalStatus, ProjectShareProjection,
+    };
+
+    /// Deterministic fake project facet over portable values only.
+    struct FakeProject {
+        lsp_enabled: bool,
+    }
+
+    impl CommandProjectContext for FakeProject {
+        fn lsp_enabled(&self) -> bool {
+            self.lsp_enabled
+        }
+
+        fn lsp_set(&mut self, enabled: bool) -> Result<(), String> {
+            self.lsp_enabled = enabled;
+            Ok(())
+        }
+
+        fn share_projection(&self) -> ProjectShareProjection {
+            ProjectShareProjection {
+                history_is_empty: true,
+                history_len: 0,
+                model: String::new(),
+                mode_label: String::new(),
+            }
+        }
+
+        fn goal_state(&self) -> ProjectGoalState {
+            ProjectGoalState {
+                objective: None,
+                status: ProjectGoalStatus::Active,
+                pause_reason: None,
+                started_at_elapsed_seconds: None,
+                time_used_seconds: 0,
+                token_budget: None,
+                tokens_used: 0,
+                session_total_tokens: 0,
+                continuation_count: 0,
+                pending_controls: false,
+                last_known_objective: None,
+                last_known_status: None,
+                conversation_present: false,
+                is_loading: false,
+                goal_continuation_waiting: false,
+            }
+        }
+    }
+
+    fn run(arg: Option<&str>) -> (CommandResult, bool) {
+        let mut project = FakeProject { lsp_enabled: false };
+        let result = lsp(&mut project, arg);
+        (result, project.lsp_enabled)
+    }
+
+    #[test]
+    fn status_off_matches_baseline() {
+        let (result, _) = run(Some("status"));
+        let msg = result.message.expect("status must be a message");
+        assert!(msg.contains("currently **off**"));
+        assert!(msg.contains("Use `/lsp on` to enable or `/lsp off` to disable"));
+    }
+
+    #[test]
+    fn bare_status_is_same_as_status() {
+        let (result, _) = run(None);
+        let msg = result.message.expect("bare must be a message");
+        assert!(msg.contains("currently **off**"));
+    }
+
+    #[test]
+    fn enable_synonyms_set_state_and_report() {
+        for synonym in ["on", "enable", "1", "true"] {
+            let (result, enabled) = run(Some(synonym));
+            assert!(enabled, "{synonym} must enable");
+            let msg = result.message.expect("enable must be a message");
+            assert!(msg.contains("LSP diagnostics enabled"));
+        }
+    }
+
+    #[test]
+    fn disable_synonyms_clear_state_and_report() {
+        let mut project = FakeProject { lsp_enabled: true };
+        for synonym in ["off", "disable", "0", "false"] {
+            let result = lsp(&mut project, Some(synonym));
+            assert!(!project.lsp_enabled, "{synonym} must disable");
+            let msg = result.message.expect("disable must be a message");
+            assert_eq!(msg, "LSP diagnostics disabled.");
+        }
+    }
+
+    #[test]
+    fn status_reflects_current_state() {
+        let mut project = FakeProject { lsp_enabled: true };
+        let result = lsp(&mut project, Some("status"));
+        assert!(result.message.unwrap().contains("currently **on**"));
+    }
+
+    #[test]
+    fn unknown_argument_errors() {
+        let (result, enabled) = run(Some("bogus"));
+        assert!(!enabled);
+        assert!(result.is_error, "unknown must error");
+        let err = result.message.expect("unknown must carry a message");
+        assert!(err.contains("Unknown /lsp argument `bogus`"));
+        assert!(err.contains("/lsp on`, `/lsp off`, or `/lsp status`"));
+    }
+
+    #[test]
+    fn missing_project_facet_fails_safely() {
+        // An empty envelope must fail safely — never panic — with the exact
+        // capability-unavailable error.
+        let result = lsp_contextual(CommandContexts::empty(), Some("status"));
+        assert!(result.is_error);
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("Command capability unavailable: project"),
+            "missing project facet must fail safely"
+        );
     }
 }

--- a/crates/tui/src/commands/groups/project/lsp.rs
+++ b/crates/tui/src/commands/groups/project/lsp.rs
@@ -5,32 +5,30 @@
 //! status/set delegates; the TUI adapter owns all host-side LSP behavior.
 
 use codewhale_command_contract::facets::CommandProjectContext;
-use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts};
-
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
 
-pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
+pub(in crate::commands) const LSP_INFO: CommandInfo = CommandInfo {
     name: "lsp",
     aliases: &[],
     usage: "/lsp [on|off|status]",
-    description_id: MessageId::CmdLspDescription,
+    description_key: "cmd_lsp_description",
 };
 
 pub(in crate::commands) struct LspCmd;
 
-impl RegisterCommand for LspCmd {
+impl RegisterCommand<CommandResult> for LspCmd {
     fn info() -> &'static CommandInfo {
-        &COMMAND_INFO
+        &LSP_INFO
     }
 
-    fn execute(app: &mut crate::tui::app::App, arg: Option<&str>) -> CommandResult {
-        // Transitional shell: build the capability bundle and delegate to the
-        // contextual dispatch. Phase 6 replaces this with the contract bridge.
-        let mut bundle = app.command_contexts();
-        lsp_contextual(bundle.contexts(CommandCapabilities::PROJECT), arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual {
+            capabilities: CommandCapabilities::PROJECT,
+            handler: lsp_contextual,
+        }
     }
 }
 

--- a/crates/tui/src/commands/groups/project/lsp.rs
+++ b/crates/tui/src/commands/groups/project/lsp.rs
@@ -5,7 +5,7 @@
 //! status/set delegates; the TUI adapter owns all host-side LSP behavior.
 
 use codewhale_command_contract::facets::CommandProjectContext;
-use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
 use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
@@ -25,10 +25,7 @@ impl RegisterCommand<CommandResult> for LspCmd {
     }
 
     fn handler() -> CommandHandler<CommandResult> {
-        CommandHandler::Contextual {
-            capabilities: CommandCapabilities::PROJECT,
-            handler: lsp_contextual,
-        }
+        CommandHandler::Contextual(lsp_contextual)
     }
 }
 

--- a/crates/tui/src/commands/groups/project/mod.rs
+++ b/crates/tui/src/commands/groups/project/mod.rs
@@ -1,33 +1,31 @@
 //! Project command area: workspace bootstrap, LSP wiring, sharing, and goals.
+//!
+//! FEAT-021 Phase 6: every command registers through the portable contract
+//! bridge (`ContextualCommand::from_contract`) with its exact capability set.
+//! The transitional App shells are gone.
 
 mod goal;
 mod init;
 mod lsp;
 pub mod share;
 
-use crate::commands::traits::{Command, CommandGroup, FunctionCommand, RegisterCommand};
+use crate::commands::traits::{Command, CommandGroup, ContextualCommand};
 
 pub struct ProjectCommands;
 
 impl CommandGroup for ProjectCommands {
     fn commands(&self) -> &'static [Box<dyn Command>] {
         cached_command_list!(vec![
-            Box::new(FunctionCommand::new(
-                init::InitCmd::info(),
-                init::InitCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                lsp::LspCmd::info(),
-                lsp::LspCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                share::ShareCmd::info(),
-                share::ShareCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                goal::GoalCmd::info(),
-                goal::GoalCmd::execute,
-            )),
+            Box::new(
+                ContextualCommand::from_contract::<init::InitCmd>().expect("init registration"),
+            ),
+            Box::new(ContextualCommand::from_contract::<lsp::LspCmd>().expect("lsp registration"),),
+            Box::new(
+                ContextualCommand::from_contract::<share::ShareCmd>().expect("share registration"),
+            ),
+            Box::new(
+                ContextualCommand::from_contract::<goal::GoalCmd>().expect("goal registration"),
+            ),
         ])
     }
 }

--- a/crates/tui/src/commands/groups/project/share.rs
+++ b/crates/tui/src/commands/groups/project/share.rs
@@ -12,12 +12,11 @@ use std::io::Write;
 use std::path::Path;
 
 use codewhale_command_contract::facets::CommandProjectContext;
-use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts};
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
-use crate::commands::traits::{CommandInfo, RegisterCommand};
 use crate::dependencies::ExternalTool;
-use crate::localization::MessageId;
 use crate::tui::app::AppAction;
 
 /// Share the current session as a web URL.
@@ -191,25 +190,25 @@ async fn upload_gist(path: &Path) -> Result<String, String> {
     Ok(stdout)
 }
 
-pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
+pub(in crate::commands) const SHARE_INFO: CommandInfo = CommandInfo {
     name: "share",
     aliases: &[],
     usage: "/share",
-    description_id: MessageId::CmdShareDescription,
+    description_key: "cmd_share_description",
 };
 
 pub(in crate::commands) struct ShareCmd;
 
-impl RegisterCommand for ShareCmd {
+impl RegisterCommand<CommandResult> for ShareCmd {
     fn info() -> &'static CommandInfo {
-        &COMMAND_INFO
+        &SHARE_INFO
     }
 
-    fn execute(app: &mut crate::tui::app::App, arg: Option<&str>) -> CommandResult {
-        // Transitional shell: build the capability bundle and delegate to the
-        // contextual dispatch. Phase 6 replaces this with the contract bridge.
-        let mut bundle = app.command_contexts();
-        share_contextual(bundle.contexts(CommandCapabilities::PROJECT), arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual {
+            capabilities: CommandCapabilities::PROJECT,
+            handler: share_contextual,
+        }
     }
 }
 

--- a/crates/tui/src/commands/groups/project/share.rs
+++ b/crates/tui/src/commands/groups/project/share.rs
@@ -12,7 +12,7 @@ use std::io::Write;
 use std::path::Path;
 
 use codewhale_command_contract::facets::CommandProjectContext;
-use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts, CommandHandler};
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
 use codewhale_command_contract::metadata::{CommandInfo, RegisterCommand};
 
 use crate::commands::CommandResult;
@@ -205,10 +205,7 @@ impl RegisterCommand<CommandResult> for ShareCmd {
     }
 
     fn handler() -> CommandHandler<CommandResult> {
-        CommandHandler::Contextual {
-            capabilities: CommandCapabilities::PROJECT,
-            handler: share_contextual,
-        }
+        CommandHandler::Contextual(share_contextual)
     }
 }
 

--- a/crates/tui/src/commands/groups/project/share.rs
+++ b/crates/tui/src/commands/groups/project/share.rs
@@ -11,18 +11,21 @@
 use std::io::Write;
 use std::path::Path;
 
+use codewhale_command_contract::facets::CommandProjectContext;
+use codewhale_command_contract::handler::{CommandCapabilities, CommandContexts};
+
 use crate::commands::CommandResult;
 use crate::commands::traits::{CommandInfo, RegisterCommand};
 use crate::dependencies::ExternalTool;
 use crate::localization::MessageId;
-use crate::tui::app::{App, AppAction};
+use crate::tui::app::AppAction;
 
 /// Share the current session as a web URL.
-fn share(app: &mut App, arg: Option<&str>) -> CommandResult {
+fn share(project: &dyn CommandProjectContext, arg: Option<&str>) -> CommandResult {
     let raw = arg.map(str::trim).unwrap_or("");
 
     match raw {
-        "" => do_share(app),
+        "" => do_share(project),
         "help" | "--help" | "-h" => CommandResult::message(
             "/share — Export the current session as a shareable web URL.\n\
              \n\
@@ -41,29 +44,26 @@ fn share(app: &mut App, arg: Option<&str>) -> CommandResult {
 }
 
 /// Export the session as HTML, upload to a Gist, and show the URL.
-fn do_share(app: &mut App) -> CommandResult {
+fn do_share(project: &dyn CommandProjectContext) -> CommandResult {
+    let share = project.share_projection();
+
     // Check if there's any session content to share
-    if app.history.is_empty() {
+    if share.history_is_empty {
         return CommandResult::error("Nothing to share. The current session is empty.");
     }
-
-    // Sanity-check: the extra info block is optional; the session itself
-    // is what we share.
-    let history_len = app.history.len();
-    let model = &app.model;
-    let mode = app.mode.label();
 
     // Use an AppAction to signal the engine to perform the async work.
     CommandResult::with_message_and_action(
         format!(
-            "Exporting {history_len} cell(s) from {model} ({mode}) session...\n\n\
+            "Exporting {} cell(s) from {} ({}) session...\n\n\
              The session will be rendered as static HTML and uploaded to a GitHub Gist.\n\
-             This requires the `gh` CLI to be installed and authenticated."
+             This requires the `gh` CLI to be installed and authenticated.",
+            share.history_len, share.model, share.mode_label
         ),
         AppAction::ShareSession {
-            history_len,
-            model: model.clone(),
-            mode: mode.to_string(),
+            history_len: share.history_len,
+            model: share.model,
+            mode: share.mode_label,
         },
     )
 }
@@ -205,14 +205,157 @@ impl RegisterCommand for ShareCmd {
         &COMMAND_INFO
     }
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        share(app, arg)
+    fn execute(app: &mut crate::tui::app::App, arg: Option<&str>) -> CommandResult {
+        // Transitional shell: build the capability bundle and delegate to the
+        // contextual dispatch. Phase 6 replaces this with the contract bridge.
+        let mut bundle = app.command_contexts();
+        share_contextual(bundle.contexts(CommandCapabilities::PROJECT), arg)
     }
+}
+
+/// Contextual `/share` dispatch (FEAT-021 Phase 4).
+///
+/// Destructures the declared `PROJECT` facet with a safe missing-facet error.
+fn share_contextual(contexts: CommandContexts<'_>, arg: Option<&str>) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let Some(project) = parts.project.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: project");
+    };
+    share(project, arg)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codewhale_command_contract::facets::{
+        ProjectGoalState, ProjectGoalStatus, ProjectShareProjection,
+    };
+
+    /// Deterministic fake project facet over portable values only.
+    struct FakeProject {
+        share: ProjectShareProjection,
+    }
+
+    impl CommandProjectContext for FakeProject {
+        fn lsp_enabled(&self) -> bool {
+            false
+        }
+
+        fn lsp_set(&mut self, _enabled: bool) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn share_projection(&self) -> ProjectShareProjection {
+            self.share.clone()
+        }
+
+        fn goal_state(&self) -> ProjectGoalState {
+            ProjectGoalState {
+                objective: None,
+                status: ProjectGoalStatus::Active,
+                pause_reason: None,
+                started_at_elapsed_seconds: None,
+                time_used_seconds: 0,
+                token_budget: None,
+                tokens_used: 0,
+                session_total_tokens: 0,
+                continuation_count: 0,
+                pending_controls: false,
+                last_known_objective: None,
+                last_known_status: None,
+                conversation_present: false,
+                is_loading: false,
+                goal_continuation_waiting: false,
+            }
+        }
+    }
+
+    fn project_with_history() -> FakeProject {
+        FakeProject {
+            share: ProjectShareProjection {
+                history_is_empty: false,
+                history_len: 3,
+                model: "deepseek-v4-pro".to_string(),
+                mode_label: "ACT".to_string(),
+            },
+        }
+    }
+
+    fn project_empty() -> FakeProject {
+        FakeProject {
+            share: ProjectShareProjection {
+                history_is_empty: true,
+                history_len: 0,
+                model: String::new(),
+                mode_label: String::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn share_empty_session_errors() {
+        let project = project_empty();
+        let result = share(&project, Some(""));
+        assert!(result.is_error);
+        assert!(
+            result.message.unwrap().contains("Nothing to share"),
+            "empty share must error"
+        );
+    }
+
+    #[test]
+    fn share_populated_session_emits_exact_action_and_message() {
+        let project = project_with_history();
+        let result = share(&project, Some(""));
+        assert!(!result.is_error);
+        let msg = result.message.unwrap();
+        assert!(
+            msg.contains("Exporting 3 cell(s) from deepseek-v4-pro (ACT) session..."),
+            "message was: {msg}"
+        );
+        assert!(
+            matches!(
+                result.action,
+                Some(AppAction::ShareSession {
+                    history_len: 3,
+                    ref model,
+                    ref mode,
+                }) if model == "deepseek-v4-pro" && mode == "ACT"
+            ),
+            "action was: {:?}",
+            result.action
+        );
+    }
+
+    #[test]
+    fn share_help_and_unknown_routes() {
+        let project = project_with_history();
+        for arg in ["help", "--help", "-h"] {
+            let result = share(&project, Some(arg));
+            assert!(!result.is_error);
+            assert!(result.message.unwrap().contains("/share"));
+        }
+        let result = share(&project, Some("bogus"));
+        assert!(result.is_error);
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("Unknown /share argument `bogus`")
+        );
+    }
+
+    #[test]
+    fn missing_project_facet_fails_safely() {
+        let result = share_contextual(CommandContexts::empty(), Some(""));
+        assert!(result.is_error);
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("Command capability unavailable: project")
+        );
+    }
 
     #[test]
     fn test_render_session_html_basic_structure() {

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -1915,6 +1915,11 @@ mod tests {
             "network",
             "task",
             "update",
+            // FEAT-021 project group.
+            "init",
+            "lsp",
+            "share",
+            "goal",
         ];
         for info in command_infos() {
             if info.name == "feat015ctx" || FEAT_018_UTILITY.contains(&info.name) {
@@ -2025,5 +2030,105 @@ mod tests {
         // /network (pure): list produces a message.
         let network = execute("/network list", &mut app);
         assert!(network.message.is_some() || network.is_error, "{network:?}");
+    }
+
+    // FEAT-021 project group public dispatch (Phase 6)
+
+    #[test]
+    fn feat021_project_entries_register_through_portable_bridge() {
+        // main's model carries no capability bitmask: each project command
+        // must register through the portable bridge as a contextual handler
+        // and dispatch safely through the public seam. Exact facet
+        // destructuring (D4) is proven by the handler tests and the adapter
+        // exposure test.
+        for name in ["init", "lsp", "share", "goal"] {
+            assert!(
+                registry().has_contextual_handler(name),
+                "/{name} must register through the portable bridge"
+            );
+            let handler = registry()
+                .get(name)
+                .expect("entry")
+                .contextual_handler()
+                .expect("contextual handler");
+            assert!(
+                matches!(
+                    handler,
+                    codewhale_command_contract::handler::CommandHandler::Contextual(_)
+                ),
+                "/{name} must be contextual"
+            );
+        }
+    }
+
+    #[test]
+    fn feat021_project_commands_dispatch_through_public_seam() {
+        let mut app = create_test_app();
+        app.workspace = PathBuf::from(".");
+
+        // /init: creating message + SendMessage action.
+        let init = execute("/init", &mut app);
+        assert!(!init.is_error, "{init:?}");
+        assert!(matches!(init.action, Some(AppAction::SendMessage(_))));
+
+        // /lsp status reaches the adapter through the public seam.
+        let lsp = execute("/lsp status", &mut app);
+        assert!(!lsp.is_error, "{lsp:?}");
+        let lsp_msg = lsp.message.expect("lsp message");
+        assert!(
+            lsp_msg.contains("LSP diagnostics are currently **"),
+            "{lsp_msg}"
+        );
+
+        // /share help is a safe no-op route.
+        let share = execute("/share help", &mut app);
+        assert!(!share.is_error, "{share:?}");
+
+        // /goal status without a goal prints usage (no panic).
+        let goal = execute("/goal status", &mut app);
+        assert!(!goal.is_error, "{goal:?}");
+
+        // Metadata bridges to the TUI localization ids.
+        for (name, id) in [
+            ("init", MessageId::CmdInitDescription),
+            ("lsp", MessageId::CmdLspDescription),
+            ("share", MessageId::CmdShareDescription),
+            ("goal", MessageId::CmdGoalDescription),
+        ] {
+            let info = registry().get_info(name).expect("info");
+            assert_eq!(info.description_id, id, "/{name} description bridge");
+        }
+    }
+
+    #[test]
+    fn feat021_public_dispatch_never_panics_on_project_commands() {
+        let mut app = create_test_app();
+        app.workspace = PathBuf::from(".");
+        for command in [
+            "/init",
+            "/init ",
+            "/lsp",
+            "/lsp status",
+            "/lsp on",
+            "/lsp off",
+            "/lsp bogus",
+            "/share",
+            "/share help",
+            "/share bogus",
+            "/goal",
+            "/goal status",
+            "/goal pause",
+            "/goal resume",
+            "/goal done",
+            "/goal bogus",
+            "/goal 42",
+        ] {
+            let result = execute(command, &mut app);
+            // Every path returns a result; none may panic.
+            assert!(
+                result.message.is_some() || result.action.is_some(),
+                "{command}: {result:?}"
+            );
+        }
     }
 }

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -1903,10 +1903,10 @@ mod tests {
         // FEAT-015 shipped no production contextual command, so the assertion
         // below used to exclude nothing. FEAT-018 migrates the utility group;
         // the remaining non-fixture commands must still use the legacy
-        // concrete-App path. The migrated utility entries (the FEAT-018 seven
-        // plus `/dispatch`, which joins the same portable path) are asserted
-        // separately by the FEAT-018 public-dispatch and inventory tests.
-        const FEAT_018_UTILITY: &[&str] = &[
+        // concrete-App path. The migrated groups (FEAT-018 utility seven plus
+        // `/dispatch`, and the FEAT-021 project four) are asserted separately
+        // by their public-dispatch and inventory tests.
+        const MIGRATED_GROUPS: &[&str] = &[
             "attach",
             "automation",
             "dispatch",
@@ -1922,7 +1922,7 @@ mod tests {
             "goal",
         ];
         for info in command_infos() {
-            if info.name == "feat015ctx" || FEAT_018_UTILITY.contains(&info.name) {
+            if info.name == "feat015ctx" || MIGRATED_GROUPS.contains(&info.name) {
                 continue;
             }
             assert!(

--- a/scripts/command-migration-topology.json
+++ b/scripts/command-migration-topology.json
@@ -284,7 +284,6 @@
     "debug",
     "memory",
     "plugins",
-    "project",
     "session",
     "skills"
   ]

--- a/scripts/test_check_command_migration_manifest.py
+++ b/scripts/test_check_command_migration_manifest.py
@@ -363,10 +363,11 @@ class LiveGateTests(unittest.TestCase):
         self.assertEqual(frontier, sorted(frontier))
         self.assertEqual(len(frontier), len(set(frontier)))
         # FEAT-018 removed the utility group from the frontier (Stage B first
-        # slice); the remaining eight groups stay pending.
+        # slice); FEAT-021 removed the project group; the remaining seven
+        # groups stay pending.
         self.assertEqual(
             set(frontier),
-            {"memory", "plugins", "project", "skills", "session", "config", "debug", "core"},
+            {"memory", "plugins", "skills", "session", "config", "debug", "core"},
         )
 
 


### PR DESCRIPTION
## Summary

FEAT-021 converts the TUI project command group (`/init`, `/lsp`, `/share`, `/goal` — no aliases) to the external command shapes introduced by FEAT-014 and hosted by FEAT-015, following the pattern FEAT-018 (utility) established. The command files remain under `codewhale-tui`; this PR changes their execution boundary without physically moving them.

**Baseline:** rebased onto `main` (`20e9574`) per maintainer request — the `codex/v0912-integration-20260823` base will not land (232 ahead / 324 behind main). The 7-commit series now carries 8 commits directly on `main`.

This PR:

- adds the contract-owned `CommandProjectContext` facet with **exact-minimum typed delegates**: `/lsp` status/set, `/share` session projection (emptiness, length, model, mode label), `/goal` goal projection (objective, status, pending controls, time, tokens, session-derived effective values) — portable DTOs (`ProjectGoalState`, `ProjectShareProjection`, `ProjectGoalStatus`);
- converts the complete `/project` dispatch and render paths to portable contract values — byte-identical output preserved;
- registers the group via `ContextualCommand::from_contract` on **main's model** (no capability bitmask on main yet — the FEAT-019/020 capability machinery lives only on the integration branch): each command is a `CommandHandler::Contextual(fn)` whose handler destructures exactly its required facets with safe missing-facet errors — `/init` → `WORKSPACE` only, `/lsp` → project, `/share` → project, `/goal` → project + presentation;
- routes the cross-group `/lsp` bridge (`config::config::lsp_command`) exclusively through the TUI adapter (FEAT-020 D1 pattern); the portable handler never imports the config group;
- resolves all catalog messages through the presentation facet for `/goal` (`goal_control_accepted`, `goal_status_idle_hint`) and the metadata bridge for all four description keys;
- removes `project` from **both** migration-frontier representations atomically (frontier now `config, core, debug, memory, plugins, session, skills` — memory/plugins remain pending on main);
- keeps the temporary TUI-owned `CommandResult` and the exact `AppAction` variants the group emits (`SendMessage`, `ShareSession`, `SetGoalStatus`, `SetGoalObjective`) bounded for FEAT-037.

Tracking: EPIC-006 / FEAT-021 in umbrella [Hmbown/CodeWhale#5316](https://github.com/Hmbown/CodeWhale/issues/5316).

## Dependency boundary

The intended dependency direction remains acyclic:

```text
future codewhale-commands project group
                 |
                 v
codewhale-command-contract ---> codewhale-core / other acyclic leaf crates
                 ^
                 |
codewhale-tui implements the host facets
```

`/project` handlers no longer name or call concrete `App`, `config::config`, `tools::goal`, or session-manager code; every host touch crosses the boundary through the `CommandProjectContext`/`WORKSPACE`/`PRESENTATION` adapters. **No new crate dependency and no crate move** — circular-reference risk is reduced to zero by keeping the contract crate leaf-only and routing cross-group calls exclusively through the TUI adapter.

**Dependency-removal tracking (FEAT-037 / FEAT-041):** the remaining TUI-owned references in the group are explicitly enumerated for removal:

- `crate::commands::CommandResult` and `crate::tui::app::AppAction` (4 variants) — bounded FEAT-037 temporary references;
- `crate::tools::goal::GoalStatus` inside `AppAction::SetGoalStatus.status` — FEAT-037 must provide a portable goal-status representation for the action payload;
- `crate::utils::{summarize_project, project_tree}` and `crate::project_context::generate_project_context_pack` (leaf, path-parameterized `/init` helpers) — FEAT-041 must re-home them before the physical move;
- engine-side share machinery co-located in `share.rs` (`perform_share`, `upload_gist`, `render_session_html`, `write_temp_html`, `html_escape`; `crate::dependencies::Gh`, tokio/tempfile/chrono) — pre-existing host code, FEAT-041 must extract it host-side.

## Review hardening

- **Missing required facets** return `Command capability unavailable: <facet>` — zero `.expect()` in production dispatch handlers (an improvement over main's current `.expect()` style in the utility group).
- **Least-capability:** `/init` destructures exactly `WORKSPACE` (the initial `PROJECT|WORKSPACE` declaration over-declared and was amended after the critical audit); the other three destructure exactly their required facets.
- **Byte-identical output** proven by parity tests with exact-string evidence (LSP status/set messages, goal status/usage/budget/elapsed, share messages, presentation fallback).

## Scope and behavior

- Only `groups/project` is migrated (four production commands: `/init`, `/lsp`, `/share`, `/goal`).
- No command file moves out of `codewhale-tui`; no shared result/action ownership moves (FEAT-037); `CommandResult` and `AppAction` remain bounded temporary data references.
- No localization system extraction occurs (FEAT-036); the presentation facet maps existing `MessageId`s.
- Names, aliases, usage strings, registry order, help/palette discovery, messages, parsing, and safety checks remain unchanged.

## Testing (verified locally on this branch)

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --locked` — clean
- [x] `cargo test -p codewhale-command-contract --lib --locked` — 15 passed
- [x] `cargo test -p codewhale-tui --lib --locked` project-scoped — 76 passed; adapter — 4 passed; full TUI lib — 11,362 passed / 0 failed (serial run; excludes documented pre-existing env failures, see below)
- [x] `cargo test -p codewhale-tui --test integration --locked` — 277 passed / 0 failed (incl. `lifecycle_outbox_exec`)
- [x] `cargo test --workspace --locked` — PASS, 0 FAILED binaries (excluding documented pre-existing env failures)
- [x] `python3 scripts/test_check_command_crate_boundaries.py` — PASS
- [x] `python3 scripts/check-command-migration-manifest.py --baseline-ref origin/main` — PASS (`project` absent from both frontier representations)
- [x] `python3 scripts/test_check_command_migration_manifest.py` — PASS

**Pre-existing failures verified on pristine `origin/main` (not caused by this PR):**
- Ghostty/SSH-cap motion tests (`config_fancy_animations_keeps_ghostty_full_motion`, `ghostty_term_program_…`, `ghostty_term_fallback_…`) — environment-sensitive (`constrained_frame_rate`), fail identically on a clean `main` checkout in this workspace.
- `runtime_api::*` tests — stack overflow in this environment, fail identically on a clean `main` checkout.
- `clippy -D warnings` reports `too_many_arguments` (9/7) in `runtime_threads.rs:2562` — untouched by this PR, fires identically on a clean `main` checkout with this toolchain; the maintainer CI configuration differs (allow or older clippy).

## Checklist

- [x] Only the project group migrated; zero concrete-`App` / `config::config` / `tools::goal` handler dependencies
- [x] `CommandProjectContext` is the only new project-specific host facet
- [x] Exact per-command facet destructuring: `/init` = `WORKSPACE`; `/lsp` = project; `/share` = project; `/goal` = project + presentation
- [x] Typed signatures and contract-owned result shapes for every operation
- [x] Existing user-facing output byte-identical (parity tests with exact-string evidence)
- [x] `project` removed from both migration-frontier representations
- [x] `/lsp` routed through the facet; adapter owns `config::config::lsp_command` (D3)
- [x] Missing facets fail safely (`Command capability unavailable: <facet>`), no `.expect()` in production dispatch
- [x] FEAT-037/FEAT-041 dependency-removal obligations enumerated (see above)
- [x] No manual UI verification required for this structural change

## CI status

**FULLY GREEN (2026-08-30, head `02e9f34b7`):** the complete Actions matrix passes — Lint ✅, Safety gate ✅, Test (ubuntu-latest) ✅, Test (macos-latest) ✅, Test (windows-latest) ✅, Change detection ✅, DCO ✅, link ✅, integrations ✅, version drift ✅, npm wrapper smoke ✅, ohos check ✅, GitGuardian ✅. Mergeable ✅.

The earlier macOS/Windows red was `main`'s own sandbox `read_guard` baseline (failing on `main`'s CI too); the maintainer's fix landed in #5724, and after rebasing onto it the matrix went fully green. The remaining transient reds on intermediate runs (a flaky `exec_persistent_service` timing test, a macOS runner stall in `tools::web`/`agent_roster`) were environmental and cleared on the final run.

No-Issue: FEAT-021 is tracked in umbrella #5316, which must remain open for the remaining decomposition FEATs.

Paulo Aboim Pinto

