### PR TITLE
fix(cli): label auth list rows by provider, not by credential slot

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3467,14 +3467,23 @@ fn auth_list_lines_with_runtime(
     let mut lines = Vec::new();
     lines.push("provider     config store env  route".to_string());
     for provider in ProviderKind::ALL {
-        let slot = provider_slot(provider);
+        // Label the row by the provider, not by its credential slot. This
+        // table has one row per ProviderKind, but several kinds share a slot
+        // (ProviderKind::secret_store_slot): SiliconflowCN shares
+        // `siliconflow`, and the four Model Studio variants share
+        // `modelstudio-token-plan`. Labelling by slot printed `siliconflow`
+        // twice and `modelstudio-token-plan` four times, so the reader could
+        // not tell which row was which provider. The status columns still
+        // read the shared slot, which is what makes one saved key light up
+        // the whole family.
+        let label = provider.as_str();
         if provider == ProviderKind::Xai {
             let diagnostics = xai_auth_diagnostics(store, runtime_overrides);
             let api_key = diagnostics
                 .evaluates_runtime_api_key()
                 .then(|| xai_runtime_api_key(store, secrets, runtime_overrides));
             lines.push(format!(
-                "{slot:<12}  {}     {}      {}   {}",
+                "{label:<12}  {}     {}      {}   {}",
                 xai_list_storage_status(api_key.as_ref(), RuntimeApiKeySource::ConfigFile),
                 xai_list_storage_status(api_key.as_ref(), RuntimeApiKeySource::Keyring),
                 xai_list_storage_status(api_key.as_ref(), RuntimeApiKeySource::Env),
@@ -3507,7 +3516,7 @@ fn auth_list_lines_with_runtime(
             "missing"
         };
         lines.push(format!(
-            "{slot:<12}  {}     {}      {}   {active}",
+            "{label:<12}  {}     {}      {}   {active}",
             yes_no(file),
             keyring_status_short(keyring),
             yes_no(env)
@@ -8362,6 +8371,42 @@ verbosity = "project-imported"
             .unwrap_or_else(|| panic!("missing openai-codex row:\n{output}"));
         assert!(row.ends_with("external-consent"), "{row}");
         assert!(!output.contains("secret-token"));
+    }
+
+    #[test]
+    fn auth_list_labels_each_row_by_its_own_provider() {
+        // ProviderKind::secret_store_slot collapses families onto one durable
+        // slot -- SiliconflowCN onto `siliconflow`, the four Model Studio
+        // variants onto `modelstudio-token-plan` -- but this table has one row
+        // per kind. Labelling rows by slot printed `siliconflow` twice and
+        // `modelstudio-token-plan` four times, so a reader could not tell which
+        // row belonged to which provider.
+        let _lock = env_lock();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let store =
+            ConfigStore::load(Some(dir.path().join("config.toml"))).expect("store should load");
+        let secrets = Secrets::new(std::sync::Arc::new(
+            codewhale_secrets::InMemoryKeyringStore::new(),
+        ));
+
+        let lines = auth_list_lines(&store, &secrets);
+        let labels: Vec<&str> = lines
+            .iter()
+            .skip(1)
+            .filter_map(|line| line.split_whitespace().next())
+            .collect();
+
+        assert_eq!(
+            labels.len(),
+            ProviderKind::ALL.len(),
+            "one row per provider kind: {labels:?}"
+        );
+        let unique: std::collections::BTreeSet<&&str> = labels.iter().collect();
+        assert_eq!(
+            unique.len(),
+            labels.len(),
+            "every row must name its own provider, not a shared slot: {labels:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`codewhale auth list` builds one row per `ProviderKind` but labelled each row with `provider_slot()`. `ProviderKind::secret_store_slot` deliberately collapses same-account families onto one durable slot, so the table printed **`siliconflow` twice** and **`modelstudio-token-plan` four times** — a reader could not tell which row belonged to which provider.

`slot` was used *only* as the row label, at both emission sites (the xAI branch and the general branch), so this changes the first column and nothing else. The status columns still read the shared slot — that is what makes one saved key light up the whole family, and it is correct.

**The test fails without the fix**, which is the point of adding it:

```
assertion `left == right` failed: every row must name its own provider, not a shared slot:
["deepseek", "nvidia-nim", ..., "siliconflow", "arcee", "siliconflow", ...,
 "modelstudio-token-plan", "google", "antigravity", "edenai", "custom"]
test result: FAILED. 0 passed; 1 failed; 0 ignored
```

and passes with it:

```
Summary [0.017s] 2 tests run: 2 passed, 352 skipped
  PASS codewhale-cli tests::auth_list_labels_each_row_by_its_own_provider
  PASS codewhale-cli tests::auth_list_uses_persisted_consent_without_probing_codex_file
```

Note the failure output also shows the four Model Studio rows collapsing to a single `modelstudio-token-plan` label — 42 kinds rendering as 39 distinct names.

No-Issue: one-line product bug found while triaging the merge queue; the row label was the only thing wrong.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to CLI auth list output; credential lookup and routing behavior are unchanged.
> 
> **Overview**
> **`codewhale auth list`** now shows each provider’s own name in the first column instead of the shared **credential slot** name.
> 
> Several `ProviderKind` values share one slot (e.g. SiliconflowCN → `siliconflow`, Model Studio variants → `modelstudio-token-plan`), so the table used to repeat the same slot label on multiple rows and it was unclear which row was which provider. Only the display label changed to `provider.as_str()`; config/store/env status still comes from the shared slot so one saved key still reflects correctly across the family.
> 
> A regression test asserts one row per `ProviderKind::ALL` and that every first-column label is unique.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f0b5d30641ebfbc6397d3343a149a46a83af717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->