### PR TITLE
docs: conform compute substrate, web origin, and profile status to the ratified PRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/login` reports the Codewhale account session and provider-key next
   steps. The internal cloud-agent credential is not user surface: there is
   no `auth set-slot`/`auth clear-slot` command, no hint, and no completion
-  entry for it — membership (`codewhale login`) is the only door.
+  entry for it — signing in with `codewhale login` is the only door.
 - Add the Tideline component family from the ratatui translation spec
   (#5698's screens, riding the #5699 work-strip layout): hero startup
   surface with quick actions and option strip, notifications inbox, merged

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/login` reports the Codewhale account session and provider-key next
   steps. The internal cloud-agent credential is not user surface: there is
   no `auth set-slot`/`auth clear-slot` command, no hint, and no completion
-  entry for it — membership (`codewhale login`) is the only door.
+  entry for it — signing in with `codewhale login` is the only door.
 - Add the Tideline component family from the ratatui translation spec
   (#5698's screens, riding the #5699 work-strip layout): hero startup
   surface with quick actions and option strip, notifications inbox, merged


### PR DESCRIPTION
No-Issue: documentation conformance to the ratified 2026-08-31 PRD substrate/origin decisions

## What this PR does

Conformance sweep of docs/, README*, web copy, and the public changelogs against the founder-ratified 2026-08-31 PRD authority:

- Daytona is the current managed Computer/sandbox/compute provider.
- The 8/16/32 GiB Computer profiles at 1x/2x/4x normalized metering are ratified launch profiles.
- AWS Lambda/Firecracker is the preferred successor behind the Computer contract; Cloudflare is the deliberate fallback; Vercel Sandbox is not a substrate.
- The public website and web app are served from Cloudflare (OpenNext); Vercel is not the web origin.
- The public changelog carries product changes only, no commercial (pricing/membership/paid-tier) prose.

## File-by-file summary

- `CHANGELOG.md` — rewrote the one remaining membership-framed line in the Unreleased `/login` entry ("membership (`codewhale login`) is the only door" → "signing in with `codewhale login` is the only door"); product behavior unchanged. This is the residue left after ddad5d0ff dropped the commercial framing from the #5781 receipt.
- `crates/tui/CHANGELOG.md` — same entry, mirrored copy.

## Sweep results (zero remaining wrong-current-state claims)

Verified on a fresh worktree off `origin/main` (ef9b344284):

- `docs/ARCHITECTURE.md` does **not** call Vercel Sandbox "the ratified target primary Linux substrate" — no such text exists on current main, and `git log -S` shows it never existed in `docs/` on this history. Nothing to correct there.
- `rg -i 'vercel'` over `docs/`, `README*.md`, `web/lib/content`, `web/app`, `web/README.md`, and both changelogs: **no matches** (remaining repo hits are provider identifiers inside `crates/` source, out of scope).
- `rg -i 'vercel sandbox'`, `'cloudflare containers'`, `'ratified.*substrate|primary linux substrate'`, `'to (be )?qualif|learning exercise|8 ?GB only'`: **no matches** in any of the swept surfaces.
- Daytona-as-current-provider docs (`docs/DAYTONA_CLOUD_DISPATCH.md`, `docs/GUIDE.md`) and Cloudflare-as-web-origin docs (`web/README.md`, OpenNext config) already read as current state and conform.
- Remaining changelog mentions of pricing/membership are third-party provider catalog facts (DeepSeek/xAI/Z.ai/Anthropic rates, Kimi Code membership route classification) — product capability documentation, not Codewhale commercial prose; left intact.
- `web/app/[locale]/pricing/page.tsx` carries pricing statements, as a pricing page should; it makes no substrate claim and is outside the changelog hygiene rule.

## Verification

- `node web/scripts/check-docs.mjs` (the `npm run check:docs` script, runnable directly — node builtins only, no `npm ci` required): **PASS** (20 doc topics, all repo source files exist, version=0.9.11, install snippets OK).
- No test asserts the changed copy (`rg 'the only door'` outside the two changelogs matches only code comments in `crates/`, which this PR deliberately does not touch).
- `rg` receipts above show zero remaining wrong-current-state claims.
