### PR TITLE
ci(cnb): post shadow GitHub check runs from linux rust gates

### DIFF
--- a/.cnb.yml
+++ b/.cnb.yml
@@ -56,6 +56,12 @@
     cpus: 16
   docker:
     image: rust:1.88-bookworm
+  # codewhale-cnb-bridge GitHub App credentials from the CNB KeyStore
+  # (codewhale.net/codewhale-ci-secrets, github-bridge.yml), injected as
+  # environment variables. Values are never printed.
+  # https://docs.cnb.cool/en/repo/secret.html
+  imports:
+    - https://cnb.cool/codewhale.net/codewhale-ci-secrets/-/blob/main/github-bridge.yml
   stages:
     - name: install linux dependencies
       script: |
@@ -83,6 +89,29 @@
         node scripts/release/npm-wrapper-smoke.js
         ./target/release/codewhale --version
         ./target/release/codew --version
+
+  # Shadow-parity bridge (ops design: CNB-PRIMARY-CI-DESIGN-20260830). Post one
+  # non-required "-cnb" Check Run on the exact GitHub SHA being built so the
+  # CNB verdict is visible on GitHub while GitHub Actions stays the canonical,
+  # required CI. endStages always run and cannot fail the pipeline, so a
+  # bridge outage never turns a green CNB build red (and vice versa: the CNB
+  # verdict is reported from CNB_PIPELINE_STATUS, not from this stage).
+  endStages:
+    - name: github shadow check run
+      script: |
+        set -eu
+        case "${CNB_PIPELINE_STATUS:-error}" in
+          success) conclusion="success" ;;
+          cancel)  conclusion="cancelled" ;;
+          *)       conclusion="failure" ;;
+        esac
+        node scripts/ci/cnb-github-checkrun.mjs \
+          --name "linux rust gates -cnb" \
+          --sha "${CNB_COMMIT}" \
+          --status completed \
+          --conclusion "${conclusion}" \
+          --details-url "${CNB_BUILD_WEB_URL:-https://cnb.cool/${CNB_REPO_SLUG}}" \
+          --summary "CNB pipeline '${CNB_PIPELINE_NAME:-linux rust gates}' finished with status ${CNB_PIPELINE_STATUS:-unknown} on ${CNB_BRANCH:-unknown branch} (${CNB_COMMIT}). Shadow lane per the CNB-primary CI design: GitHub Actions remains canonical and required; nothing is gated on this check."
 
 .linux_release_preflight: &linux_release_preflight
   name: linux release preflight

--- a/scripts/ci/cnb-github-checkrun.mjs
+++ b/scripts/ci/cnb-github-checkrun.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Post a GitHub Check Run for the exact commit a CNB pipeline is building,
+// authenticating as the codewhale-cnb-bridge GitHub App.
+//
+// Secret custody: the App credentials live in the CNB KeyStore repo
+// codewhale.net/codewhale-ci-secrets (github-bridge.yml) and are injected as
+// environment variables via `imports:` in .cnb.yml
+// (https://docs.cnb.cool/en/repo/secret.html). This script reads them from the
+// environment and never logs them. Accepted variable names (first match wins):
+//   app id:           GITHUB_APP_ID, GH_APP_ID, APP_ID
+//   installation id:  GITHUB_APP_INSTALLATION_ID, GH_APP_INSTALLATION_ID, INSTALLATION_ID
+//   private key:      GITHUB_APP_PRIVATE_KEY, GH_APP_PRIVATE_KEY, PRIVATE_KEY
+// The private key may be a raw PEM, a PEM with escaped \n, or base64-encoded.
+//
+// Usage:
+//   node scripts/ci/cnb-github-checkrun.mjs \
+//     --name "linux rust gates -cnb" --sha <40-hex> \
+//     --status completed --conclusion success \
+//     --details-url <url> --summary <text>
+import crypto from "node:crypto";
+
+const GITHUB_API = process.env.GITHUB_API_BASE || "https://api.github.com";
+const REPO = process.env.GITHUB_REPOSITORY || "Hmbown/CodeWhale";
+const USER_AGENT = "codewhale-cnb-bridge";
+
+function fail(message) {
+  console.error(`cnb-github-checkrun: ${message}`);
+  process.exit(1);
+}
+
+function envAny(...names) {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) fail(`unexpected argument ${JSON.stringify(token)}`);
+    const key = token.slice(2);
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith("--")) fail(`--${key} requires a value`);
+    args[key] = value;
+    i += 1;
+  }
+  return args;
+}
+
+function normalizePrivateKey(raw) {
+  const withNewlines = raw.replace(/\\n/g, "\n");
+  if (withNewlines.includes("BEGIN")) return withNewlines;
+  const decoded = Buffer.from(raw, "base64").toString("utf8");
+  if (decoded.includes("BEGIN")) return decoded;
+  fail("private key does not look like a PEM (raw, escaped, or base64)");
+}
+
+function mintAppJwt(appId, privateKey) {
+  const now = Math.floor(Date.now() / 1000);
+  const encode = (obj) => Buffer.from(JSON.stringify(obj)).toString("base64url");
+  const header = encode({ alg: "RS256", typ: "JWT" });
+  const payload = encode({ iat: now - 60, exp: now + 540, iss: appId });
+  const unsigned = `${header}.${payload}`;
+  const signature = crypto.sign("sha256", Buffer.from(unsigned), privateKey).toString("base64url");
+  return `${unsigned}.${signature}`;
+}
+
+async function githubApi(path, token, method, body) {
+  const response = await fetch(`${GITHUB_API}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": USER_AGENT,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!response.ok) {
+    // GitHub error bodies never contain our credentials; cap the log line anyway.
+    const text = (await response.text()).slice(0, 500);
+    fail(`${method} ${path} -> HTTP ${response.status}: ${text}`);
+  }
+  return response.json();
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const name = args.name || fail("--name is required");
+  const sha = args.sha || fail("--sha is required");
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    fail(`--sha must be a 40-character lowercase hex commit, got ${JSON.stringify(sha)}`);
+  }
+  const status = args.status || "completed";
+  if (!["queued", "in_progress", "completed"].includes(status)) {
+    fail(`--status must be queued|in_progress|completed, got ${JSON.stringify(status)}`);
+  }
+  const conclusions = ["success", "failure", "cancelled", "neutral", "skipped", "timed_out"];
+  const conclusion = args.conclusion || "";
+  if (status === "completed" && !conclusions.includes(conclusion)) {
+    fail(`--conclusion must be one of ${conclusions.join("|")} when --status completed`);
+  }
+
+  const appId = envAny("GITHUB_APP_ID", "GH_APP_ID", "APP_ID") ||
+    fail("GitHub App id env var missing (expected GITHUB_APP_ID)");
+  const installationId = envAny("GITHUB_APP_INSTALLATION_ID", "GH_APP_INSTALLATION_ID", "INSTALLATION_ID") ||
+    fail("GitHub App installation id env var missing (expected GITHUB_APP_INSTALLATION_ID)");
+  const privateKey = normalizePrivateKey(
+    envAny("GITHUB_APP_PRIVATE_KEY", "GH_APP_PRIVATE_KEY", "PRIVATE_KEY") ||
+      fail("GitHub App private key env var missing (expected GITHUB_APP_PRIVATE_KEY)"),
+  );
+
+  const jwt = mintAppJwt(appId, privateKey);
+  const installation = await githubApi(
+    `/app/installations/${encodeURIComponent(installationId)}/access_tokens`,
+    jwt,
+    "POST",
+  );
+  if (!installation.token) fail("installation token response had no token field");
+
+  const now = new Date().toISOString();
+  const checkRun = {
+    name,
+    head_sha: sha,
+    status,
+    output: {
+      title: args.title || `${name}: ${status === "completed" ? conclusion : status}`,
+      summary: args.summary || "",
+    },
+  };
+  if (args["details-url"]) checkRun.details_url = args["details-url"];
+  if (status === "completed") {
+    checkRun.conclusion = conclusion;
+    checkRun.completed_at = now;
+  } else {
+    checkRun.started_at = now;
+  }
+
+  const created = await githubApi(`/repos/${REPO}/check-runs`, installation.token, "POST", checkRun);
+  // Receipt line: id, conclusion, and URL only — never any credential material.
+  console.log(`check run ${created.id} ${status}${conclusion ? `/${conclusion}` : ""} ${created.html_url}`);
+}
+
+main().catch((error) => fail(error && error.message ? error.message : String(error)));


### PR DESCRIPTION
## What

Wire the CNB → GitHub shadow-status bridge for the first shadow lane, per the ops design `CNB-PRIMARY-CI-DESIGN-20260830.md` (GitHub canonical, CNB executes; shadow-parity protocol step 1).

- `.cnb.yml` — the `linux rust gates` pipeline now imports the CNB KeyStore file `github-bridge.yml` from `codewhale.net/codewhale-ci-secrets` via the [documented `imports:` mechanism](https://docs.cnb.cool/en/repo/secret.html) (values injected as env vars, never printed) and gains an `endStages` step that posts one **non-required** Check Run named `linux rust gates -cnb` on the exact GitHub SHA being built (`$CNB_COMMIT`), with the conclusion mapped from `CNB_PIPELINE_STATUS` (`success`→success, `cancel`→cancelled, anything else→failure) and `details_url` pointing at the CNB build log (`$CNB_BUILD_WEB_URL`).
- `scripts/ci/cnb-github-checkrun.mjs` — dependency-free Node script that mints a GitHub App JWT (RS256, `node:crypto`), exchanges it for an installation token, and `POST /repos/Hmbown/CodeWhale/check-runs`. Reads `GITHUB_APP_ID` / `GITHUB_APP_INSTALLATION_ID` / `GITHUB_APP_PRIVATE_KEY` (plus `GH_APP_*` fallbacks; key accepted as raw PEM, `\n`-escaped PEM, or base64). Receipt output is check-run id + URL only; no credential material is ever logged.

Design guarantees kept: GitHub Actions stays canonical and required; no GitHub job disabled; no branch-protection change; the bridge lives in `endStages`, which always run and whose failure cannot change the pipeline status, so a bridge/token outage can never turn a CNB build red. Scope is limited to the `linux rust gates` pipeline (main push + `fix/*|rebrand/*` push); release preflight and tag pipelines are untouched.

## Evidence (local, this branch)

- `python3 yaml.safe_load` of the edited `.cnb.yml`: `imports` + `endStages: ['github shadow check run']` present on `linux rust gates`; absent from `linux release preflight` and the tag pipeline (secrets not injected there).
- Ephemeral stub-server test (throwaway RSA key, local HTTP stub as `GITHUB_API_BASE`, harness deleted after): JWT signature verified against the public key with correct `iss`; installation token minted once per run; check-run POST carried `name`, exact 40-hex `head_sha`, `status: completed`, `conclusion`, `details_url`, `completed_at`; base64-key variant works; missing secrets and a malformed SHA fail cleanly with no secret material in output.
- No product code touched; no Rust gates affected (`.cnb.yml` is not consumed by GitHub CI).

## Unproven

- **The bridge has never run on CNB.** First real run happens when this merges to main (or a `fix/*` branch push) and the CNB mirror builds it. Until then, end-to-end is unproven.
- **KeyStore key names**: the script expects `GITHUB_APP_ID` / `GITHUB_APP_INSTALLATION_ID` / `GITHUB_APP_PRIVATE_KEY` in `github-bridge.yml` (with `GH_APP_*` fallbacks). If the KeyStore file uses different key names, the endStages step will fail loudly in the CNB log (pipeline stays green) and the names get aligned in a follow-up.
- **KeyStore `allow_*` authorization**: whether CNB permits the `codewhale.net/codewhale` repo's pipelines (and the triggering identities) to reference the KeyStore file is enforced KeyStore-side and only observable on a real build.
- Check-run naming (`linux rust gates -cnb` vs. exactly matching the GitHub job it shadows, e.g. `Test (ubuntu-latest) -cnb`) is a shadow-phase choice; final names settle per-lane at parity/cutover per the design doc.
- The ≥20-run parity record and deliberate-red canary remain ahead; nothing here changes any required check.

No-Issue: CNB-primary CI program slice tracked in the ops ledger (CNB-PRIMARY-CI-DESIGN-20260830), no product-repo issue.
