### PR TITLE
fix(tui): retain startup hero on clean launch

### DIFF
--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -421,9 +421,11 @@ pub struct Settings {
     pub composer_vim_mode: String,
     /// Transcript spacing rhythm: compact, comfortable, spacious
     pub transcript_spacing: String,
-    /// Show the pre-session launch menu. When false, Codewhale enters a new
-    /// session directly; resume remains available in-session.
-    #[serde(default)]
+    /// Retired pre-Tideline preference, retained only so existing
+    /// `launch_screen` values keep parsing. Fresh interactive launches now
+    /// always start at Tideline Startup; an intentional resume or explicit
+    /// initial prompt is the only direct-session route.
+    #[serde(default, skip_serializing)]
     pub launch_screen: bool,
     /// Default mode: "agent" (Act), "plan", or "operate". Legacy permission
     /// shorthands are accepted for migration but never advertised as modes.
@@ -1482,9 +1484,6 @@ impl Settings {
                 }
                 self.transcript_spacing = normalized.to_string();
             }
-            "launch_screen" | "launch" => {
-                self.launch_screen = parse_bool(value)?;
-            }
             "status_indicator" | "indicator" => {
                 let normalized = normalize_status_indicator(value);
                 if !["cw", "whale", "dots", "off"].contains(&normalized) {
@@ -1698,7 +1697,6 @@ impl Settings {
             self.workspace_follow_symlinks
         ));
         lines.push(format!("  default_mode:       {}", self.default_mode));
-        lines.push(format!("  launch_screen:      {}", self.launch_screen));
         lines.push(format!("  context_panel:      {}", self.context_panel));
         lines.push(format!("  cost_currency:      {}", self.cost_currency));
         lines.push(format!("  max_history:        {}", self.max_input_history));
@@ -1875,10 +1873,6 @@ impl Settings {
             (
                 "transcript_spacing",
                 "Transcript spacing: compact, comfortable, spacious",
-            ),
-            (
-                "launch_screen",
-                "Show the pre-session launch menu on startup: on/off",
             ),
             (
                 "status_indicator",
@@ -3590,7 +3584,7 @@ mod tests {
         assert_eq!(settings.transcript_spacing, "comfortable");
         assert!(
             !settings.launch_screen,
-            "returning users enter a session directly"
+            "legacy launch-screen state is inert by default"
         );
     }
 

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -425,6 +425,7 @@ pub struct Settings {
     /// `launch_screen` values keep parsing. Fresh interactive launches now
     /// always start at Tideline Startup; an intentional resume or explicit
     /// initial prompt is the only direct-session route.
+    #[allow(dead_code)] // persisted compatibility only; clean launches no longer branch on it
     #[serde(default, skip_serializing)]
     pub launch_screen: bool,
     /// Default mode: "agent" (Act), "plan", or "operate". Legacy permission

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -421,13 +421,6 @@ pub struct Settings {
     pub composer_vim_mode: String,
     /// Transcript spacing rhythm: compact, comfortable, spacious
     pub transcript_spacing: String,
-    /// Retired pre-Tideline preference, retained only so existing
-    /// `launch_screen` values keep parsing. Fresh interactive launches now
-    /// always start at Tideline Startup; an intentional resume or explicit
-    /// initial prompt is the only direct-session route.
-    #[allow(dead_code)] // persisted compatibility only; clean launches no longer branch on it
-    #[serde(default, skip_serializing)]
-    pub launch_screen: bool,
     /// Default mode: "agent" (Act), "plan", or "operate". Legacy permission
     /// shorthands are accepted for migration but never advertised as modes.
     pub default_mode: String,
@@ -611,7 +604,6 @@ impl Default for Settings {
             composer_multiline_mode: false,
             composer_vim_mode: "normal".to_string(),
             transcript_spacing: "comfortable".to_string(),
-            launch_screen: false,
             default_mode: "agent".to_string(),
             sidebar_width_percent: 28,
             sidebar_focus: "auto".to_string(),
@@ -3583,9 +3575,24 @@ mod tests {
         );
         assert!(!settings.low_motion);
         assert_eq!(settings.transcript_spacing, "comfortable");
+    }
+
+    #[test]
+    fn retired_launch_screen_setting_is_accepted_and_dropped_on_save() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("settings.toml");
+        std::fs::write(&path, "launch_screen = false\n").expect("legacy settings");
+
+        let settings = Settings::load_persisted_from_candidates(Some(path.clone()), None, None)
+            .expect("legacy setting must remain readable");
+        settings
+            .save_to_path(&path)
+            .expect("save normalized settings");
+
+        let saved = std::fs::read_to_string(&path).expect("read normalized settings");
         assert!(
-            !settings.launch_screen,
-            "legacy launch-screen state is inert by default"
+            !saved.contains("launch_screen"),
+            "the retired setting must not be written back: {saved}"
         );
     }
 

--- a/crates/tui/src/test_support.rs
+++ b/crates/tui/src/test_support.rs
@@ -324,10 +324,17 @@ pub(crate) fn test_tui_options(workspace: impl AsRef<Path>) -> crate::tui::app::
 /// `App::new` consults real persisted settings (provider/model maps,
 /// auto-model, route limits, locale, currency), so an un-pinned fixture
 /// computes against whatever the developer last configured. Every pin below
-/// exists because some test was observed to depend on it.
+/// exists because some test was observed to depend on it. This fixture models
+/// a session after the user has chosen a Startup action; direct `App::new`
+/// tests remain the clean-launch authority.
 pub(crate) fn test_app_with_options(options: crate::tui::app::TuiOptions) -> crate::tui::app::App {
     let config = crate::config::Config::default();
     let mut app = crate::tui::app::App::new(options, &config);
+
+    // Shared behavior tests operate on the live session surface. Do not make
+    // the production startup conditional for them: clean launches are covered
+    // by direct `App::new` tests that retain the Tideline Startup Hero.
+    app.launch.visible = false;
 
     // Deterministic presentation regardless of host locale.
     app.cost_currency = crate::pricing::CostCurrency::Usd;

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -113,8 +113,12 @@ impl App {
             false
         };
         settings.apply_env_overrides();
-        let launch_visible =
-            settings.launch_screen && resume_session_id.is_none() && initial_input.is_none();
+        // Tideline Startup is the fresh interactive landing surface. It must
+        // not be bypassed by a stale historical `launch_screen = false`, a
+        // provider/config notice, or a previous session record: only an
+        // intentional resume or explicit initial input enters the live session
+        // path directly.
+        let launch_visible = resume_session_id.is_none() && initial_input.is_none();
         let launch = LaunchState::new(launch_visible, &workspace);
 
         // If settings.toml exists on disk but couldn't be parsed (we fell back

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -134,6 +134,10 @@ fn initial_input_prefill_waits_for_manual_submit() {
 
     let app = App::new(options, &Config::default());
 
+    assert!(
+        !app.launch.visible,
+        "an intentional prefilled prompt must enter the live composer instead of the startup hero"
+    );
     assert_eq!(app.input, "review this PR");
     assert_eq!(app.cursor_position, "review this PR".chars().count());
     assert!(!app.auto_submit_initial_input);
@@ -148,12 +152,70 @@ fn initial_input_submit_marks_startup_dispatch() {
 
     let app = App::new(options, &Config::default());
 
+    assert!(
+        !app.launch.visible,
+        "an intentional submitted prompt must bypass the startup hero"
+    );
     assert_eq!(app.input, "阅读项目 and wait for instructions");
     assert_eq!(
         app.cursor_position,
         "阅读项目 and wait for instructions".chars().count()
     );
     assert!(app.auto_submit_initial_input);
+}
+
+#[test]
+fn clean_launch_keeps_startup_hero_despite_a_startup_notice() {
+    let _env_lock = lock_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    let _config_env = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
+    std::fs::write(tmp.path().join("settings.toml"), "launch_screen = false\n")
+        .expect("legacy settings");
+    let mut options = test_options(false);
+    options.startup_notice =
+        Some("Provider route changed; inspect the route before sending".into());
+
+    let app = App::new(options, &Config::default());
+
+    assert!(
+        app.launch.visible,
+        "a fresh interactive launch must keep the Tideline startup hero visible; a notice is not an intentional resume or prompt"
+    );
+}
+
+#[test]
+fn explicit_resume_bypasses_startup_hero() {
+    let _env_lock = lock_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    let _config_env = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
+    let mut options = test_options(false);
+    options.resume_session_id = Some("explicit-resume".into());
+
+    let app = App::new(options, &Config::default());
+
+    assert!(
+        !app.launch.visible,
+        "an explicit resume must preserve the existing session path"
+    );
+}
+
+#[test]
+fn remote_control_initial_input_bypasses_startup_hero() {
+    let _env_lock = lock_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    let _config_env = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
+    let mut options = test_options(false);
+    options.initial_input = Some(InitialInput::RemoteControl);
+
+    let app = App::new(options, &Config::default());
+
+    assert!(
+        !app.launch.visible,
+        "an intentional remote-control launch must preserve its existing direct-session path"
+    );
 }
 
 #[test]

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -2171,14 +2171,6 @@ impl ConfigView {
             },
             ConfigRow {
                 section: ConfigSection::Display,
-                key: "launch_screen".to_string(),
-                value: settings.launch_screen.to_string(),
-                editable: true,
-                scope: ConfigScope::Saved,
-                facts: ConfigRowFacts::saved_setting().apply(SettingApplySemantics::NextSession),
-            },
-            ConfigRow {
-                section: ConfigSection::Display,
                 key: "show_thinking".to_string(),
                 value: settings.show_thinking.to_string(),
                 editable: true,
@@ -3357,7 +3349,6 @@ fn config_label_message(key: &str) -> Option<MessageId> {
         "calm_mode" => MessageId::ConfigLabelCalmMode,
         "low_motion" => MessageId::ConfigLabelLowMotion,
         "fancy_animations" => MessageId::ConfigLabelFancyAnimations,
-        "launch_screen" => MessageId::ConfigLabelLaunchScreen,
         "show_thinking" => MessageId::ConfigLabelShowThinking,
         "thinking_highlight" => MessageId::ConfigLabelThinkingHighlight,
         "show_tool_details" => MessageId::ConfigLabelShowToolDetails,
@@ -3461,11 +3452,9 @@ fn config_hint_for_key(locale: Locale, key: &str) -> Cow<'static, str> {
         "managed_allow_shell" => MessageId::ConfigHintManagedAllowShell,
         "allow_shell" => MessageId::ConfigHintAllowShell,
         "composer_multiline_mode" => MessageId::ConfigHintComposerMultilineMode,
-        "auto_compact"
-        | "launch_screen"
-        | "show_tool_details"
-        | "composer_border"
-        | "paste_burst_detection" => MessageId::ConfigHintBooleanValues,
+        "auto_compact" | "show_tool_details" | "composer_border" | "paste_burst_detection" => {
+            MessageId::ConfigHintBooleanValues
+        }
         "composer_density" | "transcript_spacing" => MessageId::ConfigHintDensity,
         "inline_diffs" => MessageId::ConfigHintInlineDiffs,
         "tool_collapse" => MessageId::ConfigHintToolCollapse,
@@ -3532,7 +3521,6 @@ fn config_boolean_key(key: &str) -> bool {
             | "calm_mode"
             | "low_motion"
             | "fancy_animations"
-            | "launch_screen"
             | "show_thinking"
             | "thinking_default_expanded"
             | "thinking_highlight"

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -4350,6 +4350,9 @@ mod tests {
             ..crate::test_support::test_tui_options(PathBuf::from("."))
         };
         let mut app = App::new(options, &Config::default());
+        // Widget contracts below exercise the post-Startup conversation
+        // surface. Startup rendering has its own explicit fixture/tests.
+        app.launch.visible = false;
         app.ui_locale = Locale::En;
         app.composer.vim_enabled = false;
         // Most widget fixtures exercise the explicitly selected underwater

--- a/crates/tui/tests/cucumber/plugin_e2e_acceptance.rs
+++ b/crates/tui/tests/cucumber/plugin_e2e_acceptance.rs
@@ -795,6 +795,29 @@ fn wait_for_composer_ready(tui: &mut Harness) {
     }
 }
 
+/// This acceptance starts as a fresh interactive launch. Select the real
+/// Startup "New session" action before testing commands that belong to a
+/// live conversation; a focused pre-session composer is not itself a session.
+#[cfg(all(unix, feature = "long-running-tests"))]
+fn begin_new_session_from_startup(tui: &mut Harness) {
+    expect_visible(tui, "What are we working on?", "show Tideline Startup");
+    tui.send(keys::key::ch('w'))
+        .expect("choose Startup New session");
+    if tui
+        .wait_for(
+            |frame| !frame.text().contains("What are we working on?"),
+            BINARY_ACCEPTANCE_TIMEOUT,
+        )
+        .is_err()
+    {
+        panic!(
+            "Startup New session did not enter the live shell within {:?}\n{}",
+            qa_harness::harness::ci_scaled(BINARY_ACCEPTANCE_TIMEOUT),
+            short_diagnostics(tui, None)
+        );
+    }
+}
+
 #[cfg(all(unix, feature = "long-running-tests"))]
 fn wait_for_log(tui: &mut Harness, path: &std::path::Path, needle: &str) {
     let budget = qa_harness::harness::ci_scaled(BINARY_ACCEPTANCE_TIMEOUT);
@@ -851,6 +874,9 @@ async fn plugin_toml_binary_lifecycle_skill_and_stdio_mcp_acceptance() {
         .expect("start distributed TUI binary");
 
     // Readiness is a painted, focused composer—not localized placeholder copy.
+    // The binary begins at Tideline Startup, so choose its real New Session
+    // action before exercising the existing-session plugin contract.
+    begin_new_session_from_startup(&mut tui);
     wait_for_composer_ready(&mut tui);
     submit_tui_command(&mut tui, "/plugin show demo");
     expect_visible(

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1684,11 +1684,11 @@ Common settings keys:
   context panel, `/cost`, `/tokens`, and long-turn notification summaries. The
   aliases `rmb` and `yuan` normalize to `cny`.
 - `default_mode` (`agent`, `plan`, or `operate`; legacy values are accepted for migration but are not live mode vocabulary)
-- `launch_screen` (`on`/`off`; default `off`): show the pre-session Work/Chat/
-  Resume/Worktree menu. Work uses the current folder under the configured
-  approval policy; Chat starts a read-only conversation. With the launch
-  screen off, Codewhale enters a new session directly; resume remains
-  available in-session.
+- `launch_screen` (legacy, migration-only): this historical `on`/`off` value
+  is still accepted when reading an existing settings file, but it no longer
+  changes behavior and is omitted from new saves. A fresh interactive launch
+  always opens Tideline Startup; only an explicit resume or an explicit
+  initial prompt enters the live session directly.
 - `sidebar_focus` (legacy, migration-only): the classic right sidebar this key
   configured was removed in the 0.9.4 rail unification. The key is still read
   once so old settings carry forward, then folds into the live keys:


### PR DESCRIPTION
Closes #5761

## Product change

Fresh interactive launches now always use Tideline Startup. Intentional resume and explicit initial-input modes preserve the existing direct-session path. The historical `launch_screen` setting is parse-compatible but inert and omitted from new settings saves.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- focused app tests: fresh launch + notice, explicit resume, prefill, submit, remote-control, default settings

## Remaining acceptance gate

This PR does not claim live terminal visual acceptance or first-run/onboarding device coverage; those remain release-gate evidence.