### PR TITLE
fix(engine): emergency recovery trims with hysteresis and reports no-progress honestly

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -5700,7 +5700,10 @@ impl Engine {
         }
         self.commit_compaction_checkpoint(summary_prompt);
 
-        let trimmed = self.trim_oldest_messages_to_budget(target_budget);
+        // Trim with hysteresis: landing exactly on the input budget leaves the
+        // session a few hundred tokens under the preflight line, so the next
+        // step's output re-crosses it and recovery runs again.
+        let trimmed = self.trim_oldest_messages_to_budget(emergency_trim_budget(target_budget));
         self.emit_session_updated().await;
         let after_tokens = self.estimated_input_tokens();
         let after_count = self.session.messages.len();
@@ -5731,10 +5734,24 @@ impl Engine {
             return true;
         }
 
-        let message = format!(
-            "Emergency context compaction failed to reduce request below model limit \
-             (estimate ~{after_tokens} tokens, budget ~{target_budget})."
-        );
+        // Two distinct failures were previously conflated into one banner.
+        // When the provider rejected the request (its bill counts framing we
+        // cannot see), our estimate may already sit within the budget while
+        // the pass removed nothing — reporting that as "failed to reduce
+        // below model limit" with an estimate printed *under* the budget
+        // reads as self-contradictory. Name the actual outcome instead.
+        let message = if after_tokens > target_budget {
+            format!(
+                "Emergency context compaction failed to reduce request below model limit \
+                 (estimate ~{after_tokens} tokens, budget ~{target_budget})."
+            )
+        } else {
+            format!(
+                "Emergency context compaction made no progress (estimate ~{after_tokens} tokens \
+                 is already within the ~{target_budget} budget; the provider may count the \
+                 request differently). Run /compact or /clear."
+            )
+        };
         self.emit_compaction_failed(id.clone(), true, message.clone())
             .await;
         let _ = self.tx_event.send(Event::status(message)).await;
@@ -7580,8 +7597,9 @@ pub use context::context_input_budget_for_route;
 use context::route_context_budget_for_provider;
 use context::{
     MAX_CONTEXT_RECOVERY_ATTEMPTS, MIN_RECENT_MESSAGES_TO_KEEP,
-    effective_max_output_tokens_for_route, extract_compaction_summary_prompt,
-    is_context_length_error_message, route_context_budget_for_route, summarize_text,
+    effective_max_output_tokens_for_route, emergency_trim_budget,
+    extract_compaction_summary_prompt, is_context_length_error_message,
+    route_context_budget_for_route, summarize_text,
 };
 #[cfg(test)]
 use context::{context_input_budget_for_provider, effective_max_output_tokens};

--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -17,6 +17,20 @@ use serde_json::Value;
 pub(super) const MIN_RECENT_MESSAGES_TO_KEEP: usize = 4;
 /// Allow a few emergency recovery attempts before failing the turn.
 pub(super) const MAX_CONTEXT_RECOVERY_ATTEMPTS: u8 = 2;
+/// Emergency-recovery trim target: this fraction of the input budget below
+/// the budget itself. Trimming exactly to the budget lands the session a few
+/// hundred tokens under the preflight line, so the next turn step's output
+/// re-crosses it and recovery runs again — a per-step "trim a few oldest"
+/// thrash that eats the transcript from the front and invalidates the provider
+/// prefix cache each time. The margin buys several steps of regrowth headroom.
+pub(super) const EMERGENCY_TRIM_MARGIN_DIVISOR: usize = 5;
+
+/// Local-trim target for emergency context recovery, strictly below the input
+/// budget so one recovery buys regrowth headroom instead of landing on the
+/// preflight line.
+pub(super) fn emergency_trim_budget(input_budget: usize) -> usize {
+    input_budget.saturating_sub(input_budget / EMERGENCY_TRIM_MARGIN_DIVISOR)
+}
 /// Hard cap for any tool output inserted into model context.
 const TOOL_RESULT_CONTEXT_HARD_LIMIT_CHARS: usize = 12_000;
 /// Soft cap for known noisy tools inserted into model context.
@@ -567,4 +581,19 @@ pub(super) fn is_context_length_error_message(message: &str) -> bool {
         || lower.contains("prompt is too long")
         || lower.contains("context window")
         || (lower.contains("requested") && lower.contains("tokens") && lower.contains("maximum"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::emergency_trim_budget;
+
+    #[test]
+    fn emergency_trim_budget_leaves_a_hysteresis_margin() {
+        assert_eq!(emergency_trim_budget(246_784), 197_428);
+        // Tiny budgets lose most of the margin to integer division but never
+        // trim past the line itself.
+        assert_eq!(emergency_trim_budget(10), 8);
+        assert_eq!(emergency_trim_budget(4), 4);
+        assert_eq!(emergency_trim_budget(0), 0);
+    }
 }


### PR DESCRIPTION
## Background

Observed on a long debugging session (351-message transcript, ~247K conservative estimate on a 256K-window route): once the session ran into the emergency path, recovery became a per-step thrash — every step logged `Emergency context compaction started (preflight token budget)` followed by `Emergency compaction complete: 351 → 348 messages (3 removed), ~247,159 → ~244,269 tokens, trimmed 3 oldest`, and the next step crossed the line again. A second session produced the self-contradictory banner `failed to reduce request below model limit (estimate ~246,636 tokens, budget ~246,784)` — an estimate printed *under* the budget it supposedly failed to meet.

## Root causes addressed here

1. **No hysteresis in the local-trim fallback.** `trim_oldest_messages_to_budget` stopped the moment the estimate dipped under the input budget, so the session landed a few hundred tokens below the preflight line; the next step's output re-crossed it. While the LLM summary pass is unavailable (rate limit, network), trimming is the only reducer left, and each cycle both eats the oldest transcript and invalidates the provider prefix cache. The trim target now sits at 4/5 of the input budget (`emergency_trim_budget`), so one recovery buys several steps of regrowth headroom.

2. **Conflated failure outcomes in the banner.** On the `provider context-length rejection` path, the provider's bill counts framing the estimator cannot see, so the local estimate can already sit within the budget while the pass removes nothing; `recovered` is then `false` because no progress was made — but the printed reason ("failed to reduce request below model limit") contradicts the numbers below it. The banner now distinguishes the two outcomes: still above the limit, or no progress while already within the budget (pointing at `/compact` or `/clear`).

## What I checked and deliberately did not change

The original investigation also covered the v0.9.5-era auto-compaction trigger-units mismatch, working-set pin overflow, and the preflight work-tail asymmetry. On current `main` those are already resolved by the redesign: the pressure gate prefers provider-billed tokens, the pin heuristics are gone (retained-user-messages + summary), and the work tail no longer participates in the preflight estimate — so none of them are touched here.

## Testing

- `emergency_trim_budget_leaves_a_hysteresis_margin` (new, colocated in `core/engine/context.rs`).
- `cargo test -p codewhale-tui --lib -- compaction:: core::engine::`: 613 passed. Run with `RUST_MIN_STACK=16777216`: `cloud_code_system_prompt_rejection_is_localized_from_its_semantic_error` overflows the default test-thread stack on this aarch64 host even on clean `main` (pre-existing, reproduces without this patch); the bigger stack makes it pass.
- `cargo fmt --all -- --check` clean; clippy clean for the touched files.