### PR TITLE
feat(tui): read_media learns byte-budget delivery with an encoding ladder and an originals store

### DIFF
--- a/crates/tui/src/exec_agent.rs
+++ b/crates/tui/src/exec_agent.rs
@@ -198,6 +198,7 @@ pub(crate) async fn run_exec_agent(
     let runtime_services = crate::tools::spec::RuntimeToolServices {
         shell_manager: Some(exec_shell_manager.clone()),
         persist_services_enabled,
+        media_originals_dir: crate::media_originals::default_store_dir(),
         ..crate::tools::spec::RuntimeToolServices::default()
     };
 

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -72,6 +72,7 @@ mod logging;
 mod lsp;
 mod mcp;
 mod mcp_server;
+mod media_originals;
 mod model_catalog;
 mod model_context;
 mod model_inventory;

--- a/crates/tui/src/media_originals.rs
+++ b/crates/tui/src/media_originals.rs
@@ -1,0 +1,213 @@
+//! Content-addressed store for pre-compression image originals.
+//!
+//! When `read_media` downsamples or lossily re-encodes an image to fit the
+//! delivery budget, the model only ever sees the degraded copy. Persisting
+//! the pre-compression bytes — named by content hash — lets a later
+//! `read_media` call with a crop region read the full-resolution source back
+//! (the tool's delivery note points at the stored path), even if the
+//! workspace file has moved or changed since the first read.
+//!
+//! Design notes:
+//! - Content-addressed (sha256): repeated reads of the same image reuse one
+//!   file and repeated writes are idempotent.
+//! - Best effort: any filesystem failure returns `None`; media delivery never
+//!   blocks on persistence.
+//! - Size-capped: after each write the store is swept oldest-first (mtime)
+//!   until it fits [`MAX_TOTAL_BYTES`], so long sessions cannot fill the disk.
+//! - Placement: the production engine wires the store dir through
+//!   `RuntimeToolServices::media_originals_dir`
+//!   ([`default_store_dir`]); test and one-off contexts leave it `None`, which
+//!   disables persistence so unit tests never touch the real state dir.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest as _, Sha256};
+
+/// Total size ceiling for the store (1 GiB). Each admitted source is already
+/// capped at `read_media`'s 20 MiB source limit, so the store holds dozens of
+/// full-resolution originals before the sweep engages.
+pub const MAX_TOTAL_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Store subdirectory under the CodeWhale home directory.
+pub const MEDIA_ORIGINALS_SUBDIR: &str = "media-originals";
+
+/// The production store location: `<codewhale home>/media-originals`.
+///
+/// The directory is created lazily on first persist, not here, so resolving
+/// the path never has a filesystem side effect.
+#[must_use]
+pub fn default_store_dir() -> Option<PathBuf> {
+    codewhale_config::codewhale_home()
+        .ok()
+        .map(|home| home.join(MEDIA_ORIGINALS_SUBDIR))
+}
+
+fn extension_for_mime(mime_type: &str) -> &'static str {
+    match mime_type.trim().to_ascii_lowercase().as_str() {
+        "image/png" => "png",
+        "image/jpeg" | "image/jpg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/bmp" => "bmp",
+        "image/tiff" => "tif",
+        _ => "img",
+    }
+}
+
+/// Persist `bytes` under `dir`, returning the content-addressed path.
+///
+/// Best effort: returns `None` on any filesystem failure. A same-named entry
+/// with the same length is reused as-is (content addressing makes a length
+/// match a content match for practical purposes).
+pub fn persist_original_image(bytes: &[u8], mime_type: &str, dir: &Path) -> Option<PathBuf> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let digest = Sha256::digest(bytes);
+    let mut hash = String::with_capacity(32);
+    for byte in digest.iter().take(16) {
+        use std::fmt::Write as _;
+        let _ = write!(hash, "{byte:02x}");
+    }
+    let path = dir.join(format!("{hash}.{}", extension_for_mime(mime_type)));
+    std::fs::create_dir_all(dir).ok()?;
+    let write_needed = match std::fs::metadata(&path) {
+        Ok(meta) => meta.len() != bytes.len() as u64,
+        Err(_) => true,
+    };
+    if write_needed {
+        std::fs::write(&path, bytes).ok()?;
+    }
+    sweep_store(dir, MAX_TOTAL_BYTES);
+    std::fs::metadata(&path).ok()?;
+    Some(path)
+}
+
+/// Resolve `raw` as a read-back path inside the store.
+///
+/// Returns the canonical path only when the file exists and lives under
+/// `store_dir`. `read_media` uses this as a fallback after the workspace
+/// resolver rejects a path: the store only contains image bytes that already
+/// passed the tool's read guards, so read-back widens nothing.
+#[must_use]
+pub fn resolve_stored_original(raw: &str, workspace: &Path, store_dir: &Path) -> Option<PathBuf> {
+    let candidate = if Path::new(raw).is_absolute() {
+        PathBuf::from(raw)
+    } else {
+        workspace.join(raw)
+    };
+    let candidate = candidate.canonicalize().ok()?;
+    let store_dir = store_dir.canonicalize().ok()?;
+    candidate.starts_with(store_dir).then_some(candidate)
+}
+
+/// Oldest-first (mtime) sweep until the store fits `max_total_bytes`.
+/// Best effort: individual stat/unlink failures are skipped.
+fn sweep_store(dir: &Path, max_total_bytes: u64) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut files: Vec<(PathBuf, u64, std::time::SystemTime)> = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        files.push((
+            entry.path(),
+            meta.len(),
+            meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH),
+        ));
+    }
+    let mut total: u64 = files.iter().map(|(_, len, _)| *len).sum();
+    if total <= max_total_bytes {
+        return;
+    }
+    files.sort_by_key(|(_, _, mtime)| *mtime);
+    for (path, len, _) in files {
+        if total <= max_total_bytes {
+            break;
+        }
+        if std::fs::remove_file(&path).is_ok() {
+            total = total.saturating_sub(len);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn persist_is_content_addressed_and_idempotent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = dir.path().join("media-originals");
+        let bytes = b"\x89PNG fake-but-deterministic payload";
+
+        let first = persist_original_image(bytes, "image/png", &store).expect("persist");
+        assert!(first.exists());
+        assert_eq!(first.parent(), Some(store.as_path()));
+        assert_eq!(
+            first.extension().and_then(|e| e.to_str()),
+            Some("png"),
+            "mime drives the extension"
+        );
+        let stem = first.file_stem().unwrap().to_str().unwrap().to_string();
+        assert_eq!(stem.len(), 32, "sha256 prefix names the file: {stem}");
+
+        let second = persist_original_image(bytes, "image/png", &store).expect("re-persist");
+        assert_eq!(first, second, "same bytes reuse one file");
+        assert_eq!(std::fs::read_dir(&store).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn sweep_removes_oldest_until_under_cap() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = dir.path().to_path_buf();
+        let mut paths = Vec::new();
+        for i in 0..4u8 {
+            let path = store.join(format!("img{i}.png"));
+            std::fs::write(&path, vec![i; 100]).expect("write");
+            paths.push(path);
+        }
+        // 400 bytes total; cap at 250 -> at least the two oldest go.
+        sweep_store(&store, 250);
+        let remaining = std::fs::read_dir(&store).unwrap().count();
+        assert!(
+            remaining <= 2,
+            "sweep must evict oldest-first until under cap, {remaining} left"
+        );
+        let total: u64 = std::fs::read_dir(&store)
+            .unwrap()
+            .flatten()
+            .filter_map(|e| e.metadata().ok())
+            .map(|m| m.len())
+            .sum();
+        assert!(total <= 250);
+    }
+
+    #[test]
+    fn resolve_stored_original_admits_store_paths_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = dir.path().join("media-originals");
+        std::fs::create_dir_all(&store).unwrap();
+        let inside = store.join("abc123.png");
+        std::fs::write(&inside, b"png").unwrap();
+        let outside = dir.path().join("other.png");
+        std::fs::write(&outside, b"png").unwrap();
+
+        let resolved =
+            resolve_stored_original(inside.to_str().unwrap(), dir.path(), &store).expect("inside");
+        assert!(resolved.ends_with("abc123.png"));
+        assert!(
+            resolve_stored_original(outside.to_str().unwrap(), dir.path(), &store).is_none(),
+            "paths outside the store must not resolve through the fallback"
+        );
+        assert!(
+            resolve_stored_original("missing.png", dir.path(), &store).is_none(),
+            "non-existent files do not resolve"
+        );
+    }
+}

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -7682,6 +7682,7 @@ impl RuntimeThreadManager {
                     hook_executor: None,
                     handle_store: crate::tools::handle::new_shared_handle_store(),
                     rlm_sessions: crate::rlm::session::new_shared_rlm_session_store(),
+                    media_originals_dir: crate::media_originals::default_store_dir(),
                 },
                 subagent_model_overrides: if isolated_chat {
                     HashMap::new()

--- a/crates/tui/src/tools/read_media.rs
+++ b/crates/tui/src/tools/read_media.rs
@@ -832,8 +832,15 @@ fn colorfulness_sigma(image: &DynamicImage) -> f64 {
         return 0.0;
     }
     let (mut sum_rg, mut sum_yb, mut sum_rg2, mut sum_yb2) = (0.0f64, 0.0f64, 0.0f64, 0.0f64);
-    for px in rgb.as_raw().chunks_exact(3) {
-        let (r, g, b) = (f64::from(px[0]), f64::from(px[1]), f64::from(px[2]));
+    // An `Rgb<u8>` buffer is exactly 3 bytes per pixel, so the remainder is
+    // always empty; `as_chunks` makes the pixel stride a compile-time fact.
+    let (pixels, remainder) = rgb.as_raw().as_chunks::<3>();
+    debug_assert!(
+        remainder.is_empty(),
+        "RGB8 buffer length must be a multiple of 3"
+    );
+    for &[r, g, b] in pixels {
+        let (r, g, b) = (f64::from(r), f64::from(g), f64::from(b));
         let rg = r - g;
         let yb = (r + g) / 2.0 - b;
         sum_rg += rg;

--- a/crates/tui/src/tools/read_media.rs
+++ b/crates/tui/src/tools/read_media.rs
@@ -3,14 +3,27 @@
 //! Provides bounded decoding, decompression-bomb protection, active route
 //! vision-capability checks, crop region extraction, resolution detail modes,
 //! and typed receipt metadata without leaking credentials.
+//!
+//! Delivery is byte-budget-first: after an optional crop and the detail-mode
+//! edge cap, the image descends an encoding ladder (JPEG quality steps for
+//! photo-like content, PNG for alpha-bearing or flat/line-art content, then
+//! longest-edge halving) until the payload fits the budget. Results carry a
+//! delivery note stating exactly how the image was delivered (untouched /
+//! downsampled / crop / full) with zoom guidance, and the pre-compression
+//! original is persisted in the content-addressed [`crate::media_originals`]
+//! store so a later crop read can pull the full-resolution source. When no
+//! ladder result fits the budget the tool fails closed — nothing is sent —
+//! with the exact conversion command to retry with.
 
 use std::io::Cursor;
 
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use codewhale_config::route::CapabilityState;
+use image::codecs::jpeg::JpegEncoder;
+use image::codecs::png::{CompressionType, FilterType as PngFilter, PngEncoder};
 use image::imageops::FilterType;
-use image::{DynamicImage, GenericImageView, ImageFormat, ImageReader, Limits};
+use image::{DynamicImage, ExtendedColorType, GenericImageView, ImageEncoder, ImageReader, Limits};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -33,6 +46,34 @@ pub const MAX_DECODE_ALLOC_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Maximum inline image payload admitted on the wire (5 MiB).
 pub const MAX_WIRE_IMAGE_BYTES: usize = crate::image_attach::MAX_IMAGE_BYTES;
+
+/// Delivery byte budget for a default read (`detail` `low`/`auto`), 256 KiB.
+///
+/// Matches the reference budget in kimi-code's `READ_IMAGE_BYTE_BUDGET`: after
+/// base64 inflation this is ~350 KB on the wire — far under the 5 MiB provider
+/// ceiling — and it keeps routine reads from spending megabytes of context on
+/// PNG screenshots when a JPEG ladder step fits. `high`/`original` detail and
+/// crop (deliberate zoom) reads keep the full [`MAX_WIRE_IMAGE_BYTES`] budget.
+pub const READ_IMAGE_BYTE_BUDGET: usize = 256 * 1024;
+
+/// JPEG quality steps tried highest-first at each ladder rung (mirrors
+/// kimi-code's `JPEG_QUALITY_STEPS`).
+const JPEG_QUALITY_LADDER: [u8; 4] = [80, 60, 40, 20];
+
+/// Longest-edge floor for ladder halving (px); below this the ladder fails
+/// closed rather than delivering an unreadable thumbnail.
+const MIN_DELIVERY_EDGE_PX: u32 = 256;
+
+/// Flat/line-art images keep PNG rungs down to this longest edge before the
+/// ladder falls back to JPEG (mirrors kimi-code's `PNG_RESCALE_FLOOR_PX`).
+const PNG_EDGE_FLOOR_PX: u32 = 1000;
+
+/// Opaque images whose colorfulness sigma (spread of the `r-g` and
+/// `(r+g)/2-b` opponent channels, measured on a ≤128 px thumbnail) falls below
+/// this threshold are treated as flat/line-art and stay PNG; above it the
+/// image is photo-like and takes the JPEG ladder. Solid fills and line art
+/// score ~0; ordinary photos score well above. Heuristic, deliberately simple.
+const FLAT_COLORFULNESS_THRESHOLD: f64 = 12.0;
 
 /// Resolution/detail preference for image processing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -63,6 +104,16 @@ impl DetailMode {
             Self::Low => 1024,
             Self::Auto => 2048,
             Self::High | Self::Original => 4096,
+        }
+    }
+
+    /// Delivery byte budget for a full (non-crop) read at this detail level.
+    /// Crop reads are the deliberate zoom action and always get the full wire
+    /// budget, matching kimi-code's `cropImageForModel` default.
+    fn byte_budget(self) -> usize {
+        match self {
+            Self::Low | Self::Auto => READ_IMAGE_BYTE_BUDGET,
+            Self::High | Self::Original => MAX_WIRE_IMAGE_BYTES,
         }
     }
 
@@ -272,7 +323,28 @@ pub(crate) async fn execute_read_media(
     // spelling still matches by target; the resolved check below remains as
     // defense in depth.
     crate::tools::file::enforce_read_denylist(std::path::Path::new(path_str), "read_media")?;
-    let file_path = context.resolve_path(path_str)?;
+    let file_path = match context.resolve_path(path_str) {
+        Ok(path) => path,
+        Err(primary_err) => {
+            // Read-back fallback for tool-owned stored originals: the store
+            // only holds image bytes that already passed the guards above,
+            // named by content hash, so admitting it widens nothing.
+            match context
+                .runtime
+                .media_originals_dir
+                .as_deref()
+                .and_then(|dir| {
+                    crate::media_originals::resolve_stored_original(
+                        path_str,
+                        &context.workspace,
+                        dir,
+                    )
+                }) {
+                Some(path) => path,
+                None => return Err(primary_err),
+            }
+        }
+    };
     if crate::tools::file::is_codewhale_credential_path(&file_path) {
         return Err(ToolError::permission_denied(
             "read_media cannot read Codewhale configuration or credential-store files; use `codewhale config list` or `codewhale auth status` for safe inspection",
@@ -290,8 +362,9 @@ pub(crate) async fn execute_read_media(
     }
 
     let file_path_clone = file_path.clone();
+    let originals_dir = context.runtime.media_originals_dir.clone();
     let processed = tokio::task::spawn_blocking(move || {
-        process_media_file(&file_path_clone, crop_region, detail_mode)
+        process_media_file(&file_path_clone, crop_region, detail_mode, originals_dir)
     })
     .await
     .map_err(|join_err| {
@@ -319,29 +392,33 @@ pub(crate) async fn execute_read_media(
         "none".to_string()
     };
 
+    let delivery_note = build_delivery_note(&processed, crop_region);
+
     let content_text = format!(
-        "Read media file: {path_str} [image/png]\n\
+        "Read media file: {path_str} [{delivered_mime}]\n\
          Original dimensions: {orig_width}x{orig_height} ({mime_type})\n\
          Processed dimensions: {final_width}x{final_height}\n\
          Crop: {crop_summary}\n\
          Detail: {}\n\
+         Delivery: {delivery_note}\n\
          Size: {} (source) -> {} (wire payload)",
         detail_mode.as_str(),
         human_bytes(processed.source_bytes),
         human_bytes(processed.encoded_bytes),
+        delivered_mime = processed.delivered_mime,
         orig_width = processed.orig_width,
         orig_height = processed.orig_height,
-        mime_type = processed.mime_type,
+        mime_type = processed.source_mime,
         final_width = processed.final_width,
         final_height = processed.final_height,
     );
 
     let metadata_json = json!({
         "path": path_str,
-        "mime_type": "image/png",
+        "mime_type": processed.delivered_mime,
         "original_width": processed.orig_width,
         "original_height": processed.orig_height,
-        "original_mime_type": processed.mime_type,
+        "original_mime_type": processed.source_mime,
         "width": processed.final_width,
         "height": processed.final_height,
         "cropped": processed.crop_applied,
@@ -352,6 +429,11 @@ pub(crate) async fn execute_read_media(
             "height": c.height
         })),
         "detail": detail_mode.as_str(),
+        "delivery": processed.delivery.as_str(),
+        "original_path": processed
+            .original_path
+            .as_ref()
+            .map(|p| p.display().to_string()),
         "source_bytes": processed.source_bytes,
         "encoded_bytes": processed.encoded_bytes
     });
@@ -359,28 +441,123 @@ pub(crate) async fn execute_read_media(
     Ok(RichToolResult::with_content_blocks(
         ToolResult::success(content_text).with_metadata(metadata_json),
         vec![ToolResultContentBlock::Image {
-            mime_type: "image/png".to_string(),
+            mime_type: processed.delivered_mime.to_string(),
             data: processed.base64_payload,
         }],
     ))
 }
 
+/// The delivery-mode sentence of the result note: exactly how the image was
+/// delivered, plus zoom/offset guidance. Compression is never silent.
+fn build_delivery_note(processed: &ProcessedMedia, crop_region: Option<CropRegion>) -> String {
+    let delivered_size = human_bytes(processed.encoded_bytes);
+    match processed.delivery {
+        DeliveryMode::Untouched => format!(
+            "untouched — delivered at native resolution {}x{} ({}, {}); no downsampling applied.",
+            processed.final_width, processed.final_height, processed.delivered_mime, delivered_size
+        ),
+        DeliveryMode::Full => format!(
+            "full — shown at native resolution {}x{} ({}, {}); no downscaling applied.",
+            processed.final_width, processed.final_height, processed.delivered_mime, delivered_size
+        ),
+        DeliveryMode::Downsampled { resolution_lost } => {
+            let how = if resolution_lost {
+                format!(
+                    "downsampled to {}x{}",
+                    processed.final_width, processed.final_height
+                )
+            } else {
+                format!(
+                    "re-encoded at native resolution {}x{}",
+                    processed.final_width, processed.final_height
+                )
+            };
+            let mut note = format!(
+                "{how} ({}, {delivered_size}) to fit model limits; fine detail may be lost. \
+                 To inspect fine detail, call read_media again with the crop parameter \
+                 (original-image pixel coordinates) to view a region at full fidelity.",
+                processed.delivered_mime
+            );
+            if let Some(original_path) = &processed.original_path {
+                note.push_str(&format!(
+                    " The uncompressed original is preserved at \"{}\".",
+                    original_path.display()
+                ));
+            }
+            note
+        }
+        DeliveryMode::Crop { resized } => {
+            let region = crop_region.expect("crop delivery implies a crop region");
+            format!(
+                "crop (x={}, y={}, width={}, height={}) of the original image{} ({}, {}). \
+                 To output coordinates in original-image pixels, locate them within this crop \
+                 and add the region offset (x={}, y={}).",
+                region.x,
+                region.y,
+                region.width,
+                region.height,
+                if resized {
+                    format!(
+                        ", downsampled to {}x{}",
+                        processed.final_width, processed.final_height
+                    )
+                } else {
+                    " at native resolution".to_string()
+                },
+                processed.delivered_mime,
+                delivered_size,
+                region.x,
+                region.y
+            )
+        }
+    }
+}
+
+/// How the delivered payload relates to the source image.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeliveryMode {
+    /// Native resolution, first ladder step, `detail` `low`/`auto`.
+    Untouched,
+    /// Native resolution, first ladder step, `detail` `high`/`original`.
+    Full,
+    /// Resolution and/or encoding quality was reduced to fit the budget.
+    Downsampled { resolution_lost: bool },
+    /// A crop region was delivered; `resized` when the crop itself had to
+    /// shrink to fit the budget.
+    Crop { resized: bool },
+}
+
+impl DeliveryMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Untouched => "untouched",
+            Self::Full => "full",
+            Self::Downsampled { .. } => "downsampled",
+            Self::Crop { .. } => "crop",
+        }
+    }
+}
+
 struct ProcessedMedia {
     base64_payload: String,
+    delivered_mime: &'static str,
     orig_width: u32,
     orig_height: u32,
-    mime_type: &'static str,
+    source_mime: &'static str,
     final_width: u32,
     final_height: u32,
     crop_applied: bool,
+    delivery: DeliveryMode,
     source_bytes: usize,
     encoded_bytes: usize,
+    original_path: Option<std::path::PathBuf>,
 }
 
 fn process_media_file(
     file_path: &std::path::Path,
     crop_region: Option<CropRegion>,
     detail_mode: DetailMode,
+    originals_dir: Option<std::path::PathBuf>,
 ) -> Result<ProcessedMedia, ToolError> {
     // 3. Inspect metadata and check file bounds
     if !file_path.exists() {
@@ -486,30 +663,66 @@ fn process_media_file(
     // 8. Apply detail resolution resizing
     let (current_w, current_h) = cropped_image.dimensions();
     let max_target = detail_mode.max_dimension();
-    let final_image = if current_w > max_target || current_h > max_target {
+    let detail_resized = current_w > max_target || current_h > max_target;
+    let fitted_image = if detail_resized {
         cropped_image.resize(max_target, max_target, FilterType::Lanczos3)
     } else {
         cropped_image
     };
 
-    // 9. Re-encode to standard PNG within the wire budget
-    let (final_bytes, final_width, final_height) =
-        encode_to_bounded_png(&final_image, MAX_WIRE_IMAGE_BYTES)?;
+    // 9. Byte-budget-first encoding ladder: classify the content, then descend
+    // quality/edge rungs until the payload fits the delivery budget. Fails
+    // closed (nothing sent) with a conversion recipe when nothing fits.
+    let policy = classify_image(&fitted_image);
+    let budget = if crop_applied {
+        MAX_WIRE_IMAGE_BYTES
+    } else {
+        detail_mode.byte_budget()
+    };
+    let outcome = encode_within_budget(&fitted_image, policy, budget, file_path)?;
+
+    // 10. Persist the pre-compression original whenever the delivered copy is
+    // degraded, so a later crop read can pull the full-resolution source.
+    // Best effort: persistence never blocks delivery.
+    let degraded = detail_resized || outcome.resized || outcome.quality_reduced;
+    let original_path = if degraded && !crop_applied {
+        originals_dir.and_then(|dir| {
+            crate::media_originals::persist_original_image(&raw_bytes, mime_type, &dir)
+        })
+    } else {
+        None
+    };
+
+    let delivery = if crop_applied {
+        DeliveryMode::Crop { resized: degraded }
+    } else if degraded {
+        DeliveryMode::Downsampled {
+            resolution_lost: detail_resized || outcome.resized,
+        }
+    } else {
+        match detail_mode {
+            DetailMode::High | DetailMode::Original => DeliveryMode::Full,
+            DetailMode::Low | DetailMode::Auto => DeliveryMode::Untouched,
+        }
+    };
 
     let source_bytes = raw_bytes.len();
-    let encoded_bytes = final_bytes.len();
-    let base64_payload = BASE64.encode(&final_bytes);
+    let encoded_bytes = outcome.bytes.len();
+    let base64_payload = BASE64.encode(&outcome.bytes);
 
     Ok(ProcessedMedia {
         base64_payload,
+        delivered_mime: outcome.mime,
         orig_width,
         orig_height,
-        mime_type,
-        final_width,
-        final_height,
+        source_mime: mime_type,
+        final_width: outcome.width,
+        final_height: outcome.height,
         crop_applied,
+        delivery,
         source_bytes,
         encoded_bytes,
+        original_path,
     })
 }
 
@@ -562,40 +775,266 @@ fn decode_and_guard_image(bytes: &[u8]) -> Result<(DynamicImage, u32, u32), Tool
     Ok((dynamic_img, width, height))
 }
 
-fn encode_to_bounded_png(
-    image: &DynamicImage,
-    max_bytes: usize,
-) -> Result<(Vec<u8>, u32, u32), ToolError> {
-    let mut current = image.clone();
-    let mut attempts = 0;
+/// How the encoding ladder should treat an image's content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EncodePolicy {
+    /// Meaningful alpha present: PNG only. JPEG would silently destroy the
+    /// alpha channel, so the ladder fails closed rather than falling back.
+    RequireAlphaPng,
+    /// Opaque and flat (solid fills, line art, UI screenshots): PNG rungs
+    /// first — flat content compresses well losslessly and JPEG rings on hard
+    /// edges — then the JPEG ladder below the PNG edge floor.
+    PreferPng,
+    /// Opaque and photo-like: the JPEG quality ladder immediately. Photos as
+    /// PNG waste an order of magnitude of context bytes.
+    PreferJpeg,
+}
 
-    loop {
-        let (w, h) = current.dimensions();
-        let mut buffer = Cursor::new(Vec::new());
-        current
-            .write_to(&mut buffer, ImageFormat::Png)
+impl EncodePolicy {
+    fn prefers_png(self) -> bool {
+        !matches!(self, Self::PreferJpeg)
+    }
+}
+
+/// Content classification for the ladder: alpha first (correctness), then a
+/// colorfulness heuristic on a small thumbnail (cost).
+fn classify_image(image: &DynamicImage) -> EncodePolicy {
+    if has_meaningful_alpha(image) {
+        return EncodePolicy::RequireAlphaPng;
+    }
+    if colorfulness_sigma(image) < FLAT_COLORFULNESS_THRESHOLD {
+        EncodePolicy::PreferPng
+    } else {
+        EncodePolicy::PreferJpeg
+    }
+}
+
+/// Whether any pixel is actually transparent — not merely whether the decoded
+/// layout has an alpha channel (an opaque RGBA PNG decodes to `Rgba8` too).
+fn has_meaningful_alpha(image: &DynamicImage) -> bool {
+    match image {
+        DynamicImage::ImageRgba8(buf) => buf.pixels().any(|p| p.0[3] != u8::MAX),
+        DynamicImage::ImageLumaA8(buf) => buf.pixels().any(|p| p.0[1] != u8::MAX),
+        DynamicImage::ImageRgba16(buf) => buf.pixels().any(|p| p.0[3] != u16::MAX),
+        DynamicImage::ImageLumaA16(buf) => buf.pixels().any(|p| p.0[1] != u16::MAX),
+        _ => false,
+    }
+}
+
+/// Spread of the opponent color channels (Hasler–Süsstrunk sigma terms only —
+/// the mean terms would inflate saturated flat fills), measured on a ≤128 px
+/// thumbnail for speed. Solid fills and line art score ~0.
+fn colorfulness_sigma(image: &DynamicImage) -> f64 {
+    let thumb = image.thumbnail(128, 128);
+    let rgb = thumb.to_rgb8();
+    let n = (rgb.len() / 3) as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let (mut sum_rg, mut sum_yb, mut sum_rg2, mut sum_yb2) = (0.0f64, 0.0f64, 0.0f64, 0.0f64);
+    for px in rgb.as_raw().chunks_exact(3) {
+        let (r, g, b) = (f64::from(px[0]), f64::from(px[1]), f64::from(px[2]));
+        let rg = r - g;
+        let yb = (r + g) / 2.0 - b;
+        sum_rg += rg;
+        sum_yb += yb;
+        sum_rg2 += rg * rg;
+        sum_yb2 += yb * yb;
+    }
+    let var_rg = (sum_rg2 / n - (sum_rg / n).powi(2)).max(0.0);
+    let var_yb = (sum_yb2 / n - (sum_yb / n).powi(2)).max(0.0);
+    (var_rg + var_yb).sqrt()
+}
+
+/// One encoded ladder candidate.
+struct EncodedImage {
+    bytes: Vec<u8>,
+    mime: &'static str,
+    width: u32,
+    height: u32,
+}
+
+/// The ladder's winning candidate plus how it got there.
+#[derive(Debug)]
+struct LadderOutcome {
+    bytes: Vec<u8>,
+    mime: &'static str,
+    width: u32,
+    height: u32,
+    /// The candidate's dimensions differ from the ladder's input image.
+    resized: bool,
+    /// A JPEG quality step below the ladder's first (80) was needed.
+    quality_reduced: bool,
+}
+
+fn encode_png_best(image: &DynamicImage) -> Result<EncodedImage, ToolError> {
+    let (width, height) = image.dimensions();
+    let mut bytes: Vec<u8> = Vec::new();
+    let encoder =
+        PngEncoder::new_with_quality(&mut bytes, CompressionType::Best, PngFilter::Adaptive);
+    if image.color().has_alpha() {
+        let rgba = image.to_rgba8();
+        encoder
+            .write_image(rgba.as_raw(), width, height, ExtendedColorType::Rgba8)
             .map_err(|e| {
                 ToolError::execution_failed(format!("read_media: failed to encode PNG: {e}"))
             })?;
-
-        let encoded = buffer.into_inner();
-        if encoded.len() <= max_bytes || attempts >= 4 {
-            if encoded.len() > max_bytes {
-                return Err(ToolError::execution_failed(format!(
-                    "read_media: encoded image size ({}) exceeds the {} wire limit even after compression",
-                    human_bytes(encoded.len()),
-                    human_bytes(max_bytes)
-                )));
-            }
-            return Ok((encoded, w, h));
-        }
-
-        // Downscale progressively to fit within the 5 MiB ceiling
-        attempts += 1;
-        let next_w = ((w as f64) * 0.75).max(32.0) as u32;
-        let next_h = ((h as f64) * 0.75).max(32.0) as u32;
-        current = current.resize(next_w, next_h, FilterType::Lanczos3);
+    } else {
+        let rgb = image.to_rgb8();
+        encoder
+            .write_image(rgb.as_raw(), width, height, ExtendedColorType::Rgb8)
+            .map_err(|e| {
+                ToolError::execution_failed(format!("read_media: failed to encode PNG: {e}"))
+            })?;
     }
+    Ok(EncodedImage {
+        bytes,
+        mime: "image/png",
+        width,
+        height,
+    })
+}
+
+fn encode_jpeg(image: &DynamicImage, quality: u8) -> Result<EncodedImage, ToolError> {
+    let (width, height) = image.dimensions();
+    // Only reached for images without meaningful alpha, so dropping the
+    // channel changes nothing visible.
+    let rgb = image.to_rgb8();
+    let mut bytes: Vec<u8> = Vec::new();
+    JpegEncoder::new_with_quality(&mut bytes, quality)
+        .write_image(rgb.as_raw(), width, height, ExtendedColorType::Rgb8)
+        .map_err(|e| {
+            ToolError::execution_failed(format!("read_media: failed to encode JPEG: {e}"))
+        })?;
+    Ok(EncodedImage {
+        bytes,
+        mime: "image/jpeg",
+        width,
+        height,
+    })
+}
+
+/// Half-size Lanczos copy, or `None` once the longest edge is at the floor.
+fn halved(image: &DynamicImage) -> Option<DynamicImage> {
+    let (w, h) = image.dimensions();
+    if w.max(h) <= MIN_DELIVERY_EDGE_PX {
+        return None;
+    }
+    Some(image.resize((w / 2).max(1), (h / 2).max(1), FilterType::Lanczos3))
+}
+
+fn track_smallest(smallest: &mut Option<EncodedImage>, candidate: EncodedImage) {
+    if smallest
+        .as_ref()
+        .is_none_or(|s| candidate.bytes.len() < s.bytes.len())
+    {
+        *smallest = Some(candidate);
+    }
+}
+
+/// Descend the encoding ladder until a rung fits `budget`.
+///
+/// Rung order (mirrors kimi-code's `encodeWithinBudget`): PNG-preferring
+/// images try best-compression PNG at the current size, then halved PNG rungs
+/// down to [`PNG_EDGE_FLOOR_PX`], then the JPEG quality ladder; photo-like
+/// images start at the JPEG ladder; alpha-bearing images only ever see PNG
+/// rungs. JPEG rungs repeat the quality ladder at each halved edge down to
+/// [`MIN_DELIVERY_EDGE_PX`]. The first fitting rung wins (highest fidelity
+/// within budget). When nothing fits, fails closed — nothing is sent — with
+/// the exact conversion command to retry with.
+fn encode_within_budget(
+    image: &DynamicImage,
+    policy: EncodePolicy,
+    budget: usize,
+    path: &std::path::Path,
+) -> Result<LadderOutcome, ToolError> {
+    let (start_w, start_h) = image.dimensions();
+    let mut smallest: Option<EncodedImage> = None;
+    let mut candidate = image.clone();
+
+    if policy.prefers_png() {
+        let png_floor = match policy {
+            EncodePolicy::RequireAlphaPng => MIN_DELIVERY_EDGE_PX,
+            _ => PNG_EDGE_FLOOR_PX,
+        };
+        loop {
+            let encoded = encode_png_best(&candidate)?;
+            if encoded.bytes.len() <= budget {
+                let resized = encoded.width != start_w || encoded.height != start_h;
+                return Ok(LadderOutcome {
+                    bytes: encoded.bytes,
+                    mime: encoded.mime,
+                    width: encoded.width,
+                    height: encoded.height,
+                    resized,
+                    quality_reduced: false,
+                });
+            }
+            let longest = encoded.width.max(encoded.height);
+            track_smallest(&mut smallest, encoded);
+            if longest <= png_floor {
+                break;
+            }
+            let Some(next) = halved(&candidate) else {
+                break;
+            };
+            candidate = next;
+        }
+        if policy == EncodePolicy::RequireAlphaPng {
+            return Err(over_budget_error(path, budget, smallest));
+        }
+    }
+
+    loop {
+        for (step, quality) in JPEG_QUALITY_LADDER.iter().enumerate() {
+            let encoded = encode_jpeg(&candidate, *quality)?;
+            if encoded.bytes.len() <= budget {
+                let resized = encoded.width != start_w || encoded.height != start_h;
+                return Ok(LadderOutcome {
+                    bytes: encoded.bytes,
+                    mime: encoded.mime,
+                    width: encoded.width,
+                    height: encoded.height,
+                    resized,
+                    quality_reduced: step > 0,
+                });
+            }
+            track_smallest(&mut smallest, encoded);
+        }
+        let Some(next) = halved(&candidate) else {
+            break;
+        };
+        candidate = next;
+    }
+    Err(over_budget_error(path, budget, smallest))
+}
+
+/// Fail-closed error naming the exact conversion recipe to retry with.
+fn over_budget_error(
+    path: &std::path::Path,
+    budget: usize,
+    smallest: Option<EncodedImage>,
+) -> ToolError {
+    let smallest_desc = match &smallest {
+        Some(s) => format!(
+            "smallest deliverable: {} at {}x{}",
+            human_bytes(s.bytes.len()),
+            s.width,
+            s.height
+        ),
+        None => "no encodable result".to_string(),
+    };
+    ToolError::execution_failed(format!(
+        "read_media: {path} could not be compressed under the {budget} delivery budget ({smallest_desc}). \
+         Nothing was sent to the model; do not retry the same file unchanged. \
+         Create a smaller copy and read that instead: \
+         `sips -Z 1024 \"{path}\" --out /tmp/codewhale-smaller.png` (macOS) or \
+         `magick \"{path}\" -resize 1024x1024 /tmp/codewhale-smaller.png` (ImageMagick); \
+         for a photo-like image, JPEG output (`--out /tmp/codewhale-smaller.jpg` / `-quality 70`) \
+         compresses further. Then call read_media on the smaller copy.",
+        path = path.display(),
+        budget = human_bytes(budget),
+    ))
 }
 
 fn human_bytes(bytes: usize) -> String {
@@ -612,6 +1051,7 @@ fn human_bytes(bytes: usize) -> String {
 mod tests {
     use super::*;
     use crate::models::Role;
+    use image::ImageFormat;
     use tempfile::tempdir;
 
     fn create_test_png(width: u32, height: u32, color: [u8; 4]) -> Vec<u8> {
@@ -1260,5 +1700,285 @@ mod tests {
         assert!(!meta_str.contains("token"));
         assert!(!meta_str.contains("password"));
         assert!(!meta_str.contains("auth"));
+    }
+
+    /// Deterministic photo-like noise image (high colorfulness, hard to
+    /// compress), so the ladder takes the JPEG path without any network or
+    /// fixture dependency.
+    fn create_noise_png(width: u32, height: u32) -> Vec<u8> {
+        let mut img = image::RgbImage::new(width, height);
+        let mut state: u32 = 0x1234_5678;
+        let mut next = move || {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (state >> 24) as u8
+        };
+        for px in img.pixels_mut() {
+            *px = image::Rgb([next(), next(), next()]);
+        }
+        let mut cursor = Cursor::new(Vec::new());
+        img.write_to(&mut cursor, ImageFormat::Png).unwrap();
+        cursor.into_inner()
+    }
+
+    fn decode_payload(data: &str) -> (u32, u32, Vec<u8>) {
+        let bytes = BASE64.decode(data).expect("valid base64 payload");
+        let img = ImageReader::new(Cursor::new(&bytes))
+            .with_guessed_format()
+            .unwrap()
+            .decode()
+            .expect("delivered payload decodes");
+        (img.width(), img.height(), bytes)
+    }
+
+    #[tokio::test]
+    async fn read_media_photo_over_budget_arrives_under_budget_as_jpeg() {
+        let dir = tempdir().unwrap();
+        let img_path = dir.path().join("photo.png");
+        let png_data = create_noise_png(1600, 1200);
+        assert!(
+            png_data.len() > READ_IMAGE_BYTE_BUDGET,
+            "test image must start over the default read budget"
+        );
+        std::fs::write(&img_path, &png_data).unwrap();
+
+        let mut ctx = ToolContext::new(dir.path());
+        ctx.route_capabilities.image_input = CapabilityState::Supported;
+
+        let tool = ReadMediaTool;
+        let rich = tool
+            .execute_rich(json!({ "path": "photo.png", "detail": "auto" }), &ctx)
+            .await
+            .unwrap();
+        assert!(rich.success);
+
+        let ToolResultContentBlock::Image { mime_type, data } = &rich.content_blocks[0];
+        assert_eq!(
+            mime_type, "image/jpeg",
+            "photo-like content must go out as JPEG, not PNG"
+        );
+        let payload_len = BASE64.decode(data).unwrap().len();
+        assert!(
+            payload_len <= READ_IMAGE_BYTE_BUDGET,
+            "delivered payload {payload_len} must fit the {}-byte read budget",
+            READ_IMAGE_BYTE_BUDGET
+        );
+
+        let meta = rich.metadata.as_ref().unwrap();
+        assert_eq!(meta["mime_type"], "image/jpeg");
+        assert_eq!(meta["original_width"], 1600);
+        assert_eq!(meta["original_height"], 1200);
+        assert_eq!(
+            meta["delivery"], "downsampled",
+            "a quality- or resolution-reduced delivery is never silent"
+        );
+        assert!(rich.content.contains("fine detail may be lost"));
+        assert!(
+            rich.content
+                .contains("crop parameter (original-image pixel coordinates)")
+        );
+    }
+
+    #[tokio::test]
+    async fn read_media_small_image_passes_untouched() {
+        let dir = tempdir().unwrap();
+        let img_path = dir.path().join("small.png");
+        let png_data = create_test_png(120, 80, [10, 120, 200, 255]);
+        std::fs::write(&img_path, &png_data).unwrap();
+
+        let mut ctx = ToolContext::new(dir.path());
+        ctx.route_capabilities.image_input = CapabilityState::Supported;
+
+        let tool = ReadMediaTool;
+        let rich = tool
+            .execute_rich(json!({ "path": "small.png" }), &ctx)
+            .await
+            .unwrap();
+        assert!(rich.success);
+
+        let meta = rich.metadata.as_ref().unwrap();
+        assert_eq!(meta["delivery"], "untouched");
+        assert_eq!(meta["mime_type"], "image/png");
+        assert_eq!(meta["width"], 120);
+        assert_eq!(meta["height"], 80);
+        assert!(
+            meta["original_path"].is_null(),
+            "untouched reads keep no stored copy"
+        );
+        assert!(rich.content.contains("untouched"));
+        assert!(rich.content.contains("no downsampling applied"));
+    }
+
+    #[tokio::test]
+    async fn read_media_alpha_image_stays_png() {
+        let dir = tempdir().unwrap();
+        let img_path = dir.path().join("alpha.png");
+        // Colorful RGB with a real alpha gradient: alpha must survive.
+        let mut img = image::RgbaImage::new(640, 480);
+        for (x, _y, px) in img.enumerate_pixels_mut() {
+            *px = image::Rgba([(x % 256) as u8, 200, 90, if x < 320 { 255 } else { 100 }]);
+        }
+        let mut cursor = Cursor::new(Vec::new());
+        img.write_to(&mut cursor, ImageFormat::Png).unwrap();
+        std::fs::write(&img_path, cursor.into_inner()).unwrap();
+
+        let mut ctx = ToolContext::new(dir.path());
+        ctx.route_capabilities.image_input = CapabilityState::Supported;
+
+        let tool = ReadMediaTool;
+        let rich = tool
+            .execute_rich(json!({ "path": "alpha.png" }), &ctx)
+            .await
+            .unwrap();
+        assert!(rich.success);
+
+        let ToolResultContentBlock::Image { mime_type, data } = &rich.content_blocks[0];
+        assert_eq!(
+            mime_type, "image/png",
+            "meaningful alpha must never be flattened to JPEG"
+        );
+        let (w, h, bytes) = decode_payload(data);
+        assert_eq!((w, h), (640, 480));
+        let decoded = ImageReader::new(Cursor::new(&bytes))
+            .with_guessed_format()
+            .unwrap()
+            .decode()
+            .unwrap()
+            .to_rgba8();
+        assert!(
+            decoded.pixels().any(|p| p.0[3] == 100),
+            "alpha channel must survive delivery"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_media_delivery_note_reports_mode_dims_and_zoom_guidance() {
+        let dir = tempdir().unwrap();
+        let img_path = dir.path().join("big.png");
+        let png_data = create_test_png(3000, 1500, [0, 0, 255, 255]);
+        std::fs::write(&img_path, &png_data).unwrap();
+
+        let mut ctx = ToolContext::new(dir.path());
+        ctx.route_capabilities.image_input = CapabilityState::Supported;
+
+        let tool = ReadMediaTool;
+        let rich = tool
+            .execute_rich(json!({ "path": "big.png", "detail": "auto" }), &ctx)
+            .await
+            .unwrap();
+        assert!(rich.success);
+
+        let meta = rich.metadata.as_ref().unwrap();
+        assert_eq!(meta["delivery"], "downsampled");
+        assert_eq!(meta["width"], 2048);
+        assert_eq!(meta["height"], 1024);
+
+        let note = &rich.content;
+        assert!(note.contains("Original dimensions: 3000x1500"), "{note}");
+        assert!(note.contains("downsampled to 2048x1024"), "{note}");
+        assert!(note.contains("fine detail may be lost"), "{note}");
+        assert!(
+            note.contains(
+                "call read_media again with the crop parameter (original-image pixel coordinates)"
+            ),
+            "downsampled note must guide zoom via crop: {note}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_media_crop_after_downsample_pulls_full_res_stored_original() {
+        let dir = tempdir().unwrap();
+        let store_dir = dir.path().join("media-originals");
+        let img_path = dir.path().join("scene.png");
+        // 2600x1300 photo-like source: auto detail downsamples to 2048x1024.
+        std::fs::write(&img_path, create_noise_png(2600, 1300)).unwrap();
+
+        let mut ctx = ToolContext::new(dir.path()).with_runtime_services(
+            crate::tools::spec::RuntimeToolServices {
+                media_originals_dir: Some(store_dir.clone()),
+                ..crate::tools::spec::RuntimeToolServices::default()
+            },
+        );
+        ctx.route_capabilities.image_input = CapabilityState::Supported;
+
+        let tool = ReadMediaTool;
+        let rich = tool
+            .execute_rich(json!({ "path": "scene.png", "detail": "auto" }), &ctx)
+            .await
+            .unwrap();
+        let meta = rich.metadata.as_ref().unwrap();
+        assert_eq!(meta["delivery"], "downsampled");
+        let delivered_width = meta["width"].as_u64().unwrap();
+        assert!(
+            delivered_width <= 2048,
+            "auto detail caps at 2048px; noise may ladder further: {delivered_width}"
+        );
+        assert_eq!(meta["original_width"], 2600);
+        assert_eq!(meta["original_height"], 1300);
+
+        // The pre-compression original is persisted, content-addressed.
+        let original_path = meta["original_path"]
+            .as_str()
+            .expect("downsampled reads persist the original")
+            .to_string();
+        assert!(original_path.starts_with(store_dir.to_str().unwrap()));
+        let stored = std::fs::read(&original_path).expect("stored original bytes");
+        let stored_img = ImageReader::new(Cursor::new(&stored))
+            .with_guessed_format()
+            .unwrap()
+            .decode()
+            .unwrap();
+        assert_eq!(
+            (stored_img.width(), stored_img.height()),
+            (2600, 1300),
+            "the store holds the full-resolution source, not the downsampled copy"
+        );
+
+        // A crop that is out of bounds for the downsampled 2048-wide copy but
+        // valid for the 2600-wide original must succeed at the requested
+        // pixel size — proof the crop pulls the full-res stored source.
+        let crop = tool
+            .execute_rich(
+                json!({
+                    "path": original_path,
+                    "crop": { "x": 2200, "y": 900, "width": 300, "height": 300 }
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        let crop_meta = crop.metadata.as_ref().unwrap();
+        assert_eq!(crop_meta["delivery"], "crop");
+        assert_eq!(crop_meta["width"], 300);
+        assert_eq!(crop_meta["height"], 300);
+        assert_eq!(crop_meta["original_width"], 2600);
+        assert!(
+            crop.content.contains("region offset (x=2200, y=900)"),
+            "crop note must carry the offset guidance: {}",
+            crop.content
+        );
+    }
+
+    #[tokio::test]
+    async fn read_media_over_budget_failure_names_conversion_recipe() {
+        let dir = tempdir().unwrap();
+        let img_path = dir.path().join("noise.png");
+        std::fs::write(&img_path, create_noise_png(512, 512)).unwrap();
+        let raw = std::fs::read(&img_path).unwrap();
+        let (image, _, _) = decode_and_guard_image(&raw).unwrap();
+
+        // A 1024-byte budget is unreachable even at the 256px/q20 floor.
+        let err =
+            encode_within_budget(&image, EncodePolicy::PreferJpeg, 1024, &img_path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Nothing was sent"), "{msg}");
+        assert!(msg.contains("sips -Z 1024"), "recipe names sips: {msg}");
+        assert!(msg.contains("magick"), "recipe names ImageMagick: {msg}");
+        assert!(msg.contains("smaller copy"), "{msg}");
+
+        // Alpha-bearing images fail closed the same way rather than
+        // falling back to JPEG.
+        let err = encode_within_budget(&image, EncodePolicy::RequireAlphaPng, 1024, &img_path)
+            .unwrap_err();
+        assert!(err.to_string().contains("Nothing was sent"), "{err}");
     }
 }

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -116,6 +116,11 @@ pub struct RuntimeToolServices {
     pub handle_store: SharedHandleStore,
     /// Per-session persistent RLM kernels, keyed by caller-chosen context name.
     pub rlm_sessions: SharedRlmSessionStore,
+    /// Directory for `read_media`'s content-addressed store of
+    /// pre-compression image originals. `None` (tests and one-off contexts)
+    /// disables persistence so unit tests never touch the real state dir;
+    /// production wiring points it at `<codewhale home>/media-originals`.
+    pub media_originals_dir: Option<PathBuf>,
 }
 
 impl Default for RuntimeToolServices {
@@ -133,6 +138,7 @@ impl Default for RuntimeToolServices {
             hook_executor: None,
             handle_store: new_shared_handle_store(),
             rlm_sessions: new_shared_rlm_session_store(),
+            media_originals_dir: None,
         }
     }
 }
@@ -155,6 +161,7 @@ impl std::fmt::Debug for RuntimeToolServices {
             .field("hook_executor", &self.hook_executor.is_some())
             .field("handle_store", &true)
             .field("rlm_sessions", &true)
+            .field("media_originals_dir", &self.media_originals_dir)
             .finish()
     }
 }

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -969,6 +969,7 @@ impl App {
             runtime_services: RuntimeToolServices {
                 shell_manager: Some(shell_manager),
                 work: Some(work_runtime),
+                media_originals_dir: crate::media_originals::default_store_dir(),
                 ..RuntimeToolServices::default()
             },
             coordination_detail: None,

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -502,6 +502,7 @@ pub async fn run_tui(
         hook_executor: app.runtime_services.hook_executor.clone(),
         handle_store: app.runtime_services.handle_store.clone(),
         rlm_sessions: app.runtime_services.rlm_sessions.clone(),
+        media_originals_dir: crate::media_originals::default_store_dir(),
     };
     crate::startup_trace::mark("task_manager_ready");
     refresh_active_task_panel(&mut app, &task_manager).await;


### PR DESCRIPTION
Comparative upgrade (takeover Lane 6b), informed by kimi-code's ReadMediaFile and adapted to codewhale's existing contracts.

## What changes

- **Byte-budget-first encoding ladder.** `detail low|auto` targets 256 KiB: best-compression PNG rungs for flat/alpha content, JPEG quality steps [80,60,40,20] with edge halving for photo-like images. `detail high|original` and crop reads keep the documented 5 MiB ceiling. A documented classifier (per-pixel alpha scan + colorfulness sigma on a thumbnail) routes content — PNG-everything was wasting context on photos.
- **Delivery-mode note** on every degraded read: delivered mime/size, original dimensions, how it was delivered, and zoom guidance (re-read with `crop` in original-image coordinates).
- **Originals store** (`media_originals.rs`): degraded non-crop reads persist the pre-compression source content-addressed (sha256, 1 GiB sweep) under the state dir; crop reads resolve through a hole-punch that admits only canonical in-store paths (credential-path guard + read denylist still run after). A zoom crop now reads the full-res original, not the downsampled copy.
- **Fail-closed over budget**: nothing is sent and the error names the exact `sips`/`magick` recipe.

## Contracts preserved

Path-escape denial, credential guard, cancellation checks, absolute-pixel crop API, decompression guards, 20 MiB source cap — and the tool description + input schema are **byte-identical** (KV-cache prefix untouched per docs/CACHE.md; the delivery note rides append-only tool-result history).

## Verification

Integrator re-ran: **30 passed / 0 failed** across read_media + media_originals — 21 pre-existing read_media tests green (one permitted test-module import edit) + 9 new tests pinning the ladder, classifier, delivery note, store zoom roundtrip (crop from the stored full-res original returns exact pixels impossible from the downsampled copy), and the recipe error. fmt clean; clippy clean except the pre-existing `too_many_arguments` at runtime_threads.rs:2562 on main.

No-Issue: comparative-upgrade slice per the takeover plan (Lane 6b).