### PR TITLE
docs: adopt the ponytail decision ladder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,43 @@ Keep this file durable. Derive changing release, provider, branch, and flake
 state from the repository, tests, CI, and current issue tracker rather than from
 instructions or memory. The nearest scoped `AGENTS.md` adds path-specific rules.
 
+## The ponytail method
+
+From [dietrichgebert/ponytail](https://github.com/dietrichgebert/ponytail) —
+"the laziest senior dev in the room." *He says nothing. He writes one line. It
+works.* The best code is the code you never wrote.
+
+Before writing code, walk the decision ladder in order and stop at the first
+rung that answers:
+
+1. **Does this need to exist?** → Skip it.
+2. **Already in this codebase?** → Reuse it.
+3. **Stdlib does it?** → Use it.
+4. **Native platform feature?** → Use it.
+5. **Installed dependency?** → Use it.
+6. **One line?** → One line.
+7. **Only then:** the minimum that works.
+
+The ladder runs *after* understanding the problem. Lazy about solutions, never
+about reading the code first — a short diff written without reading the call
+sites is not ponytail, it is a guess.
+
+**Never cut, at any rung:** trust-boundary validation, data-loss handling,
+security, accessibility. Brevity is not a reason to drop a guard.
+
+Rung 2 is the one this repository keeps failing. The `model_*` / `*_config` /
+`provider_*` grep rule below is rung 2 with a name; so is "one turn loop, one
+base prompt". Two more corollaries earned here:
+
+- **An abstraction must delete caller code.** If adopting it is pure
+  obligation — required methods, no default bodies that do work — it gets
+  built, adopted once, and abandoned.
+- **Migrate the last consumer, or do not start.** Framework, one caller,
+  ticket the rest, silence the warning: that ships two systems and a comment
+  that is no longer true. If the migration will not fit, narrow the slice —
+  never the adoption. The standing `#[allow(dead_code)]` count is the running
+  receipt; `scripts/check-dead-code-budget.py` prints it.
+
 ## Working rules
 
 - Inspect status and existing consumers before editing. Preserve unrelated,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,7 @@
 The imported contract is authoritative. Do not invent stricter test or branch
 rituals: follow its code-first evidence policy, one-way migration rule, clean
 direct-main permission, and the current task's offline boundary.
+
+Its ponytail decision ladder runs before you write code, every time. Read it
+there — it is not restated here, because rung 2 is "already in this codebase?"
+and a second copy of a rule is the thing the rule forbids.


### PR DESCRIPTION
Founder-directed. Adopts [dietrichgebert/ponytail](https://github.com/dietrichgebert/ponytail) — *"the laziest senior dev in the room"*, *"the best code is the code you never wrote"* — as the rule that runs before writing code.

The ladder is encoded verbatim rather than paraphrased, because the ordering is the method:

1. **Does this need to exist?** → Skip it
2. **Already in this codebase?** → Reuse it
3. **Stdlib does it?** → Use it
4. **Native platform feature?** → Use it
5. **Installed dependency?** → Use it
6. **One line?** → One line
7. **Only then:** the minimum that works

Two parts of the source method matter as much as the rungs, so they are kept explicit:

- **The ladder runs *after* understanding the problem** — lazy about solutions, never about reading the code first. A short diff written without reading the call sites is not ponytail, it is a guess.
- **It never cuts** trust-boundary validation, data-loss handling, security, or accessibility. Brevity is not a reason to drop a guard.

**Rung 2 is the one this repo keeps failing**, so the section says so and points at the existing `model_*` / `*_config` / `provider_*` grep rule instead of restating it — that rule already *is* rung 2 with a name, as is "one turn loop, one base prompt."

Two corollaries are added because the ladder does not cover them, and both are earned here:

- *An abstraction must delete caller code.* If adopting it is pure obligation — required methods, no default bodies that do work — it gets built, adopted once, and abandoned.
- *Migrate the last consumer, or do not start.* Framework, one caller, ticket the rest, silence the warning: that ships two systems and a comment that is no longer true.

Two deliberate choices:

- **No counts in the file.** `AGENTS.md` opens with "Keep this file durable. Derive changing … state from the repository … rather than from instructions or memory." An earlier draft cited live impl and call-site counts; they would be stale within a day and would have violated the rule they sat under. The text points at `scripts/check-dead-code-budget.py` instead.
- **`CLAUDE.md` gets a pointer, not a copy.** It already imports `@AGENTS.md`; a second copy of the rule is what rung 2 forbids.

Docs only — two files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent guidance files; no runtime, CI logic, or product code paths are modified.
> 
> **Overview**
> Adds a **ponytail method** section to `AGENTS.md`: a seven-rung decision ladder (skip → reuse in-repo → stdlib → platform → deps → one line → minimum that works) with explicit carve-outs for security, validation, and accessibility, plus corollaries that tie rung 2 to existing grep rules and require abstractions to delete caller code and migrations to finish all consumers (with `scripts/check-dead-code-budget.py` as the `#[allow(dead_code)]` receipt).
> 
> `CLAUDE.md` now points agents to that ladder in `AGENTS.md` only—no duplicate copy, aligned with the “one of each thing” / reuse-in-repo intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32634a3c34317ccfa0821f20c292cb3819466e83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

No-Issue: docs only — founder-directed adoption of the ponytail decision ladder into AGENTS.md and CLAUDE.md.
