### PR TITLE
release: prepare Codewhale v0.9.12 source (bump + CHANGELOG from merged PRs; rc grammar)

### DIFF
--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -397,6 +397,36 @@ assert.match(npmPublish, /working-directory: npm\/codewhale/);
 assert.match(npmPublish, /GH_TOKEN: \$\{\{ github\.token \}\}/);
 assert.match(npmPublish, /npm publish --access public/);
 assert.doesNotMatch(npmJob[1], /NPM_TOKEN|NODE_AUTH_TOKEN|secrets\./);
+
+// A vX.Y.Z-rc.N candidate rides the same chain but never moves a stable
+// pointer: prerelease-flagged GitHub Release, npm dist-tag `next`, no GHCR
+// `latest`, no Homebrew tap write. The grammar lives in
+// scripts/release/release-version.sh.
+assert.match(release, /^      prerelease: \$\{\{ steps\.release\.outputs\.prerelease \}\}$/m);
+assert.match(release, /^      npm_dist_tag: \$\{\{ steps\.release\.outputs\.npm_dist_tag \}\}$/m);
+assert.match(release, /source \.\/scripts\/release\/release-version\.sh/);
+assert.match(
+  release,
+  /prerelease: \$\{\{ needs\.resolve\.outputs\.prerelease == 'true' \}\}/,
+  "the GitHub Release must be flagged prerelease for a release candidate",
+);
+assert.doesNotMatch(release, /prerelease: false/);
+assert.match(npmPublish, /NPM_DIST_TAG: \$\{\{ needs\.resolve\.outputs\.npm_dist_tag \}\}/);
+assert.match(npmPublish, /npm publish --access public --tag "\$\{NPM_DIST_TAG\}"/);
+assert.match(
+  release,
+  /type=raw,value=latest,enable=\$\{\{ needs\.resolve\.outputs\.prerelease != 'true' \}\}/,
+  "GHCR latest must be gated off for a release candidate",
+);
+assert.doesNotMatch(release, /type=raw,value=latest\n/);
+const homebrewJob = release.match(/\n  homebrew:\n([\s\S]*?)\n    steps:\n/);
+assert.ok(homebrewJob, "public release must retain a dedicated Homebrew job");
+assert.match(homebrewJob[1], /needs\.resolve\.outputs\.prerelease != 'true'/);
+assert.match(
+  republish,
+  /release candidates are not republished/,
+  "republish must refuse release candidates because it rewrites stable channels",
+);
 assert.ok(
   release.indexOf("Revalidate public release assets") <
     release.indexOf("Publish npm wrapper with trusted publishing"),

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -65,8 +65,10 @@ jobs:
             echo "::error::Could not parse workspace version from Cargo.toml" >&2
             exit 1
           fi
-          if ! echo "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Workspace version '$v' is not valid semver (expected X.Y.Z)" >&2
+          # shellcheck source=scripts/release/release-version.sh
+          . ./scripts/release/release-version.sh
+          if ! release_version_is_valid "$v"; then
+            echo "::error::Workspace version '$v' is not a release version (expected X.Y.Z or X.Y.Z-rc.N)" >&2
             exit 1
           fi
           echo "version=$v" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,7 @@ jobs:
           bash scripts/release/require-release-tag-checkout.test.sh
           bash scripts/release/validate-crate-publish-order.test.sh
           bash scripts/release/verify-remote-tag.test.sh
+          bash scripts/release/release-version.test.sh
           bash packaging/aur/render.test.sh
           sh scripts/dev-cache.test.sh
           bash .github/scripts/update-homebrew-tap.test.sh

--- a/.github/workflows/release-republish.yml
+++ b/.github/workflows/release-republish.yml
@@ -57,8 +57,10 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Republish recovers the stable channels (GHCR `latest`, the Homebrew
+          # tap); a vX.Y.Z-rc.N candidate never owns those, so it is refused here.
           if ! [[ "${INPUT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Version '${INPUT_VERSION}' must use X.Y.Z." >&2
+            echo "::error::Version '${INPUT_VERSION}' must use X.Y.Z (release candidates are not republished)." >&2
             exit 1
           fi
           tag="v${INPUT_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
       tag: ${{ steps.release.outputs.tag }}
       sha: ${{ steps.release.outputs.sha }}
       version: ${{ steps.release.outputs.version }}
+      # A vX.Y.Z-rc.N tag is a prerelease: GitHub Release flagged
+      # prerelease, npm dist-tag `next`, no GHCR `latest`, no Homebrew tap.
+      prerelease: ${{ steps.release.outputs.prerelease }}
+      npm_dist_tag: ${{ steps.release.outputs.npm_dist_tag }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -41,10 +45,12 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          # shellcheck source=scripts/release/release-version.sh
+          source ./scripts/release/release-version.sh
 
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            if ! [[ "${INPUT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "::error::Release version '${INPUT_VERSION}' must use X.Y.Z." >&2
+            if ! release_version_is_valid "${INPUT_VERSION}"; then
+              echo "::error::Release version '${INPUT_VERSION}' must use X.Y.Z or X.Y.Z-rc.N." >&2
               exit 1
             fi
             tag="v${INPUT_VERSION}"
@@ -56,8 +62,8 @@ jobs:
             tag="${GITHUB_REF_NAME}"
           fi
 
-          if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Release tag '${tag}' must use vX.Y.Z." >&2
+          if ! release_tag_is_valid "${tag}"; then
+            echo "::error::Release tag '${tag}' must use vX.Y.Z or vX.Y.Z-rc.N." >&2
             exit 1
           fi
           if ! git rev-parse --verify "refs/tags/${tag}^{commit}" >/dev/null 2>&1; then
@@ -72,10 +78,17 @@ jobs:
             exit 1
           fi
 
+          if release_version_is_prerelease "${tag#v}"; then
+            prerelease=true
+          else
+            prerelease=false
+          fi
           {
             echo "tag=${tag}"
             echo "sha=${sha}"
             echo "version=${tag#v}"
+            echo "prerelease=${prerelease}"
+            echo "npm_dist_tag=$(release_version_npm_dist_tag "${tag#v}")"
           } >> "${GITHUB_OUTPUT}"
       - name: Validate tagged release metadata
         shell: bash
@@ -366,7 +379,7 @@ jobs:
             type=semver,pattern=v{{major}},value=${{ needs.resolve.outputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=v${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ needs.resolve.outputs.prerelease != 'true' }}
       - name: Revalidate release tag before container publish
         env:
           EXPECTED_SHA: ${{ needs.resolve.outputs.sha }}
@@ -468,7 +481,7 @@ jobs:
         with:
           tag_name: ${{ needs.resolve.outputs.tag }}
           files: artifacts/*
-          prerelease: false
+          prerelease: ${{ needs.resolve.outputs.prerelease == 'true' }}
           body_path: release-body.md
           overwrite_files: false
           fail_on_unmatched_files: true
@@ -516,12 +529,16 @@ jobs:
           # public GitHub Release and therefore needs the same read token as
           # the explicit asset gate above.
           GH_TOKEN: ${{ github.token }}
-        run: npm publish --access public
+          # `latest` for a stable release; `next` for a vX.Y.Z-rc.N candidate
+          # so `npm install -g codewhale` never resolves to a prerelease.
+          NPM_DIST_TAG: ${{ needs.resolve.outputs.npm_dist_tag }}
+        run: npm publish --access public --tag "${NPM_DIST_TAG}"
 
   homebrew:
     timeout-minutes: 20
     needs: [release, resolve]
-    if: ${{ !cancelled() && needs.release.result == 'success' }}
+    # The tap tracks stable releases only; a release candidate never moves it.
+    if: ${{ !cancelled() && needs.release.result == 'success' && needs.resolve.outputs.prerelease != 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.12] - Unreleased candidate
 
+This is the Codewhale v0.9.12 source candidate. It is not a published release
+until the matching tag, packages, checksums, and release assets exist.
+
 Codewhale v0.9.12 makes the agent loop finite by default, lands the Tideline
 visual redesign across the TUI and the website, unifies managed Chat with
 native runtime threads, adds provider-native web search across DeepSeek,
@@ -7847,8 +7850,8 @@ overflow report and `/theme` picker edge-wrapping patch in #1814.
 
 Older releases (v0.8.39 and earlier) are archived in [docs/CHANGELOG_ARCHIVE.md](docs/CHANGELOG_ARCHIVE.md).
 
-[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.9.12...HEAD
-[0.9.12]: https://github.com/Hmbown/CodeWhale/compare/v0.9.11...v0.9.12
+[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.9.11...HEAD
+[0.9.12]: https://github.com/Hmbown/CodeWhale/compare/v0.9.11...HEAD
 [0.9.11]: https://github.com/Hmbown/CodeWhale/compare/v0.9.10...v0.9.11
 [0.9.10]: https://github.com/Hmbown/CodeWhale/compare/v0.9.9...v0.9.10
 [0.9.9]: https://github.com/Hmbown/CodeWhale/compare/v0.9.8...v0.9.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.12] - Unreleased candidate
+
+Codewhale v0.9.12 makes the agent loop finite by default, lands the Tideline
+visual redesign across the TUI and the website, unifies managed Chat with
+native runtime threads, adds provider-native web search across DeepSeek,
+Qwen, Z.AI/BigModel, Xiaomi MiMo, and Moonshot/Kimi routes, and closes a set
+of sandbox and authority gaps (read deny-list, hard-link writes, full-access
+posture truth). Every pull request merged into `main` since v0.9.11 is
+referenced by number below; direct integrator merges are described inline.
+
 ### Added
 
 - Website: the public site moves to the Tideline deep-ocean design language
   (dark by default with an opt-in light documentation sheet, palette grounded
   in the TUI's WHALE_* tokens) and the new whale brand mark across the favicon,
-  app icons, web manifest, nav wordmark, and social card (#5573).
-
-- Add `codewhale dispatch` / `/dispatch` so a local session can propose a
-  Codewhale cloud agent against an explicit `github`, `cnb`, or `gitee` remote.
+  app icons, web manifest, nav wordmark, and social card (#5573, PR #5734).
+- Add `codewhale dispatch` / `/dispatch` (PR #5701) so a local session can
+  propose a Codewhale cloud agent against an explicit `github`, `cnb`, or
+  `gitee` remote.
   Confirmation is required; missing credentials fail closed; cloud jobs share
   the existing `/jobs` surface as `kind=cloud`. See
   [DAYTONA_CLOUD_DISPATCH.md](docs/DAYTONA_CLOUD_DISPATCH.md).
@@ -24,51 +34,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no `auth set-slot`/`auth clear-slot` command, no hint, and no completion
   entry for it — membership (`codewhale login`) is the only door.
 - Add the Tideline component family from the ratatui translation spec
-  (#5698's screens, riding the #5699 work-strip layout): hero startup
+  (PR #5708; #5698's screens, riding the #5699 work-strip layout): hero startup
   surface with quick actions and option strip, composer restyle with the
   fluke cap, notifications inbox, merged footer band, pod ledger, receipt
   stream, theme list with motion toggles, live preview, settings rail,
   and the left rail — each a standalone render module pinned by 28 new
   byte-exact golden buffers. Frame wiring follows the Tideline acceptance
   gate; `NO_COLOR` is now honored by palette depth detection.
-- Route Contract Phase 1: `RouteResolver` is the runtime path for
+- Route Contract Phase 1 (PR #5702): `RouteResolver` is the runtime path for
   `resolve_runtime_options`; `codewhale providers export --json` ships the
   owned descriptor catalog; CLI `--provider` accepts any catalog route id
   (the closed `ProviderArg` enum is deleted). Catalog layers are
   bundled → models.dev → provider `/v1/models` → config.toml → user, with
   policy DENY last and never overridden.
 - Add provider-native web search for documented Xiaomi MiMo 2.5 Pro and 2.5
-  chat routes while keeping neighboring models and custom gateways fail-closed.
+  chat routes while keeping neighboring models and custom gateways fail-closed
+  (#5687 via PR #5693).
 - Add structured provider-native web search for exact Z.AI global and Zhipu
   China general API routes, using each site's documented search engine value.
   Existing `open.bigmodel.cn` configurations now share Z.AI's official model
-  namespace and credential scope; unknown model IDs still pass through.
+  namespace and credential scope; unknown model IDs still pass through
+  (#5685 via PR #5691).
 - Add provider-native web search for documented Qwen models on ModelStudio
   Token Plan's Responses Harness, without enabling Coding Plan or Anthropic
-  routes.
+  routes (#5684 via PR #5690).
 - Added `/copy` to place the latest completed assistant response on the
   clipboard without copying tools, system messages, hidden reasoning, or
-  active partial output (#5668).
+  active partial output (#5668; PRs #5692, #5696).
 - Add provider-native web search for documented DeepSeek V4 routes through the
   Responses API, with fail-closed capability gating for compatible custom
-  endpoints.
+  endpoints (PR #5683).
 - Add provider-native search for exact Moonshot K3 Formula, legacy K2.6
   built-in search, and Kimi Code membership `/search` routes. Treat the exact
-  Moonshot China endpoint as a first-party direct route.
+  Moonshot China endpoint as a first-party direct route (#5686 via PR #5720).
 - Z.ai `GLM-5.3-Flash` and OpenRouter `z-ai/glm-5.3-flash` are first-class
   picker rows (`/model GLM-5.3-Flash`). Flash is the faster/explore sibling
   of `GLM-5.3`; the Z.ai default stays `GLM-5.3`. List price is $0.15/$0.50
   per 1M (durable; the 50% promo through 2026-09-09 is not the catalog row).
 - Baseten, Groq, and Cerebras are bundled OpenAI-compatible setup templates
   (`[providers.<id>] kind = "openai-compatible"`), not new `ProviderKind`
-  variants. `/provider` fills URL, model, and env from one catalog row.
+  variants. `/provider` fills URL, model, and env from one catalog row
+  (PR #5667).
 - MCP manager copy now names the server, the failure, and one recovery
   command (`The X MCP server requires OAuth reauthentication. Run /mcp login X`).
 - Settings Advanced exposes clickable MCP Connect, Reconnect, and Diagnose
   actions, while Extensions and Problems route recovery through the existing
   `/mcp login`, `/mcp reload`, `/mcp validate`, and `/plugin validate` commands
-  (#5643, #5655).
-- Plugin prompt matching (#5579): sending a task can toast the next review
+  (#5643, PRs #5655, #5677 rescuing #5658).
+- Plugin prompt matching (#5579, PR #5663): sending a task can toast the next review
   step when the prompt strongly matches an installed-but-idle plugin or a
   marketplace catalog you added (for example a Supabase prompt suggesting
   `/plugin trust supabase`). A live composer CTA offers the same review
@@ -77,16 +90,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   review without installing. `/plugin suggest` now ranks manifest keywords and
   catalog candidates, never auto-installs, and on-disk plugin changes also
   nudge `/plugin reload` between turns.
-
-
-- Added `/import-claude` (#5557): reads `~/.claude.json` and
+- Added `/import-claude` (#5557, PR #5648): reads `~/.claude.json` and
   `~/.claude/settings.json` read-only and renders an explicit, reviewable
   migration plan plus a written report. MCP servers route through the
   existing `/mcp import <name> --approve` consent flow, allowlisted env keys
   become an unapplied portable bundle for `codewhale config import`, and
   permissions/hooks map to manual follow-ups; secret-shaped values are named
   but never echoed or imported.
-- Added the managed Chat relay: account-owned Chat commands now execute on the
+- Added the managed Chat relay (PR #5606): account-owned Chat commands now execute on the
   native runtime thread engine through a new `runtime_chat_relay` module
   instead of a second execution path. Each Chat thread is a dedicated,
   isolated runtime thread with an empty model-visible tool allowlist, a
@@ -99,7 +110,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (never queues into) a busy local Work turn with an immediate retryable
   result. Stop commands require the exact run and turn identity, and a worker
   aborts on any account or target mismatch during token refresh.
-
 - Added a verified Omarchy/AUR packaging path: `packaging/aur` now carries a
   `PKGBUILD` template, `.SRCINFO` renderer and tests, release-candidate
   render step, and docs; the live AUR compatibility alias `codewhale-tui ->
@@ -139,42 +149,101 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   context-JSON modes stay read-only and conflict with `--fix` (#5552, v1).
 - Added `/context` reporting of the real provider prompt-cache hit rate (C3)
   alongside token pressure.
+- Kimi Code `k3-256k` is a supported route with its 256k context window
+  recorded in the bundled catalog (PR #5622, @h3c-hexin).
+- The context meter reports post-compaction input tokens so the number shown
+  after a compaction is the one the next request will actually carry
+  (PR #5623, @h3c-hexin).
+- Automations remember an optional model selection on create/update and
+  forward it to scheduled and manually triggered durable tasks; legacy
+  records keep the runtime default (PR #5650, @h3c-hexin).
+- Runtime API: `GET /v1/threads/{id}/usage` exposes the provider-aware usage
+  ledger per thread with USD/CNY coverage and unpriced-reason evidence
+  preserved across reloads (#5626 via PR #5641, original by @gaord), and
+  `GET /v1/fleet/profiles` exposes the effective agent roster through the same
+  path the FleetManager uses to validate `agent_profile` ids (PR #5688,
+  @gaord).
+- Lifecycle outbox (#5531): an opt-in JSONL and webhook outbox for session,
+  turn, stall, and subagent events with workspace identity on every event,
+  bounded pre-redacted payloads, atomic sequence recovery, and bounded webhook
+  fan-out; the same PR extracts exec-agent assembly from the TUI mega-file as
+  the first compatible #5586 decomposition slice (#5592 via PR #5645,
+  contributor commits by @M-Maciej preserved).
+- Session boot now surfaces plugin discovery and enabled MCP servers as
+  session-owned boot state: connecting servers are named on the first frame,
+  failure and login recovery stay visible through `/mcp retry` and
+  `/mcp login`, and dynamic servers stay out of eager `connect_all`
+  (#5658 via PR #5677).
+- The bundled catalog carries the OpenRouter `qwen/qwen3.8-flash` route
+  (1M context, 131k output, image/video input, reasoning, tool calling,
+  durable prices) as a non-default OpenRouter-only row (#5631 via PR #5649).
+- `codewhale review --pr N [--post]` runs a headless advisory review of a
+  GitHub pull request and, with `--post`, publishes exactly one COMMENT review
+  anchored to the PR head; `.github/workflows/codewhale-review.yml` runs it
+  on non-draft PRs and no-ops green until a provider key exists (PR #5706).
+  The review bot's canonical key is the Codewhale account key
+  (`CODEWHALE_API_KEY`) with BYOK secrets as the fallback and `--provider`
+  pinning multi-route models; review reports can carry committable
+  suggestions whose fences are neutralized before posting.
+- The Tideline session shell: topbar (wordmark, context meter, clock), the
+  merged one-row footer with posture chips, and the startup stage inside the
+  shell with the launch composer docked below the option strip. The Tideline
+  Settings shell lands on typed row facts (`SettingFact` /
+  `SettingAuthority` / `SettingApplySemantics`) and one settings taxonomy
+  (PR #5730).
+- The `lsp` tool gained a bounded multi-file `read_lints` operation (capped
+  at 16 paths, 100 diagnostics, 512 characters per message) that reuses the
+  session `LspManager` transport pool (#4070, PR #5524, @wuisabel-gif). The
+  v0.9.11 notes credited this work; it merged after the v0.9.11 tag and ships
+  here.
+- Website: honest localized pricing, terms, privacy, and legal routes with
+  footer discovery (PR #5647); a local General Translation pipeline for
+  website and docs copy into the existing dictionary runtime, fail-closed
+  without BYOK `GT_API_KEY` (PR #5700); and `docs/subagents` and `docs/mcp`
+  moved onto the dictionary spine with zero `isZh` branches (#5337,
+  PR #5544, @Lstarsky0).
+- Docs: `docs/CODEWHALE_AGENT.md` maps the Codewhale Agent identity across
+  the PR-review, co-author, and chat-channel surfaces (PR #5709); an
+  interactive workbench wiring spec for the TUI; English doc corrections
+  (Ollama default model, child env, fleet protocol) plus the first `zh_hans`
+  translations of INSTALL, KEYBINDINGS, and GUIDE (PR #5613, @SparkofSpike).
 
 ### Changed
 
 - Provider-native web search now applies domain constraints before accepting an
   attempt, discards generated answers when returned citations violate those
   constraints, and preserves the caller's configured/local timeout as an
-  independent fallback budget (#5681).
+  independent fallback budget (#5681, PR #5682).
 - Idle session metrics omit zero facts (`0 turns`, `LLM 0s`) until the
   runtime has evidence. Working chrome says `in the current` instead of a
   generic `working`.
 - Deleted nine uncompiled `runtime_contract/` staging files. Live contracts
-  remain `model.rs` and `termination.rs`.
-
+  remain `model.rs` and `termination.rs` (PR #5667).
 - The first #5587 dead-code sweep converts audited test-only helpers to
   `#[cfg(test)]`, keeping production builds free of test-only APIs without
-  changing runtime behavior.
+  changing runtime behavior (#5666 via PR #5667).
 - `/plugin reload` is now discoverable when on-disk plugin bundles change: the
   next send and `/plugin list` nudge once with `Run /plugin reload to apply`
-  instead of silently keeping the stale catalog (#5579). Trust is unchanged;
+  instead of silently keeping the stale catalog (#5579, PR #5660). Trust is
+  unchanged;
   this does not auto-reload.
 - Context-pressure warnings and critical alerts now remain visible in sticky UI
   status until compaction or explicit dismissal, instead of disappearing into
-  scrolling turn metadata (#5620).
+  scrolling turn metadata (#5620, PR #5629).
 - The Runtime thread store defaults to a per-session root
   (`$CODEWHALE_HOME/sessions/<id>/runtime`) so multiple Codewhale processes on
-  one machine no longer share one owner lock (#5630). The exclusive lock is
+  one machine no longer share one owner lock (#5630, PR #5638). The exclusive lock is
   unchanged; `CODEWHALE_RUNTIME_DIR` still selects a shared root when that is
   intended.
 - Session token totals now include display-only per-model-call deltas while a
   turn is running, including input/output and cache-class counters; the
-  authoritative `TurnComplete` totals still reconcile exactly once (#5581).
+  authoritative `TurnComplete` totals still reconcile exactly once (#5581,
+  PR #5624).
 - Transcript focus now exposes per-block actions: `y` copies content, `Y`
   copies the rendered metadata view, Enter opens a fullscreen block pager, and
   `r` opens raw detail; the existing Tasks rail shortcuts remain unchanged
-  (#5551).
-- Provider neutrality (#5588): model resolution of omitted/aliased models is
+  (#5551, PR #5652).
+- Provider neutrality (#5588, PR #5654): model resolution of omitted/aliased models is
   now provider-relative, OpenAI-native defaults no longer route through
   another provider's table, CLI credentials stay provider-scoped, and NVIDIA
   credentials no longer leak into the DeepSeek keychain. Neutrality test
@@ -192,6 +261,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contributor credit: recognized agent contributors (e.g. `Codewhale Agent`)
   may now carry `Co-authored-by` trailers; unknown bot/tool trailers are
   still rejected by the credit gate.
+- Turn budgets are finite by default (R1, #5566): `max_model_steps` defaults
+  to 200, the per-turn wall clock to 3600 s, and `codewhale exec --max-turns`
+  to a finite value, with no `0`-means-unlimited sentinel; per-step stream
+  caps are configurable and human-approval waits are excluded from the wall
+  clock. Raise the caps in `[tui]` or via `CODEWHALE_*` env when a task needs
+  more.
+- Command shapes: the TUI utility group (`/attach`, `/automation`, `/jobs`,
+  `/mcp`, `/network`, `/task`, `/update`; FEAT-018, PR #5525) and the project
+  group (`/init`, `/lsp`, `/share`, `/goal`; FEAT-021, PR #5717) now execute
+  through the contract-backed dispatch path with exact-minimum external
+  facets (@aboimpinto).
+- Startup and token-accounting hot paths were folded in from #5664 / #5665
+  (@AdityaVG13) as part of the 0.9.12 consolidation (PR #5667).
+- Notifications are background-only by default; the startup fluke glyph is
+  realigned to the brand master-path pipeline (one-cell row-6 correction,
+  four startup goldens re-blessed).
+- Release tooling: `check-versions.sh` now fails when the release-note
+  receipt and contributor-credit checks cannot run instead of silently
+  passing (PR #5614); `web/scripts/sync-latest-release.mjs` keeps the
+  published-release fact current and `web.yml` gates on it (PR #5612); the
+  runbook documents unpublished-tag re-cut recovery and external publish
+  gates (PR #5565); harvested-credit checks are scoped to the exact PR range
+  (PR #5598).
+- CI: an optional self-hosted macOS runner takes the macOS test leg only for
+  trusted (non-fork) heavy events behind the `CW_SELF_HOSTED_MAC` kill
+  switch; the review workflow installs `libdbus-1-dev` before building the
+  reviewer (PR #5710); the read-guard symlink tests are whole-function
+  `#[cfg(unix)]` so hosted Windows CI compiles again.
+- Tests: the long-stream timeline bound no longer depends on durable status
+  fsync latency (PR #5640), and the stale published-fingerprint release-note
+  gate is retired (PR #5680).
+- Dependencies: tower-http 0.7.0 (#5387), similar 3.2.0 (#5540), rio-vt
+  0.5.25 (#5539), async-trait 0.1.92 (#5672), uuid 1.25.0 (#5675),
+  futures-util 0.3.34 (#5676), docker/setup-buildx-action 4.3.0 (#5537);
+  nixpkgs updated so `nix run github:hmbown/codewhale#codewhale` builds
+  again, with a monthly dependabot entry and `stdenv.hostPlatform`
+  (PR #5669, @serephus).
+- Repository: agent merge, contributor, and verification discipline is
+  recorded in `AGENTS.md`; `docs/CONTRIBUTORS.md` gains the v0.9.12 band and
+  `.github/AUTHOR_MAP` maps three more identities; @wuisabel-gif holds
+  recurring PR access (#5619).
 
 ### Fixed
 
@@ -199,25 +309,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   literal spelling. On macOS `/etc` and `/var` are symlinks into `/private`,
   so a read of `/private/etc/sudoers` walked around the `/etc/sudoers` rule,
   and a rule written against a symlinked directory never fired for the real
-  path that `canonicalize` and the process cwd hand back.
+  path that `canonicalize` and the process cwd hand back (PR #5724).
 - Background shells are first-class work-strip rows (`▾ Shells N`) you can
   open, watch, and cancel by the `shell_*` id on the row. `/jobs cancel all`
   cancels running shells; it no longer looks up a task named `all`. The
-  composer hourglass crumb no longer stands in for a shell surface.
+  composer hourglass crumb no longer stands in for a shell surface (PR #5699).
 - `codewhale logout` and `/logout` now clear the Codewhale account session
   and the Daytona secret slot, not only provider API keys. The TUI crate's
-  leftover `login --api-key` path no longer claims to save a key.
+  leftover `login --api-key` path no longer claims to save a key (PR #5704).
 - Account sessions no longer read the macOS Keychain. Unsigned or rebuilt
   `codewhale` binaries were a new Keychain ACL principal every time, so
   `codewhale web` and the TUI popped a password dialog on start. Sessions
   now use `~/.codewhale/secrets/secrets.json` (mode 0600), the same store
-  as provider keys. Extracted from the Keychain-retirement half of #5632.
+  as provider keys. Extracted from the Keychain-retirement half of #5632
+  (PR #5662).
 - Hardened the dispatcher-side config parse the same way: `ConfigStore`
   loads and project-config parsing now deserialize `ConfigToml` on a
   dedicated 16 MiB-stack thread (the guided-setup save path could overflow
   a 2 MiB worker stack the same way the TUI's `ConfigFile` parse did), and
   the #5585 setup-confirm toast test runs its runtime on an equally sized
-  thread instead of overflowing the default libtest stack.
+  thread instead of overflowing the default libtest stack (PR #5644).
 - Fixed detached interactive agents reporting worker usage after the parent
   turn ends with the usage missing from the session/live `/cost` total
   (#5597): interactive turns acquire an owner-scoped runtime usage lease,
@@ -262,16 +373,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed docs/public-surface drift: REBRAND.md no longer presents
   `api.deepseeki.com` as a China fallback (#5564), and the web facts/tool
   counts match the repository.
-
 - Heavy pull requests now run the real Linux workspace nextest, doctest, and
   lockfile lanes directly on GitHub Actions instead of reporting a green
-  placeholder while waiting for a branch-specific CNB mirror (#5547).
+  placeholder while waiting for a branch-specific CNB mirror (#5547, PR #5590).
 - Fleet roster members in a selected Fleet now expose a visible edit affordance
   and a direct `m` model-picker shortcut, while the coordinator row remains
   read-only (#5604, covers #5589).
 - The context inspector now attributes bounded tool-schema cost to the built-in
   catalog and each discovered MCP server without changing prompt assembly or
-  cache behavior (#5553).
+  cache behavior (#5553, PR #5653).
 - The goal-continuation quiet period (`[goal] continuation_delay_seconds`,
   added in #5508) now applies on every dispatch path. Previously the
   within-turn dispatch hook fired the next continuation prompt immediately
@@ -280,7 +390,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   end-to-start gaps of ~9 s with a 300 s delay configured). The wait now
   runs unconditionally inside `goal_continuation_message_if_needed`,
   remains cancellable, and pause/clear/terminal `update_goal` calls still
-  cancel a pending pass (#5534).
+  cancel a pending pass (#5534, PR #5591).
 - Two unit tests no longer depend on process-global environment state that
   sibling tests mutate concurrently.
   `route_budget::tests::v4_trigger_uses_window_percent_when_it_fits_spendable_input`
@@ -295,10 +405,116 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guard happened to be live. Both tests now hold the env barrier and pin the
   variables (the route-budget test removes the overrides; the prompts test
   points `HOME`/`USERPROFILE` at a scratch dir). Assertions unchanged.
-
 - TUI sessions now apply a subtle OSC 12 cursor accent only on explicitly
   supported terminals and restore the terminal default through normal, panic,
-  and signal cleanup paths (#5554).
+  and signal cleanup paths (#5554, PR #5599).
+- Windows verbatim device paths (`\\?\C:\...`) survive the POSIX word split
+  used by the read-only operand guard, so `cat <path>` and
+  `git -C <path> log` no longer lose their separators (PR #5610,
+  @aboimpinto).
+- Edit-last-turn locates the latest genuine user-authored prompt instead of
+  any persisted `role = "user"` message, treats unsupported user content as an
+  authoritative boundary, and emits a failed terminal outcome when an edit
+  cannot start (PR #5621, @h3c-hexin).
+- Read-only git probes stay off the user's index lock (PR #5642).
+- Route-specific tool projection keeps compatible tools on the wire, degrades
+  only route-incompatible tools, rejects a named `tool_choice` targeting an
+  omitted tool before transport, and emits one typed warning per affected
+  request (#5636 via PR #5651, patch by Lfanxing with @h3c-hexin).
+- Chat Completions replay keeps every assistant tool-call batch followed by
+  one contiguous, complete tool-result run, defers tool-result images until
+  the batch is valid, and strips incomplete or orphaned batches (PR #5679).
+- The DeepSeek model picker's default `configured` view shows a stable
+  `DeepSeek` heading and keeps every official catalog model for the active
+  provider visible (PR #5689, @musichen).
+- Durable completion commit: turn completion writes the completed snapshot
+  and clears only that session's checkpoint after the write succeeds, so a
+  failed save or mid-turn exit can no longer erase the only recovery record
+  (PR #5697).
+- Self-update aborts before any destructive rename when staged permissions
+  cannot be applied or the staged binary lacks an executable bit (#5727,
+  PR #5728).
+- The subagent contention gate no longer refuses proven read-only child shell
+  runs, a panicked child commits a crash terminal result instead of gating
+  peers forever, and headless `WaitingForUser` worker records are reconciled
+  (PR #5732).
+- Runtime Chat owner-lock acquisition reports the real IO fault; only
+  `WouldBlock` is reported as contention (#5735 partial, PR #5736).
+- A chunk-level provider error frame mid-stream now stops the stream,
+  surfaces a classified error, and fences trailing deltas; terminal provider
+  rejections render as errors, not dismissable warnings.
+- An oversized paste submits as a visible attachment card (size header,
+  `@`-mention, bounded preview) instead of a bare artifact path.
+- Settings show the live route identity (provider, model, endpoint) instead
+  of the stale saved config; the theme picker no longer discards a non-Whale
+  Deepsea pair on Enter; the launch composer applies completion menus on
+  Enter and paints the popup; the caret window budgets by display width so
+  CJK/emoji drafts keep the caret visible; sign-in hints name
+  `codewhale login`.
+
+### Security
+
+- Full access means it: a startup resolved to `danger-full-access` skips
+  `PR_SET_NO_NEW_PRIVS` on Linux so `sudo`/`su` work from the agent shell
+  exactly as advertised, every narrower posture keeps the #5413 default, the
+  decision fails closed on an unknown mode, and `CODEWHALE_NO_NEW_PRIVS=1`
+  forces the flag on even under full access (#5723, PR #5733).
+- The sandbox read deny-list (S1, #5568) ships a default credential-store
+  deny-list enforced in-process across `read`, `read_file`, `read_media`,
+  `list_dir`, and `file_search`, with raw-path-first guard ordering, fixed
+  `..`-through-symlink resolution, and a fail-closed `EngineConfig` default;
+  it now also matches a rule's resolved path (PR #5724). It remains
+  defense-in-depth: hard links and unwrapped child processes are documented
+  limits.
+- Review suggestion fences from model text cannot be smuggled through issue
+  titles or descriptions; replacements degrade to plain blocks when posted
+  and receipts record only counts and anchor spans.
+
+### Removed
+
+- The hand-drawn whale art portraits, idle-whale rows, fleet-roster portrait
+  block, and the `▚△▞` crown are gone; the startup hero keeps the generated
+  fluke block from the brand master path (net −764 lines).
+- Nine verified-dead functions and two unused dependencies were removed after
+  a whole-workspace `--force-warn dead_code` pass and cross-tooling reference
+  search (PR #5705).
+
+### Contributors
+
+- **hexin ([@h3c-hexin](https://github.com/h3c-hexin))** — provider-native
+  web search across DeepSeek (#5683), Z.AI/BigModel (#5685 via #5691), Xiaomi
+  MiMo (#5687 via #5693), and Moonshot/Kimi (#5686 via #5720) with constraint
+  enforcement before fallback (#5682); authoritative edit-last-turn
+  boundaries (#5621), Kimi Code k3-256k (#5622), post-compaction input tokens
+  (#5623), automation model selection (#5650), and the Moonshot tool
+  projection stopgap (#5636 via #5651).
+- **Isabel Wu ([@wuisabel-gif](https://github.com/wuisabel-gif))** —
+  multi-file `read_lints` (#5524), Linux workspace tests on pull requests
+  (#5590), the capability-gated cursor accent (#5599), discoverable Fleet
+  roster editing (#5604), live session token totals (#5624), persisted
+  context-pressure warnings (#5629), `/copy` (#5692 via #5696), and the
+  `#[cfg(test)]` slice of #5587 (#5666 via #5667).
+- **Paulo Aboim Pinto ([@aboimpinto](https://github.com/aboimpinto))** —
+  command shapes for the utility (#5525) and project (#5717) groups and the
+  Windows verbatim-path operand fix (#5610).
+- **M-Maciej ([@M-Maciej](https://github.com/M-Maciej))** — the goal
+  continuation cadence fix (#5591) and the lifecycle outbox (#5592 via
+  #5645).
+- **Ben Gao ([@gaord](https://github.com/gaord))** — per-thread usage with
+  CNY coverage (#5626 via #5641) and the `GET /v1/fleet/profiles` endpoint
+  (#5688).
+- **Lstarsky0 ([@Lstarsky0](https://github.com/Lstarsky0))** — `docs/subagents`
+  and `docs/mcp` on the dictionary spine (#5544).
+- **Sh1Zuku ([@SparkofSpike](https://github.com/SparkofSpike))** — English
+  doc corrections and the first Tier-2 `zh_hans` translations (#5613).
+- **Alex Musichen ([@musichen](https://github.com/musichen))** — the DeepSeek
+  configured-picker fix (#5689).
+- **AdityaVG13 ([@AdityaVG13](https://github.com/AdityaVG13))** — startup and
+  token-accounting perf (#5664, #5665 via #5667).
+- **Serephus ([@serephus](https://github.com/serephus))** — the nixpkgs
+  update and monthly dependabot entry (#5669).
+- **Lfanxing** — the original route-projection patch carried by #5651.
+- **dependabot[bot]** — #5387, #5537, #5539, #5540, #5672, #5675, #5676.
 
 ## [0.9.11] - 2026-08-22
 
@@ -7631,7 +7847,8 @@ overflow report and `/theme` picker edge-wrapping patch in #1814.
 
 Older releases (v0.8.39 and earlier) are archived in [docs/CHANGELOG_ARCHIVE.md](docs/CHANGELOG_ARCHIVE.md).
 
-[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.9.11...HEAD
+[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.9.12...HEAD
+[0.9.12]: https://github.com/Hmbown/CodeWhale/compare/v0.9.11...v0.9.12
 [0.9.11]: https://github.com/Hmbown/CodeWhale/compare/v0.9.10...v0.9.11
 [0.9.10]: https://github.com/Hmbown/CodeWhale/compare/v0.9.9...v0.9.10
 [0.9.9]: https://github.com/Hmbown/CodeWhale/compare/v0.9.8...v0.9.9

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-agent"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "codewhale-config",
  "serde",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-app-server"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -787,11 +787,11 @@ dependencies = [
 
 [[package]]
 name = "codewhale-build-support"
-version = "0.9.11"
+version = "0.9.12"
 
 [[package]]
 name = "codewhale-cli"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,14 +832,14 @@ dependencies = [
 
 [[package]]
 name = "codewhale-command-contract"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "codewhale-core",
 ]
 
 [[package]]
 name = "codewhale-config"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "codewhale-execpolicy",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-core"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-execpolicy"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "codewhale-protocol",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-hooks"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-lane"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-mcp"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "serde",
@@ -936,14 +936,14 @@ dependencies = [
 
 [[package]]
 name = "codewhale-paths"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "codewhale-protocol"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "chrono",
  "serde",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-release"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-secrets"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "chrono",
  "codewhale-paths",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-state"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-telemetry"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tools"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tui"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-workflow"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-workflow-js"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.11"
+version = "0.9.12"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -11,5 +11,5 @@ description = "Model/provider registry and fallback strategy for Codewhale"
 workspace = true
 
 [dependencies]
-codewhale-config = { path = "../config", version = "0.9.11" }
+codewhale-config = { path = "../config", version = "0.9.12" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -15,16 +15,16 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true
-codewhale-agent = { path = "../agent", version = "0.9.11" }
-codewhale-config = { path = "../config", version = "0.9.11" }
-codewhale-core = { path = "../core", version = "0.9.11" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.9.11" }
-codewhale-hooks = { path = "../hooks", version = "0.9.11" }
-codewhale-mcp = { path = "../mcp", version = "0.9.11" }
-codewhale-protocol = { path = "../protocol", version = "0.9.11" }
-codewhale-release = { path = "../release", version = "0.9.11" }
-codewhale-state = { path = "../state", version = "0.9.11" }
-codewhale-tools = { path = "../tools", version = "0.9.11" }
+codewhale-agent = { path = "../agent", version = "0.9.12" }
+codewhale-config = { path = "../config", version = "0.9.12" }
+codewhale-core = { path = "../core", version = "0.9.12" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.9.12" }
+codewhale-hooks = { path = "../hooks", version = "0.9.12" }
+codewhale-mcp = { path = "../mcp", version = "0.9.12" }
+codewhale-protocol = { path = "../protocol", version = "0.9.12" }
+codewhale-release = { path = "../release", version = "0.9.12" }
+codewhale-state = { path = "../state", version = "0.9.12" }
+codewhale-tools = { path = "../tools", version = "0.9.12" }
 serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,19 +18,19 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-codewhale-tui = { path = "../tui", version = "0.9.11" }
-codewhale-agent = { path = "../agent", version = "0.9.11" }
-codewhale-app-server = { path = "../app-server", version = "0.9.11" }
-codewhale-config = { path = "../config", version = "0.9.11" }
-codewhale-lane = { path = "../lane", version = "0.9.11" }
-codewhale-workflow = { path = "../workflow", version = "0.9.11" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.9.11" }
-codewhale-mcp = { path = "../mcp", version = "0.9.11" }
-codewhale-paths = { path = "../paths", version = "0.9.11" }
-codewhale-release = { path = "../release", version = "0.9.11" }
-codewhale-secrets = { path = "../secrets", version = "0.9.11" }
-codewhale-state = { path = "../state", version = "0.9.11" }
-codewhale-telemetry = { path = "../telemetry", version = "0.9.11" }
+codewhale-tui = { path = "../tui", version = "0.9.12" }
+codewhale-agent = { path = "../agent", version = "0.9.12" }
+codewhale-app-server = { path = "../app-server", version = "0.9.12" }
+codewhale-config = { path = "../config", version = "0.9.12" }
+codewhale-lane = { path = "../lane", version = "0.9.12" }
+codewhale-workflow = { path = "../workflow", version = "0.9.12" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.9.12" }
+codewhale-mcp = { path = "../mcp", version = "0.9.12" }
+codewhale-paths = { path = "../paths", version = "0.9.12" }
+codewhale-release = { path = "../release", version = "0.9.12" }
+codewhale-secrets = { path = "../secrets", version = "0.9.12" }
+codewhale-state = { path = "../state", version = "0.9.12" }
+codewhale-telemetry = { path = "../telemetry", version = "0.9.12" }
 chrono.workspace = true
 console = "0.16.3"
 dirs.workspace = true
@@ -49,7 +49,7 @@ webbrowser = "1.0"
 zeroize = "1.8.2"
 
 [build-dependencies]
-codewhale-build-support = { path = "../build-support", version = "0.9.11" }
+codewhale-build-support = { path = "../build-support", version = "0.9.12" }
 
 # Parent-death cleanup for delegated server children (#3259): on Linux the
 # dispatcher sets PR_SET_PDEATHSIG so the child is signalled if the dispatcher

--- a/crates/command-contract/Cargo.toml
+++ b/crates/command-contract/Cargo.toml
@@ -11,4 +11,4 @@ description = "Prototype command capability and dispatch shapes for the staged T
 workspace = true
 
 [dependencies]
-codewhale-core = { path = "../core", version = "0.9.11" }
+codewhale-core = { path = "../core", version = "0.9.12" }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -12,9 +12,9 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-codewhale-execpolicy = { path = "../execpolicy", version = "0.9.11" }
-codewhale-paths = { path = "../paths", version = "0.9.11" }
-codewhale-secrets = { path = "../secrets", version = "0.9.11" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.9.12" }
+codewhale-paths = { path = "../paths", version = "0.9.12" }
+codewhale-secrets = { path = "../secrets", version = "0.9.12" }
 fd-lock = "4.0.4"
 libc = "0.2"
 serde.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,14 +15,14 @@ anyhow.workspace = true
 chrono.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-codewhale-agent = { path = "../agent", version = "0.9.11" }
-codewhale-config = { path = "../config", version = "0.9.11" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.9.11" }
-codewhale-hooks = { path = "../hooks", version = "0.9.11" }
-codewhale-mcp = { path = "../mcp", version = "0.9.11" }
-codewhale-protocol = { path = "../protocol", version = "0.9.11" }
-codewhale-state = { path = "../state", version = "0.9.11" }
-codewhale-tools = { path = "../tools", version = "0.9.11" }
+codewhale-agent = { path = "../agent", version = "0.9.12" }
+codewhale-config = { path = "../config", version = "0.9.12" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.9.12" }
+codewhale-hooks = { path = "../hooks", version = "0.9.12" }
+codewhale-mcp = { path = "../mcp", version = "0.9.12" }
+codewhale-protocol = { path = "../protocol", version = "0.9.12" }
+codewhale-state = { path = "../state", version = "0.9.12" }
+codewhale-tools = { path = "../tools", version = "0.9.12" }
 regex = "1.11"
 serde_json = { workspace = true, features = ["preserve_order"] }
 tokio = { workspace = true, features = ["time"] }

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -12,5 +12,5 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.9.11" }
+codewhale-protocol = { path = "../protocol", version = "0.9.12" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.9.11" }
-codewhale-release = { path = "../release", version = "0.9.11" }
+codewhale-protocol = { path = "../protocol", version = "0.9.12" }
+codewhale-release = { path = "../release", version = "0.9.12" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/lane/Cargo.toml
+++ b/crates/lane/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-config = { path = "../config", version = "0.9.11" }
+codewhale-config = { path = "../config", version = "0.9.12" }
 fd-lock = "4.0.4"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -11,7 +11,7 @@ description = "Secret storage backends for Codewhale, with OS keyring and file f
 workspace = true
 
 [dependencies]
-codewhale-paths = { path = "../paths", version = "0.9.11" }
+codewhale-paths = { path = "../paths", version = "0.9.12" }
 chrono.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-paths = { path = "../paths", version = "0.9.11" }
-codewhale-protocol = { path = "../protocol", version = "0.9.11" }
+codewhale-paths = { path = "../paths", version = "0.9.12" }
+codewhale-protocol = { path = "../protocol", version = "0.9.12" }
 fd-lock = "4.0.4"
 rusqlite.workspace = true
 serde.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -13,9 +13,9 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-config = { path = "../config", version = "0.9.11" }
-codewhale-paths = { path = "../paths", version = "0.9.11" }
-codewhale-release = { path = "../release", version = "0.9.11" }
+codewhale-config = { path = "../config", version = "0.9.12" }
+codewhale-paths = { path = "../paths", version = "0.9.12" }
+codewhale-release = { path = "../release", version = "0.9.12" }
 fd-lock = "4.0.4"
 reqwest = { workspace = true, features = ["blocking"] }
 serde.workspace = true
@@ -25,9 +25,9 @@ tracing.workspace = true
 uuid.workspace = true
 
 [build-dependencies]
-codewhale-build-support = { path = "../build-support", version = "0.9.11" }
+codewhale-build-support = { path = "../build-support", version = "0.9.12" }
 
 [dev-dependencies]
 # Used as an *assertion*, never as a filter: every string leaf of a serialized
 # batch is run through `redact_for_disclosure` and must come back unredacted.
-codewhale-workflow = { path = "../workflow", version = "0.9.11" }
+codewhale-workflow = { path = "../workflow", version = "0.9.12" }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.9.11" }
+codewhale-protocol = { path = "../protocol", version = "0.9.12" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,15 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.12] - Unreleased candidate
+
+Codewhale v0.9.12 makes the agent loop finite by default, lands the Tideline
+visual redesign across the TUI and the website, unifies managed Chat with
+native runtime threads, adds provider-native web search across DeepSeek,
+Qwen, Z.AI/BigModel, Xiaomi MiMo, and Moonshot/Kimi routes, and closes a set
+of sandbox and authority gaps (read deny-list, hard-link writes, full-access
+posture truth). Every pull request merged into `main` since v0.9.11 is
+referenced by number below; direct integrator merges are described inline.
+
 ### Added
 
 - Website: the public site moves to the Tideline deep-ocean design language
   (dark by default with an opt-in light documentation sheet, palette grounded
   in the TUI's WHALE_* tokens) and the new whale brand mark across the favicon,
-  app icons, web manifest, nav wordmark, and social card (#5573).
-
-- Add `codewhale dispatch` / `/dispatch` so a local session can propose a
-  Codewhale cloud agent against an explicit `github`, `cnb`, or `gitee` remote.
+  app icons, web manifest, nav wordmark, and social card (#5573, PR #5734).
+- Add `codewhale dispatch` / `/dispatch` (PR #5701) so a local session can
+  propose a Codewhale cloud agent against an explicit `github`, `cnb`, or
+  `gitee` remote.
   Confirmation is required; missing credentials fail closed; cloud jobs share
   the existing `/jobs` surface as `kind=cloud`. See
   [DAYTONA_CLOUD_DISPATCH.md](docs/DAYTONA_CLOUD_DISPATCH.md).
@@ -24,51 +34,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no `auth set-slot`/`auth clear-slot` command, no hint, and no completion
   entry for it — membership (`codewhale login`) is the only door.
 - Add the Tideline component family from the ratatui translation spec
-  (#5698's screens, riding the #5699 work-strip layout): hero startup
+  (PR #5708; #5698's screens, riding the #5699 work-strip layout): hero startup
   surface with quick actions and option strip, composer restyle with the
   fluke cap, notifications inbox, merged footer band, pod ledger, receipt
   stream, theme list with motion toggles, live preview, settings rail,
   and the left rail — each a standalone render module pinned by 28 new
   byte-exact golden buffers. Frame wiring follows the Tideline acceptance
   gate; `NO_COLOR` is now honored by palette depth detection.
-- Route Contract Phase 1: `RouteResolver` is the runtime path for
+- Route Contract Phase 1 (PR #5702): `RouteResolver` is the runtime path for
   `resolve_runtime_options`; `codewhale providers export --json` ships the
   owned descriptor catalog; CLI `--provider` accepts any catalog route id
   (the closed `ProviderArg` enum is deleted). Catalog layers are
   bundled → models.dev → provider `/v1/models` → config.toml → user, with
   policy DENY last and never overridden.
 - Add provider-native web search for documented Xiaomi MiMo 2.5 Pro and 2.5
-  chat routes while keeping neighboring models and custom gateways fail-closed.
+  chat routes while keeping neighboring models and custom gateways fail-closed
+  (#5687 via PR #5693).
 - Add structured provider-native web search for exact Z.AI global and Zhipu
   China general API routes, using each site's documented search engine value.
   Existing `open.bigmodel.cn` configurations now share Z.AI's official model
-  namespace and credential scope; unknown model IDs still pass through.
+  namespace and credential scope; unknown model IDs still pass through
+  (#5685 via PR #5691).
 - Add provider-native web search for documented Qwen models on ModelStudio
   Token Plan's Responses Harness, without enabling Coding Plan or Anthropic
-  routes.
+  routes (#5684 via PR #5690).
 - Added `/copy` to place the latest completed assistant response on the
   clipboard without copying tools, system messages, hidden reasoning, or
-  active partial output (#5668).
+  active partial output (#5668; PRs #5692, #5696).
 - Add provider-native web search for documented DeepSeek V4 routes through the
   Responses API, with fail-closed capability gating for compatible custom
-  endpoints.
+  endpoints (PR #5683).
 - Add provider-native search for exact Moonshot K3 Formula, legacy K2.6
   built-in search, and Kimi Code membership `/search` routes. Treat the exact
-  Moonshot China endpoint as a first-party direct route.
+  Moonshot China endpoint as a first-party direct route (#5686 via PR #5720).
 - Z.ai `GLM-5.3-Flash` and OpenRouter `z-ai/glm-5.3-flash` are first-class
   picker rows (`/model GLM-5.3-Flash`). Flash is the faster/explore sibling
   of `GLM-5.3`; the Z.ai default stays `GLM-5.3`. List price is $0.15/$0.50
   per 1M (durable; the 50% promo through 2026-09-09 is not the catalog row).
 - Baseten, Groq, and Cerebras are bundled OpenAI-compatible setup templates
   (`[providers.<id>] kind = "openai-compatible"`), not new `ProviderKind`
-  variants. `/provider` fills URL, model, and env from one catalog row.
+  variants. `/provider` fills URL, model, and env from one catalog row
+  (PR #5667).
 - MCP manager copy now names the server, the failure, and one recovery
   command (`The X MCP server requires OAuth reauthentication. Run /mcp login X`).
 - Settings Advanced exposes clickable MCP Connect, Reconnect, and Diagnose
   actions, while Extensions and Problems route recovery through the existing
   `/mcp login`, `/mcp reload`, `/mcp validate`, and `/plugin validate` commands
-  (#5643, #5655).
-- Plugin prompt matching (#5579): sending a task can toast the next review
+  (#5643, PRs #5655, #5677 rescuing #5658).
+- Plugin prompt matching (#5579, PR #5663): sending a task can toast the next review
   step when the prompt strongly matches an installed-but-idle plugin or a
   marketplace catalog you added (for example a Supabase prompt suggesting
   `/plugin trust supabase`). A live composer CTA offers the same review
@@ -77,16 +90,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   review without installing. `/plugin suggest` now ranks manifest keywords and
   catalog candidates, never auto-installs, and on-disk plugin changes also
   nudge `/plugin reload` between turns.
-
-
-- Added `/import-claude` (#5557): reads `~/.claude.json` and
+- Added `/import-claude` (#5557, PR #5648): reads `~/.claude.json` and
   `~/.claude/settings.json` read-only and renders an explicit, reviewable
   migration plan plus a written report. MCP servers route through the
   existing `/mcp import <name> --approve` consent flow, allowlisted env keys
   become an unapplied portable bundle for `codewhale config import`, and
   permissions/hooks map to manual follow-ups; secret-shaped values are named
   but never echoed or imported.
-- Added the managed Chat relay: account-owned Chat commands now execute on the
+- Added the managed Chat relay (PR #5606): account-owned Chat commands now execute on the
   native runtime thread engine through a new `runtime_chat_relay` module
   instead of a second execution path. Each Chat thread is a dedicated,
   isolated runtime thread with an empty model-visible tool allowlist, a
@@ -99,7 +110,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (never queues into) a busy local Work turn with an immediate retryable
   result. Stop commands require the exact run and turn identity, and a worker
   aborts on any account or target mismatch during token refresh.
-
 - Added a verified Omarchy/AUR packaging path: `packaging/aur` now carries a
   `PKGBUILD` template, `.SRCINFO` renderer and tests, release-candidate
   render step, and docs; the live AUR compatibility alias `codewhale-tui ->
@@ -139,42 +149,101 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   context-JSON modes stay read-only and conflict with `--fix` (#5552, v1).
 - Added `/context` reporting of the real provider prompt-cache hit rate (C3)
   alongside token pressure.
+- Kimi Code `k3-256k` is a supported route with its 256k context window
+  recorded in the bundled catalog (PR #5622, @h3c-hexin).
+- The context meter reports post-compaction input tokens so the number shown
+  after a compaction is the one the next request will actually carry
+  (PR #5623, @h3c-hexin).
+- Automations remember an optional model selection on create/update and
+  forward it to scheduled and manually triggered durable tasks; legacy
+  records keep the runtime default (PR #5650, @h3c-hexin).
+- Runtime API: `GET /v1/threads/{id}/usage` exposes the provider-aware usage
+  ledger per thread with USD/CNY coverage and unpriced-reason evidence
+  preserved across reloads (#5626 via PR #5641, original by @gaord), and
+  `GET /v1/fleet/profiles` exposes the effective agent roster through the same
+  path the FleetManager uses to validate `agent_profile` ids (PR #5688,
+  @gaord).
+- Lifecycle outbox (#5531): an opt-in JSONL and webhook outbox for session,
+  turn, stall, and subagent events with workspace identity on every event,
+  bounded pre-redacted payloads, atomic sequence recovery, and bounded webhook
+  fan-out; the same PR extracts exec-agent assembly from the TUI mega-file as
+  the first compatible #5586 decomposition slice (#5592 via PR #5645,
+  contributor commits by @M-Maciej preserved).
+- Session boot now surfaces plugin discovery and enabled MCP servers as
+  session-owned boot state: connecting servers are named on the first frame,
+  failure and login recovery stay visible through `/mcp retry` and
+  `/mcp login`, and dynamic servers stay out of eager `connect_all`
+  (#5658 via PR #5677).
+- The bundled catalog carries the OpenRouter `qwen/qwen3.8-flash` route
+  (1M context, 131k output, image/video input, reasoning, tool calling,
+  durable prices) as a non-default OpenRouter-only row (#5631 via PR #5649).
+- `codewhale review --pr N [--post]` runs a headless advisory review of a
+  GitHub pull request and, with `--post`, publishes exactly one COMMENT review
+  anchored to the PR head; `.github/workflows/codewhale-review.yml` runs it
+  on non-draft PRs and no-ops green until a provider key exists (PR #5706).
+  The review bot's canonical key is the Codewhale account key
+  (`CODEWHALE_API_KEY`) with BYOK secrets as the fallback and `--provider`
+  pinning multi-route models; review reports can carry committable
+  suggestions whose fences are neutralized before posting.
+- The Tideline session shell: topbar (wordmark, context meter, clock), the
+  merged one-row footer with posture chips, and the startup stage inside the
+  shell with the launch composer docked below the option strip. The Tideline
+  Settings shell lands on typed row facts (`SettingFact` /
+  `SettingAuthority` / `SettingApplySemantics`) and one settings taxonomy
+  (PR #5730).
+- The `lsp` tool gained a bounded multi-file `read_lints` operation (capped
+  at 16 paths, 100 diagnostics, 512 characters per message) that reuses the
+  session `LspManager` transport pool (#4070, PR #5524, @wuisabel-gif). The
+  v0.9.11 notes credited this work; it merged after the v0.9.11 tag and ships
+  here.
+- Website: honest localized pricing, terms, privacy, and legal routes with
+  footer discovery (PR #5647); a local General Translation pipeline for
+  website and docs copy into the existing dictionary runtime, fail-closed
+  without BYOK `GT_API_KEY` (PR #5700); and `docs/subagents` and `docs/mcp`
+  moved onto the dictionary spine with zero `isZh` branches (#5337,
+  PR #5544, @Lstarsky0).
+- Docs: `docs/CODEWHALE_AGENT.md` maps the Codewhale Agent identity across
+  the PR-review, co-author, and chat-channel surfaces (PR #5709); an
+  interactive workbench wiring spec for the TUI; English doc corrections
+  (Ollama default model, child env, fleet protocol) plus the first `zh_hans`
+  translations of INSTALL, KEYBINDINGS, and GUIDE (PR #5613, @SparkofSpike).
 
 ### Changed
 
 - Provider-native web search now applies domain constraints before accepting an
   attempt, discards generated answers when returned citations violate those
   constraints, and preserves the caller's configured/local timeout as an
-  independent fallback budget (#5681).
+  independent fallback budget (#5681, PR #5682).
 - Idle session metrics omit zero facts (`0 turns`, `LLM 0s`) until the
   runtime has evidence. Working chrome says `in the current` instead of a
   generic `working`.
 - Deleted nine uncompiled `runtime_contract/` staging files. Live contracts
-  remain `model.rs` and `termination.rs`.
-
+  remain `model.rs` and `termination.rs` (PR #5667).
 - The first #5587 dead-code sweep converts audited test-only helpers to
   `#[cfg(test)]`, keeping production builds free of test-only APIs without
-  changing runtime behavior.
+  changing runtime behavior (#5666 via PR #5667).
 - `/plugin reload` is now discoverable when on-disk plugin bundles change: the
   next send and `/plugin list` nudge once with `Run /plugin reload to apply`
-  instead of silently keeping the stale catalog (#5579). Trust is unchanged;
+  instead of silently keeping the stale catalog (#5579, PR #5660). Trust is
+  unchanged;
   this does not auto-reload.
 - Context-pressure warnings and critical alerts now remain visible in sticky UI
   status until compaction or explicit dismissal, instead of disappearing into
-  scrolling turn metadata (#5620).
+  scrolling turn metadata (#5620, PR #5629).
 - The Runtime thread store defaults to a per-session root
   (`$CODEWHALE_HOME/sessions/<id>/runtime`) so multiple Codewhale processes on
-  one machine no longer share one owner lock (#5630). The exclusive lock is
+  one machine no longer share one owner lock (#5630, PR #5638). The exclusive lock is
   unchanged; `CODEWHALE_RUNTIME_DIR` still selects a shared root when that is
   intended.
 - Session token totals now include display-only per-model-call deltas while a
   turn is running, including input/output and cache-class counters; the
-  authoritative `TurnComplete` totals still reconcile exactly once (#5581).
+  authoritative `TurnComplete` totals still reconcile exactly once (#5581,
+  PR #5624).
 - Transcript focus now exposes per-block actions: `y` copies content, `Y`
   copies the rendered metadata view, Enter opens a fullscreen block pager, and
   `r` opens raw detail; the existing Tasks rail shortcuts remain unchanged
-  (#5551).
-- Provider neutrality (#5588): model resolution of omitted/aliased models is
+  (#5551, PR #5652).
+- Provider neutrality (#5588, PR #5654): model resolution of omitted/aliased models is
   now provider-relative, OpenAI-native defaults no longer route through
   another provider's table, CLI credentials stay provider-scoped, and NVIDIA
   credentials no longer leak into the DeepSeek keychain. Neutrality test
@@ -192,6 +261,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contributor credit: recognized agent contributors (e.g. `Codewhale Agent`)
   may now carry `Co-authored-by` trailers; unknown bot/tool trailers are
   still rejected by the credit gate.
+- Turn budgets are finite by default (R1, #5566): `max_model_steps` defaults
+  to 200, the per-turn wall clock to 3600 s, and `codewhale exec --max-turns`
+  to a finite value, with no `0`-means-unlimited sentinel; per-step stream
+  caps are configurable and human-approval waits are excluded from the wall
+  clock. Raise the caps in `[tui]` or via `CODEWHALE_*` env when a task needs
+  more.
+- Command shapes: the TUI utility group (`/attach`, `/automation`, `/jobs`,
+  `/mcp`, `/network`, `/task`, `/update`; FEAT-018, PR #5525) and the project
+  group (`/init`, `/lsp`, `/share`, `/goal`; FEAT-021, PR #5717) now execute
+  through the contract-backed dispatch path with exact-minimum external
+  facets (@aboimpinto).
+- Startup and token-accounting hot paths were folded in from #5664 / #5665
+  (@AdityaVG13) as part of the 0.9.12 consolidation (PR #5667).
+- Notifications are background-only by default; the startup fluke glyph is
+  realigned to the brand master-path pipeline (one-cell row-6 correction,
+  four startup goldens re-blessed).
+- Release tooling: `check-versions.sh` now fails when the release-note
+  receipt and contributor-credit checks cannot run instead of silently
+  passing (PR #5614); `web/scripts/sync-latest-release.mjs` keeps the
+  published-release fact current and `web.yml` gates on it (PR #5612); the
+  runbook documents unpublished-tag re-cut recovery and external publish
+  gates (PR #5565); harvested-credit checks are scoped to the exact PR range
+  (PR #5598).
+- CI: an optional self-hosted macOS runner takes the macOS test leg only for
+  trusted (non-fork) heavy events behind the `CW_SELF_HOSTED_MAC` kill
+  switch; the review workflow installs `libdbus-1-dev` before building the
+  reviewer (PR #5710); the read-guard symlink tests are whole-function
+  `#[cfg(unix)]` so hosted Windows CI compiles again.
+- Tests: the long-stream timeline bound no longer depends on durable status
+  fsync latency (PR #5640), and the stale published-fingerprint release-note
+  gate is retired (PR #5680).
+- Dependencies: tower-http 0.7.0 (#5387), similar 3.2.0 (#5540), rio-vt
+  0.5.25 (#5539), async-trait 0.1.92 (#5672), uuid 1.25.0 (#5675),
+  futures-util 0.3.34 (#5676), docker/setup-buildx-action 4.3.0 (#5537);
+  nixpkgs updated so `nix run github:hmbown/codewhale#codewhale` builds
+  again, with a monthly dependabot entry and `stdenv.hostPlatform`
+  (PR #5669, @serephus).
+- Repository: agent merge, contributor, and verification discipline is
+  recorded in `AGENTS.md`; `docs/CONTRIBUTORS.md` gains the v0.9.12 band and
+  `.github/AUTHOR_MAP` maps three more identities; @wuisabel-gif holds
+  recurring PR access (#5619).
 
 ### Fixed
 
@@ -199,25 +309,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   literal spelling. On macOS `/etc` and `/var` are symlinks into `/private`,
   so a read of `/private/etc/sudoers` walked around the `/etc/sudoers` rule,
   and a rule written against a symlinked directory never fired for the real
-  path that `canonicalize` and the process cwd hand back.
+  path that `canonicalize` and the process cwd hand back (PR #5724).
 - Background shells are first-class work-strip rows (`▾ Shells N`) you can
   open, watch, and cancel by the `shell_*` id on the row. `/jobs cancel all`
   cancels running shells; it no longer looks up a task named `all`. The
-  composer hourglass crumb no longer stands in for a shell surface.
+  composer hourglass crumb no longer stands in for a shell surface (PR #5699).
 - `codewhale logout` and `/logout` now clear the Codewhale account session
   and the Daytona secret slot, not only provider API keys. The TUI crate's
-  leftover `login --api-key` path no longer claims to save a key.
+  leftover `login --api-key` path no longer claims to save a key (PR #5704).
 - Account sessions no longer read the macOS Keychain. Unsigned or rebuilt
   `codewhale` binaries were a new Keychain ACL principal every time, so
   `codewhale web` and the TUI popped a password dialog on start. Sessions
   now use `~/.codewhale/secrets/secrets.json` (mode 0600), the same store
-  as provider keys. Extracted from the Keychain-retirement half of #5632.
+  as provider keys. Extracted from the Keychain-retirement half of #5632
+  (PR #5662).
 - Hardened the dispatcher-side config parse the same way: `ConfigStore`
   loads and project-config parsing now deserialize `ConfigToml` on a
   dedicated 16 MiB-stack thread (the guided-setup save path could overflow
   a 2 MiB worker stack the same way the TUI's `ConfigFile` parse did), and
   the #5585 setup-confirm toast test runs its runtime on an equally sized
-  thread instead of overflowing the default libtest stack.
+  thread instead of overflowing the default libtest stack (PR #5644).
 - Fixed detached interactive agents reporting worker usage after the parent
   turn ends with the usage missing from the session/live `/cost` total
   (#5597): interactive turns acquire an owner-scoped runtime usage lease,
@@ -262,16 +373,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed docs/public-surface drift: REBRAND.md no longer presents
   `api.deepseeki.com` as a China fallback (#5564), and the web facts/tool
   counts match the repository.
-
 - Heavy pull requests now run the real Linux workspace nextest, doctest, and
   lockfile lanes directly on GitHub Actions instead of reporting a green
-  placeholder while waiting for a branch-specific CNB mirror (#5547).
+  placeholder while waiting for a branch-specific CNB mirror (#5547, PR #5590).
 - Fleet roster members in a selected Fleet now expose a visible edit affordance
   and a direct `m` model-picker shortcut, while the coordinator row remains
   read-only (#5604, covers #5589).
 - The context inspector now attributes bounded tool-schema cost to the built-in
   catalog and each discovered MCP server without changing prompt assembly or
-  cache behavior (#5553).
+  cache behavior (#5553, PR #5653).
 - The goal-continuation quiet period (`[goal] continuation_delay_seconds`,
   added in #5508) now applies on every dispatch path. Previously the
   within-turn dispatch hook fired the next continuation prompt immediately
@@ -280,7 +390,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   end-to-start gaps of ~9 s with a 300 s delay configured). The wait now
   runs unconditionally inside `goal_continuation_message_if_needed`,
   remains cancellable, and pause/clear/terminal `update_goal` calls still
-  cancel a pending pass (#5534).
+  cancel a pending pass (#5534, PR #5591).
 - Two unit tests no longer depend on process-global environment state that
   sibling tests mutate concurrently.
   `route_budget::tests::v4_trigger_uses_window_percent_when_it_fits_spendable_input`
@@ -295,10 +405,116 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guard happened to be live. Both tests now hold the env barrier and pin the
   variables (the route-budget test removes the overrides; the prompts test
   points `HOME`/`USERPROFILE` at a scratch dir). Assertions unchanged.
-
 - TUI sessions now apply a subtle OSC 12 cursor accent only on explicitly
   supported terminals and restore the terminal default through normal, panic,
-  and signal cleanup paths (#5554).
+  and signal cleanup paths (#5554, PR #5599).
+- Windows verbatim device paths (`\\?\C:\...`) survive the POSIX word split
+  used by the read-only operand guard, so `cat <path>` and
+  `git -C <path> log` no longer lose their separators (PR #5610,
+  @aboimpinto).
+- Edit-last-turn locates the latest genuine user-authored prompt instead of
+  any persisted `role = "user"` message, treats unsupported user content as an
+  authoritative boundary, and emits a failed terminal outcome when an edit
+  cannot start (PR #5621, @h3c-hexin).
+- Read-only git probes stay off the user's index lock (PR #5642).
+- Route-specific tool projection keeps compatible tools on the wire, degrades
+  only route-incompatible tools, rejects a named `tool_choice` targeting an
+  omitted tool before transport, and emits one typed warning per affected
+  request (#5636 via PR #5651, patch by Lfanxing with @h3c-hexin).
+- Chat Completions replay keeps every assistant tool-call batch followed by
+  one contiguous, complete tool-result run, defers tool-result images until
+  the batch is valid, and strips incomplete or orphaned batches (PR #5679).
+- The DeepSeek model picker's default `configured` view shows a stable
+  `DeepSeek` heading and keeps every official catalog model for the active
+  provider visible (PR #5689, @musichen).
+- Durable completion commit: turn completion writes the completed snapshot
+  and clears only that session's checkpoint after the write succeeds, so a
+  failed save or mid-turn exit can no longer erase the only recovery record
+  (PR #5697).
+- Self-update aborts before any destructive rename when staged permissions
+  cannot be applied or the staged binary lacks an executable bit (#5727,
+  PR #5728).
+- The subagent contention gate no longer refuses proven read-only child shell
+  runs, a panicked child commits a crash terminal result instead of gating
+  peers forever, and headless `WaitingForUser` worker records are reconciled
+  (PR #5732).
+- Runtime Chat owner-lock acquisition reports the real IO fault; only
+  `WouldBlock` is reported as contention (#5735 partial, PR #5736).
+- A chunk-level provider error frame mid-stream now stops the stream,
+  surfaces a classified error, and fences trailing deltas; terminal provider
+  rejections render as errors, not dismissable warnings.
+- An oversized paste submits as a visible attachment card (size header,
+  `@`-mention, bounded preview) instead of a bare artifact path.
+- Settings show the live route identity (provider, model, endpoint) instead
+  of the stale saved config; the theme picker no longer discards a non-Whale
+  Deepsea pair on Enter; the launch composer applies completion menus on
+  Enter and paints the popup; the caret window budgets by display width so
+  CJK/emoji drafts keep the caret visible; sign-in hints name
+  `codewhale login`.
+
+### Security
+
+- Full access means it: a startup resolved to `danger-full-access` skips
+  `PR_SET_NO_NEW_PRIVS` on Linux so `sudo`/`su` work from the agent shell
+  exactly as advertised, every narrower posture keeps the #5413 default, the
+  decision fails closed on an unknown mode, and `CODEWHALE_NO_NEW_PRIVS=1`
+  forces the flag on even under full access (#5723, PR #5733).
+- The sandbox read deny-list (S1, #5568) ships a default credential-store
+  deny-list enforced in-process across `read`, `read_file`, `read_media`,
+  `list_dir`, and `file_search`, with raw-path-first guard ordering, fixed
+  `..`-through-symlink resolution, and a fail-closed `EngineConfig` default;
+  it now also matches a rule's resolved path (PR #5724). It remains
+  defense-in-depth: hard links and unwrapped child processes are documented
+  limits.
+- Review suggestion fences from model text cannot be smuggled through issue
+  titles or descriptions; replacements degrade to plain blocks when posted
+  and receipts record only counts and anchor spans.
+
+### Removed
+
+- The hand-drawn whale art portraits, idle-whale rows, fleet-roster portrait
+  block, and the `▚△▞` crown are gone; the startup hero keeps the generated
+  fluke block from the brand master path (net −764 lines).
+- Nine verified-dead functions and two unused dependencies were removed after
+  a whole-workspace `--force-warn dead_code` pass and cross-tooling reference
+  search (PR #5705).
+
+### Contributors
+
+- **hexin ([@h3c-hexin](https://github.com/h3c-hexin))** — provider-native
+  web search across DeepSeek (#5683), Z.AI/BigModel (#5685 via #5691), Xiaomi
+  MiMo (#5687 via #5693), and Moonshot/Kimi (#5686 via #5720) with constraint
+  enforcement before fallback (#5682); authoritative edit-last-turn
+  boundaries (#5621), Kimi Code k3-256k (#5622), post-compaction input tokens
+  (#5623), automation model selection (#5650), and the Moonshot tool
+  projection stopgap (#5636 via #5651).
+- **Isabel Wu ([@wuisabel-gif](https://github.com/wuisabel-gif))** —
+  multi-file `read_lints` (#5524), Linux workspace tests on pull requests
+  (#5590), the capability-gated cursor accent (#5599), discoverable Fleet
+  roster editing (#5604), live session token totals (#5624), persisted
+  context-pressure warnings (#5629), `/copy` (#5692 via #5696), and the
+  `#[cfg(test)]` slice of #5587 (#5666 via #5667).
+- **Paulo Aboim Pinto ([@aboimpinto](https://github.com/aboimpinto))** —
+  command shapes for the utility (#5525) and project (#5717) groups and the
+  Windows verbatim-path operand fix (#5610).
+- **M-Maciej ([@M-Maciej](https://github.com/M-Maciej))** — the goal
+  continuation cadence fix (#5591) and the lifecycle outbox (#5592 via
+  #5645).
+- **Ben Gao ([@gaord](https://github.com/gaord))** — per-thread usage with
+  CNY coverage (#5626 via #5641) and the `GET /v1/fleet/profiles` endpoint
+  (#5688).
+- **Lstarsky0 ([@Lstarsky0](https://github.com/Lstarsky0))** — `docs/subagents`
+  and `docs/mcp` on the dictionary spine (#5544).
+- **Sh1Zuku ([@SparkofSpike](https://github.com/SparkofSpike))** — English
+  doc corrections and the first Tier-2 `zh_hans` translations (#5613).
+- **Alex Musichen ([@musichen](https://github.com/musichen))** — the DeepSeek
+  configured-picker fix (#5689).
+- **AdityaVG13 ([@AdityaVG13](https://github.com/AdityaVG13))** — startup and
+  token-accounting perf (#5664, #5665 via #5667).
+- **Serephus ([@serephus](https://github.com/serephus))** — the nixpkgs
+  update and monthly dependabot entry (#5669).
+- **Lfanxing** — the original route-projection patch carried by #5651.
+- **dependabot[bot]** — #5387, #5537, #5539, #5540, #5672, #5675, #5676.
 
 ## [0.9.11] - 2026-08-22
 
@@ -5015,130 +5231,6 @@ reproductions shaped v0.9.0:
   mock LLM placeholders (#3841), dead model-catalog helpers (#3842), the
   unused execpolicy amend module, and dead MCP/client retry helpers.
 - Retired the deprecated `WHALE.md` context fallback (#3798).
-
-## [0.8.66] - 2026-06-29
-
-### Added
-
-- Added `codewhale doctor` / `codewhale doctor --json` legacy-state
-  diagnostics that compare known `~/.deepseek` state paths with their
-  `~/.codewhale` counterparts and flag unmigrated or dual-root data (#3727).
-- Added Sakana AI Fugu as a first-class OpenAI-compatible provider with
-  `sakana`/`fugu` aliases, `FUGU_API_KEY` / `SAKANA_API_KEY` discovery,
-  provider-picker wiring, model completions, and provider docs. Harvested from
-  #3748 by @lerugray.
-- Added WhaleFlow-to-Fleet launch-shape validation: the default Fleet workflow
-  contract allows up to 100 total agents and 5 recursive rings, requires
-  bounded loops/expands before launch, and preserves per-slot model selection.
-- Added a read-only `/config ask-rules` view for the resolved
-  `permissions.toml` path, file status, rule count, and configured
-  tool/command/path ask rules. Merged from #3569 by @greyfreedom.
-- Added provider-level `context_window` overrides so OpenAI-compatible
-  gateways and self-hosted providers can budget against their real model
-  context window (#3545).
-- Added the native `codew` shim to release archives, Windows installer inputs,
-  local release-asset preparation, and checksum verification so manual installs
-  receive the same short command that Cargo installs build.
-- Added OpenModel as a first-class Anthropic Messages provider, with config,
-  CLI, provider picker, docs, and registry coverage. Harvested from #3585 by
-  @noaft.
-- Added WeCom Bridge deployment and security documentation, with shipped
-  runtime/bridge commands and approval-timeout environment guidance. Harvested
-  from #3640 by @pkeging.
-- Added a token/cache/cost `scorecard` command for offline release gating,
-  baseline regression checks, and per-turn cost visibility (#3388). Stream-JSON
-  exec metadata now also reports conservative `input_analysis` and
-  `visible_final_answer_chars`, so benchmark harnesses can measure transcript
-  growth and final-answer bloat without guessing (#2956, #2957).
-- Added a release evidence ledger for v0.8.66 and opened the external ACP
-  registry submission for CodeWhale after validating the published
-  `codewhale@0.8.65` ACP auth handshake against the upstream registry checker
-  (#3192).
-- Added a typed `[verifier]` config table for the verifier-preview lane, with
-  `enabled` and the shipped `verdict_policy = "hunt"` mapping documented and
-  validated (#2093).
-- Added Hotbar `Alt+1`–`Alt+8` quick-slot switching with decision-card key
-  disambiguation, plus an introductory card that explains and can dismiss the
-  Hotbar (#3796, #3788).
-- Release/docs hygiene: guarded public install/version snippets and the npm
-  `codewhaleBinaryVersion` pointer against drift, made `check-docs`/`check-facts`
-  fail on stale snippets or unmapped providers, and stopped `sync-changelog`
-  from dropping a release when only `[Unreleased]` exists (#3767, #3768, #3769,
-  #3770, #3771, #3772).
-
-### Changed
-
-- Deferred Auto mode from the user-facing mode picker, cycle, hotbar, `/mode`
-  command, and runtime-thread mode overrides until it has a distinct prompt and
-  auto-review behavior; existing `auto` mode text now folds back to Agent
-  instead of selecting a hollow mode, and approval modal copy no longer implies
-  the current mode is YOLO (#3730, #3733).
-- Clarified the Fleet setup surface and docs so Fleet is treated as the durable
-  sub-agent configuration layer while WhaleFlow is the agent-authored
-  orchestration plan that selects and monitors Fleet slots.
-- Slimmed the default Constitution prompt while keeping its required structural
-  anchors under regression coverage, reducing the static prompt footprint for
-  cache-sensitive turns (#2953).
-- Made the approval prompt inline and bottom-anchored instead of a full-screen
-  takeover, so context and controls stay visible while a tool awaits a decision
-  (#3799).
-- The Hotbar is now hidden by default until explicit setup opt-in (#3807); the
-  interactive Agent shell also defaults to approval-gated on with a shared
-  baseline (#3756).
-- Mode authority now resolves approval prompts through a single authority
-  source instead of per-surface checks (#3795).
-
-### Fixed
-
-- Surfaced legacy state relocation with a user-visible migration notice whenever
-  `~/.deepseek/<state>` is moved or copied into `~/.codewhale/<state>`, so
-  upgraded users know their data was preserved and where the canonical state
-  now lives (#3726).
-- Restored legacy `.deepseek/sessions` visibility for upgraded installs where
-  an empty `~/.codewhale/sessions` directory already existed, by copying
-  missing legacy session entries into the primary CodeWhale session store
-  without overwriting newer data (#3724).
-- Calmed approval risk classification for read-only shell commands such as
-  `codewhale --version`, `codewhale --help`, and `git status --porcelain` so
-  the modal no longer labels proven read-only shell as destructive (#3730).
-- Added provider/model route columns to `/cache` turn telemetry so DeepSeek
-  cache-hit regressions can be correlated with Auto route changes (#3738).
-- Fixed runtime API approval handling so workspace trust no longer auto-resolves
-  ordinary tool approvals; trust now only participates in full-access retry
-  decisions while YOLO/auto-approve remains the approval bypass (#3736).
-- Fixed modal surfaces so the shared view stack paints an opaque backdrop before
-  any overlay, while Plan/request-input popup interiors stay opaque and the Plan
-  confirmation footer keeps action choices visible on narrow terminals (#3732).
-- Added a turn-loop Plan-mode guard for file-writing tools and write-capable MCP
-  tools so Plan's "no writes" promise is enforced before approval or execution,
-  not only by the sandbox/catalog layer (#3734).
-- Preserved the durable review safety floor for publish-like shell actions in
-  YOLO mode, so `cargo publish`, `npm publish`, and tag/release pushes force
-  approval instead of silently auto-approving (#3735).
-- Fixed Ctrl+O external-editor freezes where CodeWhale's terminal input pump
-  could keep reading keys while Vim/editor owned the terminal, especially in
-  Windows mintty/cygwin shells. Thanks @buko for the precise repro (#3657).
-- Hardened the OHOS dependency drift check against transient Cargo registry EOFs
-  by retrying the dependency graph probe before failing CI.
-- Updated the `/links` provider fallback to the current CodeWhale docs URL and
-  added a Baidu Qianfan docs link. Harvested from #3621 by @noaft.
-- Hardened `CODEWHALE_TOOL_SURFACE=shell-only` for benchmark/exec runs: the
-  shell-only surface hides native tools from the model-visible catalog, and
-  unknown `CODEWHALE_TOOL_SURFACE` values now warn instead of silently falling
-  back to the full tool surface (#2954).
-- Sub-agent fanout and lock hot paths: preserved event-channel headroom for
-  progress events (#3783, thanks @cyq1017), let independent sub-agent starts
-  join a single parallel dispatch batch instead of serializing (#3801), rendered
-  the sub-agent sidebar/ListSubAgents from a read-only snapshot with bounded
-  cleanup (#3803), used nonblocking best-effort sends for ListSubAgents refresh
-  while still awaiting critical events (#3802), moved sub-agent state
-  persistence disk I/O off the manager write lock (#3805), and used `try_lock`
-  for shell-manager refresh in async UI paths (#3804).
-- Provenance: runtime continuations and `SubAgentHandoff` now inherit standing
-  YOLO authority, while `MemoryRecall`, `ImportedTranscript`, and
-  `AssistantGenerated` inputs remain guarded (#3817).
-- Approval honesty: labeled session-scoped approvals accurately instead of
-  "always", and surfaced approval decisions in tool results (#3766).
 
 ---
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.12] - Unreleased candidate
 
+This is the Codewhale v0.9.12 source candidate. It is not a published release
+until the matching tag, packages, checksums, and release assets exist.
+
 Codewhale v0.9.12 makes the agent loop finite by default, lands the Tideline
 visual redesign across the TUI and the website, unifies managed Chat with
 native runtime threads, adds provider-native web search across DeepSeek,

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -30,20 +30,20 @@ path = "src/main.rs"
 [dependencies]
 ahash = "0.8"
 anyhow.workspace = true
-codewhale-config = { path = "../config", version = "0.9.11" }
-codewhale-command-contract = { path = "../command-contract", version = "0.9.11" }
-codewhale-core = { path = "../core", version = "0.9.11" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.9.11" }
-codewhale-hooks = { path = "../hooks", version = "0.9.11" }
-codewhale-lane = { path = "../lane", version = "0.9.11" }
-codewhale-paths = { path = "../paths", version = "0.9.11" }
-codewhale-protocol = { path = "../protocol", version = "0.9.11" }
-codewhale-release = { path = "../release", version = "0.9.11" }
-codewhale-secrets = { path = "../secrets", version = "0.9.11" }
-codewhale-telemetry = { path = "../telemetry", version = "0.9.11" }
-codewhale-tools = { path = "../tools", version = "0.9.11" }
-codewhale-workflow = { path = "../workflow", version = "0.9.11" }
-codewhale-workflow-js = { path = "../workflow-js", version = "0.9.11" }
+codewhale-config = { path = "../config", version = "0.9.12" }
+codewhale-command-contract = { path = "../command-contract", version = "0.9.12" }
+codewhale-core = { path = "../core", version = "0.9.12" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.9.12" }
+codewhale-hooks = { path = "../hooks", version = "0.9.12" }
+codewhale-lane = { path = "../lane", version = "0.9.12" }
+codewhale-paths = { path = "../paths", version = "0.9.12" }
+codewhale-protocol = { path = "../protocol", version = "0.9.12" }
+codewhale-release = { path = "../release", version = "0.9.12" }
+codewhale-secrets = { path = "../secrets", version = "0.9.12" }
+codewhale-telemetry = { path = "../telemetry", version = "0.9.12" }
+codewhale-tools = { path = "../tools", version = "0.9.12" }
+codewhale-workflow = { path = "../workflow", version = "0.9.12" }
+codewhale-workflow-js = { path = "../workflow-js", version = "0.9.12" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait.workspace = true
@@ -110,7 +110,7 @@ shell-words = "1.1.1"
 mimalloc.workspace = true
 
 [build-dependencies]
-codewhale-build-support = { path = "../build-support", version = "0.9.11" }
+codewhale-build-support = { path = "../build-support", version = "0.9.12" }
 
 [dev-dependencies]
 cucumber = "0.23.0"

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -57,6 +57,10 @@ notes, and relevant issue/PR comments.
   translations for the Tier-2 docs (#5613)
 - **[M-Maciej](https://github.com/M-Maciej)** — goal continuation cadence fix
   (#5591)
+- **[AdityaVG13](https://github.com/AdityaVG13)** — startup and token-accounting
+  performance work consolidated in #5667 from #5664 and #5665
+- **[Lstarsky0](https://github.com/Lstarsky0)** — moved `docs/subagents` and
+  `docs/mcp` onto the shared dictionary spine (#5544)
 - **[Serephus / serephus](https://github.com/serephus)** — nixpkgs update
   (#5669)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,7 +10,7 @@ If you just want the short version, see the
 [main README](../README.md#install) or
 [简体中文 README](../README.zh-CN.md#安装).
 
-This branch describes the **v0.9.11 source candidate**. Install commands that use
+This branch describes the **v0.9.12 source candidate**. Install commands that use
 `latest` resolve to the latest published package or GitHub Release, which may
 trail the source candidate. A candidate is not a published install until the
 matching package, tag, checksums, and release assets exist.
@@ -30,7 +30,7 @@ verifies them against `codewhale-artifacts-sha256.txt`, installs to
 ## 1. Supported platforms
 
 Published Codewhale releases ship matched `codewhale` and `codew` prebuilt binaries for their supported platform/architecture
-combinations. The table below is the intended v0.9.11 candidate matrix;
+combinations. The table below is the intended v0.9.12 candidate matrix;
 Android/Termux is preview pending real-device QA. Linux ARM64 is available from
 v0.8.8 onward. Linux RISC-V prebuilts are temporarily paused because the locked
 `rquickjs-sys` dependency does not ship `riscv64gc-unknown-linux-gnu` bindings.
@@ -54,7 +54,7 @@ v0.8.8 onward. Linux RISC-V prebuilts are temporarily paused because the locked
   [Build from source](#7-build-from-source) below.
 ³ RISC-V source builds currently need upstream `rquickjs-sys` RISC-V bindings or
   a bindgen-enabled dependency build.
-⁴ The v0.9.11 source-candidate npm wrapper recognizes Android arm64 and resolves
+⁴ The v0.9.12 source-candidate npm wrapper recognizes Android arm64 and resolves
   the matching `codewhale` and `codew` Android assets. npm
   installation works only for a package version whose GitHub Release publishes
   those matching assets. The Android/Termux path remains preview-only until the
@@ -66,7 +66,7 @@ Linux `codewhale-linux-arm64` archive in Termux; use the Termux-specific
 Android archive when a release or release candidate publishes one, or build
 from source inside Termux.
 
-The Linux **x64 and arm64** v0.9.11 candidate assets are **static musl builds**.
+The Linux **x64 and arm64** v0.9.12 candidate assets are **static musl builds**.
 The x64 release path has used musl since v0.8.65; v0.9.6 extends the same build
 and static-launch check to arm64. These binaries have no glibc dependency and
 run on their matching architecture across Ubuntu, Debian, RHEL/CentOS, and
@@ -84,7 +84,7 @@ version `GLIBC_2.39' not found
 ```
 
 The npm wrapper, `codewhale update`, and the Unix archive installer retain their
-GNU-binary preflight for older releases. The v0.9.11 arm64 candidate instead uses
+GNU-binary preflight for older releases. The v0.9.12 arm64 candidate instead uses
 `aarch64-unknown-linux-musl`, so it has no `GLIBC_*` floor. If you are installing
 an earlier release on an older arm64 distribution, use:
 

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -46,6 +46,36 @@ Current packaging note:
   - leave `codewhaleBinaryVersion` pinned to the previously released Rust binaries
   - rerun `npm pack` smoke checks before `npm publish`
 
+### Release candidates
+
+`X.Y.Z-rc.N` (tag `vX.Y.Z-rc.N`, `N >= 1`) is the only accepted prerelease
+shape. The grammar lives in `scripts/release/release-version.sh` and is
+pinned by `scripts/release/release-version.test.sh`; every gate on the
+publish path (`prepare-release.sh`, `check-versions.sh`,
+`verify-remote-tag.sh`, `require-release-tag-checkout.sh`,
+`ensure-release-assets-absent.js`, `auto-tag.yml`, `release.yml`) sources
+or mirrors it.
+
+A candidate rides the same chain as a stable release — bump with
+`./scripts/release/prepare-release.sh X.Y.Z-rc.N`, give the CHANGELOG a dated
+`## [X.Y.Z-rc.N] - YYYY-MM-DD` section with a
+`compare/vPREV...vX.Y.Z-rc.N` link, dispatch `auto-tag.yml`, let
+`release.yml` build the same 34 assets — but never moves a stable pointer:
+
+- the GitHub Release is flagged **prerelease**, so `/releases/latest`, the
+  website's published-release fact, and the self-updater ignore it;
+- npm publishes under dist-tag **`next`** (`npm install -g codewhale@next`);
+  `latest` is untouched;
+- GHCR receives the version and tag images without **`latest`**;
+- the Homebrew tap job is skipped, `packaging/aur/render.sh` renders nothing
+  (AUR `pkgver` cannot carry a hyphen), winget is stable-only, and
+  `release-republish.yml` refuses candidates;
+- crates.io receives ordinary prerelease versions that `cargo install` only
+  selects with an explicit `--version`.
+
+The stable `X.Y.Z` that follows is a separate bump commit and tag from the
+frozen `main`; never re-tag the candidate SHA.
+
 ## Release Source Timing
 
 Freeze the source before creating a public `vX.Y.Z` tag. The version bump is

--- a/docs/public-surface-facts.json
+++ b/docs/public-surface-facts.json
@@ -20,7 +20,7 @@
     ]
   },
   "sourceCandidate": {
-    "version": "0.9.11",
+    "version": "0.9.12",
     "providerCount": 45,
     "toolCount": 75,
     "sandboxBackends": [

--- a/docs/public-surface-facts.json
+++ b/docs/public-surface-facts.json
@@ -221,10 +221,16 @@
       "web/lib/release-credits.ts"
     ],
     "requiredCandidateCredits": [
-      "@bistack",
-      "@aboimpinto",
+      "@h3c-hexin",
       "@wuisabel-gif",
-      "@RepentStar"
+      "@aboimpinto",
+      "@M-Maciej",
+      "@gaord",
+      "@Lstarsky0",
+      "@SparkofSpike",
+      "@musichen",
+      "@AdityaVG13",
+      "@serephus"
     ]
   },
   "screenshot": {

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codewhale-vscode",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codewhale-vscode",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.19.27",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "codewhale-vscode",
   "displayName": "CodeWhale",
   "description": "Official CodeWhale VS Code integration scaffold for local runtime attach and terminal launch.",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "publisher": "codewhale",
   "license": "MIT",
   "repository": {

--- a/npm/codewhale/package.json
+++ b/npm/codewhale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codewhale",
-  "version": "0.9.11",
-  "codewhaleBinaryVersion": "0.9.11",
+  "version": "0.9.12",
+  "codewhaleBinaryVersion": "0.9.12",
   "description": "Terminal coding agent for supported hosted and local models. One runtime on your machine. Rust, MIT.",
   "author": "Hmbown",
   "license": "MIT",

--- a/npm/runtime-sdk/package.json
+++ b/npm/runtime-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codewhale/runtime-sdk",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Typed JavaScript helpers for Codewhale Runtime API Fleet endpoints.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,7 +1559,7 @@
       }
     },
     "npm/codewhale": {
-      "version": "0.9.11",
+      "version": "0.9.12",
       "funding": [
         {
           "type": "github",
@@ -1600,7 +1600,7 @@
     },
     "npm/runtime-sdk": {
       "name": "@codewhale/runtime-sdk",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/packaging/aur/render.sh
+++ b/packaging/aur/render.sh
@@ -37,9 +37,17 @@ workspace_version="$(
     | head -n 1 \
     | sed -E 's/^version = "([^"]+)".*/\1/'
 )"
-if [[ ! "${workspace_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "workspace version must be X.Y.Z, got: ${workspace_version:-<missing>}" >&2
+# shellcheck source=scripts/release/release-version.sh
+source "${repo_root}/scripts/release/release-version.sh"
+if ! release_version_is_valid "${workspace_version}"; then
+  echo "workspace version must be X.Y.Z or X.Y.Z-rc.N, got: ${workspace_version:-<missing>}" >&2
   exit 1
+fi
+if release_version_is_prerelease "${workspace_version}"; then
+  # AUR pkgver cannot carry a hyphen and the package tracks stable
+  # releases only, so a release candidate renders nothing on purpose.
+  echo "AUR is a stable-only channel; skipping PKGBUILD render for release candidate ${workspace_version}."
+  exit 0
 fi
 if [[ ! "${pkgrel}" =~ ^[1-9][0-9]*(\.[1-9][0-9]*)?$ ]]; then
   echo "PKGREL must be a positive integer or positive x.y value, got: ${pkgrel}" >&2

--- a/scripts/release/check-versions.sh
+++ b/scripts/release/check-versions.sh
@@ -38,6 +38,8 @@ if [[ "$#" -ne 0 ]]; then
 fi
 
 cd "$(dirname "$0")/../.."
+# shellcheck source=scripts/release/release-version.sh
+source ./scripts/release/release-version.sh
 
 fail=0
 
@@ -168,7 +170,7 @@ if [[ -z "${compare_line}" ]]; then
   echo "::error::CHANGELOG.md must include a compare link for ${workspace_version}." >&2
   fail=1
 elif [[ "${require_dated_release}" == "1" ]] &&
-  ! grep -qE "^\\[${workspace_version}\\]: https://github.com/Hmbown/CodeWhale/compare/v[0-9]+\\.[0-9]+\\.[0-9]+\\.\\.\\.v${workspace_version}$" <<<"${compare_line}"; then
+  ! grep -qE "^\\[${workspace_version}\\]: https://github.com/Hmbown/CodeWhale/compare/v${RELEASE_VERSION_GREP}\\.\\.\\.v${workspace_version}$" <<<"${compare_line}"; then
   echo "::error::Publication requires the ${workspace_version} compare link to end at v${workspace_version}." >&2
   fail=1
 fi
@@ -191,7 +193,7 @@ ${unreleased_section}"
 # surface.
 previous_tag=""
 current_tag="v${workspace_version}"
-if [[ "${compare_line}" =~ compare/(v[0-9]+\.[0-9]+\.[0-9]+)\.\.\.${current_tag} ]]; then
+if [[ "${compare_line}" =~ compare/(v${RELEASE_VERSION_GREP})\.\.\.${current_tag} ]]; then
   previous_tag="${BASH_REMATCH[1]}"
 fi
 if [[ -n "${previous_tag}" ]]; then
@@ -247,10 +249,10 @@ fi
 if [[ ! -f web/lib/facts.generated.ts ]]; then
   node web/scripts/derive-facts.mjs
 fi
-facts_version="$(grep -oE '"version": "[0-9]+\.[0-9]+\.[0-9]+"' web/lib/facts.generated.ts | head -n1 | sed -E 's/.*"([0-9.]+)".*/\1/')"
+facts_version="$(grep -oE "\"version\": \"${RELEASE_VERSION_GREP}\"" web/lib/facts.generated.ts | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')"
 if [[ "${facts_version}" != "${workspace_version}" ]]; then
   node web/scripts/derive-facts.mjs
-  facts_version="$(grep -oE '"version": "[0-9]+\.[0-9]+\.[0-9]+"' web/lib/facts.generated.ts | head -n1 | sed -E 's/.*"([0-9.]+)".*/\1/')"
+  facts_version="$(grep -oE "\"version\": \"${RELEASE_VERSION_GREP}\"" web/lib/facts.generated.ts | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')"
   if [[ "${facts_version}" != "${workspace_version}" ]]; then
     echo "::error::web/lib/facts.generated.ts version (${facts_version}) does not match workspace (${workspace_version}). Run: node web/scripts/derive-facts.mjs" >&2
     fail=1
@@ -284,13 +286,13 @@ for doc in README.md README.zh-CN.md README.ja-JP.md README.vi.md README.ko-KR.m
 done
 
 # The publish pointer can wrap onto the next line; also scan the line after the lead-in.
-wrapper_pointer_version="$(grep -A1 -E -- "wrapper is published at" docs/INSTALL.md | grep -oE -- "v[0-9]+\.[0-9]+\.[0-9]+" | head -n1 || true)"
+wrapper_pointer_version="$(grep -A1 -E -- "wrapper is published at" docs/INSTALL.md | grep -oE -- "v${RELEASE_VERSION_GREP}" | head -n1 || true)"
 if [[ -n "${wrapper_pointer_version}" && "${wrapper_pointer_version}" != "v${workspace_version}" ]]; then
   echo "::error::docs/INSTALL.md npm-wrapper publish pointer is ${wrapper_pointer_version}, want v${workspace_version}." >&2
   fail=1
 fi
 
-remote_smoke_tag="$(grep -oE 'RELEASE_TAG:-v[0-9]+\.[0-9]+\.[0-9]+' scripts/remote-smoke/setup-vm.sh | head -n1 | sed 's/.*:-//' || true)"
+remote_smoke_tag="$(grep -oE "RELEASE_TAG:-v${RELEASE_VERSION_GREP}" scripts/remote-smoke/setup-vm.sh | head -n1 | sed 's/.*:-//' || true)"
 if [[ "${remote_smoke_tag}" != "v${workspace_version}" ]]; then
   echo "::error::scripts/remote-smoke/setup-vm.sh defaults to ${remote_smoke_tag:-<missing>}, want v${workspace_version}." >&2
   fail=1

--- a/scripts/release/ensure-release-assets-absent.js
+++ b/scripts/release/ensure-release-assets-absent.js
@@ -10,7 +10,8 @@ function validateTarget(repo, tag) {
   if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
     throw new Error(`Invalid GitHub repository: ${repo}`);
   }
-  if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) {
+  // Same grammar as scripts/release/release-version.sh: vX.Y.Z or vX.Y.Z-rc.N.
+  if (!/^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[1-9][0-9]*)?$/.test(tag)) {
     throw new Error(`Invalid release tag: ${tag}`);
   }
 }

--- a/scripts/release/ensure-release-assets-absent.test.js
+++ b/scripts/release/ensure-release-assets-absent.test.js
@@ -74,6 +74,9 @@ test("release lookup parses the exact tag endpoint and validates targets", () =>
   assert.equal(invocation[0], "/fake/gh");
   assert.deepEqual(invocation[1], ["api", "repos/Hmbown/CodeWhale/releases/tags/v0.9.1"]);
   assert.doesNotThrow(() => validateTarget("Hmbown/CodeWhale", "v0.9.1"));
+  assert.doesNotThrow(() => validateTarget("Hmbown/CodeWhale", "v0.9.12-rc.1"));
+  assert.throws(() => validateTarget("Hmbown/CodeWhale", "v0.9.12-rc.0"), /Invalid release tag/);
+  assert.throws(() => validateTarget("Hmbown/CodeWhale", "v0.9.12-beta.1"), /Invalid release tag/);
   assert.throws(() => validateTarget("bad repo", "v0.9.1"), /Invalid GitHub repository/);
   assert.throws(() => validateTarget("Hmbown/CodeWhale", "main"), /Invalid release tag/);
 });

--- a/scripts/release/prepare-release.sh
+++ b/scripts/release/prepare-release.sh
@@ -16,13 +16,16 @@
 # let check-versions.sh (run at the end here) confirm everything agrees.
 set -euo pipefail
 
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/release/release-version.sh
+source "${repo}/scripts/release/release-version.sh"
+
 new="${1:?usage: $0 <new-version>}"
-if ! [[ "${new}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "error: '${new}' is not a plain X.Y.Z version" >&2
+if ! release_version_is_valid "${new}"; then
+  echo "error: '${new}' is not a plain X.Y.Z or X.Y.Z-rc.N version" >&2
   exit 1
 fi
 
-repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${repo}"
 
 # Release preparation spans generated files and two package managers. Preserve
@@ -120,7 +123,7 @@ def bump(path, pattern, repl, minimum):
 # Validate every versioned README install tag before writing any file. A README
 # with no pinned tag is valid; if a tag exists, it must match the workspace so
 # the release helper cannot silently preserve stale public install instructions.
-release_tag_pattern = re.compile(r"--tag v([0-9]+\.[0-9]+\.[0-9]+)\b")
+release_tag_pattern = re.compile(r"--tag v([0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?)\b")
 for readme in readmes:
     versions = sorted(set(release_tag_pattern.findall(pathlib.Path(readme).read_text())))
     stale = [version for version in versions if version != old]
@@ -197,7 +200,7 @@ version_doc_files = [
 for doc in version_doc_files:
     p = pathlib.Path(doc)
     text = p.read_text()
-    versions = sorted(set(re.findall(r"codewhale --version\s+#\s*([0-9]+\.[0-9]+\.[0-9]+)\b", text)))
+    versions = sorted(set(re.findall(r"codewhale --version\s+#\s*([0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?)\b", text)))
     stale = [version for version in versions if version != old]
     if stale:
         sys.exit(
@@ -212,7 +215,7 @@ for doc in version_doc_files:
 
 install = pathlib.Path("docs/INSTALL.md")
 install_text = install.read_text()
-pointer_versions = sorted(set(re.findall(r"wrapper is published at\s+v([0-9]+\.[0-9]+\.[0-9]+)\b", install_text)))
+pointer_versions = sorted(set(re.findall(r"wrapper is published at\s+v([0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?)\b", install_text)))
 stale_pointers = [version for version in pointer_versions if version != old]
 if stale_pointers:
     sys.exit(

--- a/scripts/release/prepare-release.test.sh
+++ b/scripts/release/prepare-release.test.sh
@@ -22,6 +22,8 @@ make_fixture() {
 
   cp "${repo_root}/scripts/release/prepare-release.sh" \
     "${root}/scripts/release/prepare-release.sh"
+  cp "${repo_root}/scripts/release/release-version.sh" \
+    "${root}/scripts/release/release-version.sh"
 
   cat >"${root}/Cargo.toml" <<'EOF'
 [workspace]

--- a/scripts/release/release-version.sh
+++ b/scripts/release/release-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Shared release-version grammar for the publish chain. Source this file from
+# bash; it defines patterns and predicates and never runs anything itself.
+#
+# Accepted shapes:
+#   X.Y.Z        stable release      -> GitHub Release, npm `latest`, GHCR
+#                                       `latest`, Homebrew tap, crates.io
+#   X.Y.Z-rc.N   release candidate   -> GitHub *prerelease*, npm dist-tag
+#                (N >= 1)               `next`, GHCR without `latest`, no
+#                                       Homebrew tap update, crates.io
+#
+# A release candidate rides the same tag/asset/registry chain as a stable
+# release so the chain itself is exercised, but never moves a stable channel
+# pointer. Anything other than these two shapes is refused everywhere.
+#
+# JavaScript consumers (scripts/release/ensure-release-assets-absent.js,
+# web/scripts/check-docs.mjs) carry the same grammar inline; keep them in step
+# with RELEASE_VERSION_GREP below.
+
+# Anchored ERE forms for `[[ =~ ]]`.
+RELEASE_VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[1-9][0-9]*)?$'
+RELEASE_TAG_PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[1-9][0-9]*)?$'
+# Unanchored ERE form for `grep -oE` / `grep -E` extraction (used by sourcing
+# scripts, hence the unused-variable waiver).
+# shellcheck disable=SC2034
+RELEASE_VERSION_GREP='[0-9]+\.[0-9]+\.[0-9]+(-rc\.[1-9][0-9]*)?'
+
+# release_version_is_valid X.Y.Z[-rc.N]
+release_version_is_valid() {
+  [[ "${1:-}" =~ ${RELEASE_VERSION_PATTERN} ]]
+}
+
+# release_tag_is_valid vX.Y.Z[-rc.N]
+release_tag_is_valid() {
+  [[ "${1:-}" =~ ${RELEASE_TAG_PATTERN} ]]
+}
+
+# release_version_is_prerelease VERSION  -> 0 only for a valid X.Y.Z-rc.N
+release_version_is_prerelease() {
+  release_version_is_valid "${1:-}" && [[ "${1}" == *-rc.* ]]
+}
+
+# release_version_npm_dist_tag VERSION -> `next` for a candidate, else `latest`
+release_version_npm_dist_tag() {
+  if release_version_is_prerelease "${1:-}"; then
+    echo next
+  else
+    echo latest
+  fi
+}

--- a/scripts/release/release-version.test.sh
+++ b/scripts/release/release-version.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Contract tests for the shared release-version grammar.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/release/release-version.sh
+source "${repo_root}/scripts/release/release-version.sh"
+
+fail=0
+expect_valid() {
+  if ! release_version_is_valid "$1"; then
+    echo "expected valid version: $1" >&2
+    fail=1
+  fi
+}
+expect_invalid() {
+  if release_version_is_valid "$1"; then
+    echo "expected invalid version: $1" >&2
+    fail=1
+  fi
+}
+expect_tag_valid() {
+  if ! release_tag_is_valid "$1"; then
+    echo "expected valid tag: $1" >&2
+    fail=1
+  fi
+}
+expect_tag_invalid() {
+  if release_tag_is_valid "$1"; then
+    echo "expected invalid tag: $1" >&2
+    fail=1
+  fi
+}
+expect_prerelease() {
+  if ! release_version_is_prerelease "$1"; then
+    echo "expected prerelease: $1" >&2
+    fail=1
+  fi
+}
+expect_stable() {
+  if release_version_is_prerelease "$1"; then
+    echo "expected stable (not prerelease): $1" >&2
+    fail=1
+  fi
+}
+expect_dist_tag() {
+  local actual
+  actual="$(release_version_npm_dist_tag "$1")"
+  if [[ "${actual}" != "$2" ]]; then
+    echo "expected npm dist-tag $2 for $1, got ${actual}" >&2
+    fail=1
+  fi
+}
+
+# Stable releases.
+expect_valid 0.9.12
+expect_valid 1.0.0
+expect_valid 10.20.30
+expect_stable 0.9.12
+expect_dist_tag 0.9.12 latest
+
+# Release candidates.
+expect_valid 0.9.12-rc.1
+expect_valid 0.9.12-rc.12
+expect_prerelease 0.9.12-rc.1
+expect_dist_tag 0.9.12-rc.1 next
+
+# Refused shapes: anything that is not exactly X.Y.Z or X.Y.Z-rc.N.
+expect_invalid ""
+expect_invalid v0.9.12
+expect_invalid 0.9
+expect_invalid 0.9.12.1
+expect_invalid 0.9.12-rc
+expect_invalid 0.9.12-rc.
+expect_invalid 0.9.12-rc.0
+expect_invalid 0.9.12-rc.01
+expect_invalid 0.9.12-rc1
+expect_invalid 0.9.12-beta.1
+expect_invalid 0.9.12-alpha
+expect_invalid 0.9.12+build.5
+expect_invalid 0.9.12-rc.1+build.5
+expect_invalid ' 0.9.12'
+expect_invalid '0.9.12 '
+expect_invalid main
+expect_stable 0.9.12-beta.1   # invalid shapes are never reported as prerelease
+
+# Tags carry a mandatory leading v.
+expect_tag_valid v0.9.12
+expect_tag_valid v0.9.12-rc.3
+expect_tag_invalid 0.9.12
+expect_tag_invalid v0.9.12-rc
+expect_tag_invalid v0.9.12-rc.0
+expect_tag_invalid v0.9.12-beta.1
+expect_tag_invalid main
+
+# The grep form extracts the whole version, suffix included, and nothing more.
+# shellcheck disable=SC2016  # the literal ${RELEASE_TAG:-...} text is the fixture
+extracted="$(printf 'RELEASE_TAG="${RELEASE_TAG:-v0.9.12-rc.4}"\n' | grep -oE "v${RELEASE_VERSION_GREP}" | head -n1)"
+if [[ "${extracted}" != "v0.9.12-rc.4" ]]; then
+  echo "grep form extracted '${extracted}', want v0.9.12-rc.4" >&2
+  fail=1
+fi
+extracted="$(printf '"version": "0.9.12"\n' | grep -oE "\"version\": \"${RELEASE_VERSION_GREP}\"" | head -n1)"
+if [[ "${extracted}" != '"version": "0.9.12"' ]]; then
+  echo "grep form extracted '${extracted}', want \"version\": \"0.9.12\"" >&2
+  fail=1
+fi
+
+if [[ "${fail}" -ne 0 ]]; then
+  exit 1
+fi
+echo "release-version grammar tests passed"

--- a/scripts/release/require-release-tag-checkout.sh
+++ b/scripts/release/require-release-tag-checkout.sh
@@ -5,14 +5,16 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${repo_root}"
+# shellcheck source=scripts/release/release-version.sh
+source "${repo_root}/scripts/release/release-version.sh"
 
 version="${1:-}"
 if [[ -z "${version}" ]]; then
   version="$(grep -E '^version = "' Cargo.toml | head -n1 | sed -E 's/^version = "([^"]+)".*/\1/')"
 fi
 version="${version#v}"
-if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "error: release version '${version}' must use X.Y.Z" >&2
+if ! release_version_is_valid "${version}"; then
+  echo "error: release version '${version}' must use X.Y.Z or X.Y.Z-rc.N" >&2
   exit 2
 fi
 

--- a/scripts/release/verify-remote-tag.sh
+++ b/scripts/release/verify-remote-tag.sh
@@ -12,8 +12,10 @@ remote="$1"
 tag="$2"
 expected_sha="$3"
 
-if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "error: release tag '${tag}' must use vX.Y.Z" >&2
+# shellcheck source=scripts/release/release-version.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/release-version.sh"
+if ! release_tag_is_valid "${tag}"; then
+  echo "error: release tag '${tag}' must use vX.Y.Z or vX.Y.Z-rc.N" >&2
   exit 2
 fi
 if ! [[ "${expected_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then

--- a/scripts/remote-smoke/setup-vm.sh
+++ b/scripts/remote-smoke/setup-vm.sh
@@ -20,7 +20,7 @@
 # Uses prebuilt release binaries instead of a Rust build.
 set -euo pipefail
 
-RELEASE_TAG="${RELEASE_TAG:-v0.9.11}"
+RELEASE_TAG="${RELEASE_TAG:-v0.9.12}"
 REPO_URL="${REPO_URL:-https://github.com/Hmbown/CodeWhale.git}"
 REPO_BRANCH="${REPO_BRANCH:-main}"
 SECRETS_FILE="${SECRETS_FILE:-/tmp/cw-secrets.env}"

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -27,10 +27,10 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-08-29T03:01:38.446Z",
+  "generatedAt": "2026-08-30T18:21:51.387Z",
   "sourceRevision": null,
   "sourceCommittedAt": null,
-  "version": "0.9.11",
+  "version": "0.9.12",
   "crates": [
     "agent",
     "app-server",

--- a/web/lib/release-credits.ts
+++ b/web/lib/release-credits.ts
@@ -20,13 +20,18 @@
 
 /** Contributors whose PRs were merged or harvested into this release. */
 export const RELEASE_CONTRIBUTORS: string[] = [
-  "@bistack",
-  "@aboimpinto",
+  "@h3c-hexin",
   "@wuisabel-gif",
+  "@aboimpinto",
+  "@M-Maciej",
+  "@gaord",
+  "@SparkofSpike",
+  "@musichen",
+  "@AdityaVG13",
+  "@serephus",
 ];
 
 /** Contributors who helped with reports, reproductions, and verification. */
 export const RELEASE_HELPERS: string[] = [
   "@Lstarsky0",
-  "@RepentStar",
 ];

--- a/web/scripts/check-docs.mjs
+++ b/web/scripts/check-docs.mjs
@@ -94,7 +94,8 @@ function checkInstallSnippets() {
   if (!existsSync(installPath)) return { ok: true, note: "install page not found" };
 
   const src = readFileSync(installPath, "utf-8");
-  const versionRefs = [...src.matchAll(/codewhale.*?([\d]+\.[\d]+\.[\d]+)/g)];
+  // Same grammar as scripts/release/release-version.sh: X.Y.Z or X.Y.Z-rc.N.
+  const versionRefs = [...src.matchAll(/codewhale.*?([\d]+\.[\d]+\.[\d]+(?:-rc\.[1-9]\d*)?)/g)];
   const stale = [];
   for (const ref of versionRefs) {
     const v = ref[1];


### PR DESCRIPTION
## Draft — source prep for v0.9.12. Do not merge until the founder cuts the release.

- Commit 1: workspace/npm/runtime-sdk/VS Code extension versions → 0.9.12 with locks; `CHANGELOG.md` gains `## [0.9.12] - Unreleased candidate` (113 bullets derived from every PR merged since `v0.9.11`: Added 40, Changed 23, Fixed 33, Security 3, Removed 2, Contributors 12) under a fresh empty `[Unreleased]`; compare links; `crates/tui/CHANGELOG.md` synced.
- Commit 2 (drop-able): lets `vX.Y.Z-rc.N` flow through `prepare-release.sh` / `check-versions.sh` / auto-tag / `release.yml` (prerelease flag, npm `--tag next`, GHCR `latest` gated, Homebrew skipped) — the chain rejected rc tags at every layer before this.

## Receipts
`prepare-release.sh 0.9.12` and `check-versions.sh` exit 0 ("Version state OK: workspace=0.9.12, npm=0.9.12, npm-binary=0.9.12, lockfile in sync"; 41 linked issue references checked); `sync-changelog.sh --check` up to date; `cargo check -p codewhale-cli --locked` Finished; release-version + prepare-release script tests pass. `--require-dated-release` correctly refuses the undated section until the cut.

## Release-manager review: fix-needed before any tag
- **Blocker**: P0 #5543 (durable child approval receipts) is closed on GitHub as completed but its content lives only on the stale `codex/v0912-integration-20260823` branch — re-land PR #5584's content on main (or reopen #5543 and drop it from the milestone).
- **Major**: #5569 S2 Windows half (`b3484165e`) never re-landed on main; the Unix half did.
- Other blockers (chain, not this branch): source not frozen (14 open PRs), no `v0.9.12` milestone, main CI queued/cancelled at head, npm Trusted Publishing E404 on the last two releases, 124 CodeQL alerts, winget manifests stale at 0.9.6.

P0/P1 re-verification vs main: #5566 ✅ #5567 ✅ #5568 ✅ #5552 ✅ #5557 ✅ #5553 ✅ · #5569 partial · #5572 partial · #4394 partial · **#5543 not on main**. Tracker #5573 still names the stale integration branch.

No-Issue: release source preparation for v0.9.12 (tracker #5573)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aDEyM2a4pPZ9qqMDrP5YX