### PR TITLE
fix(tui): stop the subagent contention gate from falsely refusing child shell calls

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -4160,13 +4160,9 @@ impl SubAgentManager {
             .find(|record| record.claim.owner == owner && !record.isolated_worktree)
     }
 
-    /// Is another *live* child writing in the shared checkout?
-    ///
-    /// This is the question the unbounded-write gate actually needs. A claim
-    /// bounds a child so concurrent children cannot overwrite each other's
-    /// files; with no second writer in the shared tree there is nothing to
-    /// collide with, and a shell redirect is no more dangerous than the `File`
-    /// write the same child is already allowed to perform.
+    /// The live peers whose shared-checkout write claims gate `owner` — the
+    /// names the contention refusal must surface so a refused child knows
+    /// what it is waiting on and what to cancel or release.
     ///
     /// Liveness is the load-bearing part. Claims outlive the agents that
     /// registered them, so a workspace accumulates one per builder that ever
@@ -4183,12 +4179,14 @@ impl SubAgentManager {
     ///
     /// Worktree-isolated peers are excluded too: they write into their own
     /// checkout and can never contend for these paths.
-    fn has_peer_shared_write_claim(&self, owner: &str) -> bool {
+    fn live_peer_shared_write_claim_owners(&self, owner: &str) -> Vec<String> {
         self.coordination
             .write_claims
             .iter()
             .filter(|record| record.claim.owner != owner && !record.isolated_worktree)
-            .any(|record| self.is_live_coordination_owner(&record.claim.owner))
+            .filter(|record| self.is_live_coordination_owner(&record.claim.owner))
+            .map(|record| record.claim.owner.clone())
+            .collect()
     }
 
     /// Classify an agent by its `session_boot_id`: `true` when the
@@ -4916,20 +4914,29 @@ impl SubAgentManager {
 
     /// The single definition of a live coordination claimant.
     ///
-    /// One predicate, two callers: claim admission (`active_coordination_owners`)
-    /// and the shared-checkout peer gate (`has_peer_shared_write_claim`). They
-    /// used to disagree, which let a claim from a crashed prior session (an
-    /// agent record restored as `Running` with a different boot id, or an owner
-    /// whose record was never loaded at all) keep looking like a live writer
-    /// forever — every later builder/worker was then denied all command
-    /// execution (issue #5562: "stale write-claims persist forever and
-    /// cascade-lock other agents"). A claim cannot contend for an owner that
-    /// cannot write.
+    /// One predicate, evaluated per owner id by every caller: claim admission
+    /// (`active_coordination_owners` delegates below), the shared-checkout peer
+    /// gate (`live_peer_shared_write_claim_owners`), and stale-claim release.
+    /// The admission and gate sides used to disagree, which let a claim from a
+    /// crashed prior session (an agent record restored as `Running` with a
+    /// different boot id, or an owner whose record was never loaded at all)
+    /// keep looking like a live writer forever — every later builder/worker
+    /// was then denied all command execution (issue #5562: "stale write-claims
+    /// persist forever and cascade-lock other agents"). A claim cannot contend
+    /// for an owner that cannot write.
     fn is_live_coordination_owner(&self, id: &str) -> bool {
         self.agents.get(id).is_some_and(|agent| {
             agent.status == SubAgentStatus::Running && !self.is_from_prior_session(agent)
         }) || self.worker_records.get(id).is_some_and(|record| {
             !record.status.is_terminal()
+                // A headless worker (no paired agent entry) that reaches
+                // WaitingForUser can never be answered: no user path will
+                // resume or finalize it, so counting it live leaks its claim
+                // as a permanent gate on every later writer. A *paired*
+                // waiting child keeps its claim — the user can still answer
+                // and the child will write again.
+                && !(record.status == AgentWorkerStatus::WaitingForUser
+                    && !self.agents.contains_key(id))
                 && !self
                     .agents
                     .get(id)
@@ -4937,33 +4944,16 @@ impl SubAgentManager {
         })
     }
 
+    // Worker records carry no boot id of their own, so the per-id predicate
+    // consults the paired agent when one exists; delegating keeps admission,
+    // the peer gate, and stale-claim release on one liveness definition.
     fn active_coordination_owners(&self) -> std::collections::HashSet<String> {
-        let mut owners = std::collections::HashSet::new();
-        for (id, agent) in &self.agents {
-            // A prior-session agent (mismatched/empty boot id) is not a live
-            // claimant even if its restored status still reads Running.
-            if agent.status == SubAgentStatus::Running && !self.is_from_prior_session(agent) {
-                owners.insert(id.clone());
-            }
-        }
-        for (id, record) in &self.worker_records {
-            if record.status.is_terminal() {
-                continue;
-            }
-            // Worker records don't carry their own boot id, so consult the
-            // paired agent when one exists. A headless worker (no agent
-            // entry) is a live current-session owner by virtue of its
-            // non-terminal record; a paired agent from a prior session means
-            // the worker is an orphan that must never gate a new writer.
-            let prior_session = self
-                .agents
-                .get(id)
-                .is_some_and(|agent| self.is_from_prior_session(agent));
-            if !prior_session {
-                owners.insert(id.clone());
-            }
-        }
-        owners
+        self.agents
+            .keys()
+            .chain(self.worker_records.keys())
+            .filter(|id| self.is_live_coordination_owner(id))
+            .cloned()
+            .collect()
     }
 
     fn namespace_write_claim(
@@ -10261,8 +10251,62 @@ struct SubAgentTask {
     _foreground_child_registration: Option<ForegroundChildRegistration>,
 }
 
-#[allow(clippy::too_many_lines)]
+/// Spawn the child task body under a panic guard.
+///
+/// Children run under `spawn_supervised`, which catch_unwinds a panic so the
+/// parent process survives — and that used to be where the story ended: the
+/// terminal commit at the end of `run_subagent_task_inner` never ran, so the
+/// panicked child stayed `Running` and its write claim kept gating live peers
+/// until heartbeat auto-cancel (indefinitely, while a lingering shell kept
+/// the heartbeat fresh). The guard catches the panic first, commits a crash
+/// terminal result through the same `finish_terminal_result` arbitration every
+/// other terminal path uses, then resumes unwinding so the supervisor still
+/// logs the panic and writes its crash dump.
 async fn run_subagent_task(task: SubAgentTask) {
+    let agent_id = task.agent_id.clone();
+    let manager_handle = task.manager_handle.clone();
+    supervise_subagent_task_body(manager_handle, agent_id, run_subagent_task_inner(task)).await;
+}
+
+async fn supervise_subagent_task_body(
+    manager_handle: SharedSubAgentManager,
+    agent_id: String,
+    body: impl std::future::Future<Output = ()> + Send,
+) {
+    use futures_util::FutureExt;
+    let panicked = std::panic::AssertUnwindSafe(body).catch_unwind().await;
+    let Err(panic) = panicked else {
+        return;
+    };
+    let message = crate::utils::panic_message(&*panic);
+    {
+        let mut manager = manager_handle.write().await;
+        match manager.get_result(&agent_id) {
+            Ok(mut result) => {
+                result.status =
+                    SubAgentStatus::Failed(format!("sub-agent task panicked: {message}"));
+                result.result = None;
+                result.needs_input = None;
+                // Arbitrated exactly like the natural terminal commit: when a
+                // cancel or another terminal outcome already won, this is a
+                // no-op rather than a second result.
+                manager.finish_terminal_result(&agent_id, result, false, true);
+            }
+            Err(err) => {
+                tracing::error!(
+                    target: "subagent",
+                    agent_id = %agent_id,
+                    ?err,
+                    "panicked task no longer has a manager record"
+                );
+            }
+        }
+    }
+    std::panic::resume_unwind(panic);
+}
+
+#[allow(clippy::too_many_lines)]
+async fn run_subagent_task_inner(task: SubAgentTask) {
     // `spawn_background_with_assignment_options` installs this before the task
     // is scheduled. Keep this fallback for internal/test task launchers so a
     // manually-created worker still owns the same terminal fan-in contract.
@@ -15357,6 +15401,10 @@ impl SubAgentToolRegistry {
                 .map_err(anyhow::Error::msg)?;
         } else if self.enforce_write_claim
             && !is_internal_coordination_state_tool(name)
+            // A shell run the read-only classifier proves mutation-free cannot
+            // collide with the peer's writes no matter how contended the
+            // checkout is, so the gate below does not apply to it.
+            && !proven_readonly_shell_run(name, &input)
             && (is_unbounded_shell_run(name, &input)
                 || self.registry.get(name).is_some_and(|spec| {
                     let canonical = canonical_action_alias(name, &input);
@@ -15385,12 +15433,15 @@ impl SubAgentToolRegistry {
             // no safety while making a builder unable to run ordinary shell
             // work in the workspace the operator actually watches — worktree
             // isolation "fixes" that by writing somewhere they never see.
-            if manager.shared_write_claim(&self.owner_agent_id).is_some()
-                && manager.has_peer_shared_write_claim(&self.owner_agent_id)
-            {
-                return Err(anyhow!(
-                    "Tool {name} cannot prove a bounded file target, and another child is writing in this shared checkout. Use scope-aware file tools, or launch the children with worktree isolation."
-                ));
+            if manager.shared_write_claim(&self.owner_agent_id).is_some() {
+                let blocking_peers =
+                    manager.live_peer_shared_write_claim_owners(&self.owner_agent_id);
+                if !blocking_peers.is_empty() {
+                    return Err(anyhow!(
+                        "Tool {name} cannot prove a bounded file target, and another child is writing in this shared checkout (blocking peers: {}). Wait for the peer to finish, ask the parent to cancel it, run agents/coordinate action=release to clear a stale claim, or relaunch the children with worktree isolation.",
+                        blocking_peers.join(", ")
+                    ));
+                }
             }
         }
         let context = self
@@ -15462,6 +15513,20 @@ impl SubAgentToolRegistry {
 
 fn is_unbounded_shell_run(name: &str, input: &Value) -> bool {
     canonical_action_alias(name, input) == "exec_shell"
+}
+
+/// Whether this exact call is a shell run the agent read-only classifier
+/// proves mutation-free — the contention gate's carve-out.
+///
+/// This shares its classifier with `bounded_readonly_bash_evidence` but not
+/// its role restriction, deliberately: the envelope helper's carve-out
+/// *grants* shell to inspection roles that otherwise lack it, so it is scoped
+/// to them; the contention gate grants nothing — shell authority, posture, and
+/// the envelope have already settled by the time it runs — and asks only
+/// whether this call can collide with a live peer's writes. A proven
+/// read-only `ls` cannot, whichever role runs it.
+fn proven_readonly_shell_run(name: &str, input: &Value) -> bool {
+    is_unbounded_shell_run(name, input) && crate::tools::shell::agent_readonly_bash_input(input)
 }
 
 /// Parameter names whose *value* is a location to reach, rather than content.

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -11508,6 +11508,257 @@ fn shared_claim_shell_gate_normalizes_only_the_run_action() {
     }
 }
 
+/// Build one registry per contended child, both bound to the same shared
+/// manager and workspace — the two-builder shared-checkout topology.
+fn contended_builder_registry(
+    manager: &SharedSubAgentManager,
+    workspace: &Path,
+    owner: &str,
+) -> SubAgentToolRegistry {
+    let mut runtime = stub_runtime();
+    runtime.manager = Arc::clone(manager);
+    runtime.context = ToolContext::new(workspace);
+    runtime.context.auto_approve = true;
+    runtime.worker_profile = WorkerRuntimeProfile::for_role(FleetRole::Builder);
+    SubAgentToolRegistry::new_with_owner(
+        runtime,
+        FleetRole::Builder,
+        owner.to_string(),
+        "implementer".into(),
+        Some(vec!["File".into(), "Bash".into()]),
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    )
+}
+
+/// Two live write-capable children with disjoint `exact_files` claims in one
+/// shared checkout: a bash call the read-only classifier proves mutation-free
+/// must still run on both. The contention gate used to re-test
+/// `is_unbounded_shell_run` unconditionally, so a provably read-only `ls` was
+/// refused whenever a peer held a claim — even though the ledger had already
+/// proven the two claims disjoint at admission.
+#[tokio::test]
+async fn contended_shared_writers_keep_proven_readonly_shell() {
+    let tmp = tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
+    {
+        let mut guard = manager.write().await;
+        assert_eq!(guard.insert_test_running_agent("a", tmp.path()), "agent_a");
+        assert_eq!(guard.insert_test_running_agent("b", tmp.path()), "agent_b");
+        let live: HashSet<String> = ["agent_a".to_string(), "agent_b".to_string()]
+            .into_iter()
+            .collect();
+        for (owner, file) in [("agent_a", "src/a.txt"), ("agent_b", "src/b.txt")] {
+            guard
+                .coordination
+                .register_claim(
+                    WriteScopeClaim {
+                        owner: owner.into(),
+                        roots: vec![],
+                        exact_files: vec![file.into()],
+                        contracts: vec![],
+                    },
+                    false,
+                    |candidate| live.contains(candidate),
+                )
+                .expect("disjoint exact-file claims admit both live writers");
+        }
+    }
+    for owner in ["agent_a", "agent_b"] {
+        let registry = contended_builder_registry(&manager, tmp.path(), owner);
+        registry
+            .execute(owner, "Bash", json!({"action": "run", "command": "ls src"}))
+            .await
+            .unwrap_or_else(|err| {
+                panic!("proven read-only shell must survive contention for {owner}: {err}")
+            });
+    }
+}
+
+/// The same contention still refuses a shell call the classifier cannot prove
+/// read-only — and the refusal names the blocking peer and its remediation so
+/// the child can recover instead of retrying blindly.
+#[tokio::test]
+async fn contended_shared_writer_refusal_names_blocking_peer_and_remediation() {
+    let tmp = tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
+    {
+        let mut guard = manager.write().await;
+        assert_eq!(guard.insert_test_running_agent("a", tmp.path()), "agent_a");
+        assert_eq!(guard.insert_test_running_agent("b", tmp.path()), "agent_b");
+        let live: HashSet<String> = ["agent_a".to_string(), "agent_b".to_string()]
+            .into_iter()
+            .collect();
+        for (owner, file) in [("agent_a", "src/a.txt"), ("agent_b", "src/b.txt")] {
+            guard
+                .coordination
+                .register_claim(
+                    WriteScopeClaim {
+                        owner: owner.into(),
+                        roots: vec![],
+                        exact_files: vec![file.into()],
+                        contracts: vec![],
+                    },
+                    false,
+                    |candidate| live.contains(candidate),
+                )
+                .expect("disjoint exact-file claims admit both live writers");
+        }
+    }
+    let registry = contended_builder_registry(&manager, tmp.path(), "agent_a");
+    let err = registry
+        .execute(
+            "agent_a",
+            "Bash",
+            json!({"action": "run", "command": "touch src/a2.txt"}),
+        )
+        .await
+        .expect_err("mutating shell under contention must stay refused")
+        .to_string();
+    assert!(
+        err.contains("cannot prove a bounded file target"),
+        "refusal kind: {err}"
+    );
+    assert!(
+        err.contains("agent_b"),
+        "refusal must name the blocking peer: {err}"
+    );
+    assert!(
+        err.contains("agents/coordinate action=release") && err.contains("worktree isolation"),
+        "refusal must state concrete remediation: {err}"
+    );
+    assert!(
+        !tmp.path().join("src/a2.txt").exists(),
+        "the refused command must not have run"
+    );
+}
+
+/// A child whose task body panics must still reach a terminal state.
+/// `spawn_supervised` catches the panic to keep the parent alive; without the
+/// guard committing a crash result the child stayed `Running` and its write
+/// claim kept gating live peers until heartbeat auto-cancel — or forever while
+/// a lingering shell kept the heartbeat fresh.
+#[tokio::test]
+async fn panicked_child_task_terminalizes_and_stops_gating_peers() {
+    let tmp = tempdir().expect("tempdir");
+    let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
+    let agent_id = {
+        let mut guard = manager.write().await;
+        let agent_id = guard.insert_test_running_agent("panicked", tmp.path());
+        guard
+            .coordination
+            .register_claim(
+                WriteScopeClaim {
+                    owner: agent_id.clone(),
+                    roots: vec!["src".into()],
+                    exact_files: vec![],
+                    contracts: vec![],
+                },
+                false,
+                |_| false,
+            )
+            .expect("panicked child's claim");
+        assert!(guard.is_live_coordination_owner(&agent_id));
+        agent_id
+    };
+
+    // Drive a panic through the same guard the production spawn path wraps
+    // around the task body.
+    let handle = tokio::spawn(supervise_subagent_task_body(
+        Arc::clone(&manager),
+        agent_id.clone(),
+        async { panic!("intentional test panic") },
+    ));
+    let join_error = handle
+        .await
+        .expect_err("the panic must still reach the task supervisor");
+    assert!(join_error.is_panic());
+
+    let guard = manager.read().await;
+    let result = guard.get_result(&agent_id).expect("agent record survives");
+    assert!(
+        matches!(&result.status, SubAgentStatus::Failed(message) if message.contains("panicked")),
+        "panicked child must commit a crash terminal result, got {:?}",
+        result.status
+    );
+    assert!(
+        guard
+            .get_worker_record(&agent_id)
+            .expect("worker record")
+            .status
+            .is_terminal(),
+        "the paired worker record terminalizes with the agent"
+    );
+    assert!(
+        !guard.is_live_coordination_owner(&agent_id),
+        "a panicked child must not keep gating peers as a live writer"
+    );
+}
+
+/// A headless fleet worker (a worker record with no paired agent entry) that
+/// reaches `WaitingForUser` can never be answered — nothing will resume or
+/// finalize it — so it must not count as a live coordination owner, and the
+/// `agents/coordinate action=release` remediation the gate names must be able
+/// to clear its claim. A *paired* child waiting on the user is untouched.
+#[test]
+fn waiting_for_user_headless_worker_is_not_a_live_coordination_owner() {
+    let tmp = tempdir().expect("tempdir");
+    let workspace = tmp.path().canonicalize().expect("canonical workspace");
+    let mut manager = SubAgentManager::new(workspace.clone(), 8);
+
+    manager
+        .register_worker_with_coordination(make_write_worker_spec(
+            "worker-waiting",
+            workspace.clone(),
+            "src/waiting",
+        ))
+        .expect("headless worker registration");
+    assert!(manager.is_live_coordination_owner("worker-waiting"));
+    manager
+        .worker_records
+        .get_mut("worker-waiting")
+        .expect("worker record")
+        .status = AgentWorkerStatus::WaitingForUser;
+    assert!(
+        !manager.is_live_coordination_owner("worker-waiting"),
+        "a headless worker can never answer WaitingForUser"
+    );
+    assert!(
+        !manager
+            .active_coordination_owners()
+            .contains("worker-waiting"),
+        "admission and stale-claim release share the same liveness answer"
+    );
+    let released = manager
+        .release_stale_write_claims(Some("worker-waiting".to_string()))
+        .expect("release sweep");
+    assert_eq!(
+        released,
+        vec!["worker-waiting".to_string()],
+        "the remediation the gate names must actually clear the leaked claim"
+    );
+
+    // The interactive case is preserved: a paired child waiting on the user
+    // keeps its claim — the user can still answer and the child will write.
+    let paired = manager.insert_test_running_agent("paired", &workspace);
+    manager
+        .agents
+        .get_mut(&paired)
+        .expect("paired agent")
+        .status = SubAgentStatus::Interrupted("awaiting user input".to_string());
+    manager
+        .worker_records
+        .get_mut(&paired)
+        .expect("paired worker record")
+        .status = AgentWorkerStatus::WaitingForUser;
+    assert!(
+        manager.is_live_coordination_owner(&paired),
+        "an interactive child waiting on the user stays live"
+    );
+}
+
 #[tokio::test]
 async fn subagent_blocks_mcp_action_without_parent_auto_approve() {
     let registry = subagent_registry_with_mcp_action(false);


### PR DESCRIPTION
Dogfood repro: a delegated child's bash was refused with "another child is writing in this shared checkout" even for read-only commands and even when the peer was long finished; the parent burned turns, cancelled the child, and redid the work in the foreground.

## Root causes fixed (claim/liveness layer)

- **Gate ignored read-only evidence** the execution envelope had already computed — a proven mutation-free shell run (`ls`, `git status`) is now carved out of the contention refusal.
- **Panicked child never went terminal** (`spawn_supervised` caught the panic, the terminal commit never ran), staying `Running` and gating peers until heartbeat auto-cancel — indefinitely with a lingering shell. The task body now runs under a guard that commits a crash terminal result through the existing arbitration, then resumes unwinding.
- **Headless `WaitingForUser` worker records** (no paired agent entry — no user can ever answer) counted as live claimants forever; the predicate now excludes them.
- **`active_coordination_owners` duplicated and drifted from the liveness predicate** — it now delegates, so admission, the peer gate, and `agents/coordinate action=release` share one definition and release can actually clear a leaked claim.
- **The refusal is recoverable**: it names the blocking peer ids and the concrete remediations.

## Tests

Four regression tests, each proven red on its bug signature pre-fix and green post-fix; 169/169 claim/contention/coordination families; full lib suite 11530/0 on post-#5724 main; fmt clean. (One pre-existing main clippy lint at runtime_threads.rs:2562 is untouched and reproduced with this change stashed.)

No-Issue: dogfood-reported defect, tracked in the Ops takeover plan (Lane 1).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->