### PR TITLE
fix(tui): report Runtime Chat owner-lock IO faults truthfully

### DIFF
--- a/crates/tui/src/runtime_chat_relay.rs
+++ b/crates/tui/src/runtime_chat_relay.rs
@@ -255,8 +255,8 @@ impl RuntimeChatRelayHost {
             fs::set_permissions(&private_dir, fs::Permissions::from_mode(0o700))
                 .map_err(|_| "Runtime Chat could not protect private local state.".to_string())?;
         }
-        let scope_lock = RelayScopeLock::acquire(&private_dir.join(SCOPE_LOCK_FILE))
-            .map_err(|error| {
+        let scope_lock =
+            RelayScopeLock::acquire(&private_dir.join(SCOPE_LOCK_FILE)).map_err(|error| {
                 // Only WouldBlock is genuine contention. Any other lock
                 // failure is a local IO fault, and misreporting it as
                 // ownership hides the cause (#5735's flake evidence).

--- a/crates/tui/src/runtime_chat_relay.rs
+++ b/crates/tui/src/runtime_chat_relay.rs
@@ -255,10 +255,20 @@ impl RuntimeChatRelayHost {
             fs::set_permissions(&private_dir, fs::Permissions::from_mode(0o700))
                 .map_err(|_| "Runtime Chat could not protect private local state.".to_string())?;
         }
-        let scope_lock =
-            RelayScopeLock::acquire(&private_dir.join(SCOPE_LOCK_FILE)).map_err(|_| {
-                "Another Codewhale process already owns this Runtime Chat account session."
-                    .to_string()
+        let scope_lock = RelayScopeLock::acquire(&private_dir.join(SCOPE_LOCK_FILE))
+            .map_err(|error| {
+                // Only WouldBlock is genuine contention. Any other lock
+                // failure is a local IO fault, and misreporting it as
+                // ownership hides the cause (#5735's flake evidence).
+                let contention = error
+                    .downcast_ref::<std::io::Error>()
+                    .is_some_and(|io| io.kind() == std::io::ErrorKind::WouldBlock);
+                if contention {
+                    "Another Codewhale process already owns this Runtime Chat account session."
+                        .to_string()
+                } else {
+                    format!("Runtime Chat could not take its owner lock: {error:#}")
+                }
             })?;
         let state_path = private_dir.join(STATE_FILE);
         let state = load_state(&state_path).map_err(|_| {


### PR DESCRIPTION
Refs #5735.

The `RuntimeChatRelayHost::open` lock path mapped every acquire failure to "another process owns this session", discarding the underlying io error — which is why the flaky Safety-gate failure said nothing actionable. Only `WouldBlock` is genuine contention; other failures now report themselves.

Verified: `cargo test -p codewhale-tui --lib -- runtime_chat_relay` — **16 passed / 0 failed**, including the genuine-contention test (message unchanged for that path).

This is the diagnosis-enabling half of #5735; the flake itself stays open until a run reports the real errno.

No-Issue: partial fix for tracked flake #5735 — does not close it.