### PR TITLE
fix(sandbox): canonicalize deny-rule paths at build; unbreak macOS/Windows read_guard baseline

### DIFF
--- a/crates/tui/src/sandbox/read_guard.rs
+++ b/crates/tui/src/sandbox/read_guard.rs
@@ -161,11 +161,19 @@ impl ReadDenylist {
     ///   from the built-in defaults only.
     #[must_use]
     pub fn build(include_defaults: bool, extra: &[PathBuf], exempt: &[PathBuf]) -> Self {
+        // Every rule/exempt path is canonicalized (after lexical
+        // normalization) so `check()`'s canonicalized candidates compare
+        // against a canonicalized rule. On macOS this matters because the
+        // system redirects `/var` (and `/tmp`) to their real `/private/...`
+        // locations: a lexical-only rule would silently miss the canonical
+        // candidate and the deny could be walked around (the read_guard
+        // symlink/`..` baseline failures on the macOS CI runner).
         let exempt_normalized: Vec<PathBuf> = exempt
             .iter()
             .cloned()
             .map(expand_home_prefix)
             .map(|p| normalize_lexically(&p))
+            .map(|p| canonicalize_best_effort(&p))
             .collect();
 
         let mut subtrees = Vec::new();
@@ -182,7 +190,7 @@ impl ReadDenylist {
                     .is_some_and(|name| name == std::ffi::OsStr::new(".env"))
             });
             for (raw, label) in default_denied_subtrees() {
-                let path = normalize_lexically(&raw);
+                let path = canonicalize_best_effort(&normalize_lexically(&raw));
                 if exempt_normalized.iter().any(|e| path_is_within(&path, e)) {
                     continue;
                 }
@@ -197,6 +205,7 @@ impl ReadDenylist {
             if path.as_os_str().is_empty() {
                 continue;
             }
+            let path = canonicalize_best_effort(&path);
             subtrees.push(DenyRule::Subtree {
                 path,
                 label: "a path in `sandbox_denied_read_paths`",
@@ -1024,7 +1033,10 @@ mod tests {
         let list = ReadDenylist::build(false, &[tmp.path().to_path_buf()], &[]);
         let paths = list.subtree_paths();
         assert_eq!(paths.len(), 1);
-        assert_eq!(paths[0], normalize_lexically(tmp.path()));
+        // Rules are canonicalized at build (symlinked roots such as macOS
+        // `/var` → `/private/var` must not split the comparison), so the OS
+        // wrapper handoff is the canonical form of the temp dir.
+        assert_eq!(paths[0], canonicalize_best_effort(tmp.path()));
     }
 
     #[test]
@@ -1055,9 +1067,21 @@ mod tests {
 
     #[test]
     fn root_parent_traversal_does_not_escape_above_root() {
+        // Unix: a leading `/` is absolute, so `/../../etc` must clamp to
+        // `/etc` — the root never pops above itself.
+        #[cfg(unix)]
         assert_eq!(
             normalize_lexically(Path::new("/../../etc")),
             PathBuf::from("/etc")
+        );
+        // Windows: a drive-rooted path must clamp to the drive root, never
+        // above it. (A leading `/` alone is not absolute on Windows — it is
+        // drive-relative and joins the current directory, so the Unix
+        // expectation does not hold there.)
+        #[cfg(windows)]
+        assert_eq!(
+            normalize_lexically(Path::new(r"C:\..\..\etc")),
+            PathBuf::from(r"C:\etc")
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the `sandbox::read_guard` baseline failures that are currently red on `main`'s own CI (macOS + Windows) and block every PR targeting `main` — including [FEAT-021 #5717](https://github.com/Hmbown/CodeWhale/pull/5717), whose only red checks are these exact tests.

Two independent defects in `crates/tui/src/sandbox/read_guard.rs`:

**1. macOS — deny rules were lexical while candidates were canonical (real deny-bypass gap).**

- `ReadDenylist::build` stored rule and exempt paths with `normalize_lexically` only.
- `check()` compares `canonicalize_best_effort`d candidates against those rules via `path_is_within` (component-wise).
- On macOS the system redirects `/var` (and `/tmp`) to `/private/...`. A temp-dir deny rule stayed `/var/folders/...` while the canonical candidate was `/private/var/folders/...` → first component mismatch → the deny was silently missed. This is why the symlink/`..` evasion tests (`dot_dot_through_a_symlink…`, `symlink_chains…`, `relative_read_from_inside_a_denied_tree…`, `symlinked_parent_directory…`, `symlink_pointing_into_a_denied_tree…`, `denial_message_names_the_rule…`) fail on macOS but pass on Linux.
- Consequence in production: any user-listed deny under a symlinked root on macOS could be bypassed.

**Fix:** canonicalize every rule and exempt path at build time (`canonicalize_best_effort(&normalize_lexically(&path))`), so both sides of `path_is_within` compare canonical paths. `subtree_paths()` now hands the OS wrappers the canonical form, which is also the correct form for Seatbelt on macOS. Non-existent built-ins (`~/.ssh`, …) resolve to their canonical parent + suffix as before. `canonicalize_best_effort` never fails to produce at least the root-canonicalized path, so no rule can be lost.

**2. Windows — `root_parent_traversal_does_not_escape_above_root` asserted Unix path semantics everywhere.**

- The test asserted `normalize_lexically(Path::new("/../../etc")) == PathBuf::from("/etc")`. On Windows a leading `/` is **not absolute** (drive-relative), so the path joins `current_dir()` and normalizes to the drive root — the assertion failed.
- On macOS it also failed because `subtree_paths_feed_the_os_wrappers_and_omit_the_filename_rule` compared against the lexical form (now canonical).

**Fix:** per-platform assertions — Unix keeps `/../../etc` → `/etc`; Windows uses a drive-rooted path `C:\..\..\etc` → `C:\etc` (the root never pops above itself). The subtree_paths test now asserts the canonical form.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-tui --lib --locked sandbox::read_guard` — 20 passed / 0 failed (Linux)
- [x] `cargo test -p codewhale-tui --lib --locked sandbox::` — 74 passed / 0 failed (Linux)
- [x] `cargo check --workspace --locked` — clean
- macOS/Windows behavior verified by reasoning (canonicalize resolves the `/var → /private/var` redirect; the per-platform test expectations follow the respective path models); the previous CI matrix on `main` reproduced the failures, so a green macOS/Windows run on this PR is the acceptance signal.

Note: the only remaining clippy error in this workspace (`too_many_arguments` in `runtime_threads.rs:2562`) is pre-existing on `main` with this toolchain and unrelated to this change.

Paulo Aboim Pinto

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->