### PR TITLE
fix(tui): one focus owner, so Tab and Shift+Tab stop guessing

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -45,6 +45,7 @@ use crate::tui::motion::MotionPolicy;
 use crate::tui::paste_burst::{FlushResult, PasteBurst};
 use crate::tui::scrolling::{MouseScrollState, TranscriptLineMeta, TranscriptScroll};
 use crate::tui::selection::{SelectionAutoscroll, TranscriptSelection};
+use crate::tui::shell_key_routing::Focus;
 use crate::tui::sidebar::SidebarWorkSummary;
 use crate::tui::streaming::StreamingState;
 use crate::tui::transcript::TranscriptViewCache;
@@ -2303,6 +2304,34 @@ fn push_enabled_provider_model(
 }
 
 impl App {
+    /// Who owns the keyboard right now.
+    ///
+    /// The single derivation of [`Focus`], mirroring the order in which the
+    /// event loop actually offers a key to each surface. Shell bindings ask
+    /// this; only genuine composer *editing* keys may ask whether the
+    /// composer has text.
+    #[must_use]
+    pub fn focus(&self) -> Focus {
+        if let Some(kind) = self.view_stack.top_kind() {
+            return Focus::Modal(kind);
+        }
+        if self.onboarding != OnboardingState::None {
+            return Focus::Onboarding;
+        }
+        if self.launch.visible {
+            return Focus::Launch;
+        }
+        if self.work_surface.focused
+            || self
+                .workflow_panel
+                .as_ref()
+                .is_some_and(|panel| panel.keyboard_focus)
+        {
+            return Focus::Panel;
+        }
+        Focus::Composer
+    }
+
     /// Persist the pending session route as the explicit choice (`/pod save`,
     /// `/pod save-as`, `/model save-default`). Returns the receipt
     /// message naming the exact file written — or an error message when the

--- a/crates/tui/src/tui/shell_key_routing.rs
+++ b/crates/tui/src/tui/shell_key_routing.rs
@@ -19,6 +19,60 @@ use std::borrow::Cow;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::tui::key_shortcuts;
+use crate::tui::views::ModalKind;
+
+/// Who owns the keyboard right now.
+///
+/// One value, derived in one place ([`crate::tui::app::App::focus`]), in
+/// place of the `app.input.is_empty()` guesses that used composer *content*
+/// as a stand-in for composer *focus*. Composer editing keys still ask about
+/// the text itself; every shell binding asks this instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Focus {
+    /// The onboarding rail owns every key until it finishes.
+    Onboarding,
+    /// A modal view is on top of the stack and handles its own keys.
+    Modal(ModalKind),
+    /// The pre-session launch screen — its menu or its composer.
+    Launch,
+    /// A focused rail or workflow panel inside a live session.
+    Panel,
+    /// The session composer: the default owner.
+    Composer,
+}
+
+/// Which focus states a binding is live in — the `ShellBinding` focus rule
+/// that used to be re-invented at every call site as
+/// `&& app.view_stack.is_empty()`. The variants nest: each admits everything
+/// the one above it does, plus one more surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FocusScope {
+    /// A live session: the composer, or a rail/workflow panel that has taken
+    /// the keys from it.
+    SessionShell,
+    /// [`FocusScope::SessionShell`], plus the pre-session launch stage.
+    AnyShell,
+    /// [`FocusScope::AnyShell`], plus the Config modal, which displays the
+    /// very setting the binding changes.
+    AnyShellOrConfig,
+    /// Every focus state, onboarding and modals included.
+    Everywhere,
+}
+
+impl FocusScope {
+    #[must_use]
+    pub fn admits(self, focus: Focus) -> bool {
+        match self {
+            Self::SessionShell => matches!(focus, Focus::Composer | Focus::Panel),
+            Self::AnyShell => matches!(focus, Focus::Composer | Focus::Panel | Focus::Launch),
+            Self::AnyShellOrConfig => matches!(
+                focus,
+                Focus::Composer | Focus::Panel | Focus::Launch | Focus::Modal(ModalKind::Config)
+            ),
+            Self::Everywhere => true,
+        }
+    }
+}
 
 /// Stable binding ids shared by handlers, footer hints, and help catalog.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,6 +81,11 @@ pub enum ShellBindingId {
     ContextInspector,
     ProviderRoute,
     Help,
+    Settings,
+    /// Tab: cycle the session mode.
+    ModeCycle,
+    /// Shift+Tab: cycle the permission posture.
+    PermissionCycle,
 }
 
 /// One advertised binding with the portable catalog chord and focus rules.
@@ -38,6 +97,39 @@ pub struct ShellBinding {
     pub catalog_chord: &'static str,
     /// Compact footer chord when this binding is advertised.
     pub footer_chord: &'static str,
+    /// The focus states this binding is live in. Never composer content:
+    /// a shell binding does the same thing whether or not you have typed.
+    pub focus: FocusScope,
+}
+
+impl ShellBinding {
+    /// Does this key press this binding, ignoring focus?
+    #[must_use]
+    pub fn matches(&self, key: &KeyEvent) -> bool {
+        match self.id {
+            ShellBindingId::ToolDetails => is_tool_details_shortcut(key),
+            ShellBindingId::ContextInspector => is_context_inspector_shortcut(key),
+            ShellBindingId::ProviderRoute => is_provider_route_shortcut(key),
+            ShellBindingId::Help => is_help_shortcut(key),
+            ShellBindingId::Settings => is_settings_shortcut(key),
+            ShellBindingId::ModeCycle => is_mode_cycle_shortcut(key),
+            ShellBindingId::PermissionCycle => is_permission_cycle_shortcut(key),
+        }
+    }
+}
+
+/// The shell's single key-admission authority: which binding, if any, this
+/// key presses for this focus owner.
+///
+/// Callers keep their position in the event loop — that ordering is a real
+/// statement about which surface sees a key first — but none of them decides
+/// admission any more, and none of them may ask about composer content.
+#[must_use]
+pub fn route(focus: Focus, key: &KeyEvent) -> Option<ShellBindingId> {
+    SHELL_BINDINGS
+        .iter()
+        .find(|binding| binding.focus.admits(focus) && binding.matches(key))
+        .map(|binding| binding.id)
 }
 
 /// Canonical shell bindings. Handlers and chrome read from here.
@@ -46,6 +138,9 @@ pub const SHELL_BINDINGS: &[ShellBinding] = &[
         id: ShellBindingId::ToolDetails,
         catalog_chord: "Alt+V",
         footer_chord: "Alt+V",
+        // The rail claims the details chord for a selected row before the
+        // transcript pager sees it; both are session surfaces.
+        focus: FocusScope::SessionShell,
     },
     ShellBinding {
         id: ShellBindingId::ContextInspector,
@@ -53,18 +148,49 @@ pub const SHELL_BINDINGS: &[ShellBinding] = &[
         // handler until proven in Cursor/Terminal.app/iTerm2/tmux/PTY.
         catalog_chord: "/context",
         footer_chord: "/context",
+        focus: FocusScope::SessionShell,
     },
     ShellBinding {
         id: ShellBindingId::ProviderRoute,
         // `/provider` remains the portable, explicit command path.
         catalog_chord: "F3 / /provider",
         footer_chord: "F3",
+        // The route is also pickable before a session exists.
+        focus: FocusScope::AnyShell,
     },
     ShellBinding {
         id: ShellBindingId::Help,
         // `/help` also opens this; Ctrl+/ is the secondary fallback.
         catalog_chord: "F1 / Ctrl+/",
         footer_chord: "F1",
+        focus: FocusScope::Everywhere,
+    },
+    ShellBinding {
+        id: ShellBindingId::Settings,
+        catalog_chord: "F2",
+        footer_chord: "F2",
+        // Shell-global for the same reason as Help: a settings route that
+        // disappears inside onboarding or a modal is not a route.
+        focus: FocusScope::Everywhere,
+    },
+    ShellBinding {
+        id: ShellBindingId::ModeCycle,
+        catalog_chord: "Tab",
+        footer_chord: "Tab",
+        // Tab is the session's mode cycle. The composer's own completions
+        // get the key first, but *having typed* never disables it. The
+        // launch screen is excluded: there Tab moves focus between the
+        // startup menu and the pre-session composer.
+        focus: FocusScope::SessionShell,
+    },
+    ShellBinding {
+        id: ShellBindingId::PermissionCycle,
+        catalog_chord: "Shift+Tab",
+        footer_chord: "Shift+Tab",
+        // A shell-level permission control, live wherever the shell is —
+        // including the launch screen, where it used to be dead — plus the
+        // Config modal that displays the posture it changes.
+        focus: FocusScope::AnyShellOrConfig,
     },
 ];
 
@@ -217,6 +343,29 @@ pub fn is_help_shortcut(key: &KeyEvent) -> bool {
 #[must_use]
 pub fn is_settings_shortcut(key: &KeyEvent) -> bool {
     matches!(key.code, KeyCode::F(2)) && key.modifiers.is_empty()
+}
+
+/// Tab cycles the session mode. Terminal chords that mean something else to
+/// the host (Ctrl/Alt/Cmd+Tab) are not ours, and Shift+Tab is the permission
+/// cycle below.
+#[must_use]
+pub fn is_mode_cycle_shortcut(key: &KeyEvent) -> bool {
+    matches!(key.code, KeyCode::Tab)
+        && !key.modifiers.intersects(
+            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER | KeyModifiers::SHIFT,
+        )
+}
+
+/// Shift+Tab cycles the permission posture. Terminals encode the same chord
+/// either as `BackTab` or as `Tab` + SHIFT; accept both.
+#[must_use]
+pub fn is_permission_cycle_shortcut(key: &KeyEvent) -> bool {
+    let forbidden = KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER;
+    if key.modifiers.intersects(forbidden) {
+        return false;
+    }
+    matches!(key.code, KeyCode::BackTab)
+        || (matches!(key.code, KeyCode::Tab) && key.modifiers.contains(KeyModifiers::SHIFT))
 }
 
 #[cfg(test)]
@@ -377,6 +526,83 @@ mod tests {
             KeyCode::Char('3'),
             KeyModifiers::NONE
         )));
+    }
+
+    #[test]
+    fn footer_only_advertises_chords_that_are_live_where_it_is_shown() {
+        // The footer hint row is built from this table, so it must not be
+        // able to name a chord the same table refuses at the focus the
+        // footer is rendered in.
+        let hints = footer_action_hints_for_platform(true, false);
+        for id in [
+            ShellBindingId::ToolDetails,
+            ShellBindingId::ContextInspector,
+            ShellBindingId::Help,
+        ] {
+            let binding = binding(id);
+            assert!(hints.contains(binding.footer_chord), "{hints}");
+            assert!(
+                binding.focus.admits(Focus::Composer),
+                "footer advertises {id:?}, which the table does not admit at the composer"
+            );
+        }
+    }
+
+    #[test]
+    fn focus_scopes_nest_from_the_session_outwards() {
+        let ladder = [
+            FocusScope::SessionShell,
+            FocusScope::AnyShell,
+            FocusScope::AnyShellOrConfig,
+            FocusScope::Everywhere,
+        ];
+        let states = [
+            Focus::Composer,
+            Focus::Panel,
+            Focus::Launch,
+            Focus::Modal(ModalKind::Config),
+            Focus::Modal(ModalKind::Approval),
+            Focus::Onboarding,
+        ];
+        for pair in ladder.windows(2) {
+            for focus in states {
+                assert!(
+                    !pair[0].admits(focus) || pair[1].admits(focus),
+                    "{:?} admits {focus:?} but the wider {:?} does not",
+                    pair[0],
+                    pair[1]
+                );
+            }
+        }
+        // Nothing but Help/Settings may reach a focused workflow.
+        for binding in SHELL_BINDINGS {
+            assert_eq!(
+                binding.focus.admits(Focus::Modal(ModalKind::Approval)),
+                binding.focus == FocusScope::Everywhere,
+                "{:?} must not reach across an approval decision",
+                binding.id
+            );
+        }
+    }
+
+    #[test]
+    fn tab_and_shift_tab_are_distinct_bindings() {
+        let tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+        let shift_tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::SHIFT);
+        assert_eq!(
+            route(Focus::Composer, &tab),
+            Some(ShellBindingId::ModeCycle)
+        );
+        assert_eq!(
+            route(Focus::Composer, &shift_tab),
+            Some(ShellBindingId::PermissionCycle)
+        );
+        // Tab moves focus on the launch stage; the posture control still works.
+        assert_eq!(route(Focus::Launch, &tab), None);
+        assert_eq!(
+            route(Focus::Launch, &shift_tab),
+            Some(ShellBindingId::PermissionCycle)
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -15,6 +15,7 @@ use super::task_projection::{
 };
 use super::*;
 use crate::models::Role;
+use crate::tui::shell_key_routing::ShellBindingId;
 
 pub(super) fn event_owner_is_active(
     current_session_id: Option<&str>,
@@ -166,6 +167,81 @@ pub(super) fn flush_paste_burst_before_composer(app: &mut App, now: Instant) -> 
             true
         }
         crate::tui::paste_burst::FlushResult::None => false,
+    }
+}
+
+/// The shell's key admission, asked exactly as the event loop asks it: which
+/// binding does this key press, for whoever owns the keyboard right now?
+///
+/// Every seam below calls this instead of re-deriving focus from
+/// `view_stack`, `launch.visible`, or — the bug this replaces — whether the
+/// composer happens to hold text.
+pub(crate) fn shell_binding_for_key(app: &App, key: &KeyEvent) -> Option<ShellBindingId> {
+    crate::tui::shell_key_routing::route(app.focus(), key)
+}
+
+/// What pressing Tab did — see [`dispatch_tab_key`].
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum TabDispatch {
+    /// One of the composer's own completions consumed the key.
+    Completion,
+    /// Nobody owns Tab in this focus state.
+    Ignored,
+    /// The session mode cycled. The caller syncs the engine.
+    ModeCycled {
+        prior_mode: AppMode,
+        prior_model: String,
+    },
+}
+
+/// Tab dispatch, lifted out of the event loop body so a test can press Tab.
+///
+/// The composer's completions get the key first: a mention menu, a slash
+/// menu, an in-progress command or file mention, a waiting prompt
+/// suggestion. Those are genuine composer *editing* questions about the
+/// text. Once none of them claims the key, Tab is the shell's mode cycle,
+/// admitted by [`App::focus`] alone — whether the composer holds text is not
+/// part of that decision. It used to be: `if !app.input.is_empty()
+/// { continue; }` killed Tab the moment the user typed anything.
+pub(crate) fn dispatch_tab_key(
+    app: &mut App,
+    key: &KeyEvent,
+    mention_menu_entries: &[String],
+    slash_menu_entries: &[crate::tui::widgets::SlashMenuEntry],
+) -> TabDispatch {
+    if !mention_menu_entries.is_empty()
+        && crate::tui::file_mention::apply_mention_menu_selection(app, mention_menu_entries)
+    {
+        return TabDispatch::Completion;
+    }
+    if !slash_menu_entries.is_empty() && apply_slash_menu_selection(app, slash_menu_entries, true) {
+        return TabDispatch::Completion;
+    }
+    if try_autocomplete_slash_command(app) {
+        return TabDispatch::Completion;
+    }
+    if crate::tui::file_mention::try_autocomplete_file_mention(app) {
+        return TabDispatch::Completion;
+    }
+    if app.input.is_empty()
+        && let Some(suggestion) = app.prompt_suggestion.take()
+    {
+        app.input = suggestion;
+        app.cursor_position = app.input.chars().count();
+        app.needs_redraw = true;
+        return TabDispatch::Completion;
+    }
+    if shell_binding_for_key(app, key) != Some(ShellBindingId::ModeCycle) {
+        return TabDispatch::Ignored;
+    }
+    // Sending or queueing input is reserved for Enter, so Tab never changes
+    // roles based on whether a turn happens to be running.
+    let prior_model = app.model.clone();
+    let prior_mode = app.mode;
+    app.cycle_mode();
+    TabDispatch::ModeCycled {
+        prior_mode,
+        prior_model,
     }
 }
 
@@ -4401,20 +4477,30 @@ pub(crate) async fn run_event_loop(
                 continue;
             }
 
-            // Help is shell-global, including onboarding, launch, and modal
-            // surfaces. `/help` remains the guaranteed textual route; this
-            // handles function-key and control-key terminal encodings.
-            if crate::tui::shell_key_routing::is_help_shortcut(&key) {
-                toggle_help_view(app);
-                continue;
-            }
-
-            // F2 is the shell-global typed settings route. Keep it available
-            // from onboarding and modal surfaces just like Help; pressing it
-            // again closes the editor without applying an in-progress value.
-            if crate::tui::shell_key_routing::is_settings_shortcut(&key) {
-                toggle_settings_view(app);
-                continue;
+            // The shell's key admission runs through one table
+            // (`shell_key_routing::SHELL_BINDINGS`) keyed by one focus owner
+            // (`app.focus()`) — never by whether the composer happens to hold
+            // text. Help and Settings are shell-global, including onboarding,
+            // launch, and modal surfaces (`/help` and `/provider` remain the
+            // guaranteed textual routes); Shift+Tab is a shell-level
+            // permission control and is claimed here, before the launch
+            // screen swallows it. The remaining bindings are admitted by the
+            // same table at their owners' seams below, where the composer's
+            // completions and the agent-focus projection get the key first.
+            match shell_binding_for_key(app, &key) {
+                Some(ShellBindingId::Help) => {
+                    toggle_help_view(app);
+                    continue;
+                }
+                Some(ShellBindingId::Settings) => {
+                    toggle_settings_view(app);
+                    continue;
+                }
+                Some(ShellBindingId::PermissionCycle) => {
+                    cycle_permission_posture(app, config, &engine_handle).await;
+                    continue;
+                }
+                _ => {}
             }
 
             // Provider onboarding is a real ProviderPickerView, not a
@@ -4598,9 +4684,7 @@ pub(crate) async fn run_event_loop(
             // route segment in the shared topbar. Route it through the same
             // typed event as mouse input; `/provider` remains the portable
             // direct command path for terminals that do not forward F-keys.
-            if crate::tui::shell_key_routing::is_provider_route_shortcut(&key)
-                && app.view_stack.is_empty()
-            {
+            if shell_binding_for_key(app, &key) == Some(ShellBindingId::ProviderRoute) {
                 if handle_view_events_boxed(
                     terminal,
                     app,
@@ -4948,22 +5032,8 @@ pub(crate) async fn run_event_loop(
                 continue;
             }
 
-            if crate::tui::shell_key_routing::is_context_inspector_shortcut(&key)
-                && app.view_stack.is_empty()
-            {
+            if shell_binding_for_key(app, &key) == Some(ShellBindingId::ContextInspector) {
                 open_context_inspector(app);
-                continue;
-            }
-
-            // Shift+Tab is a shell-level permission control. Keep it live in
-            // the composer and the Config surface, while leaving approval,
-            // elevation, setup, and other focused workflows in full control
-            // of their own keys. Accept both terminal encodings used for the
-            // same chord (`BackTab` and `Tab` + SHIFT).
-            if is_permission_cycle_shortcut(&key)
-                && matches!(app.view_stack.top_kind(), None | Some(ModalKind::Config))
-            {
-                cycle_permission_posture(app, config, &engine_handle).await;
                 continue;
             }
 
@@ -5067,7 +5137,7 @@ pub(crate) async fn run_event_loop(
 
             // Tool details: Alt+V / Option+V only. Bare `v` always types `v`
             // in every focus state (TUI-DOG-002).
-            if crate::tui::shell_key_routing::is_tool_details_shortcut(&key) {
+            if shell_binding_for_key(app, &key) == Some(ShellBindingId::ToolDetails) {
                 // While a worker is focused the details chord is that
                 // worker's bounded Agent Details projection.
                 if let Some(agent_id) = app.agent_focus.as_ref().map(|f| f.agent_id.clone()) {
@@ -5191,7 +5261,6 @@ pub(crate) async fn run_event_loop(
                 }
                 KeyCode::Char('l')
                     if key_shortcuts::alt_nav_modifiers(key.modifiers)
-                        && app.input.is_empty()
                         && open_pager_for_last_message(app) =>
                 {
                     continue;
@@ -5611,66 +5680,40 @@ pub(crate) async fn run_event_loop(
                     app.scroll_down(page);
                 }
                 KeyCode::Tab => {
-                    if mention_menu_open
-                        && crate::tui::file_mention::apply_mention_menu_selection(
-                            app,
-                            &mention_menu_entries,
-                        )
-                    {
-                        continue;
-                    }
-                    if slash_menu_open && apply_slash_menu_selection(app, &slash_menu_entries, true)
-                    {
-                        continue;
-                    }
-                    if try_autocomplete_slash_command(app) {
-                        continue;
-                    }
-                    if crate::tui::file_mention::try_autocomplete_file_mention(app) {
-                        continue;
-                    }
-                    if app.input.is_empty()
-                        && let Some(suggestion) = app.prompt_suggestion.take()
-                    {
-                        app.input = suggestion;
-                        app.cursor_position = app.input.chars().count();
-                        app.needs_redraw = true;
-                        continue;
-                    }
-                    // Tab is completion when the composer has content and a
-                    // mode switch only when it is empty. Sending or queueing
-                    // input is reserved for Enter so Tab never changes roles
-                    // based on whether a turn happens to be running.
-                    if !app.input.is_empty() {
-                        continue;
-                    }
-                    let prior_model = app.model.clone();
-                    let prior_mode = app.mode;
-                    app.cycle_mode();
-                    if app.mode != prior_mode {
-                        sync_mode_update(app, &engine_handle).await;
-                    }
-                    if app.model != prior_model {
-                        let _ = engine_handle
-                            .send(Op::SetModel {
-                                model: app.model.clone(),
-                                mode: app.mode,
-                                route_limits: app.active_route_limits,
-                            })
-                            .await;
+                    match dispatch_tab_key(app, &key, &mention_menu_entries, &slash_menu_entries) {
+                        TabDispatch::Completion | TabDispatch::Ignored => continue,
+                        TabDispatch::ModeCycled {
+                            prior_mode,
+                            prior_model,
+                        } => {
+                            if app.mode != prior_mode {
+                                sync_mode_update(app, &engine_handle).await;
+                            }
+                            if app.model != prior_model {
+                                let _ = engine_handle
+                                    .send(Op::SetModel {
+                                        model: app.model.clone(),
+                                        mode: app.mode,
+                                        route_limits: app.active_route_limits,
+                                    })
+                                    .await;
+                            }
+                        }
                     }
                 }
                 // Transcript-nav shortcuts now require Alt, leaving most bare
-                // letters free to insert as text. Before v0.8.30, bare `g`,
+                // letters free to insert as text. Requiring Alt is also why
+                // none of them asks whether the composer is empty: an Alt
+                // chord is never composer text, so `input.is_empty()` there
+                // was guessing at focus and only ever broke the shortcut for
+                // anyone mid-draft. Before v0.8.30, bare `g`,
                 // `G`, `[`, `]`, `?`, and `l` on an empty composer were
                 // hijacked for navigation — typing "good" yielded "ood" with
                 // no whale and no warning. The Alt-prefixed shortcuts mirror
                 // the Alt+R / Alt+C pattern already in use. Shift is
                 // permitted for most capital-letter forms.
                 KeyCode::Char('g')
-                    if key_shortcuts::alt_nav_modifiers(key.modifiers)
-                        && app.input.is_empty()
-                        && !slash_menu_open =>
+                    if key_shortcuts::alt_nav_modifiers(key.modifiers) && !slash_menu_open =>
                 {
                     if let Some(anchor) =
                         TranscriptScroll::anchor_for(app.viewport.transcript_cache.line_meta(), 0)
@@ -5679,15 +5722,12 @@ pub(crate) async fn run_event_loop(
                     }
                 }
                 KeyCode::Char('G')
-                    if key_shortcuts::alt_nav_modifiers(key.modifiers)
-                        && app.input.is_empty()
-                        && !slash_menu_open =>
+                    if key_shortcuts::alt_nav_modifiers(key.modifiers) && !slash_menu_open =>
                 {
                     app.scroll_to_bottom();
                 }
                 KeyCode::Char('[')
                     if key_shortcuts::alt_nav_modifiers(key.modifiers)
-                        && app.input.is_empty()
                         && !slash_menu_open
                         && !jump_to_adjacent_tool_cell(app, SearchDirection::Backward) =>
                 {
@@ -5695,7 +5735,6 @@ pub(crate) async fn run_event_loop(
                 }
                 KeyCode::Char(']')
                     if key_shortcuts::alt_nav_modifiers(key.modifiers)
-                        && app.input.is_empty()
                         && !slash_menu_open
                         && !jump_to_adjacent_tool_cell(app, SearchDirection::Forward) =>
                 {

--- a/crates/tui/src/tui/ui/overlays.rs
+++ b/crates/tui/src/tui/ui/overlays.rs
@@ -185,15 +185,6 @@ pub(crate) fn hotbar_slot_from_key(app: &App, key: &event::KeyEvent) -> Option<u
     None
 }
 
-pub(crate) fn is_permission_cycle_shortcut(key: &KeyEvent) -> bool {
-    let forbidden = KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER;
-    if key.modifiers.intersects(forbidden) {
-        return false;
-    }
-    matches!(key.code, KeyCode::BackTab)
-        || (matches!(key.code, KeyCode::Tab) && key.modifiers.contains(KeyModifiers::SHIFT))
-}
-
 pub(crate) async fn cycle_permission_posture(
     app: &mut App,
     config: &mut Config,

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3,6 +3,7 @@ use super::compaction_flow::{
     apply_compaction_started, maybe_warn_context_pressure, should_auto_compact_before_send,
     should_auto_compact_before_send_with_config,
 };
+use super::event_loop::{TabDispatch, dispatch_tab_key, shell_binding_for_key};
 use super::observer_hooks::{
     bounded_subagent_hook_preview, subagent_completion_status, subagent_failure_notice,
     subagent_status_from_completion_result, turn_end_observer_metadata,
@@ -32,7 +33,9 @@ use crate::tui::history::{
 };
 use crate::tui::hotbar::actions::{HotbarActionCategory, HotbarDispatch};
 use crate::tui::provider_picker::ProviderPickerView;
-use crate::tui::shell_key_routing::is_permission_cycle_shortcut;
+use crate::tui::shell_key_routing::{
+    Focus, SHELL_BINDINGS, ShellBindingId, is_permission_cycle_shortcut,
+};
 use crate::tui::ui_text::truncate_line_to_width;
 use crate::tui::views::{HelpView, ModalView, ViewAction};
 use crate::working_set::Workspace;
@@ -588,6 +591,194 @@ fn permission_cycle_shortcut_accepts_both_shift_tab_encodings() {
         KeyCode::BackTab,
         KeyModifiers::CONTROL,
     )));
+}
+
+/// A live session in a deterministic focus state: no onboarding, no launch
+/// screen, no modal, composer owns the keys.
+fn focus_test_app() -> App {
+    let mut app = create_test_app();
+    app.onboarding = crate::tui::app::OnboardingState::None;
+    app.launch.visible = false;
+    app.work_surface.focused = false;
+    app.workflow_panel = None;
+    app
+}
+
+/// One representative terminal encoding per shell binding.
+fn shell_binding_probe(id: ShellBindingId) -> KeyEvent {
+    match id {
+        ShellBindingId::ToolDetails => KeyEvent::new(KeyCode::Char('v'), KeyModifiers::ALT),
+        ShellBindingId::ContextInspector => KeyEvent::new(KeyCode::Char('c'), KeyModifiers::ALT),
+        ShellBindingId::ProviderRoute => KeyEvent::new(KeyCode::F(3), KeyModifiers::NONE),
+        ShellBindingId::Help => KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE),
+        ShellBindingId::Settings => KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE),
+        ShellBindingId::ModeCycle => KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
+        ShellBindingId::PermissionCycle => KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE),
+    }
+}
+
+#[test]
+fn shell_key_seam_presses_a_key_at_the_event_loop() {
+    // The harness in one line: build an App, press a real crossterm key at
+    // the same admission the event loop uses, read the binding back.
+    let app = focus_test_app();
+    assert_eq!(
+        shell_binding_for_key(&app, &KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE)),
+        Some(ShellBindingId::Help)
+    );
+    assert_eq!(
+        shell_binding_for_key(&app, &KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE)),
+        None,
+        "an ordinary character belongs to the composer"
+    );
+}
+
+#[test]
+fn no_shell_binding_changes_meaning_once_the_composer_has_text() {
+    // The whole bug family in one assertion: a shell binding answers to the
+    // focus owner, never to whether the user has started typing. Tab was the
+    // visible case (`if !app.input.is_empty() { continue; }`), but the same
+    // guess was spread across ~21 `input.is_empty()` sites.
+    for binding in SHELL_BINDINGS {
+        let key = shell_binding_probe(binding.id);
+        let empty = focus_test_app();
+        let mut typed = focus_test_app();
+        typed.input = "draft in progress".to_string();
+        typed.cursor_position = typed.input.chars().count();
+
+        let on_empty = shell_binding_for_key(&empty, &key);
+        let on_typed = shell_binding_for_key(&typed, &key);
+        assert_eq!(
+            on_empty, on_typed,
+            "{:?} changed meaning because the composer has text",
+            binding.id
+        );
+        assert_eq!(
+            on_typed,
+            Some(binding.id),
+            "{:?} must still be live mid-draft",
+            binding.id
+        );
+
+        // Admission is only half the family: the handler behind a binding
+        // must not re-guess focus from the text either. Tab is the one with
+        // a dispatcher of its own, so press it in both states.
+        if binding.id == ShellBindingId::ModeCycle {
+            let mut empty = focus_test_app();
+            empty.prompt_suggestion = None;
+            let mut typed = focus_test_app();
+            typed.prompt_suggestion = None;
+            typed.input = "draft in progress".to_string();
+            typed.cursor_position = typed.input.chars().count();
+            assert_eq!(
+                dispatch_tab_key(&mut empty, &key, &[], &[]),
+                dispatch_tab_key(&mut typed, &key, &[], &[]),
+                "Tab dispatched differently because the composer has text"
+            );
+        }
+    }
+
+    // The exception the rule is for: the composer's own editing keys are
+    // never shell bindings, empty or not.
+    for code in [
+        KeyCode::Backspace,
+        KeyCode::Enter,
+        KeyCode::Char('y'),
+        KeyCode::Char(' '),
+    ] {
+        let mut typed = focus_test_app();
+        typed.input = "draft".to_string();
+        let key = KeyEvent::new(code, KeyModifiers::NONE);
+        assert_eq!(shell_binding_for_key(&focus_test_app(), &key), None);
+        assert_eq!(shell_binding_for_key(&typed, &key), None);
+    }
+}
+
+#[test]
+fn tab_still_cycles_the_mode_after_the_user_has_typed() {
+    // Regression: Tab used to stop working the moment the composer held any
+    // text, which is most of the time you are actually using the product.
+    let mut app = focus_test_app();
+    app.prompt_suggestion = None;
+    app.input = "explain this repo".to_string();
+    app.cursor_position = app.input.chars().count();
+    let before = app.mode;
+
+    let dispatch = dispatch_tab_key(
+        &mut app,
+        &KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
+        &[],
+        &[],
+    );
+
+    assert!(
+        matches!(dispatch, TabDispatch::ModeCycled { .. }),
+        "Tab with a typed composer dispatched {dispatch:?}"
+    );
+    assert_ne!(app.mode, before, "the session mode must actually change");
+    assert_eq!(
+        app.input, "explain this repo",
+        "cycling the mode must not disturb the draft"
+    );
+}
+
+#[test]
+fn shift_tab_cycles_permission_from_every_shell_surface() {
+    // Regression: Shift+Tab was admitted only after the launch screen had
+    // already swallowed the key, so the posture control was dead on the
+    // first screen the user sees. Both terminal encodings, both surfaces.
+    for key in [
+        KeyEvent::new(KeyCode::BackTab, KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT),
+        KeyEvent::new(KeyCode::Tab, KeyModifiers::SHIFT),
+    ] {
+        let mut session = focus_test_app();
+        session.input = "draft in progress".to_string();
+        assert_eq!(
+            shell_binding_for_key(&session, &key),
+            Some(ShellBindingId::PermissionCycle),
+            "session composer: {key:?}"
+        );
+
+        let mut launch = focus_test_app();
+        launch.launch.visible = true;
+        assert_eq!(launch.focus(), Focus::Launch);
+        assert_eq!(
+            shell_binding_for_key(&launch, &key),
+            Some(ShellBindingId::PermissionCycle),
+            "launch screen: {key:?}"
+        );
+    }
+}
+
+#[test]
+fn focus_owner_follows_the_surface_that_owns_the_keys() {
+    let mut app = focus_test_app();
+    assert_eq!(app.focus(), Focus::Composer);
+
+    app.work_surface.focused = true;
+    assert_eq!(app.focus(), Focus::Panel);
+    app.work_surface.focused = false;
+
+    app.launch.visible = true;
+    assert_eq!(app.focus(), Focus::Launch);
+    app.launch.visible = false;
+
+    app.onboarding = crate::tui::app::OnboardingState::Welcome;
+    assert_eq!(app.focus(), Focus::Onboarding);
+    app.onboarding = crate::tui::app::OnboardingState::None;
+
+    app.view_stack.push(HelpView::new_for_locale(app.ui_locale));
+    assert_eq!(app.focus(), Focus::Modal(ModalKind::Help));
+    // A modal owns Tab and the details chord; Help still does not.
+    assert_eq!(
+        shell_binding_for_key(&app, &KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+        None
+    );
+    assert_eq!(
+        shell_binding_for_key(&app, &KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE)),
+        Some(ShellBindingId::Help)
+    );
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -32,6 +32,7 @@ use crate::tui::history::{
 };
 use crate::tui::hotbar::actions::{HotbarActionCategory, HotbarDispatch};
 use crate::tui::provider_picker::ProviderPickerView;
+use crate::tui::shell_key_routing::is_permission_cycle_shortcut;
 use crate::tui::ui_text::truncate_line_to_width;
 use crate::tui::views::{HelpView, ModalView, ViewAction};
 use crate::working_set::Workspace;


### PR DESCRIPTION
## Summary

Not a Tab bug: a missing focus owner. The event loop had ~128 `KeyCode` arms and ~21 `app.input.is_empty()` tests, each re-deriving who owns a key from whatever state was nearby, so composer *content* stood in for composer *focus*. Tab cycled the mode only on an empty composer (`event_loop.rs:5644`), and Shift+Tab's handler sat after the launch-stage `continue`, dead on the first screen a user sees.

- `Focus` (`Composer | Panel | Launch | Modal(kind) | Onboarding`) lives in `shell_key_routing.rs` and is **derived** in one place, `App::focus()` — not stored, so there is no second source of truth.
- `ShellBinding` gains the `focus: FocusScope` field its doc already promised (`SessionShell ⊂ AnyShell ⊂ AnyShellOrConfig ⊂ Everywhere`) plus `Settings`, `ModeCycle`, `PermissionCycle`. `route(focus, key)` is the single admission authority; the loop's seams keep their order but none decides admission.
- Harness: `shell_binding_for_key(&App, &KeyEvent)` and `dispatch_tab_key(...)` are the real loop's entry points; tests press real crossterm `KeyEvent`s at them.

Deliberate behaviour changes: Tab cycles the mode whether or not the composer holds text (completions still win first); Shift+Tab cycles permission from the launch stage; `Alt+L/G/Shift+G/[/]` drop their `input.is_empty()` guards (an Alt chord is never composer text); `Ctrl+Tab` no longer cycles the mode; `Alt+C` opens the context inspector from the launch stage.

Design rationale: codewhale-ops `design/SHELL-DESIGN-20260901.md` §2.4. Prior art: grokbuild's `ActionDef.context: When` — copied the contract, not the code.

## Testing

Regression tests shown failing without the fix (guard restored, `PermissionCycle` narrowed back):
```
test result: FAILED. 4 passed; 4 failed; 0 ignored; 0 measured; 11830 filtered out
    tui::shell_key_routing::tests::tab_and_shift_tab_are_distinct_bindings
    tui::ui::tests::no_shell_binding_changes_meaning_once_the_composer_has_text
    tui::ui::tests::shift_tab_cycles_permission_from_every_shell_surface
    tui::ui::tests::tab_still_cycles_the_mode_after_the_user_has_typed
```
With the fix: `test result: ok. 8 passed; 0 failed`. Full: tui lib `11825 tests run: 11825 passed, 13 skipped`; tui-integration `277 passed`; tui-cucumber `16 passed`. No golden changed.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-tui --all-targets` warning-free under the CI allow list
- [x] tui suites above (`cargo test --workspace` not run; change is confined to `codewhale-tui`)

## Checklist

- [x] This PR adds a new layer/module/abstraction — it names or deletes the layer it replaces (extends `ShellBinding`; deletes the `is_empty()` focus guesses on the migrated arms)
- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — key routing only; goldens unchanged
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address — n/a

Remaining `input.is_empty()` sites are genuine composer editing (Enter/Space/Backspace/Ctrl+D/S/Y/Up) and stay; the rail Tasks-panel `y/Y` guard is a real focus guess left for a separate slice because migrating it changes when clipboard copy fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdbuqwHAXSDcikPiS6L6Qw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TUI input routing and deliberately changes Tab, Shift+Tab, and Alt-chord behavior across launch, session, and modal surfaces.
> 
> **Overview**
> Replaces scattered `view_stack` / `input.is_empty()` checks with a single **focus owner** (`App::focus()` → `Focus`) and a **shell binding table** (`route(focus, key)` with per-binding `FocusScope`).
> 
> **Tab** can cycle session mode after the user has typed (completions still take priority via extracted `dispatch_tab_key`). **Shift+Tab** permission cycling is admitted earlier so it works on the launch screen and from the Config modal, not only on an empty composer. Help, Settings, F3 provider route, context inspector, and tool details now go through the same admission path.
> 
> Alt+navigation chords (`Alt+L`, `Alt+G`, `[`, `]`, etc.) no longer require an empty composer. `is_permission_cycle_shortcut` moves from `overlays` into `shell_key_routing` alongside new mode-cycle matchers and regression tests that shell bindings do not change meaning when the composer holds text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2cc010c78b3b71ad5bc6b119f6304ddaf629823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->