### PR TITLE
fix(tui): make topbar route segment interactive

### DIFF
--- a/crates/tui/src/tui/keybindings.rs
+++ b/crates/tui/src/tui/keybindings.rs
@@ -242,6 +242,13 @@ pub const KEYBINDINGS: &[KeybindingEntry] = &[
         section: KeybindingSection::Submission,
     },
     KeybindingEntry {
+        // `/provider` remains the portable command route; F3 mirrors the
+        // clickable topbar route segment without consuming composer text.
+        chord: "F3 / /provider",
+        description_id: crate::localization::MessageId::CmdProviderDescription,
+        section: KeybindingSection::Submission,
+    },
+    KeybindingEntry {
         chord: "Alt+L",
         description_id: crate::localization::MessageId::KbLastMessagePager,
         section: KeybindingSection::Submission,
@@ -531,10 +538,15 @@ mod tests {
             binding(ShellBindingId::ContextInspector).catalog_chord,
             "/context"
         );
+        assert_eq!(
+            binding(ShellBindingId::ProviderRoute).catalog_chord,
+            "F3 / /provider"
+        );
         assert_eq!(binding(ShellBindingId::Help).catalog_chord, "F1 / Ctrl+/");
         for id in [
             ShellBindingId::ToolDetails,
             ShellBindingId::ContextInspector,
+            ShellBindingId::ProviderRoute,
             ShellBindingId::Help,
         ] {
             let chord = binding(id).catalog_chord;

--- a/crates/tui/src/tui/mouse_ui.rs
+++ b/crates/tui/src/tui/mouse_ui.rs
@@ -459,6 +459,29 @@ pub(crate) fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEv
         return app.view_stack.handle_mouse(mouse);
     }
 
+    // Topbar facts are typed controls, not decorative text. Route this before
+    // either launch or session content so a segment painted in the one shared
+    // header has identical mouse behavior in both shell states.
+    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+        let action = app
+            .viewport
+            .interaction_targets
+            .target_at(mouse.column, mouse.row)
+            .and_then(|target| target.mouse_action);
+        if let Some(action) = action {
+            app.needs_redraw = true;
+            return match action {
+                InteractionAction::InspectContext => {
+                    open_context_inspector(app);
+                    Vec::new()
+                }
+                InteractionAction::OpenProviderPicker => {
+                    vec![ViewEvent::TopbarRoutePickerRequested]
+                }
+            };
+        }
+    }
+
     // The launch surface owns the whole frame until a session is chosen.
     // Consume every mouse event here so wheel input cannot leak into the
     // transcript or composer behind the splash.
@@ -540,25 +563,6 @@ pub(crate) fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEv
         }
         app.needs_redraw = true;
         return Vec::new();
-    }
-
-    // Header facts are inspectable targets, not decorative text. The context
-    // meter shares its destination with the existing Alt+C shortcut; use the
-    // typed target recorded by the renderer instead of guessing from a label
-    // or rebuilding chrome geometry in input handling.
-    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
-        let action = app
-            .viewport
-            .interaction_targets
-            .target_at(mouse.column, mouse.row)
-            .and_then(|target| target.mouse_action);
-        if let Some(action) = action {
-            match action {
-                InteractionAction::InspectContext => open_context_inspector(app),
-            }
-            app.needs_redraw = true;
-            return Vec::new();
-        }
     }
 
     // Ocean work surface owns its rect, scrolling, focus, and row actions.
@@ -1830,7 +1834,7 @@ mod tests {
         ContextBudgetSnapshot, InspectDetail, InteractionAction, InteractionFocus,
         InteractionTarget, InteractionTargetId,
     };
-    use crate::tui::views::{ContextMenuAction, ModalKind};
+    use crate::tui::views::{ContextMenuAction, ModalKind, ViewEvent};
     use crossterm::event::{
         KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
@@ -2058,6 +2062,33 @@ mod tests {
                 KeyModifiers::ALT
             ))
         );
+    }
+
+    #[test]
+    fn topbar_route_click_emits_provider_picker_request() {
+        let mut app = create_test_app();
+        // The launch screen shares the same header, so this specifically
+        // protects against its old catch-all mouse route swallowing the
+        // topbar affordance before it reached the event handler.
+        app.launch.visible = true;
+        app.viewport
+            .interaction_targets
+            .register(InteractionTarget {
+                id: InteractionTargetId::HEADER_ROUTE,
+                area: Rect::new(20, 0, 24, 1),
+                focus: InteractionFocus::Direct,
+                keyboard_action: Some(InteractionAction::OpenProviderPicker),
+                mouse_action: Some(InteractionAction::OpenProviderPicker),
+                inspect_detail: InspectDetail::Route,
+            });
+
+        let events = handle_mouse_event(&mut app, left_click(24, 0));
+
+        assert!(matches!(
+            events.as_slice(),
+            [ViewEvent::TopbarRoutePickerRequested]
+        ));
+        assert!(app.view_stack.is_empty());
     }
 
     #[test]

--- a/crates/tui/src/tui/shell_key_routing.rs
+++ b/crates/tui/src/tui/shell_key_routing.rs
@@ -6,6 +6,8 @@
 //! panel, or modal (TUI-DOG-002). Details/output fires only on
 //! Option+V / Alt+V, and macOS renders the label as `⌥V`, never `Alt`/`Cmd`.
 //! Help is `F1` (with `/help`); `Ctrl+/` stays as a secondary fallback.
+//! Provider/route is `F3` (with `/provider`); it is non-printable so it can
+//! remain available while the composer owns ordinary text input.
 //! `Alt+?` and `Alt+C` are still accepted where terminals deliver them but
 //! are never advertised until proven in real terminals (TUI-DOG-003);
 //! `/context` is the guaranteed context path.
@@ -23,6 +25,7 @@ use crate::tui::key_shortcuts;
 pub enum ShellBindingId {
     ToolDetails,
     ContextInspector,
+    ProviderRoute,
     Help,
 }
 
@@ -50,6 +53,12 @@ pub const SHELL_BINDINGS: &[ShellBinding] = &[
         // handler until proven in Cursor/Terminal.app/iTerm2/tmux/PTY.
         catalog_chord: "/context",
         footer_chord: "/context",
+    },
+    ShellBinding {
+        id: ShellBindingId::ProviderRoute,
+        // `/provider` remains the portable, explicit command path.
+        catalog_chord: "F3 / /provider",
+        footer_chord: "F3",
     },
     ShellBinding {
         id: ShellBindingId::Help,
@@ -166,6 +175,14 @@ pub fn is_tool_details_shortcut(key: &KeyEvent) -> bool {
 pub fn is_context_inspector_shortcut(key: &KeyEvent) -> bool {
     matches!(key.code, KeyCode::Char('c') | KeyCode::Char('C'))
         && key_shortcuts::alt_nav_modifiers(key.modifiers)
+}
+
+/// Route entry stays on a non-printable function key so it never steals a
+/// model/provider name from the composer. `/provider` remains available in
+/// terminals that do not forward function keys.
+#[must_use]
+pub fn is_provider_route_shortcut(key: &KeyEvent) -> bool {
+    matches!(key.code, KeyCode::F(3)) && key.modifiers.is_empty()
 }
 
 #[must_use]
@@ -347,6 +364,22 @@ mod tests {
     }
 
     #[test]
+    fn topbar_route_f3_requires_a_plain_function_key() {
+        assert!(is_provider_route_shortcut(&KeyEvent::new(
+            KeyCode::F(3),
+            KeyModifiers::NONE
+        )));
+        assert!(!is_provider_route_shortcut(&KeyEvent::new(
+            KeyCode::F(3),
+            KeyModifiers::ALT
+        )));
+        assert!(!is_provider_route_shortcut(&KeyEvent::new(
+            KeyCode::Char('3'),
+            KeyModifiers::NONE
+        )));
+    }
+
+    #[test]
     fn catalog_chords_match_final_contract() {
         assert_eq!(binding(ShellBindingId::Help).catalog_chord, "F1 / Ctrl+/");
         assert_eq!(
@@ -354,6 +387,10 @@ mod tests {
             "/context"
         );
         assert_eq!(binding(ShellBindingId::ToolDetails).catalog_chord, "Alt+V");
+        assert_eq!(
+            binding(ShellBindingId::ProviderRoute).catalog_chord,
+            "F3 / /provider"
+        );
         for binding in SHELL_BINDINGS {
             assert!(!binding.catalog_chord.contains("Alt+?"));
             assert_ne!(binding.catalog_chord, "v");

--- a/crates/tui/src/tui/tideline.rs
+++ b/crates/tui/src/tui/tideline.rs
@@ -164,12 +164,19 @@ pub struct InteractionTargetId(&'static str);
 
 impl InteractionTargetId {
     pub const HEADER_CONTEXT: Self = Self("header.context");
+    /// The rendered route/model segment. This is intentionally an affordance
+    /// id only: the provider picker remains the owner of route catalog and
+    /// readiness facts.
+    pub const HEADER_ROUTE: Self = Self("header.route");
 }
 
 /// Typed destination shared by keyboard and mouse input routes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InteractionAction {
     InspectContext,
+    /// Open the existing provider/route picker without making this chrome
+    /// target another source of catalog or runtime authority.
+    OpenProviderPicker,
 }
 
 /// Focus metadata for a selectable target.
@@ -189,6 +196,9 @@ pub enum InteractionFocus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InspectDetail {
     ContextBudget(ContextBudgetSnapshot),
+    /// The topbar exposes a route entry point, not a copied route snapshot.
+    /// `ProviderPickerView` remains the authoritative presentation owner.
+    Route,
 }
 
 /// A selectable region painted in the current frame.
@@ -259,6 +269,26 @@ mod tests {
                 percent_basis_points: 3_000,
             }),
         }
+    }
+
+    #[test]
+    fn topbar_route_target_is_typed_without_copying_route_facts() {
+        let target = InteractionTarget {
+            id: InteractionTargetId::HEADER_ROUTE,
+            area: Rect::new(20, 0, 24, 1),
+            focus: InteractionFocus::Direct,
+            keyboard_action: Some(InteractionAction::OpenProviderPicker),
+            mouse_action: Some(InteractionAction::OpenProviderPicker),
+            inspect_detail: InspectDetail::Route,
+        };
+
+        assert_eq!(target.id, InteractionTargetId::HEADER_ROUTE);
+        assert_eq!(
+            target.keyboard_action,
+            Some(InteractionAction::OpenProviderPicker)
+        );
+        assert_eq!(target.mouse_action, target.keyboard_action);
+        assert_eq!(target.inspect_detail, InspectDetail::Route);
     }
 
     #[test]

--- a/crates/tui/src/tui/ui/apply.rs
+++ b/crates/tui/src/tui/ui/apply.rs
@@ -1716,28 +1716,7 @@ pub(crate) async fn apply_command_result(
                 }
             }
             AppAction::OpenProviderPicker => {
-                if app.onboarding == OnboardingState::Provider {
-                    let recover_configured_route = app.onboarding_missing_key_recovery;
-                    open_onboarding_provider_picker(
-                        app,
-                        config,
-                        engine_handle,
-                        recover_configured_route,
-                    )
-                    .await;
-                } else if app.view_stack.top_kind() != Some(ModalKind::ProviderPicker) {
-                    let runtime_status = query_provider_runtime_status(engine_handle).await;
-                    app.view_stack.push(
-                        crate::tui::provider_picker::ProviderPickerView::new_with_runtime_status_and_memory(
-                            app.api_provider,
-                            config,
-                            runtime_status,
-                            app.provider_picker_memory.as_ref(),
-                        )
-                        .with_locale(app.ui_locale)
-                        .with_provider_health(&app.provider_health),
-                    );
-                }
+                open_provider_picker(app, config, engine_handle).await;
             }
             AppAction::OpenProviderSetup { provider } => {
                 if app.view_stack.top_kind() != Some(ModalKind::ProviderPicker) {

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -4407,6 +4407,29 @@ pub(crate) async fn run_event_loop(
                 continue;
             }
 
+            // F3 is the non-printable keyboard counterpart to the clickable
+            // route segment in the shared topbar. Route it through the same
+            // typed event as mouse input; `/provider` remains the portable
+            // direct command path for terminals that do not forward F-keys.
+            if crate::tui::shell_key_routing::is_provider_route_shortcut(&key)
+                && app.view_stack.is_empty()
+            {
+                if handle_view_events_boxed(
+                    terminal,
+                    app,
+                    config,
+                    &task_manager,
+                    &mut engine_handle,
+                    &mut web_config_session,
+                    vec![ViewEvent::TopbarRoutePickerRequested],
+                )
+                .await?
+                {
+                    return Ok(());
+                }
+                continue;
+            }
+
             // The pre-session launch menu owns every key until the user has
             // chosen a real session/worktree action. Resume and changelog may
             // place a shared surface above it; those views keep their normal

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -127,22 +127,29 @@ pub(crate) fn topbar_segments(app: &App, width: u16) -> Vec<TopbarSegment> {
     segments
 }
 
+/// The topbar controls that actually painted in this frame.
+///
+/// The route target intentionally contains no copied route metadata. The
+/// provider picker retains catalog, readiness, credential, and apply
+/// authority; chrome only exposes its entry point.
+#[derive(Debug, Clone, Copy, Default)]
+struct TopbarInteractionHitboxes {
+    context: Option<Rect>,
+    route: Option<Rect>,
+}
+
 /// Render the Tideline topbar into one header row and record its segment
 /// hitboxes (spec §5b `Constraint::Length(1)`). The ONE header on every
 /// screen: the session shell and the launch screen both call this, so the
 /// brand lockup, contextual segments, and the pinned meter + clock never
 /// change identity between pre- and post-session states. Segment rects are
 /// recorded for hover (this frame's highlight resolves against the previous
-/// frame's rects, the standard one-frame-lag registry pattern) and for click
-/// routing in a follow-up slice.
-/// Render the Tideline topbar row and record its segment hitboxes. Returns
-/// the pinned context meter's hitbox — the chrome row's one always-present
-/// inspector target (`Alt+C`'s mouse route) — or `None` when the meter could
-/// not paint whole and clear of the brand at this width.
-pub(crate) fn render_topbar_row(f: &mut Frame, app: &mut App, area: Rect) -> Option<Rect> {
+/// frame's rects, the standard one-frame-lag registry pattern) and for typed
+/// click routing.
+fn render_topbar_row(f: &mut Frame, app: &mut App, area: Rect) -> TopbarInteractionHitboxes {
     if area.height == 0 {
         app.viewport.last_topbar_hitboxes.clear();
-        return None;
+        return TopbarInteractionHitboxes::default();
     }
     let segments = topbar_segments(app, area.width);
     let clock = topbar_clock();
@@ -162,7 +169,13 @@ pub(crate) fn render_topbar_row(f: &mut Frame, app: &mut App, area: Rect) -> Opt
     .ascii_safe(crate::tui::color_compat::ascii_safe_enabled())
     .hovered(hovered);
     let hitboxes = topbar_hitboxes(&topbar, area);
-    let context_hitbox = crate::tui::topbar::context_meter_hitbox(&topbar, area);
+    let interaction_hitboxes = TopbarInteractionHitboxes {
+        context: crate::tui::topbar::context_meter_hitbox(&topbar, area),
+        route: hitboxes
+            .iter()
+            .find(|hitbox| hitbox.id == TopbarSegmentId::Model)
+            .map(|hitbox| hitbox.area),
+    };
     // Keep the header row's quiet background under the widget itself.
     let buf = f.buffer_mut();
     Block::default()
@@ -170,7 +183,75 @@ pub(crate) fn render_topbar_row(f: &mut Frame, app: &mut App, area: Rect) -> Opt
         .render(area, buf);
     ratatui::widgets::Widget::render(topbar, area, buf);
     app.viewport.last_topbar_hitboxes = hitboxes;
-    context_hitbox
+    interaction_hitboxes
+}
+
+/// Register the topbar's drawn controls as one typed input surface.
+///
+/// Both the launch stage and a live session use this exact registration, so
+/// mouse routing cannot advertise a header segment on only one shell state.
+fn register_topbar_interaction_targets(app: &mut App, hitboxes: TopbarInteractionHitboxes) {
+    if let (Some(hitbox), Some(context_budget)) = (
+        hitboxes.context,
+        crate::tui::tideline::ContextBudgetSnapshot::from_app(app),
+    ) {
+        app.viewport
+            .interaction_targets
+            .register(crate::tui::tideline::InteractionTarget {
+                id: crate::tui::tideline::InteractionTargetId::HEADER_CONTEXT,
+                area: hitbox,
+                focus: crate::tui::tideline::InteractionFocus::Direct,
+                keyboard_action: Some(crate::tui::tideline::InteractionAction::InspectContext),
+                mouse_action: Some(crate::tui::tideline::InteractionAction::InspectContext),
+                inspect_detail: crate::tui::tideline::InspectDetail::ContextBudget(context_budget),
+            });
+    }
+    if let Some(hitbox) = hitboxes.route {
+        app.viewport
+            .interaction_targets
+            .register(crate::tui::tideline::InteractionTarget {
+                id: crate::tui::tideline::InteractionTargetId::HEADER_ROUTE,
+                area: hitbox,
+                focus: crate::tui::tideline::InteractionFocus::Direct,
+                keyboard_action: Some(crate::tui::tideline::InteractionAction::OpenProviderPicker),
+                mouse_action: Some(crate::tui::tideline::InteractionAction::OpenProviderPicker),
+                inspect_detail: crate::tui::tideline::InspectDetail::Route,
+            });
+    }
+
+    for target in app.viewport.interaction_targets.iter() {
+        let label = match target.mouse_action {
+            Some(crate::tui::tideline::InteractionAction::InspectContext) => format!(
+                "{} · {}",
+                crate::localization::tr(
+                    app.ui_locale,
+                    crate::localization::MessageId::CtxMenuContextInspector,
+                ),
+                crate::localization::tr(
+                    app.ui_locale,
+                    crate::localization::MessageId::CtxMenuContextInspectorDesc,
+                ),
+            ),
+            Some(crate::tui::tideline::InteractionAction::OpenProviderPicker) => format!(
+                "{} · {}",
+                crate::localization::tr(
+                    app.ui_locale,
+                    crate::localization::MessageId::RoutePanelHeader,
+                ),
+                crate::localization::tr(
+                    app.ui_locale,
+                    crate::localization::MessageId::CmdProviderDescription,
+                ),
+            ),
+            None => continue,
+        };
+        crate::tui::hover_layer::register_rect(
+            crate::tui::hover_hit::HoverTargetKind::Link,
+            target.area,
+            label,
+            false,
+        );
+    }
 }
 
 /// Map the host terminal rect onto the session shell canvas.
@@ -917,7 +998,8 @@ pub(crate) fn render(f: &mut Frame, app: &mut App, _config: &Config) -> Option<(
                 Constraint::Length(1), // merged footer (slots 6+8)
             ])
             .areas(size);
-        render_topbar_row(f, app, topbar_area);
+        let topbar_interactions = render_topbar_row(f, app, topbar_area);
+        register_topbar_interaction_targets(app, topbar_interactions);
         let startup = crate::tui::underwater::tideline_startup_from_app(app);
         let hitboxes = crate::tui::underwater::tideline_startup_hitboxes(stage_area);
         crate::tui::underwater::render_tideline_startup(stage_area, f.buffer_mut(), &startup);
@@ -1168,49 +1250,13 @@ pub(crate) fn render(f: &mut Frame, app: &mut App, _config: &Config) -> Option<(
     // segments, then the pinned context meter + clock. The route identity
     // the old identity band carried below the composer now lives here as
     // the Model segment — its new permanent home.
-    let mut topbar_context_hitbox = None;
+    let mut topbar_interactions = TopbarInteractionHitboxes::default();
     if header_height > 0 {
-        topbar_context_hitbox = render_topbar_row(f, app, header_area);
+        topbar_interactions = render_topbar_row(f, app, header_area);
     } else {
         app.viewport.last_topbar_hitboxes.clear();
     }
-    if let (Some(hitbox), Some(context_budget)) = (
-        topbar_context_hitbox,
-        crate::tui::tideline::ContextBudgetSnapshot::from_app(app),
-    ) {
-        app.viewport
-            .interaction_targets
-            .register(crate::tui::tideline::InteractionTarget {
-                id: crate::tui::tideline::InteractionTargetId::HEADER_CONTEXT,
-                area: hitbox,
-                focus: crate::tui::tideline::InteractionFocus::Direct,
-                keyboard_action: Some(crate::tui::app::HeaderActionTarget::InspectContext),
-                mouse_action: Some(crate::tui::app::HeaderActionTarget::InspectContext),
-                inspect_detail: crate::tui::tideline::InspectDetail::ContextBudget(context_budget),
-            });
-    }
-    for target in app.viewport.interaction_targets.iter() {
-        let label = match target.mouse_action {
-            Some(crate::tui::tideline::InteractionAction::InspectContext) => format!(
-                "{} · {}",
-                crate::localization::tr(
-                    app.ui_locale,
-                    crate::localization::MessageId::CtxMenuContextInspector,
-                ),
-                crate::localization::tr(
-                    app.ui_locale,
-                    crate::localization::MessageId::CtxMenuContextInspectorDesc,
-                ),
-            ),
-            None => continue,
-        };
-        crate::tui::hover_layer::register_rect(
-            crate::tui::hover_hit::HoverTargetKind::Link,
-            target.area,
-            label,
-            false,
-        );
-    }
+    register_topbar_interaction_targets(app, topbar_interactions);
 
     // Render the transcript and optional file-tree sidecar. The underwater
     // default deliberately has no legacy right sidebar: Tasks and To-do own
@@ -1745,7 +1791,48 @@ pub(crate) fn workflow_tool_is_running(app: &App) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::short_title_truncate;
+    use super::{register_topbar_interaction_targets, render_topbar_row, short_title_truncate};
+    use ratatui::{Terminal, backend::TestBackend};
+
+    #[test]
+    fn topbar_route_segment_registers_interaction_target() {
+        let mut app =
+            crate::test_support::test_app_with_options(crate::test_support::test_tui_options("."));
+        let mut terminal =
+            Terminal::new(TestBackend::new(160, 1)).expect("topbar test terminal should build");
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let hitboxes = render_topbar_row(frame, &mut app, area);
+                register_topbar_interaction_targets(&mut app, hitboxes);
+            })
+            .expect("topbar should render");
+
+        let segment = app
+            .viewport
+            .last_topbar_hitboxes
+            .iter()
+            .find(|hitbox| hitbox.id == crate::tui::topbar::TopbarSegmentId::Model)
+            .expect("wide topbar should paint its model segment");
+        let target = app
+            .viewport
+            .interaction_targets
+            .iter()
+            .find(|target| target.id == crate::tui::tideline::InteractionTargetId::HEADER_ROUTE)
+            .expect("painted route segment should have a typed target");
+
+        assert_eq!(target.area, segment.area);
+        assert_eq!(
+            target.keyboard_action,
+            Some(crate::tui::tideline::InteractionAction::OpenProviderPicker)
+        );
+        assert_eq!(target.mouse_action, target.keyboard_action);
+        assert_eq!(
+            target.inspect_detail,
+            crate::tui::tideline::InspectDetail::Route
+        );
+    }
 
     #[test]
     fn truncates_at_ascii_word_boundary() {

--- a/crates/tui/src/tui/ui/handlers.rs
+++ b/crates/tui/src/tui/ui/handlers.rs
@@ -1909,6 +1909,9 @@ pub(crate) async fn handle_view_events(
                 app.status_message = Some(message);
                 app.needs_redraw = true;
             }
+            ViewEvent::TopbarRoutePickerRequested => {
+                open_provider_picker(app, config, engine_handle).await;
+            }
             ViewEvent::ProviderPickerDismissed {
                 catalog_view,
                 selected_provider_id,

--- a/crates/tui/src/tui/ui/overlays.rs
+++ b/crates/tui/src/tui/ui/overlays.rs
@@ -278,6 +278,30 @@ pub(crate) async fn open_launch_provider_picker(
     app.needs_redraw = true;
 }
 
+/// Open the existing provider/route surface from any shell entry point.
+///
+/// The chrome and `/provider` command both delegate here, so they expose the
+/// same picker without duplicating catalog or runtime-readiness facts. A
+/// picker preview remains non-authoritative until its normal apply handler
+/// commits a route.
+pub(crate) async fn open_provider_picker(
+    app: &mut App,
+    config: &Config,
+    engine_handle: &EngineHandle,
+) {
+    if app.onboarding == OnboardingState::Provider {
+        open_onboarding_provider_picker(
+            app,
+            config,
+            engine_handle,
+            app.onboarding_missing_key_recovery,
+        )
+        .await;
+    } else {
+        open_launch_provider_picker(app, config, engine_handle).await;
+    }
+}
+
 pub(crate) fn open_text_pager(app: &mut App, title: String, content: String) {
     let width = app
         .viewport

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -786,6 +786,10 @@ pub enum ViewEvent {
     StatusMessage {
         message: String,
     },
+    /// The Tideline topbar's route segment requested the normal `/provider`
+    /// surface. It carries no catalog, readiness, or selected-route payload:
+    /// those facts remain owned by the provider picker and its apply path.
+    TopbarRoutePickerRequested,
     /// Emitted by the `/provider` picker on Esc so the next open can restore
     /// the browsing context — view mode and highlighted row.
     ProviderPickerDismissed {

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -12,6 +12,7 @@ Global key chords are not yet user-configurable — tracked for a future release
 |----------------------|---------------------------------------------------------------|
 | `F1` or `Ctrl-/`     | Toggle the help overlay                                       |
 | `F2`                 | Toggle the typed Settings editor                              |
+| `F3`                 | Open the provider/model picker (same as `/provider`)          |
 | `Ctrl-K`             | Open the command palette (slash-command finder)                |
 | `Ctrl-C`             | Cancel current turn / dismiss modal / arm-then-confirm quit    |
 | `Ctrl-B`             | Move a supported foreground shell wait into `/jobs` so the turn can continue; use `/jobs` or `Bash` with `action: "wait"` to inspect it |


### PR DESCRIPTION
Closes #5756

## Product change

The painted route/model segment now opens the existing provider picker by click or F3. Both entry points delegate to the same picker/apply path as `/provider`; the header owns neither catalog data nor route authority.

## Verification

- focused topbar interaction target test
- mouse click event test, including Startup shell routing
- F3 routing and keybinding contract tests
- `cargo fmt --all -- --check`
- `git diff --check`

## Boundary

This makes the visible control truthful. It does not resolve #5755, the wider single-authority provider/runtime/catalog lifecycle problem.