### PR TITLE
fix(workflow-js): qualify rustdoc intra-doc links in driver.rs

### DIFF
--- a/crates/workflow-js/src/driver.rs
+++ b/crates/workflow-js/src/driver.rs
@@ -100,7 +100,7 @@ pub struct TaskRequest {
     /// Bounded repair attempts after a failed `responseSchema` decode
     /// (#5583): re-ask the same route with the schema and the failed reply.
     /// `None` uses the default of one attempt; `Some(0)` disables repair.
-    /// Clamped at parse time to [`SCHEMA_REPAIR_MAX_ATTEMPTS`]. The driver
+    /// Clamped at parse time to [`crate::SCHEMA_REPAIR_MAX_ATTEMPTS`]. The driver
     /// treats a repair spawn like any other task — same admission, budget,
     /// and usage accounting.
     pub schema_repair_attempts: Option<u32>,
@@ -196,7 +196,7 @@ pub enum ProgressEvent {
         /// The validation error already surfaced to JS.
         message: String,
         /// Raw reply text of the failed attempt, bounded by
-        /// [`SCHEMA_RAW_CARRY_CHARS`]; the host writes the durable artifact.
+        /// [`crate::SCHEMA_RAW_CARRY_CHARS`]; the host writes the durable artifact.
         raw: String,
         /// True when `raw` was capped at the carry limit.
         raw_truncated: bool,
@@ -216,7 +216,7 @@ pub enum ProgressEvent {
         /// The decode error of that attempt.
         message: String,
         /// Raw reply text of that attempt, bounded by
-        /// [`SCHEMA_RAW_CARRY_CHARS`].
+        /// [`crate::SCHEMA_RAW_CARRY_CHARS`].
         raw: String,
         /// True when `raw` was capped at the carry limit.
         raw_truncated: bool,


### PR DESCRIPTION
No-Issue: three-line rustdoc link qualification unblocking the Documentation CI job (failure seen in run 33351684365); pre-existing main defect, no behavior change.

Fixes the Documentation CI failure seen in run 33351684365: three unresolved intra-doc links (`SCHEMA_REPAIR_MAX_ATTEMPTS`, `SCHEMA_RAW_CARRY_CHARS` x2) in `crates/workflow-js/src/driver.rs`, qualified as `crate::` paths.

Local proof: `cargo doc -p codewhale-workflow-js --no-deps --locked` generates cleanly.