### PR TITLE
fix(tui): keep MCP boot detail out of chat

### DIFF
--- a/crates/tui/src/tui/phase_strip.rs
+++ b/crates/tui/src/tui/phase_strip.rs
@@ -194,6 +194,17 @@ fn status_toast_ink(level: crate::tui::app::StatusToastLevel) -> ChromeInk {
     }
 }
 
+/// Map the boot surface's typed severity through the same semantic palette as
+/// every other footer fact. Keeping this conversion closed makes the plugin
+/// warning/failure distinction testable without guessing from its text.
+fn boot_activity_ink(level: crate::tui::session_boot::SessionBootActivityLevel) -> ChromeInk {
+    match level {
+        crate::tui::session_boot::SessionBootActivityLevel::Active => ChromeInk::Active,
+        crate::tui::session_boot::SessionBootActivityLevel::Attention => ChromeInk::Attention,
+        crate::tui::session_boot::SessionBootActivityLevel::Failure => ChromeInk::Failure,
+    }
+}
+
 /// Pick the notice a band owes its row to right now, if any. Shared by the
 /// classic activity band and the Tideline merged footer so the two can never
 /// disagree about which toast is live. Completion may land in the same event
@@ -321,6 +332,24 @@ mod tests {
         assert_ne!(
             crate::tui::underwater::phase_ink(ShellPhase::Working).family(),
             crate::palette::SemanticFamily::Failure
+        );
+    }
+
+    #[test]
+    fn boot_activity_levels_keep_plugin_attention_and_failure_distinct() {
+        use crate::tui::session_boot::SessionBootActivityLevel;
+
+        assert_eq!(
+            boot_activity_ink(SessionBootActivityLevel::Active),
+            ChromeInk::Active
+        );
+        assert_eq!(
+            boot_activity_ink(SessionBootActivityLevel::Attention),
+            ChromeInk::Attention
+        );
+        assert_eq!(
+            boot_activity_ink(SessionBootActivityLevel::Failure),
+            ChromeInk::Failure
         );
     }
 
@@ -578,7 +607,7 @@ pub struct TidelineFooter<'a> {
     /// Permission chip (`ask` / `auto review` / `full access`, plus the
     /// filesystem scope notice when it deviates) in its Permission ink.
     pub permission_chip: Option<(&'a str, crate::palette::ChromeInk)>,
-    /// Urgent session notice (status toast / MCP boot chip) that owns the
+    /// Urgent session notice (status toast / boot activity chip) that owns the
     /// right-hand keys slot while it is live.
     pub notice: Option<(&'a str, crate::palette::ChromeInk)>,
     pub ascii_safe: bool,
@@ -930,8 +959,9 @@ pub fn tideline_footer_depth_hitbox(area: Rect, footer: &TidelineFooter<'_>) -> 
 ///   the activity band's `Esc to interrupt` while a turn is live.
 /// - `mode_chip`/`permission_chip` — the old header's posture lockup
 ///   (`underwater::posture_chips`, same words, same inks).
-/// - `notice` — the activity band's status toast, or the MCP boot chip when
-///   no toast is live; it owns the trailing right slot while present.
+/// - `notice` — the activity band's status toast, or the compact MCP/plugin
+///   boot chip when no toast is live; it owns the trailing right slot while
+///   present.
 ///
 /// Session metrics (turns/steps/TTFT/cache) move behind `/cost` per spec §3.
 pub(crate) struct TidelineFooterFacts {
@@ -1029,28 +1059,18 @@ pub(crate) fn tideline_footer_from_app(app: &mut App, width: u16) -> TidelineFoo
         chip.map(|(text, ink)| (text.into_owned(), ink))
     };
 
-    // The notice: the live status toast if one is owed, else the MCP boot
-    // chip (a slow optional server must not look like a hung turn). Clause-
-    // shed against half the row — the depth line owns the other half.
+    // The notice: the live status toast if one is owed, else the compact MCP
+    // or plugin boot chip. A slow optional server must not look like a hung
+    // turn, while plugin diagnostics stay available through `/plugins` rather
+    // than taking rows from the transcript. Clause-shed against half the row
+    // — the depth line owns the other half.
     let notice_budget = (usize::from(width) / 2).max(8);
     let notice = selected_notice(app.active_status_toast(), phase, &phase_word)
         .map(|(text, ink, _urgent)| (text, ink))
         .or_else(|| {
-            crate::tui::session_boot::activity_chip(app, notice_budget).map(|chip| {
-                let boot = crate::tui::session_boot::SessionBootSurface::from_app(app);
-                let ink = if boot.servers.iter().any(|row| {
-                    matches!(
-                        row.state,
-                        crate::tui::session_boot::McpServerBootState::Failed
-                            | crate::tui::session_boot::McpServerBootState::NeedsLogin
-                    )
-                }) {
-                    crate::palette::ChromeInk::Failure
-                } else {
-                    crate::palette::ChromeInk::Active
-                };
-                (chip, ink)
-            })
+            let boot = crate::tui::session_boot::SessionBootSurface::from_app(app);
+            boot.activity_notice(app.ui_locale, notice_budget)
+                .map(|chip| (chip.text, boot_activity_ink(chip.level)))
         })
         .and_then(|(text, ink)| fit_notice(&text, notice_budget).map(|fitted| (fitted, ink)));
 

--- a/crates/tui/src/tui/session_boot.rs
+++ b/crates/tui/src/tui/session_boot.rs
@@ -1,24 +1,16 @@
 //! Session-page MCP + plugin boot surface.
 //!
 //! Plugin discovery and every enabled MCP server boot as a **set**, not a
-//! toast per name. The activity strip carries the compact pulse
-//! (`MCP · 4 connecting`); the receipt under it keeps per-server outcomes
-//! and next actions until retry succeeds. Slack is one server in that set.
+//! toast per name. The Tideline footer carries the compact pulse
+//! (`MCP · 4 connecting`); detailed diagnosis and actions belong in `/mcp`,
+//! never as multi-row boot output between the transcript and composer.
 
 use std::borrow::Cow;
 
-use ratatui::{
-    buffer::Buffer,
-    layout::Rect,
-    style::Style,
-    text::{Line, Span},
-    widgets::{Block, Paragraph, Widget},
-};
 use unicode_width::UnicodeWidthStr;
 
 use crate::localization::{Locale, MessageId, tr};
 use crate::mcp::{McpManagerSnapshot, McpServerSnapshot};
-use crate::palette::ChromeInk;
 use crate::plugins::PluginRegistry;
 use crate::plugins::types::{PluginDiagnosticLevel, PluginTrustStatus};
 use crate::tui::app::App;
@@ -185,11 +177,6 @@ impl SessionBootSurface {
     }
 
     #[must_use]
-    pub fn is_hidden(&self) -> bool {
-        self.phase == SessionBootPhase::Hidden
-    }
-
-    #[must_use]
     pub fn activity_chip(&self, locale: Locale, budget: usize) -> Option<String> {
         if self.phase == SessionBootPhase::Hidden || budget == 0 {
             return None;
@@ -342,15 +329,6 @@ impl SessionBootSurface {
         lines.truncate(MAX_RECEIPT_ROWS as usize);
         lines
     }
-
-    #[must_use]
-    pub fn receipt_height(&self, locale: Locale, width: u16) -> u16 {
-        if self.is_hidden() {
-            return 0;
-        }
-        let lines = self.receipt_lines(locale, usize::from(width));
-        (lines.len() as u16).min(MAX_RECEIPT_ROWS)
-    }
 }
 
 fn row_from_snapshot(
@@ -495,55 +473,6 @@ pub fn activity_chip(app: &App, budget: usize) -> Option<String> {
     SessionBootSurface::from_app(app).activity_chip(app.ui_locale, budget)
 }
 
-/// Rows the compact boot receipt wants above the activity band.
-#[must_use]
-pub fn receipt_height(app: &App, width: u16, budget: u16) -> u16 {
-    if budget == 0 {
-        return 0;
-    }
-    SessionBootSurface::from_app(app)
-        .receipt_height(app.ui_locale, width)
-        .min(budget)
-}
-
-/// Paint the compact boot receipt. Text only: Reduced/Still skip any spin.
-pub fn render(area: Rect, buf: &mut Buffer, app: &App) {
-    if area.width == 0 || area.height == 0 {
-        return;
-    }
-    let surface = SessionBootSurface::from_app(app);
-    let lines = surface.receipt_lines(app.ui_locale, usize::from(area.width));
-    if lines.is_empty() {
-        return;
-    }
-    Block::default()
-        .style(Style::default().bg(app.ui_theme.surface_bg))
-        .render(area, buf);
-    let ink = if surface.servers.iter().any(|row| {
-        matches!(
-            row.state,
-            McpServerBootState::Failed | McpServerBootState::NeedsLogin
-        )
-    }) {
-        ChromeInk::Failure
-    } else if surface.phase == SessionBootPhase::Booting {
-        ChromeInk::Active
-    } else {
-        ChromeInk::Metadata
-    };
-    let rendered: Vec<Line<'static>> = lines
-        .into_iter()
-        .take(area.height as usize)
-        .map(|line| {
-            Line::from(Span::styled(
-                line,
-                Style::default().fg(ink.color(&app.ui_theme)),
-            ))
-        })
-        .collect();
-    Paragraph::new(rendered).render(area, buf);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -590,7 +519,6 @@ mod tests {
         assert_eq!(surface.phase, SessionBootPhase::Hidden);
         assert!(surface.activity_chip(Locale::En, 80).is_none());
         assert!(surface.receipt_lines(Locale::En, 80).is_empty());
-        assert_eq!(surface.receipt_height(Locale::En, 80), 0);
     }
 
     #[test]

--- a/crates/tui/src/tui/session_boot.rs
+++ b/crates/tui/src/tui/session_boot.rs
@@ -2,8 +2,9 @@
 //!
 //! Plugin discovery and every enabled MCP server boot as a **set**, not a
 //! toast per name. The Tideline footer carries the compact pulse
-//! (`MCP · 4 connecting`); detailed diagnosis and actions belong in `/mcp`,
-//! never as multi-row boot output between the transcript and composer.
+//! (`MCP · 4 connecting` or `Plugins · Problems: 2 · /plugins`); detailed
+//! diagnosis and actions belong in `/mcp` or `/plugins`, never as multi-row
+//! boot output between the transcript and composer.
 
 use unicode_width::UnicodeWidthStr;
 
@@ -49,7 +50,17 @@ pub struct PluginBootSummary {
 impl PluginBootSummary {
     #[must_use]
     pub fn is_quiet(self) -> bool {
-        self.loaded == 0 && self.invalid == 0 && self.duplicate == 0 && self.needs_setup == 0
+        self.problem_count() == 0
+    }
+
+    #[must_use]
+    pub fn problem_count(self) -> usize {
+        self.invalid + self.duplicate + self.needs_setup
+    }
+
+    #[must_use]
+    pub fn has_failures(self) -> bool {
+        self.invalid > 0 || self.duplicate > 0
     }
 
     #[must_use]
@@ -72,10 +83,7 @@ impl PluginBootSummary {
                 .any(|diagnostic| diagnostic.level == PluginDiagnosticLevel::Error)
             {
                 invalid += 1;
-            } else if matches!(
-                plugin.trust_status,
-                PluginTrustStatus::NeverReviewed | PluginTrustStatus::CapabilitiesChanged
-            ) {
+            } else if plugin_trust_needs_setup(plugin.trust_status) {
                 needs_setup += 1;
             }
         }
@@ -86,6 +94,33 @@ impl PluginBootSummary {
             needs_setup,
         }
     }
+}
+
+fn plugin_trust_needs_setup(status: PluginTrustStatus) -> bool {
+    matches!(
+        status,
+        PluginTrustStatus::NeverReviewed
+            | PluginTrustStatus::ContentChanged
+            | PluginTrustStatus::CapabilitiesChanged
+    )
+}
+
+/// Semantic severity for the compact boot activity notice.
+///
+/// The text carries no color names or inferred state. Its consumer maps this
+/// closed state into the Tideline palette, so a plugin warning cannot inherit
+/// an unrelated MCP color merely because both use the same footer slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionBootActivityLevel {
+    Active,
+    Attention,
+    Failure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionBootActivityChip {
+    pub text: String,
+    pub level: SessionBootActivityLevel,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -164,7 +199,11 @@ impl SessionBootSurface {
     }
 
     #[must_use]
-    pub fn activity_chip(&self, locale: Locale, budget: usize) -> Option<String> {
+    pub fn activity_notice(
+        &self,
+        locale: Locale,
+        budget: usize,
+    ) -> Option<SessionBootActivityChip> {
         if self.phase == SessionBootPhase::Hidden || budget == 0 {
             return None;
         }
@@ -190,28 +229,79 @@ impl SessionBootSurface {
             .filter(|row| row.state == McpServerBootState::Connected)
             .count();
 
-        let mut candidates = Vec::new();
         if !connecting.is_empty() {
             let count = connecting.len();
             let named = named_chip_line("MCP", count, "connecting", &connecting);
-            candidates.push(named);
-            candidates.push(format!("MCP{ITEM_SEPARATOR}{count} connecting"));
-        } else if failed > 0 {
-            candidates.push(format!(
-                "MCP{ITEM_SEPARATOR}{connected} {}{ITEM_SEPARATOR}{failed} {}",
-                tr(locale, MessageId::ExtensionsStateConnected),
-                tr(locale, MessageId::PhaseFailed)
-            ));
-            candidates.push(format!("MCP{ITEM_SEPARATOR}{failed} failed"));
-        } else if self.phase == SessionBootPhase::Booting {
+            return activity_notice_from_candidates(
+                SessionBootActivityLevel::Active,
+                vec![named, format!("MCP{ITEM_SEPARATOR}{count} connecting")],
+                budget,
+            );
+        }
+        if failed > 0 {
+            return activity_notice_from_candidates(
+                SessionBootActivityLevel::Failure,
+                vec![
+                    format!(
+                        "MCP{ITEM_SEPARATOR}{connected} {}{ITEM_SEPARATOR}{failed} {}",
+                        tr(locale, MessageId::ExtensionsStateConnected),
+                        tr(locale, MessageId::PhaseFailed)
+                    ),
+                    format!("MCP{ITEM_SEPARATOR}{failed} failed"),
+                ],
+                budget,
+            );
+        }
+        if self.phase == SessionBootPhase::Booting {
             let count = self.servers.len().max(self.unnamed_connecting);
             if count > 0 {
-                candidates.push(format!("MCP{ITEM_SEPARATOR}{count} connecting"));
+                return activity_notice_from_candidates(
+                    SessionBootActivityLevel::Active,
+                    vec![format!("MCP{ITEM_SEPARATOR}{count} connecting")],
+                    budget,
+                );
             }
         }
 
-        candidates.into_iter().find(|line| line.width() <= budget)
+        if self.plugins.is_quiet() {
+            return None;
+        }
+
+        let plugins = tr(locale, MessageId::ExtensionsTabPlugins);
+        let problems = tr(locale, MessageId::ExtensionsGroupProblems);
+        let count = self.plugins.problem_count();
+        let level = if self.plugins.has_failures() {
+            SessionBootActivityLevel::Failure
+        } else {
+            SessionBootActivityLevel::Attention
+        };
+        activity_notice_from_candidates(
+            level,
+            vec![
+                format!("{plugins}{ITEM_SEPARATOR}{problems}: {count}{ITEM_SEPARATOR}/plugins"),
+                format!("{plugins}{ITEM_SEPARATOR}{problems}: {count}"),
+                format!("{plugins}{ITEM_SEPARATOR}{count}"),
+            ],
+            budget,
+        )
     }
+
+    #[must_use]
+    pub fn activity_chip(&self, locale: Locale, budget: usize) -> Option<String> {
+        self.activity_notice(locale, budget)
+            .map(|notice| notice.text)
+    }
+}
+
+fn activity_notice_from_candidates(
+    level: SessionBootActivityLevel,
+    candidates: Vec<String>,
+    budget: usize,
+) -> Option<SessionBootActivityChip> {
+    candidates
+        .into_iter()
+        .find(|line| line.width() <= budget)
+        .map(|text| SessionBootActivityChip { text, level })
 }
 
 fn row_from_snapshot(
@@ -280,12 +370,6 @@ fn named_chip_line(kind: &str, count: usize, verb: &str, names: &[&str]) -> Stri
     line
 }
 
-/// Activity-strip chip for the current session boot set.
-#[must_use]
-pub fn activity_chip(app: &App, budget: usize) -> Option<String> {
-    SessionBootSurface::from_app(app).activity_chip(app.ui_locale, budget)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,6 +415,108 @@ mod tests {
             SessionBootSurface::from_parts(None, false, &[], 0, PluginBootSummary::default());
         assert_eq!(surface.phase, SessionBootPhase::Hidden);
         assert!(surface.activity_chip(Locale::En, 80).is_none());
+    }
+
+    #[test]
+    fn healthy_loaded_plugins_do_not_claim_the_boot_surface() {
+        let surface = SessionBootSurface::from_parts(
+            None,
+            false,
+            &[],
+            0,
+            PluginBootSummary {
+                loaded: 2,
+                ..PluginBootSummary::default()
+            },
+        );
+        assert_eq!(surface.phase, SessionBootPhase::Hidden);
+        assert!(surface.activity_notice(Locale::En, 80).is_none());
+    }
+
+    #[test]
+    fn changed_plugin_content_requires_setup() {
+        assert!(plugin_trust_needs_setup(PluginTrustStatus::ContentChanged));
+        assert!(plugin_trust_needs_setup(PluginTrustStatus::NeverReviewed));
+        assert!(plugin_trust_needs_setup(
+            PluginTrustStatus::CapabilitiesChanged
+        ));
+        assert!(!plugin_trust_needs_setup(PluginTrustStatus::Trusted));
+    }
+
+    #[test]
+    fn plugin_problems_have_a_compact_footer_action() {
+        let surface = SessionBootSurface::from_parts(
+            None,
+            false,
+            &[],
+            0,
+            PluginBootSummary {
+                loaded: 3,
+                invalid: 1,
+                duplicate: 1,
+                needs_setup: 1,
+            },
+        );
+        assert_eq!(surface.phase, SessionBootPhase::Settled);
+        assert_eq!(
+            surface.activity_notice(Locale::En, 40),
+            Some(SessionBootActivityChip {
+                text: "Plugins · Problems: 3 · /plugins".to_string(),
+                level: SessionBootActivityLevel::Failure,
+            })
+        );
+    }
+
+    #[test]
+    fn plugin_review_notice_uses_attention_and_sheds_whole_fields() {
+        let surface = SessionBootSurface::from_parts(
+            None,
+            false,
+            &[],
+            0,
+            PluginBootSummary {
+                loaded: 1,
+                needs_setup: 1,
+                ..PluginBootSummary::default()
+            },
+        );
+        assert_eq!(
+            surface.activity_notice(Locale::En, 40),
+            Some(SessionBootActivityChip {
+                text: "Plugins · Problems: 1 · /plugins".to_string(),
+                level: SessionBootActivityLevel::Attention,
+            })
+        );
+        assert_eq!(
+            surface.activity_chip(Locale::En, 22).as_deref(),
+            Some("Plugins · Problems: 1")
+        );
+        assert_eq!(
+            surface.activity_chip(Locale::En, 12).as_deref(),
+            Some("Plugins · 1")
+        );
+    }
+
+    #[test]
+    fn mcp_activity_outranks_plugin_problems() {
+        let snap = snapshot(vec![server("alpha", true, false, None)]);
+        let surface = SessionBootSurface::from_parts(
+            Some(&snap),
+            true,
+            &["alpha".to_string()],
+            1,
+            PluginBootSummary {
+                invalid: 1,
+                ..PluginBootSummary::default()
+            },
+        );
+        assert_eq!(
+            surface.activity_notice(Locale::En, 80),
+            Some(SessionBootActivityChip {
+                text: "MCP · 1 connecting · alpha".to_string(),
+                level: SessionBootActivityLevel::Active,
+            })
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/session_boot.rs
+++ b/crates/tui/src/tui/session_boot.rs
@@ -285,12 +285,6 @@ impl SessionBootSurface {
             budget,
         )
     }
-
-    #[must_use]
-    pub fn activity_chip(&self, locale: Locale, budget: usize) -> Option<String> {
-        self.activity_notice(locale, budget)
-            .map(|notice| notice.text)
-    }
 }
 
 fn activity_notice_from_candidates(
@@ -414,7 +408,12 @@ mod tests {
         let surface =
             SessionBootSurface::from_parts(None, false, &[], 0, PluginBootSummary::default());
         assert_eq!(surface.phase, SessionBootPhase::Hidden);
-        assert!(surface.activity_chip(Locale::En, 80).is_none());
+        assert!(
+            surface
+                .activity_notice(Locale::En, 80)
+                .map(|notice| notice.text)
+                .is_none()
+        );
     }
 
     #[test]
@@ -488,11 +487,17 @@ mod tests {
             })
         );
         assert_eq!(
-            surface.activity_chip(Locale::En, 22).as_deref(),
+            surface
+                .activity_notice(Locale::En, 22)
+                .map(|notice| notice.text)
+                .as_deref(),
             Some("Plugins · Problems: 1")
         );
         assert_eq!(
-            surface.activity_chip(Locale::En, 12).as_deref(),
+            surface
+                .activity_notice(Locale::En, 12)
+                .map(|notice| notice.text)
+                .as_deref(),
             Some("Plugins · 1")
         );
     }
@@ -532,7 +537,10 @@ mod tests {
         assert_eq!(surface.phase, SessionBootPhase::Booting);
         assert_eq!(surface.servers.len(), 1);
         assert_eq!(surface.servers[0].state, McpServerBootState::Connecting);
-        let chip = surface.activity_chip(Locale::En, 80).expect("chip");
+        let chip = surface
+            .activity_notice(Locale::En, 80)
+            .map(|notice| notice.text)
+            .expect("chip");
         assert!(chip.contains("alpha"), "{chip}");
         assert!(!chip.to_ascii_lowercase().contains("slack"), "{chip}");
     }
@@ -557,7 +565,10 @@ mod tests {
             PluginBootSummary::default(),
         );
         assert_eq!(surface.phase, SessionBootPhase::Booting);
-        let chip = surface.activity_chip(Locale::En, 80).expect("chip");
+        let chip = surface
+            .activity_notice(Locale::En, 80)
+            .map(|notice| notice.text)
+            .expect("chip");
         assert!(chip.contains("4 connecting"), "{chip}");
         assert!(chip.contains("alpha"), "{chip}");
         assert!(chip.contains("docs"), "{chip}");
@@ -621,7 +632,10 @@ mod tests {
             3,
             PluginBootSummary::default(),
         );
-        let chip = surface.activity_chip(Locale::En, 22).expect("chip");
+        let chip = surface
+            .activity_notice(Locale::En, 22)
+            .map(|notice| notice.text)
+            .expect("chip");
         assert_eq!(chip, "MCP · 3 connecting");
     }
 
@@ -647,7 +661,10 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["alpha", "docs", "gamma"]
         );
-        let chip = surface.activity_chip(Locale::En, 80).expect("chip");
+        let chip = surface
+            .activity_notice(Locale::En, 80)
+            .map(|notice| notice.text)
+            .expect("chip");
         assert!(chip.contains("3 connecting"), "{chip}");
         assert!(chip.contains("alpha"), "{chip}");
         assert!(chip.contains("gamma"), "{chip}");
@@ -661,7 +678,10 @@ mod tests {
         assert_eq!(surface.phase, SessionBootPhase::Booting);
         assert!(surface.servers.is_empty());
         assert_eq!(
-            surface.activity_chip(Locale::En, 80).as_deref(),
+            surface
+                .activity_notice(Locale::En, 80)
+                .map(|notice| notice.text)
+                .as_deref(),
             Some("MCP · 4 connecting")
         );
     }

--- a/crates/tui/src/tui/session_boot.rs
+++ b/crates/tui/src/tui/session_boot.rs
@@ -5,8 +5,6 @@
 //! (`MCP · 4 connecting`); detailed diagnosis and actions belong in `/mcp`,
 //! never as multi-row boot output between the transcript and composer.
 
-use std::borrow::Cow;
-
 use unicode_width::UnicodeWidthStr;
 
 use crate::localization::{Locale, MessageId, tr};
@@ -16,7 +14,6 @@ use crate::plugins::types::{PluginDiagnosticLevel, PluginTrustStatus};
 use crate::tui::app::App;
 
 const ITEM_SEPARATOR: &str = " · ";
-const MAX_RECEIPT_ROWS: u16 = 6;
 const MAX_NAMED_CHIPS: usize = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,19 +32,10 @@ pub enum McpServerBootState {
     Disabled,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum McpServerAction {
-    Retry,
-    Login,
-    Diagnose,
-    None,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct McpServerBootRow {
     pub name: String,
     pub state: McpServerBootState,
-    pub action: McpServerAction,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -144,7 +132,6 @@ impl SessionBootSurface {
                 .map(|name| McpServerBootRow {
                     name,
                     state: McpServerBootState::Connecting,
-                    action: McpServerAction::None,
                 })
                 .collect()
         } else {
@@ -225,110 +212,6 @@ impl SessionBootSurface {
 
         candidates.into_iter().find(|line| line.width() <= budget)
     }
-
-    #[must_use]
-    pub fn receipt_lines(&self, locale: Locale, width: usize) -> Vec<String> {
-        if self.phase == SessionBootPhase::Hidden || width == 0 {
-            return Vec::new();
-        }
-        let mut lines = Vec::new();
-        if let Some(plugin_line) = plugin_receipt_line(self.plugins, locale, width) {
-            lines.push(plugin_line);
-        }
-
-        match self.phase {
-            SessionBootPhase::Hidden => {}
-            SessionBootPhase::Booting => {
-                let connecting: Vec<&str> = self
-                    .servers
-                    .iter()
-                    .filter(|row| row.state == McpServerBootState::Connecting)
-                    .map(|row| row.name.as_str())
-                    .collect();
-                if connecting.is_empty() && self.servers.is_empty() {
-                    if self.unnamed_connecting > 0 {
-                        lines.push(format!(
-                            "MCP{ITEM_SEPARATOR}{} connecting",
-                            self.unnamed_connecting
-                        ));
-                    }
-                } else {
-                    let count = if connecting.is_empty() {
-                        self.servers.len()
-                    } else {
-                        connecting.len()
-                    };
-                    let named = named_chip_line("MCP", count, "connecting", &connecting);
-                    lines.push(truncate_to_width(&named, width));
-                }
-            }
-            SessionBootPhase::Settled => {
-                if self.servers.len() == 1 {
-                    lines.push(truncate_to_width(
-                        &server_row_text(&self.servers[0], locale),
-                        width,
-                    ));
-                } else {
-                    let mut remaining =
-                        MAX_RECEIPT_ROWS.saturating_sub(lines.len() as u16) as usize;
-                    if remaining == 0 {
-                        return lines;
-                    }
-                    let notable: Vec<&McpServerBootRow> = self
-                        .servers
-                        .iter()
-                        .filter(|row| {
-                            matches!(
-                                row.state,
-                                McpServerBootState::Failed
-                                    | McpServerBootState::NeedsLogin
-                                    | McpServerBootState::Disabled
-                            )
-                        })
-                        .collect();
-                    let connected = self
-                        .servers
-                        .iter()
-                        .filter(|row| row.state == McpServerBootState::Connected)
-                        .count();
-                    if notable.is_empty() {
-                        if connected > 0 {
-                            lines.push(truncate_to_width(
-                                &format!(
-                                    "MCP{ITEM_SEPARATOR}{connected} {}",
-                                    tr(locale, MessageId::ExtensionsStateConnected)
-                                ),
-                                width,
-                            ));
-                        }
-                    } else {
-                        if connected > 0 && remaining > 1 {
-                            lines.push(format!(
-                                "MCP{ITEM_SEPARATOR}{connected} {}",
-                                tr(locale, MessageId::ExtensionsStateConnected)
-                            ));
-                            remaining = remaining.saturating_sub(1);
-                        }
-                        let overflow = notable.len() > remaining;
-                        let show = if overflow {
-                            remaining.saturating_sub(1)
-                        } else {
-                            notable.len()
-                        };
-                        for row in notable.iter().take(show) {
-                            lines.push(truncate_to_width(&server_row_text(row, locale), width));
-                        }
-                        let hidden = notable.len().saturating_sub(show);
-                        if hidden > 0 {
-                            lines.push(format!("+{hidden} more · /mcp"));
-                        }
-                    }
-                }
-            }
-        }
-        lines.truncate(MAX_RECEIPT_ROWS as usize);
-        lines
-    }
 }
 
 fn row_from_snapshot(
@@ -336,22 +219,16 @@ fn row_from_snapshot(
     initializing: bool,
     connecting: &[String],
 ) -> McpServerBootRow {
-    let valid_name = server
-        .name
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'));
     if !server.enabled {
         return McpServerBootRow {
             name: server.name.clone(),
             state: McpServerBootState::Disabled,
-            action: McpServerAction::None,
         };
     }
     if server.connected {
         return McpServerBootRow {
             name: server.name.clone(),
             state: McpServerBootState::Connected,
-            action: McpServerAction::None,
         };
     }
     if let Some(error) = server.error.as_deref() {
@@ -359,21 +236,11 @@ fn row_from_snapshot(
             return McpServerBootRow {
                 name: server.name.clone(),
                 state: McpServerBootState::NeedsLogin,
-                action: if valid_name {
-                    McpServerAction::Login
-                } else {
-                    McpServerAction::Diagnose
-                },
             };
         }
         return McpServerBootRow {
             name: server.name.clone(),
             state: McpServerBootState::Failed,
-            action: if valid_name {
-                McpServerAction::Retry
-            } else {
-                McpServerAction::Diagnose
-            },
         };
     }
     let connecting_now = initializing || connecting.iter().any(|name| name == &server.name);
@@ -383,13 +250,6 @@ fn row_from_snapshot(
             McpServerBootState::Connecting
         } else {
             McpServerBootState::Failed
-        },
-        action: if connecting_now {
-            McpServerAction::None
-        } else if valid_name {
-            McpServerAction::Retry
-        } else {
-            McpServerAction::Diagnose
         },
     }
 }
@@ -418,53 +278,6 @@ fn named_chip_line(kind: &str, count: usize, verb: &str, names: &[&str]) -> Stri
         }
     }
     line
-}
-
-fn server_row_text(row: &McpServerBootRow, locale: Locale) -> String {
-    let state = match row.state {
-        McpServerBootState::Connecting => Cow::Borrowed("connecting"),
-        McpServerBootState::Connected => tr(locale, MessageId::ExtensionsStateConnected),
-        McpServerBootState::Failed => tr(locale, MessageId::PhaseFailed),
-        McpServerBootState::NeedsLogin => Cow::Borrowed("needs login"),
-        McpServerBootState::Disabled => tr(locale, MessageId::HotbarSetupStatusDisabled),
-    };
-    let action = match row.action {
-        McpServerAction::Retry => format!(" · /mcp retry {}", row.name),
-        McpServerAction::Login => format!(" · /mcp login {}", row.name),
-        McpServerAction::Diagnose => " · /mcp doctor".to_string(),
-        McpServerAction::None => String::new(),
-    };
-    format!("{}{ITEM_SEPARATOR}{state}{action}", row.name)
-}
-
-fn plugin_receipt_line(summary: PluginBootSummary, locale: Locale, width: usize) -> Option<String> {
-    if summary.is_quiet() {
-        return None;
-    }
-    let mut parts = vec![format!(
-        "{}{ITEM_SEPARATOR}{} {}",
-        tr(locale, MessageId::ExtensionsTabPlugins),
-        summary.loaded,
-        "loaded"
-    )];
-    if summary.invalid > 0 {
-        parts.push(format!(
-            "{} {}",
-            summary.invalid,
-            tr(locale, MessageId::ExtensionsStateInvalid)
-        ));
-    }
-    if summary.duplicate > 0 {
-        parts.push(format!("{} duplicate", summary.duplicate));
-    }
-    if summary.needs_setup > 0 {
-        parts.push(format!("{} need setup", summary.needs_setup));
-    }
-    Some(truncate_to_width(&parts.join(ITEM_SEPARATOR), width))
-}
-
-fn truncate_to_width(text: &str, width: usize) -> String {
-    crate::localization::truncate_to_width(text, width)
 }
 
 /// Activity-strip chip for the current session boot set.
@@ -518,7 +331,6 @@ mod tests {
             SessionBootSurface::from_parts(None, false, &[], 0, PluginBootSummary::default());
         assert_eq!(surface.phase, SessionBootPhase::Hidden);
         assert!(surface.activity_chip(Locale::En, 80).is_none());
-        assert!(surface.receipt_lines(Locale::En, 80).is_empty());
     }
 
     #[test]
@@ -537,9 +349,6 @@ mod tests {
         let chip = surface.activity_chip(Locale::En, 80).expect("chip");
         assert!(chip.contains("alpha"), "{chip}");
         assert!(!chip.to_ascii_lowercase().contains("slack"), "{chip}");
-        let receipt = surface.receipt_lines(Locale::En, 80);
-        assert_eq!(receipt.len(), 1);
-        assert!(receipt[0].contains("alpha"), "{receipt:?}");
     }
 
     #[test]
@@ -567,13 +376,10 @@ mod tests {
         assert!(chip.contains("alpha"), "{chip}");
         assert!(chip.contains("docs"), "{chip}");
         assert!(!chip.to_ascii_lowercase().contains("slack"), "{chip}");
-        let receipt = surface.receipt_lines(Locale::En, 80);
-        assert_eq!(receipt.len(), 1, "{receipt:?}");
-        assert!(receipt[0].contains("4 connecting"), "{receipt:?}");
     }
 
     #[test]
-    fn settled_failures_keep_retry_and_login_on_the_row() {
+    fn settled_failures_remain_classified_for_the_footer_chip() {
         let snap = snapshot(vec![
             server("alpha", true, true, None),
             server("beta", true, false, Some("protocol negotiation timed out")),
@@ -590,12 +396,7 @@ mod tests {
             false,
             &[],
             4,
-            PluginBootSummary {
-                loaded: 12,
-                invalid: 1,
-                duplicate: 2,
-                needs_setup: 0,
-            },
+            PluginBootSummary::default(),
         );
         assert_eq!(surface.phase, SessionBootPhase::Settled);
         assert_eq!(
@@ -603,27 +404,17 @@ mod tests {
                 .servers
                 .iter()
                 .find(|row| row.name == "beta")
-                .map(|row| (row.state, row.action)),
-            Some((McpServerBootState::Failed, McpServerAction::Retry))
+                .map(|row| row.state),
+            Some(McpServerBootState::Failed)
         );
         assert_eq!(
             surface
                 .servers
                 .iter()
                 .find(|row| row.name == "gamma")
-                .map(|row| (row.state, row.action)),
-            Some((McpServerBootState::NeedsLogin, McpServerAction::Login))
+                .map(|row| row.state),
+            Some(McpServerBootState::NeedsLogin)
         );
-        let receipt = surface.receipt_lines(Locale::En, 100);
-        let joined = receipt.join("\n");
-        assert!(joined.contains("Plugins"), "{joined}");
-        assert!(joined.contains("12 loaded"), "{joined}");
-        assert!(joined.contains("1 invalid"), "{joined}");
-        assert!(joined.contains("2 duplicate"), "{joined}");
-        assert!(joined.contains("/mcp retry beta"), "{joined}");
-        assert!(joined.contains("/mcp login gamma"), "{joined}");
-        assert!(!joined.contains("/mcp auth"), "{joined}");
-        assert!(!joined.to_ascii_lowercase().contains("slack"), "{joined}");
     }
 
     #[test]
@@ -675,10 +466,6 @@ mod tests {
         assert!(chip.contains("alpha"), "{chip}");
         assert!(chip.contains("gamma"), "{chip}");
         assert!(!chip.to_ascii_lowercase().contains("slack"), "{chip}");
-        let receipt = surface.receipt_lines(Locale::En, 80);
-        assert_eq!(receipt.len(), 1, "{receipt:?}");
-        assert!(receipt[0].contains("alpha"), "{receipt:?}");
-        assert!(receipt[0].contains("docs"), "{receipt:?}");
     }
 
     #[test]
@@ -691,113 +478,5 @@ mod tests {
             surface.activity_chip(Locale::En, 80).as_deref(),
             Some("MCP · 4 connecting")
         );
-        assert_eq!(
-            surface.receipt_lines(Locale::En, 80),
-            vec!["MCP · 4 connecting".to_string()]
-        );
-    }
-
-    #[test]
-    fn settled_single_server_keeps_the_name_and_next_action() {
-        let snap = snapshot(vec![server(
-            "alpha",
-            true,
-            false,
-            Some("protocol negotiation timed out"),
-        )]);
-        let surface = SessionBootSurface::from_parts(
-            Some(&snap),
-            false,
-            &[],
-            1,
-            PluginBootSummary::default(),
-        );
-        assert_eq!(surface.phase, SessionBootPhase::Settled);
-        assert_eq!(
-            surface.receipt_lines(Locale::En, 80),
-            vec!["alpha · failed · /mcp retry alpha".to_string()]
-        );
-    }
-
-    #[test]
-    fn settled_all_connected_collapses_to_the_count() {
-        let snap = snapshot(vec![
-            server("alpha", true, true, None),
-            server("beta", true, true, None),
-        ]);
-        let surface = SessionBootSurface::from_parts(
-            Some(&snap),
-            false,
-            &[],
-            2,
-            PluginBootSummary::default(),
-        );
-        assert_eq!(surface.phase, SessionBootPhase::Settled);
-        assert_eq!(
-            surface.receipt_lines(Locale::En, 80),
-            vec!["MCP · 2 connected".to_string()]
-        );
-        assert!(surface.activity_chip(Locale::En, 80).is_none());
-    }
-
-    #[test]
-    fn overflow_receipt_keeps_a_plus_more_row() {
-        let snap = snapshot(
-            (0..8)
-                .map(|i| {
-                    server(
-                        &format!("s{i}"),
-                        true,
-                        false,
-                        Some("protocol negotiation timed out"),
-                    )
-                })
-                .collect(),
-        );
-        let surface = SessionBootSurface::from_parts(
-            Some(&snap),
-            false,
-            &[],
-            8,
-            PluginBootSummary::default(),
-        );
-        let receipt = surface.receipt_lines(Locale::En, 80);
-        assert_eq!(receipt.len(), 6, "{receipt:?}");
-        assert!(
-            receipt.last().is_some_and(|line| line.contains("+3 more")),
-            "{receipt:?}"
-        );
-        assert!(
-            receipt.iter().any(|line| line.contains("/mcp retry s0")),
-            "{receipt:?}"
-        );
-        assert!(!receipt.join("\n").contains("/mcp auth"), "{receipt:?}");
-    }
-
-    #[test]
-    fn plugin_line_sits_beside_connecting_mcp_names() {
-        let connecting = ["alpha", "beta"]
-            .into_iter()
-            .map(str::to_string)
-            .collect::<Vec<_>>();
-        let surface = SessionBootSurface::from_parts(
-            None,
-            true,
-            &connecting,
-            2,
-            PluginBootSummary {
-                loaded: 12,
-                invalid: 1,
-                duplicate: 2,
-                needs_setup: 0,
-            },
-        );
-        let receipt = surface.receipt_lines(Locale::En, 100);
-        let joined = receipt.join("\n");
-        assert!(joined.contains("Plugins"), "{joined}");
-        assert!(joined.contains("12 loaded"), "{joined}");
-        assert!(joined.contains("alpha"), "{joined}");
-        assert!(joined.contains("beta"), "{joined}");
-        assert!(!joined.to_ascii_lowercase().contains("slack"), "{joined}");
     }
 }

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -6214,7 +6214,8 @@ mod session_boot_event_tests {
         assert_eq!(app.mcp_configured_count, 2);
         let surface = crate::tui::session_boot::SessionBootSurface::from_app(&app);
         let chip = surface
-            .activity_chip(crate::localization::Locale::En, 80)
+            .activity_notice(crate::localization::Locale::En, 80)
+            .map(|notice| notice.text)
             .expect("chip");
         assert!(chip.contains("alpha"), "{chip}");
         assert!(chip.contains("beta"), "{chip}");

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -1106,20 +1106,8 @@ pub(crate) fn render(f: &mut Frame, app: &mut App, _config: &Config) -> Option<(
     // up to three compact rows at the release floor.
     let preview_cap = if size.height >= 20 { 4 } else { 3 };
     let preview_height = desired_preview_height.min(auxiliary_budget.min(preview_cap));
-    let session_boot_height = if mini {
-        0
-    } else {
-        crate::tui::session_boot::receipt_height(
-            app,
-            shell_area.width,
-            auxiliary_budget.saturating_sub(preview_height),
-        )
-    };
-    let workflow_panel_height = desired_workflow_panel_height.min(
-        auxiliary_budget
-            .saturating_sub(preview_height)
-            .saturating_sub(session_boot_height),
-    );
+    let workflow_panel_height =
+        desired_workflow_panel_height.min(auxiliary_budget.saturating_sub(preview_height));
 
     // One pinned footer row brackets the composer from below (spec §3: the
     // activity band and identity band merged into it): phase · live detail ·
@@ -1138,16 +1126,14 @@ pub(crate) fn render(f: &mut Frame, app: &mut App, _config: &Config) -> Option<(
             Constraint::Length(workflow_panel_height), // Workflow panel (#4121)
             Constraint::Length(preview_height),        // Pending input preview (0 if empty)
             Constraint::Length(indicator_height),      // Background-work chip (#5286, 0 if idle)
-            Constraint::Length(session_boot_height),   // MCP+plugin boot receipt (0 if quiet)
             Constraint::Length(plugin_cta_height),     // Live plugin CTA (0 unless matched)
             Constraint::Length(composer_height),       // Composer
             Constraint::Length(footer_height),         // Merged Tideline footer (slots 6+8)
         ])
         .split(body_area);
-    let session_boot_slot = 5;
-    let plugin_cta_slot = 6;
-    let composer_slot = 7;
-    let footer_slot = 8;
+    let plugin_cta_slot = 5;
+    let composer_slot = 6;
+    let footer_slot = 7;
 
     let (work_chat_area, side_work_area) = if mini && !mini_cfg.keep_sidebar {
         // Mini mode without the side rail: the transcript takes the whole
@@ -1313,11 +1299,6 @@ pub(crate) fn render(f: &mut Frame, app: &mut App, _config: &Config) -> Option<(
         crate::tui::background_indicator::render(body_chunks[4], buf, app, &pending_work);
     }
 
-    if session_boot_height > 0 {
-        let buf = f.buffer_mut();
-        crate::tui::session_boot::render(body_chunks[session_boot_slot], buf, app);
-    }
-
     if plugin_cta_height > 0 {
         let buf = f.buffer_mut();
         crate::tui::plugin_suggestions::draw_plugin_cta(app, body_chunks[plugin_cta_slot], buf);
@@ -1440,13 +1421,6 @@ pub(crate) fn render(f: &mut Frame, app: &mut App, _config: &Config) -> Option<(
         column.paint_matching(work_chat_area, f.buffer_mut(), app.ui_theme.surface_bg);
         column.paint_matching(body_chunks[2], f.buffer_mut(), app.ui_theme.surface_bg);
         column.paint_matching(body_chunks[3], f.buffer_mut(), app.ui_theme.surface_bg);
-        if session_boot_height > 0 {
-            column.paint_matching(
-                body_chunks[session_boot_slot],
-                f.buffer_mut(),
-                app.ui_theme.surface_bg,
-            );
-        }
         if plugin_cta_height > 0 {
             column.paint_matching(
                 body_chunks[plugin_cta_slot],

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4135,6 +4135,63 @@ fn wide_underwater_shell_aligns_transcript_and_composer_on_the_shared_canvas() {
 }
 
 #[test]
+fn failed_mcp_is_a_footer_chip_not_multiline_chat_boot_output() {
+    fn app() -> App {
+        let mut app = create_test_app();
+        app.onboarding_workspace_trust_gate = false;
+        app.onboarding = OnboardingState::None;
+        app.launch.visible = false;
+        app
+    }
+
+    let mut baseline = app();
+    let _ = render_underwater_test_app(&mut baseline, 100, 30);
+    let baseline_composer = baseline
+        .viewport
+        .last_composer_area
+        .expect("baseline composer area");
+
+    let mut failed = app();
+    failed.mcp_snapshot = Some(crate::mcp::McpManagerSnapshot {
+        config_path: PathBuf::from("mcp.json"),
+        config_exists: true,
+        reload_required: false,
+        servers: vec![crate::mcp::McpServerSnapshot {
+            name: "alpha".to_string(),
+            enabled: true,
+            required: false,
+            transport: "stdio".to_string(),
+            command_or_url: "alpha-mcp".to_string(),
+            connect_timeout: 5,
+            execute_timeout: 5,
+            read_timeout: 5,
+            connected: false,
+            error: Some("protocol negotiation timed out".to_string()),
+            capability_metadata: crate::mcp::McpServerCapabilityMetadata::NotObserved,
+            tools: Vec::new(),
+            resources: Vec::new(),
+            prompts: Vec::new(),
+        }],
+    });
+    let rendered = render_underwater_test_app(&mut failed, 100, 30);
+
+    assert_eq!(
+        failed
+            .viewport
+            .last_composer_area
+            .expect("failed-MCP composer area"),
+        baseline_composer,
+        "MCP diagnostics must not reserve chat/composer rows"
+    );
+    assert!(
+        rendered.contains("MCP · 0 connected · 1 failed"),
+        "{rendered}"
+    );
+    assert!(!rendered.contains("alpha · failed"), "{rendered}");
+    assert!(!rendered.contains("/mcp retry alpha"), "{rendered}");
+}
+
+#[test]
 fn wide_underwater_canvas_carries_the_ocean_to_both_terminal_edges() {
     let mut app = create_test_app();
     app.ui_theme = crate::palette::UI_THEME;


### PR DESCRIPTION
Closes #5759

## Product change

Moves per-server MCP boot detail out of the chat/composer shell. The existing footer is the compact status surface; `/mcp` remains the detailed diagnostic and action surface. The retired multi-row receipt renderer and its dead action metadata are removed rather than left as warning-producing legacy code.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib --locked failed_mcp_is_a_footer_chip_not_multiline_chat_boot_output`
- `CODEWHALE_DEV_NEXTEST=0 ./scripts/dev-test.sh tui session_boot` (12 passed)

No live-terminal visual acceptance is claimed by this PR.