### PR TITLE
fix(tui): full access means it — skip PR_SET_NO_NEW_PRIVS under danger-full-access startup

### DIFF
--- a/crates/tui/locales/ca.json
+++ b/crates/tui/locales/ca.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "sandbox workspace-write, xarxa activada",
   "StatusSafetyWorkspaceWriteNetworkOff": "sandbox workspace-write, xarxa desactivada",
   "StatusSafetyDisabled": "sandbox desactivat, xarxa sense restriccions",
+  "StatusSafetyDisabledSetuidBlocked": "sandbox desactivat, xarxa sense restriccions; sudo/setuid blocat (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "sandbox desactivat, xarxa sense restriccions; sudo/setuid permès",
   "StatusSafetyExternal": "sandbox extern, xarxa delegada a l'amfitrió",
   "StatusPointers": "Tokens per torn: /tokens · Elements del peu: /statusline",
   "AutoReviewReceiptGuardianAllowed": "L'Auto-Review ha permès '{tool}' (risc {risk}, guardià del model): {reason}",

--- a/crates/tui/locales/de.json
+++ b/crates/tui/locales/de.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "Sandbox workspace-write, Netzwerk an",
   "StatusSafetyWorkspaceWriteNetworkOff": "Sandbox workspace-write, Netzwerk aus",
   "StatusSafetyDisabled": "Sandbox deaktiviert, Netzwerk uneingeschränkt",
+  "StatusSafetyDisabledSetuidBlocked": "Sandbox deaktiviert, Netzwerk uneingeschränkt; sudo/setuid blockiert (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "Sandbox deaktiviert, Netzwerk uneingeschränkt; sudo/setuid erlaubt",
   "StatusSafetyExternal": "externe Sandbox, Netzwerksteuerung an Host delegiert",
   "StatusPointers": "Token pro Runde: /tokens · Fußzeilenelemente: /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review hat '{tool}' erlaubt (Risiko {risk}, Modell-Guardian): {reason}",

--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "sandbox workspace-write, network on",
   "StatusSafetyWorkspaceWriteNetworkOff": "sandbox workspace-write, network off",
   "StatusSafetyDisabled": "sandbox disabled, network unrestricted",
+  "StatusSafetyDisabledSetuidBlocked": "sandbox disabled, network unrestricted; sudo/setuid blocked (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "sandbox disabled, network unrestricted; sudo/setuid allowed",
   "StatusSafetyExternal": "external sandbox, network delegated to host",
   "StatusPointers": "Per-turn tokens: /tokens · Footer items: /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review allowed '{tool}' ({risk} risk, model guardian): {reason}",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "sandbox workspace-write, red activada",
   "StatusSafetyWorkspaceWriteNetworkOff": "sandbox workspace-write, red desactivada",
   "StatusSafetyDisabled": "sandbox desactivado, red sin restricciones",
+  "StatusSafetyDisabledSetuidBlocked": "sandbox desactivado, red sin restricciones; sudo/setuid bloqueado (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "sandbox desactivado, red sin restricciones; sudo/setuid permitido",
   "StatusSafetyExternal": "sandbox externo, red delegada al host",
   "StatusPointers": "Tokens por turno: /tokens · Elementos del pie: /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review permitió '{tool}' (riesgo {risk}, guardián del modelo): {reason}",

--- a/crates/tui/locales/fr.json
+++ b/crates/tui/locales/fr.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "sandbox workspace-write, réseau activé",
   "StatusSafetyWorkspaceWriteNetworkOff": "sandbox workspace-write, réseau désactivé",
   "StatusSafetyDisabled": "sandbox désactivée, réseau sans restriction",
+  "StatusSafetyDisabledSetuidBlocked": "sandbox désactivée, réseau sans restriction ; sudo/setuid bloqué (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "sandbox désactivée, réseau sans restriction ; sudo/setuid autorisé",
   "StatusSafetyExternal": "sandbox externe, réseau délégué à l'hôte",
   "StatusPointers": "Jetons par tour : /tokens · Éléments du pied : /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review a autorisé '{tool}' (risque {risk}, gardien du modèle) : {reason}",

--- a/crates/tui/locales/hi.json
+++ b/crates/tui/locales/hi.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "सैंडबॉक्स workspace-write, नेटवर्क चालू",
   "StatusSafetyWorkspaceWriteNetworkOff": "सैंडबॉक्स workspace-write, नेटवर्क बंद",
   "StatusSafetyDisabled": "सैंडबॉक्स बंद, नेटवर्क अप्रतिबंधित",
+  "StatusSafetyDisabledSetuidBlocked": "सैंडबॉक्स बंद, नेटवर्क अप्रतिबंधित; sudo/setuid अवरुद्ध (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "सैंडबॉक्स बंद, नेटवर्क अप्रतिबंधित; sudo/setuid अनुमत",
   "StatusSafetyExternal": "बाहरी सैंडबॉक्स, नेटवर्क नियंत्रण होस्ट को सौंपा गया",
   "StatusPointers": "हर टर्न के टोकन: /tokens · फुटर आइटम: /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review ने '{tool}' की अनुमति दी (जोखिम {risk}, मॉडल गार्जियन): {reason}",

--- a/crates/tui/locales/id.json
+++ b/crates/tui/locales/id.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "sandbox workspace-write, jaringan aktif",
   "StatusSafetyWorkspaceWriteNetworkOff": "sandbox workspace-write, jaringan nonaktif",
   "StatusSafetyDisabled": "sandbox nonaktif, jaringan tanpa batas",
+  "StatusSafetyDisabledSetuidBlocked": "sandbox nonaktif, jaringan tanpa batas; sudo/setuid diblokir (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "sandbox nonaktif, jaringan tanpa batas; sudo/setuid diizinkan",
   "StatusSafetyExternal": "sandbox eksternal, jaringan didelegasikan ke host",
   "StatusPointers": "Token per giliran: /tokens · Item footer: /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review mengizinkan '{tool}' (risiko {risk}, penjaga model): {reason}",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "サンドボックスは workspace-write、ネットワーク有効",
   "StatusSafetyWorkspaceWriteNetworkOff": "サンドボックスは workspace-write、ネットワーク無効",
   "StatusSafetyDisabled": "サンドボックス無効、ネットワーク制限なし",
+  "StatusSafetyDisabledSetuidBlocked": "サンドボックス無効、ネットワーク制限なし。sudo/setuid はブロック中（no-new-privs）",
+  "StatusSafetyDisabledSetuidAllowed": "サンドボックス無効、ネットワーク制限なし。sudo/setuid は許可されています",
   "StatusSafetyExternal": "外部サンドボックス、ネットワーク制御はホストに委任",
   "StatusPointers": "ターン別トークン: /tokens · フッター項目: /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review が '{tool}' を許可しました（リスク {risk}、モデルガーディアン）: {reason}",

--- a/crates/tui/locales/ko.json
+++ b/crates/tui/locales/ko.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "샌드박스 workspace-write, 네트워크 켜짐",
   "StatusSafetyWorkspaceWriteNetworkOff": "샌드박스 workspace-write, 네트워크 꺼짐",
   "StatusSafetyDisabled": "샌드박스 꺼짐, 네트워크 제한 없음",
+  "StatusSafetyDisabledSetuidBlocked": "샌드박스 꺼짐, 네트워크 제한 없음; sudo/setuid 차단됨(no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "샌드박스 꺼짐, 네트워크 제한 없음; sudo/setuid 허용됨",
   "StatusSafetyExternal": "외부 샌드박스, 네트워크 제어는 호스트에 위임",
   "StatusPointers": "턴별 토큰: /tokens · 바닥글 항목: /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review가 '{tool}'을(를) 허용했습니다 (위험 {risk}, 모델 가디언): {reason}",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "sandbox workspace-write, rede ativada",
   "StatusSafetyWorkspaceWriteNetworkOff": "sandbox workspace-write, rede desativada",
   "StatusSafetyDisabled": "sandbox desativado, rede sem restrições",
+  "StatusSafetyDisabledSetuidBlocked": "sandbox desativado, rede sem restrições; sudo/setuid bloqueado (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "sandbox desativado, rede sem restrições; sudo/setuid permitido",
   "StatusSafetyExternal": "sandbox externo, rede delegada ao host",
   "StatusPointers": "Tokens por turno: /tokens · Itens do rodapé: /statusline",
   "AutoReviewReceiptGuardianAllowed": "O Auto-Review permitiu '{tool}' (risco {risk}, guardião do modelo): {reason}",

--- a/crates/tui/locales/ru.json
+++ b/crates/tui/locales/ru.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "песочница workspace-write, сеть включена",
   "StatusSafetyWorkspaceWriteNetworkOff": "песочница workspace-write, сеть отключена",
   "StatusSafetyDisabled": "песочница отключена, сеть без ограничений",
+  "StatusSafetyDisabledSetuidBlocked": "песочница отключена, сеть без ограничений; sudo/setuid заблокированы (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "песочница отключена, сеть без ограничений; sudo/setuid разрешены",
   "StatusSafetyExternal": "внешняя песочница, управление сетью делегировано хосту",
   "StatusPointers": "Токены по ходам: /tokens · Элементы строки состояния: /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review разрешил '{tool}' (риск {risk}, модельный страж): {reason}",

--- a/crates/tui/locales/uk.json
+++ b/crates/tui/locales/uk.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "пісочниця workspace-write, мережу увімкнено",
   "StatusSafetyWorkspaceWriteNetworkOff": "пісочниця workspace-write, мережу вимкнено",
   "StatusSafetyDisabled": "пісочницю вимкнено, мережа без обмежень",
+  "StatusSafetyDisabledSetuidBlocked": "пісочницю вимкнено, мережа без обмежень; sudo/setuid заблоковано (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "пісочницю вимкнено, мережа без обмежень; sudo/setuid дозволено",
   "StatusSafetyExternal": "зовнішня пісочниця, керування мережею делеговано хосту",
   "StatusPointers": "Токени за ходами: /tokens · Елементи рядка стану: /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review дозволив '{tool}' (ризик {risk}, модельний вартовий): {reason}",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "sandbox workspace-write, mạng bật",
   "StatusSafetyWorkspaceWriteNetworkOff": "sandbox workspace-write, mạng tắt",
   "StatusSafetyDisabled": "sandbox tắt, mạng không giới hạn",
+  "StatusSafetyDisabledSetuidBlocked": "sandbox tắt, mạng không giới hạn; sudo/setuid bị chặn (no-new-privs)",
+  "StatusSafetyDisabledSetuidAllowed": "sandbox tắt, mạng không giới hạn; sudo/setuid được phép",
   "StatusSafetyExternal": "sandbox bên ngoài, mạng do máy chủ quản lý",
   "StatusPointers": "Token từng lượt: /tokens · Mục chân trang: /statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review đã cho phép '{tool}' (rủi ro {risk}, bộ giám hộ mô hình): {reason}",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "沙箱为 workspace-write，网络开启",
   "StatusSafetyWorkspaceWriteNetworkOff": "沙箱为 workspace-write，网络关闭",
   "StatusSafetyDisabled": "沙箱已禁用，网络不受限",
+  "StatusSafetyDisabledSetuidBlocked": "沙箱已禁用，网络不受限；sudo/setuid 仍被阻止（no-new-privs）",
+  "StatusSafetyDisabledSetuidAllowed": "沙箱已禁用，网络不受限；sudo/setuid 已放开",
   "StatusSafetyExternal": "外部沙箱，网络控制委托给主机",
   "StatusPointers": "每轮令牌：/tokens · 页脚项目：/statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review 已允许 '{tool}'（风险 {risk}，模型守护者）：{reason}",

--- a/crates/tui/locales/zh-Hant.json
+++ b/crates/tui/locales/zh-Hant.json
@@ -1666,6 +1666,8 @@
   "StatusSafetyWorkspaceWriteNetworkOn": "沙箱為 workspace-write，網路開啟",
   "StatusSafetyWorkspaceWriteNetworkOff": "沙箱為 workspace-write，網路關閉",
   "StatusSafetyDisabled": "沙箱已停用，網路不受限",
+  "StatusSafetyDisabledSetuidBlocked": "沙箱已停用，網路不受限；sudo/setuid 仍被封鎖（no-new-privs）",
+  "StatusSafetyDisabledSetuidAllowed": "沙箱已停用，網路不受限；sudo/setuid 已放寬",
   "StatusSafetyExternal": "外部沙箱，網路控制委派給主機",
   "StatusPointers": "每回合權杖：/tokens · 頁尾項目：/statusline",
   "AutoReviewReceiptGuardianAllowed": "Auto-Review 已允許 '{tool}'（風險 {risk}，模型守護者）：{reason}",

--- a/crates/tui/src/commands/groups/config/status.rs
+++ b/crates/tui/src/commands/groups/config/status.rs
@@ -309,10 +309,25 @@ fn safety_summary(app: &App) -> Cow<'static, str> {
                 MessageId::StatusSafetyWorkspaceWriteNetworkOff
             }
         }
-        crate::sandbox::SandboxPolicy::DangerFullAccess => MessageId::StatusSafetyDisabled,
+        crate::sandbox::SandboxPolicy::DangerFullAccess => {
+            safety_disabled_message(crate::sandbox::process_hardening::no_new_privs_active())
+        }
         crate::sandbox::SandboxPolicy::ExternalSandbox { .. } => MessageId::StatusSafetyExternal,
     };
     tr(app.ui_locale, message)
+}
+
+/// The full-access safety row must disclose the residual setuid block
+/// truthfully (#5723): the no-new-privileges kernel flag is set at startup in
+/// every narrower posture and is irreversible, so "sandbox disabled" alone
+/// would promise `sudo`/setuid workflows the process tree cannot perform.
+/// `None` is a platform without the flag, where the plain label is accurate.
+fn safety_disabled_message(no_new_privs_active: Option<bool>) -> MessageId {
+    match no_new_privs_active {
+        Some(true) => MessageId::StatusSafetyDisabledSetuidBlocked,
+        Some(false) => MessageId::StatusSafetyDisabledSetuidAllowed,
+        None => MessageId::StatusSafetyDisabled,
+    }
 }
 
 fn project_docs(workspace: &Path, locale: Locale) -> String {
@@ -747,6 +762,41 @@ mod tests {
         app.mode = AppMode::Yolo;
         let yolo = format_status(&app);
         assert!(yolo.contains("sandbox disabled, network unrestricted"));
+    }
+
+    #[test]
+    fn status_safety_row_discloses_no_new_privs_flag_state_for_full_access() {
+        // #5723: both flag states get a distinct, truthful row; a platform
+        // without the flag keeps the plain full-access label. The live query
+        // is host-dependent, so the selector is pinned directly.
+        let blocked = tr(Locale::En, safety_disabled_message(Some(true)));
+        assert!(
+            blocked.contains("sandbox disabled, network unrestricted"),
+            "{blocked}"
+        );
+        assert!(blocked.contains("sudo/setuid blocked"), "{blocked}");
+
+        let relaxed = tr(Locale::En, safety_disabled_message(Some(false)));
+        assert!(
+            relaxed.contains("sandbox disabled, network unrestricted"),
+            "{relaxed}"
+        );
+        assert!(relaxed.contains("sudo/setuid allowed"), "{relaxed}");
+
+        let plain = safety_disabled_message(None);
+        assert_eq!(
+            tr(Locale::En, plain),
+            tr(Locale::En, MessageId::StatusSafetyDisabled)
+        );
+
+        // The disclosure is real prose, so every complete pack must carry a
+        // translation rather than a copy of the English string.
+        for id in [
+            safety_disabled_message(Some(true)),
+            safety_disabled_message(Some(false)),
+        ] {
+            assert_ne!(tr(Locale::Ja, id), tr(Locale::En, id), "{id:?}");
+        }
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -3483,7 +3483,12 @@ impl Engine {
             ),
             format!(
                 "Current sandbox posture: {}",
-                sandbox_posture.posture_label_with_enforcement(self.sandbox_enforcement)
+                sandbox_posture.posture_label_with_enforcement_and_no_new_privs(
+                    self.sandbox_enforcement,
+                    // Fixed at process start, so the per-turn line stays
+                    // byte-stable for the session.
+                    crate::sandbox::process_hardening::no_new_privs_active(),
+                )
             ),
         ];
         if approval_mode == crate::tui::approval::ApprovalMode::Never {

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -6,7 +6,7 @@ use super::turn_loop::{
     auto_review_block_tool_error, initial_stream_error_user_message, merge_new_runtime_mcp_tools,
     preview_request_error_user_message, registered_tool_approval_required,
     registered_tool_forces_prompt, repo_law_must_block_without_prompt,
-    requested_sandbox_escalation, workspace_write_carve_out_applies,
+    requested_sandbox_escalation, sandbox_escalation_denial, workspace_write_carve_out_applies,
 };
 use crate::config::ApiProvider;
 use crate::models::{SystemBlock, Usage};
@@ -8060,6 +8060,41 @@ fn sandbox_escalation_requires_a_pair_and_a_strictly_wider_mode() {
         .is_none(),
         "field-name collisions on non-shell tools must not create authority"
     );
+}
+
+#[test]
+fn sandbox_escalation_denial_names_no_new_privs_remediation_only_when_flag_active() {
+    use crate::sandbox::SandboxPolicy;
+
+    let full = SandboxPolicy::DangerFullAccess;
+
+    // Flag active + a full-access request: the denial must name both
+    // startup-level remediation paths, because no per-call grant can lift the
+    // irreversible kernel flag (#5723).
+    let error = sandbox_escalation_denial("danger-full-access", &full, Some(true));
+    let message = error.to_string();
+    assert!(message.contains("not strictly wider"), "{message}");
+    assert!(
+        message.contains("sandbox_mode = \"danger-full-access\""),
+        "{message}"
+    );
+    assert!(message.contains("CODEWHALE_NO_NEW_PRIVS=0"), "{message}");
+
+    // Flag relaxed (the startup posture disabled it) or absent (non-Linux):
+    // no remediation clause — sudo works in this tree, or the flag never
+    // applied.
+    for flag in [Some(false), None] {
+        let message = sandbox_escalation_denial("danger-full-access", &full, flag).to_string();
+        assert!(message.contains("not strictly wider"), "{message}");
+        assert!(!message.contains("CODEWHALE_NO_NEW_PRIVS"), "{message}");
+        assert!(!message.contains("sandbox_mode"), "{message}");
+    }
+
+    // The clause attaches only to a full-access request: a workspace-write
+    // denial is about write scope, not privilege transitions.
+    let message = sandbox_escalation_denial("workspace-write", &full, Some(true)).to_string();
+    assert!(message.contains("not strictly wider"), "{message}");
+    assert!(!message.contains("CODEWHALE_NO_NEW_PRIVS"), "{message}");
 }
 
 #[test]

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -215,10 +215,11 @@ pub(super) fn requested_sandbox_escalation(
             "danger-full-access",
         ) => crate::sandbox::SandboxPolicy::DangerFullAccess,
         (_, "workspace-write" | "danger-full-access") => {
-            return Err(ToolError::permission_denied(format!(
-                "sandbox escalation to '{requested}' is not strictly wider than this call's current '{}' posture",
-                effective.posture_label()
-            )));
+            return Err(sandbox_escalation_denial(
+                requested,
+                effective,
+                crate::sandbox::process_hardening::no_new_privs_active(),
+            ));
         }
         (_, other) => {
             return Err(ToolError::invalid_input(format!(
@@ -227,6 +228,35 @@ pub(super) fn requested_sandbox_escalation(
         }
     };
     Ok(Some((policy, justification)))
+}
+
+/// Denial for a per-call sandbox escalation that is not strictly wider than
+/// the call's current posture.
+///
+/// When the request aims at `danger-full-access` but the irreversible
+/// no-new-privileges kernel flag was set at startup, even the widest per-call
+/// grant cannot unblock `sudo`/setuid for this process tree — the flag is
+/// process-lifetime and can never be lifted from inside (#5723). Name the two
+/// startup-level paths that actually relax it so the model stops burning
+/// turns on escalation shapes that cannot work.
+pub(super) fn sandbox_escalation_denial(
+    requested: &str,
+    effective: &crate::sandbox::SandboxPolicy,
+    no_new_privs_active: Option<bool>,
+) -> ToolError {
+    let base = format!(
+        "sandbox escalation to '{requested}' is not strictly wider than this call's current '{}' posture",
+        effective.posture_label()
+    );
+    if requested == "danger-full-access" && no_new_privs_active == Some(true) {
+        ToolError::permission_denied(format!(
+            "{base}; sudo/setuid remain blocked by the no-new-privileges kernel flag set at \
+             startup — relaunch with sandbox_mode = \"danger-full-access\" in the config file \
+             or CODEWHALE_NO_NEW_PRIVS=0 to relax it"
+        ))
+    } else {
+        ToolError::permission_denied(base)
+    }
 }
 
 /// Whether a [`Usage`] carries any provider-reported data. The

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1583,6 +1583,39 @@ enum SandboxCommand {
 
 const CODEWHALE_MAIN_STACK_BYTES: usize = 16 * 1024 * 1024;
 
+/// Pre-clap seam feeding `apply_process_hardening` (#5723): resolve only the
+/// *startup* sandbox posture — `CODEWHALE_SANDBOX_MODE` /
+/// `DEEPSEEK_SANDBOX_MODE` first, then the config file's `sandbox_mode` key —
+/// so the irreversible `PR_SET_NO_NEW_PRIVS` decision can honor a
+/// `danger-full-access` launch.
+///
+/// This is deliberately a narrow single-key read, not a config-system
+/// reorder: the full pipeline (clap flags such as `--config`/`exec
+/// --sandbox`, profiles, managed and project overlays) cannot run before
+/// process hardening, which must land before Tokio and any worker threads.
+/// What the seam cannot see keeps the hardened default — fail-closed. The
+/// one deliberate gap in the other direction: a later-resolved override that
+/// *tightens* a config-file `danger-full-access` (e.g. managed requirements)
+/// leaves the flag off; `CODEWHALE_NO_NEW_PRIVS=1` remains the explicit
+/// override that forces it on in any posture. The env path override
+/// (`CODEWHALE_CONFIG_PATH`) is honored through `resolve_load_config_path`;
+/// only clap-parsed paths are invisible here.
+fn resolve_startup_sandbox_mode_for_hardening() -> Option<String> {
+    if let Ok(value) =
+        std::env::var("CODEWHALE_SANDBOX_MODE").or_else(|_| std::env::var("DEEPSEEK_SANDBOX_MODE"))
+    {
+        return Some(value);
+    }
+    let path = crate::config::resolve_load_config_path(None)
+        .ok()
+        .flatten()?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    let doc = raw.parse::<toml::Value>().ok()?;
+    doc.get("sandbox_mode")
+        .and_then(toml::Value::as_str)
+        .map(str::to_string)
+}
+
 /// Entry point for the single binary. Takes argv including binary name at 0,
 /// parses with clap, and runs the TUI/runtime dispatch. Returns process exit
 /// code for the caller to exit with.
@@ -1618,7 +1651,11 @@ fn run_with_args(args: Vec<String>) -> Result<()> {
     // ── Process hardening (#2183) ─────────────────────────────────────────
     // MUST run before Tokio is booted and before any threads are spawned.
     // See crates/tui/src/sandbox/process_hardening.rs for ordering rationale.
-    crate::sandbox::process_hardening::apply_process_hardening();
+    // The startup-posture read is the narrow seam documented above: a startup
+    // resolved to danger-full-access skips PR_SET_NO_NEW_PRIVS (#5723), every
+    // other outcome keeps it.
+    let startup_sandbox_mode = resolve_startup_sandbox_mode_for_hardening();
+    crate::sandbox::process_hardening::apply_process_hardening(startup_sandbox_mode.as_deref());
 
     // ── Fatal-signal terminal guard (#5424) ───────────────────────────────
     // Abort-class deaths (stack overflow, allocation failure, double panic)

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -1482,6 +1482,8 @@ pub enum MessageId {
     StatusSafetyWorkspaceWriteNetworkOn,
     StatusSafetyWorkspaceWriteNetworkOff,
     StatusSafetyDisabled,
+    StatusSafetyDisabledSetuidBlocked,
+    StatusSafetyDisabledSetuidAllowed,
     StatusSafetyExternal,
     StatusPointers,
     // Underwater post-launch empty state.
@@ -3260,6 +3262,8 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::StatusSafetyWorkspaceWriteNetworkOn,
     MessageId::StatusSafetyWorkspaceWriteNetworkOff,
     MessageId::StatusSafetyDisabled,
+    MessageId::StatusSafetyDisabledSetuidBlocked,
+    MessageId::StatusSafetyDisabledSetuidAllowed,
     MessageId::StatusSafetyExternal,
     MessageId::StatusPointers,
     MessageId::EmptyStateNoGit,

--- a/crates/tui/src/sandbox/policy.rs
+++ b/crates/tui/src/sandbox/policy.rs
@@ -241,6 +241,56 @@ impl SandboxPolicy {
         }
     }
 
+    /// Posture label with the no-new-privileges kernel flag's effect on
+    /// privilege escalation named, for surfaces that can observe the live
+    /// flag state.
+    ///
+    /// `no_new_privs_active` is `Some(true)` when the irreversible flag is set
+    /// on this process tree, `Some(false)` when startup relaxed it, and `None`
+    /// on platforms without the flag (see
+    /// [`super::process_hardening::no_new_privs_active`]). Only the full-access
+    /// posture gains a clause: it is the posture whose name promises
+    /// unrestricted privilege transitions (#5723), so a residual setuid block
+    /// there is a lie of omission. Narrower postures keep the plain label —
+    /// setuid was never expected to work inside them.
+    #[must_use]
+    pub fn posture_label_with_no_new_privs(&self, no_new_privs_active: Option<bool>) -> String {
+        match (self, no_new_privs_active) {
+            (SandboxPolicy::DangerFullAccess, Some(true)) => format!(
+                "{}; sudo/setuid still blocked by the no-new-privs kernel flag set at startup",
+                self.posture_label()
+            ),
+            (SandboxPolicy::DangerFullAccess, Some(false)) => format!(
+                "{}; sudo/setuid allowed (no-new-privs relaxed at startup)",
+                self.posture_label()
+            ),
+            _ => self.posture_label(),
+        }
+    }
+
+    /// Render the policy together with the session-pinned execution boundary
+    /// and the live no-new-privileges flag state.
+    ///
+    /// The setuid clause only describes privilege transitions in *this*
+    /// process tree, so an external execution backend — where commands run on
+    /// the configured service — keeps the plain enforcement label.
+    #[must_use]
+    pub fn posture_label_with_enforcement_and_no_new_privs(
+        &self,
+        enforcement: SandboxEnforcement,
+        no_new_privs_active: Option<bool>,
+    ) -> String {
+        match (self, enforcement) {
+            (SandboxPolicy::DangerFullAccess, SandboxEnforcement::ExternalBackend) => {
+                self.posture_label_with_enforcement(enforcement)
+            }
+            (SandboxPolicy::DangerFullAccess, _) => {
+                self.posture_label_with_no_new_privs(no_new_privs_active)
+            }
+            _ => self.posture_label_with_enforcement(enforcement),
+        }
+    }
+
     /// Get the list of writable roots for this policy.
     ///
     /// This includes:
@@ -614,6 +664,78 @@ mod tests {
         assert_eq!(
             full_unavailable,
             SandboxPolicy::DangerFullAccess.posture_label()
+        );
+    }
+
+    #[test]
+    fn posture_labels_disclose_the_no_new_privs_flag_for_full_access() {
+        // #5723: "full access" promises unrestricted privilege transitions, so
+        // the label must say when the irreversible kernel flag still blocks
+        // sudo/setuid — and when the startup posture relaxed it.
+        let blocked = SandboxPolicy::DangerFullAccess.posture_label_with_no_new_privs(Some(true));
+        assert!(
+            blocked.contains("full access (sandbox disabled)"),
+            "{blocked}"
+        );
+        assert!(blocked.contains("sudo/setuid still blocked"), "{blocked}");
+        assert!(blocked.contains("no-new-privs"), "{blocked}");
+
+        let relaxed = SandboxPolicy::DangerFullAccess.posture_label_with_no_new_privs(Some(false));
+        assert!(relaxed.contains("sudo/setuid allowed"), "{relaxed}");
+
+        // No flag on this platform → the plain label, byte-identical.
+        let unknown = SandboxPolicy::DangerFullAccess.posture_label_with_no_new_privs(None);
+        assert_eq!(unknown, SandboxPolicy::DangerFullAccess.posture_label());
+
+        // Narrower postures never promised setuid; the clause is full-access
+        // only, in either flag state.
+        for flag in [Some(true), Some(false), None] {
+            assert_eq!(
+                SandboxPolicy::default().posture_label_with_no_new_privs(flag),
+                SandboxPolicy::default().posture_label(),
+            );
+            assert_eq!(
+                SandboxPolicy::ReadOnly.posture_label_with_no_new_privs(flag),
+                SandboxPolicy::ReadOnly.posture_label(),
+            );
+        }
+    }
+
+    #[test]
+    fn enforcement_and_no_new_privs_labels_compose_only_where_they_apply() {
+        // The setuid clause describes this process tree; an external backend
+        // runs commands on its own service, so its label stays untouched.
+        let external = SandboxPolicy::DangerFullAccess
+            .posture_label_with_enforcement_and_no_new_privs(
+                SandboxEnforcement::ExternalBackend,
+                Some(true),
+            );
+        assert_eq!(
+            external,
+            SandboxPolicy::DangerFullAccess
+                .posture_label_with_enforcement(SandboxEnforcement::ExternalBackend),
+            "{external}"
+        );
+
+        let local_blocked = SandboxPolicy::DangerFullAccess
+            .posture_label_with_enforcement_and_no_new_privs(
+                SandboxEnforcement::LocalOs,
+                Some(true),
+            );
+        assert!(
+            local_blocked.contains("sudo/setuid still blocked"),
+            "{local_blocked}"
+        );
+
+        // Other postures keep exactly the enforcement label.
+        let workspace = SandboxPolicy::default().posture_label_with_enforcement_and_no_new_privs(
+            SandboxEnforcement::LocalOs,
+            Some(false),
+        );
+        assert_eq!(
+            workspace,
+            SandboxPolicy::default().posture_label_with_enforcement(SandboxEnforcement::LocalOs),
+            "{workspace}"
         );
     }
 

--- a/crates/tui/src/sandbox/process_hardening.rs
+++ b/crates/tui/src/sandbox/process_hardening.rs
@@ -402,13 +402,12 @@ mod linux_flag_tests {
         }
         let mode = std::env::var(CHILD_MODE_ENV).ok();
         apply_process_hardening(mode.as_deref());
-        let status = std::fs::read_to_string("/proc/self/status").expect("read /proc/self/status");
-        let flag = status
-            .lines()
-            .find_map(|line| line.strip_prefix("NoNewPrivs:"))
-            .expect("NoNewPrivs line in /proc/self/status")
-            .trim();
-        println!("NNP={flag}");
+        // Read the flag back through PR_GET_NO_NEW_PRIVS, not
+        // /proc/self/status: no_new_privs is per-task and /proc/self/status
+        // shows the *main* thread's flag, while libtest runs this test on a
+        // spawned thread — the /proc read always reports 0 here.
+        let flag = no_new_privs_active().expect("PR_GET_NO_NEW_PRIVS reads the flag on Linux");
+        println!("NNP={}", if flag { "1" } else { "0" });
     }
 
     fn run_child(mode: Option<&str>, env_override: Option<&str>) -> String {

--- a/crates/tui/src/sandbox/process_hardening.rs
+++ b/crates/tui/src/sandbox/process_hardening.rs
@@ -23,8 +23,10 @@
 //!    Because this also blocks intentional privilege gains — `sudo`, `su`,
 //!    setuid helpers — a user who runs Codewhale as a wheel/wheel-equivalent
 //!    administrator and wants the model to be able to escalate can opt out of
-//!    exactly this one measure with `CODEWHALE_NO_NEW_PRIVS=0` (#5413). The
-//!    other two measures stay on.
+//!    exactly this one measure with `CODEWHALE_NO_NEW_PRIVS=0` (#5413), and a
+//!    session whose startup sandbox mode resolves to `danger-full-access`
+//!    skips it by default so full access means what it says (#5723). The
+//!    other two measures stay on in every posture.
 //!
 //! 3. `RLIMIT_CORE` — disables core dumps so that sensitive in-memory data
 //!    (API keys, tokens, prompt content) is never written to disk on a crash.
@@ -36,15 +38,16 @@
 //! from the `libc` crate). On non-Linux platforms, `apply_process_hardening()`
 //! is a no-op that logs a debug-level message.
 
-/// Environment variable that opts the process out of `PR_SET_NO_NEW_PRIVS`.
+/// Environment variable carrying the explicit no-new-privileges decision.
 ///
 /// `PR_SET_NO_NEW_PRIVS` is an irreversible, inherited-by-children kernel
 /// flag, so applying it by default breaks workflows where the user *wants*
 /// Codewhale to be able to escalate: `sudo`, `su`, setuid/fscaps helpers run
 /// by a wheel-group administrator (#5413). Setting this variable to any
 /// falsey value (`0`, `false`, `no`, `off`, `disabled`, or empty) skips
-/// exactly this one measure. Any other value, or leaving it unset, keeps the
-/// default hardening. `PR_SET_DUMPABLE` and `RLIMIT_CORE` are never skipped.
+/// exactly this one measure; any other set value forces it on, and leaving it
+/// unset lets the startup sandbox posture decide (#5723). `PR_SET_DUMPABLE`
+/// and `RLIMIT_CORE` are never skipped.
 pub(crate) const NO_NEW_PRIVS_ENV: &str = "CODEWHALE_NO_NEW_PRIVS";
 
 /// Whether a `CODEWHALE_NO_NEW_PRIVS` value requests skipping the
@@ -58,20 +61,80 @@ fn is_no_new_privs_opt_out(value: &str) -> bool {
     )
 }
 
-fn no_new_privs_opted_out() -> bool {
+/// The explicit `CODEWHALE_NO_NEW_PRIVS` decision as the tri-state
+/// [`should_apply_no_new_privs`] consumes: `Some(false)` opts out (falsey
+/// value), `Some(true)` forces the flag on (any other set value), and `None`
+/// leaves the decision to the startup posture.
+fn no_new_privs_env_override() -> Option<bool> {
     std::env::var_os(NO_NEW_PRIVS_ENV)
-        .is_some_and(|value| is_no_new_privs_opt_out(&value.to_string_lossy()))
+        .map(|value| !is_no_new_privs_opt_out(&value.to_string_lossy()))
+}
+
+/// Whether startup should set the kernel's irreversible no-new-privileges
+/// flag, given the resolved startup sandbox mode and the explicit
+/// `CODEWHALE_NO_NEW_PRIVS` override.
+///
+/// Precedence (#5723):
+///
+/// 1. An explicit override wins in both directions: a falsey value skips the
+///    flag (#5413); a truthy value forces it on even under
+///    `danger-full-access`.
+/// 2. Otherwise a startup resolved to `danger-full-access` skips the flag so
+///    "full access (sandbox disabled)" means it: `sudo`/`su`/setuid helpers
+///    keep working from the agent shell.
+/// 3. Every other — or unreadable — posture keeps the flag. Defense-in-depth
+///    stays the default (#5413) and the decision is fail-closed.
+///
+/// The mode string is normalized the same way config validation normalizes
+/// `sandbox_mode` (`Config::validate`): trimmed, ASCII case-insensitive. An
+/// unrecognized value keeps the flag on — it cannot silently relax into a
+/// posture the runtime would reject.
+pub(crate) fn should_apply_no_new_privs(
+    resolved_startup_mode: Option<&str>,
+    env_override: Option<bool>,
+) -> bool {
+    if let Some(apply) = env_override {
+        return apply;
+    }
+    !resolved_startup_mode
+        .is_some_and(|mode| mode.trim().eq_ignore_ascii_case("danger-full-access"))
+}
+
+/// Live state of the kernel's no-new-privileges flag for this process tree.
+///
+/// Returns `Some(true)`/`Some(false)` on Linux, where `PR_GET_NO_NEW_PRIVS`
+/// reads back the irreversible flag set (or deliberately skipped) at startup,
+/// and `None` on platforms where the flag does not exist or the query fails.
+/// Status and denial surfaces use this to disclose the residual setuid block
+/// truthfully instead of replaying the startup decision (#5723).
+pub(crate) fn no_new_privs_active() -> Option<bool> {
+    #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
+    {
+        // Safety: PR_GET_NO_NEW_PRIVS only reads the calling process's flag.
+        let result = unsafe { libc::prctl(libc::PR_GET_NO_NEW_PRIVS, 0i64, 0i64, 0i64, 0i64) };
+        if result < 0 { None } else { Some(result == 1) }
+    }
+    #[cfg(not(all(target_os = "linux", not(target_env = "ohos"))))]
+    {
+        None
+    }
 }
 
 /// Apply process-level hardening measures.
 ///
 /// On Linux, this:
 /// - Sets `PR_SET_DUMPABLE` to 0 (prevents ptrace, core dumps)
-/// - Sets `PR_SET_NO_NEW_PRIVS` to 1 (irreversible no-new-privileges),
-///   unless `CODEWHALE_NO_NEW_PRIVS` holds a falsey value (#5413)
+/// - Sets `PR_SET_NO_NEW_PRIVS` to 1 (irreversible no-new-privileges), unless
+///   [`should_apply_no_new_privs`] skips it: an explicit falsey
+///   `CODEWHALE_NO_NEW_PRIVS` (#5413), or a startup sandbox mode resolved to
+///   `danger-full-access` (#5723)
 /// - Sets `RLIMIT_CORE` to 0 (disables core dumps)
 ///
 /// On non-Linux platforms this is a no-op.
+///
+/// `resolved_startup_mode` is the narrow pre-parse read of the startup sandbox
+/// mode (`CODEWHALE_SANDBOX_MODE`, else the config file's `sandbox_mode` key);
+/// see `run_with_args` in `crate::lib` for the seam and its limits.
 ///
 /// # Panics
 ///
@@ -79,20 +142,21 @@ fn no_new_privs_opted_out() -> bool {
 /// hardening is defense-in-depth. A failure does not abort startup or change
 /// whether a separately configured Seatbelt/bubblewrap command wrapper is
 /// available.
-pub fn apply_process_hardening() {
+pub fn apply_process_hardening(resolved_startup_mode: Option<&str>) {
     #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
     {
-        apply_linux_hardening();
+        apply_linux_hardening(resolved_startup_mode);
     }
     #[cfg(not(all(target_os = "linux", not(target_env = "ohos"))))]
     {
+        let _ = resolved_startup_mode;
         tracing::debug!("Process hardening skipped: not on Linux");
     }
 }
 
 /// Linux-specific hardening implementation.
 #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
-fn apply_linux_hardening() {
+fn apply_linux_hardening(resolved_startup_mode: Option<&str>) {
     // ── PR_SET_DUMPABLE = 0 ────────────────────────────────────────────────
     //
     // When dumpable is 0:
@@ -123,21 +187,24 @@ fn apply_linux_hardening() {
     //
     // That strength is also the flag's one legitimate break: a wheel-group
     // administrator running Codewhale over ssh loses `sudo`/`su`/setuid
-    // helpers for the whole process tree (#5413). `CODEWHALE_NO_NEW_PRIVS`
-    // with a falsey value skips only this measure, before any thread exists —
-    // the same point in startup where the flag itself is applied.
+    // helpers for the whole process tree (#5413). Two startup-level paths skip
+    // exactly this measure, before any thread exists — the same point in
+    // startup where the flag itself is applied:
+    //
+    // - `CODEWHALE_NO_NEW_PRIVS` with a falsey value (#5413). A truthy value
+    //   is the opposite explicit decision: it forces the flag on even under a
+    //   `danger-full-access` startup.
+    // - A startup sandbox mode resolved to `danger-full-access` (#5723):
+    //   "full access (sandbox disabled)" must mean it, so the agent shell's
+    //   `sudo`/setuid workflows keep working. Every narrower posture keeps
+    //   the flag as defense-in-depth.
     //
     // Pattern from openai/codex codex-rs/codex-sandbox/src/linux.rs; reimplemented.
     //
     // Safety: prctl with PR_SET_NO_NEW_PRIVS modifies only the calling process
     // and its future descendants.
-    if no_new_privs_opted_out() {
-        tracing::info!(
-            target: "sandbox",
-            "PR_SET_NO_NEW_PRIVS skipped via {NO_NEW_PRIVS_ENV}: setuid/sudo escalation is \
-             allowed for this process tree"
-        );
-    } else {
+    let env_override = no_new_privs_env_override();
+    if should_apply_no_new_privs(resolved_startup_mode, env_override) {
         let result = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1i64, 0i64, 0i64, 0i64) };
         if result != 0 {
             let err = std::io::Error::last_os_error();
@@ -148,6 +215,18 @@ fn apply_linux_hardening() {
         } else {
             tracing::debug!("PR_SET_NO_NEW_PRIVS=1 applied");
         }
+    } else if env_override == Some(false) {
+        tracing::info!(
+            target: "sandbox",
+            "PR_SET_NO_NEW_PRIVS skipped via {NO_NEW_PRIVS_ENV}: setuid/sudo escalation is \
+             allowed for this process tree"
+        );
+    } else {
+        tracing::info!(
+            target: "sandbox",
+            "PR_SET_NO_NEW_PRIVS skipped: startup sandbox mode resolved to danger-full-access \
+             (#5723); setuid/sudo escalation is allowed for this process tree"
+        );
     }
 
     // ── RLIMIT_CORE = 0 ────────────────────────────────────────────────────
@@ -181,7 +260,7 @@ mod tests {
     fn test_apply_process_hardening_does_not_panic() {
         // This test exists to ensure the function can be called without
         // panicking, even on platforms where hardening is a no-op.
-        apply_process_hardening();
+        apply_process_hardening(None);
     }
 
     #[test]
@@ -231,7 +310,166 @@ mod tests {
         // test in the process.
         assert_eq!(NO_NEW_PRIVS_ENV, "CODEWHALE_NO_NEW_PRIVS");
         let projected = std::env::var_os(NO_NEW_PRIVS_ENV)
-            .is_some_and(|value| is_no_new_privs_opt_out(&value.to_string_lossy()));
-        assert_eq!(projected, no_new_privs_opted_out());
+            .map(|value| !is_no_new_privs_opt_out(&value.to_string_lossy()));
+        assert_eq!(projected, no_new_privs_env_override());
+    }
+
+    #[test]
+    fn should_apply_no_new_privs_defaults_on_without_full_access_startup() {
+        // No posture information at all, and every narrower posture, keeps
+        // the defense-in-depth default (#5413).
+        for mode in [
+            None,
+            Some("read-only"),
+            Some("workspace-write"),
+            Some("external-sandbox"),
+        ] {
+            assert!(
+                should_apply_no_new_privs(mode, None),
+                "{mode:?} must keep PR_SET_NO_NEW_PRIVS"
+            );
+        }
+    }
+
+    #[test]
+    fn should_apply_no_new_privs_skips_for_danger_full_access_startup() {
+        // The product decision behind #5723: "full access (sandbox disabled)"
+        // must mean it, so the irreversible setuid block is relaxed when the
+        // startup posture resolves to danger-full-access.
+        assert!(!should_apply_no_new_privs(Some("danger-full-access"), None));
+        // Mode strings are normalized the way config validation normalizes
+        // them: surrounding whitespace and ASCII case do not matter.
+        assert!(!should_apply_no_new_privs(
+            Some(" Danger-Full-Access "),
+            None
+        ));
+    }
+
+    #[test]
+    fn should_apply_no_new_privs_env_override_wins_over_posture() {
+        // Explicit override beats posture in both directions (#5413, #5723):
+        // falsey opts out under a narrow posture, truthy forces the flag on
+        // under full access.
+        assert!(!should_apply_no_new_privs(
+            Some("workspace-write"),
+            Some(false)
+        ));
+        assert!(!should_apply_no_new_privs(None, Some(false)));
+        assert!(should_apply_no_new_privs(
+            Some("danger-full-access"),
+            Some(true)
+        ));
+        assert!(should_apply_no_new_privs(
+            Some("workspace-write"),
+            Some(true)
+        ));
+    }
+
+    #[test]
+    fn should_apply_no_new_privs_is_fail_closed_for_unknown_modes() {
+        // A mode string the runtime would reject as invalid must never relax
+        // the flag by accident.
+        for mode in ["danger_full_access", "full-access", "yolo", "", "danger"] {
+            assert!(
+                should_apply_no_new_privs(Some(mode), None),
+                "{mode:?} must keep PR_SET_NO_NEW_PRIVS"
+            );
+        }
+    }
+}
+
+/// Kernel-flag proof. `PR_SET_NO_NEW_PRIVS` is irreversible and inherited by
+/// descendants, so the decision can only be observed end-to-end in a fresh
+/// child process: the child applies hardening under one posture and reports
+/// the kernel's own record from `/proc/self/status`. These tests exist only
+/// on Linux; on other hosts `apply_process_hardening` is a no-op and the flag
+/// does not exist.
+#[cfg(all(test, target_os = "linux", not(target_env = "ohos")))]
+mod linux_flag_tests {
+    use super::*;
+
+    const CHILD_ENV: &str = "CODEWHALE_NNP_TEST_CHILD";
+    const CHILD_MODE_ENV: &str = "CODEWHALE_NNP_TEST_MODE";
+
+    /// Child-process entry point. Run directly (child env marker unset) it is
+    /// a trivial pass; run under the parent tests below it applies hardening
+    /// with the posture named by `CODEWHALE_NNP_TEST_MODE` and prints the
+    /// kernel-recorded flag as `NNP=0|1`.
+    #[test]
+    fn no_new_privs_child_reports_kernel_flag() {
+        if std::env::var_os(CHILD_ENV).is_none() {
+            return;
+        }
+        let mode = std::env::var(CHILD_MODE_ENV).ok();
+        apply_process_hardening(mode.as_deref());
+        let status = std::fs::read_to_string("/proc/self/status").expect("read /proc/self/status");
+        let flag = status
+            .lines()
+            .find_map(|line| line.strip_prefix("NoNewPrivs:"))
+            .expect("NoNewPrivs line in /proc/self/status")
+            .trim();
+        println!("NNP={flag}");
+    }
+
+    fn run_child(mode: Option<&str>, env_override: Option<&str>) -> String {
+        let output = std::process::Command::new(std::env::current_exe().expect("test binary"))
+            .args(["no_new_privs_child_reports_kernel_flag", "--nocapture"])
+            .env(CHILD_ENV, "1")
+            // The ambient developer/CI environment must not leak into the
+            // matrix: the child decides from exactly the inputs passed here.
+            .env_remove(NO_NEW_PRIVS_ENV)
+            .env_remove(CHILD_MODE_ENV)
+            .envs(mode.map(|m| (CHILD_MODE_ENV, m)))
+            .envs(env_override.map(|v| (NO_NEW_PRIVS_ENV, v)))
+            .output()
+            .expect("spawn child test process");
+        assert!(
+            output.status.success(),
+            "child failed: status={:?} stderr={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    #[test]
+    fn no_new_privs_flag_tracks_startup_posture_in_child_processes() {
+        // Never recurse when this test binary is itself the spawned child.
+        if std::env::var_os(CHILD_ENV).is_some() {
+            return;
+        }
+        for (mode, expected) in [
+            (None, "1"),
+            (Some("workspace-write"), "1"),
+            (Some("read-only"), "1"),
+            (Some("external-sandbox"), "1"),
+            (Some("danger-full-access"), "0"),
+        ] {
+            let stdout = run_child(mode, None);
+            assert!(
+                stdout.contains(&format!("NNP={expected}")),
+                "mode {mode:?}: expected NoNewPrivs={expected}, got:\n{stdout}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_new_privs_env_override_beats_posture_in_child_processes() {
+        if std::env::var_os(CHILD_ENV).is_some() {
+            return;
+        }
+        for (mode, override_value, expected) in [
+            // Explicit truthy forces the flag on even under full access.
+            ("danger-full-access", "1", "1"),
+            // Explicit falsey opts out under a narrow posture (#5413).
+            ("workspace-write", "0", "0"),
+        ] {
+            let stdout = run_child(Some(mode), Some(override_value));
+            assert!(
+                stdout.contains(&format!("NNP={expected}")),
+                "mode {mode:?} with {NO_NEW_PRIVS_ENV}={override_value}: \
+                 expected NoNewPrivs={expected}, got:\n{stdout}"
+            );
+        }
     }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1118,10 +1118,14 @@ the `CODEWHALE_*` value wins.
 - `CODEWHALE_NO_NEW_PRIVS` (`0`/`false`/`no`/`off`/`disabled` opts out) — Linux only. The
   TUI process sets the kernel's irreversible no-new-privileges flag at startup
   as defense-in-depth, which blocks `sudo`/`su`/setuid helpers for Codewhale's
-  whole process tree. Set this variable to a falsey value before launching if
-  you administer through Codewhale as a wheel-group user and need escalation
-  to work (#5413); the other startup hardening (no ptrace, no core dumps)
-  stays on. Any other value keeps the default hardened posture.
+  whole process tree. The flag is already skipped when the startup sandbox
+  mode resolves to `danger-full-access` (#5723), so this variable is the
+  explicit override in the remaining cases: set it to a falsey value before
+  launching if you administer through Codewhale as a wheel-group user under a
+  narrower posture and need escalation to work (#5413), or set a truthy value
+  to force the flag on even under `danger-full-access`. Unset, the posture
+  decides; the other startup hardening (no ptrace, no core dumps) always
+  stays on.
 - `CODEWHALE_MANAGED_CONFIG_PATH`
 - `CODEWHALE_REQUIREMENTS_PATH`
 - `CODEWHALE_MAX_SUBAGENTS` (clamped to `1..=128`)

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -123,6 +123,16 @@ logged and startup continues. These controls reduce process-inspection,
 privilege-escalation, and core-dump risk; they do not create filesystem or
 network isolation for a child command and are not listed as a sandbox backend.
 
+The one exception is the startup posture itself: when the startup sandbox mode
+resolves to `danger-full-access` (via `CODEWHALE_SANDBOX_MODE` or the config
+file's `sandbox_mode` key), `PR_SET_NO_NEW_PRIVS` is skipped so that
+`sudo`/`su`/setuid helpers keep working from the agent shell (#5723) — "full
+access" means it. Every narrower posture keeps the flag as defense-in-depth,
+and `CODEWHALE_NO_NEW_PRIVS` overrides the posture in both directions
+(#5413): a falsey value always skips the flag, a truthy value always sets it.
+The flag is irreversible for the process tree, so the decision can only be
+made at launch; per-call sandbox escalation inside a session cannot lift it.
+
 ## External OpenSandbox execution
 
 When `sandbox_backend = "opensandbox"` is configured, shell execution is sent
@@ -148,7 +158,10 @@ sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-acc
 
 - `read-only` and `workspace-write` are enforced by Seatbelt or bubblewrap only
   when that wrapper is selected and available.
-- `danger-full-access` deliberately bypasses the local OS wrapper.
+- `danger-full-access` deliberately bypasses the local OS wrapper. On Linux it
+  also skips the `PR_SET_NO_NEW_PRIVS` process-hardening flag at startup so
+  `sudo`/setuid workflows keep running (#5723); see the process-hardening
+  section above.
 - `external-sandbox` declares that execution is already externally isolated
   and bypasses a second local wrapper.
 - When no wrapper is selected, the shell command runs without Codewhale OS


### PR DESCRIPTION
Closes #5723.

`PR_SET_NO_NEW_PRIVS` was applied to the agent process tree unconditionally on Linux, so the widest advertised posture — "full access (sandbox disabled)" — still blocked `sudo`/`su`/setuid while claiming host-equivalent execution. The reporter's reading was right; the posture was lying.

## What changes

- **Posture decides.** A startup resolved to `danger-full-access` skips the flag, so sudo works from the agent shell exactly like the interactive shell. Every narrower posture keeps it — the #5413 defense-in-depth default is untouched, and the decision is fail-closed on any unreadable/unknown mode.
- **Explicit override both ways.** `CODEWHALE_NO_NEW_PRIVS=0` still opts out (#5413); `=1` (or any truthy value) now forces the flag on even under full access.
- **Kernel truth on surfaces.** `no_new_privs_active()` reads `PR_GET_NO_NEW_PRIVS`; the full-access posture label and the `/status` safety row disclose whether sudo/setuid is blocked or relaxed (all 15 locale packs; parity check PASS).
- **Recoverable denial.** When a per-call escalation hits the not-strictly-wider arm with the flag live, the error names the two working remediations (config `sandbox_mode = "danger-full-access"` + relaunch, or the env var) instead of dead-ending.

Seam note: the startup mode is resolved by a narrow pre-clap read (env, then the config file's `sandbox_mode` key); what it cannot see keeps the hardened default. Documented in the seam comment and docs/SANDBOX.md.

## Tests

Pure-fn precedence matrix; escalation-denial test; posture-label + status-row disclosure tests; Linux-only subprocess proofs assert the kernel `/proc/self/status` line per combo (cfg(linux) — they run on Linux CI, not executable on the macOS host; stated plainly). Focused 14/14 (integrator re-run); full lib suite 11534/0 via nextest; locale parity 1748/1748; fmt clean. One pre-existing main clippy lint (`too_many_arguments`, runtime_threads.rs:2562) is untouched and reproduced on pristine HEAD.

Thanks @ronohara for the precise report.