### PR TITLE
tui: tool cells carry their own state

### DIFF
--- a/crates/tui/src/deepseek_theme.rs
+++ b/crates/tui/src/deepseek_theme.rs
@@ -67,10 +67,10 @@ impl Theme {
             tool_title_color: palette::TEXT_SOFT,
             tool_value_color: palette::TEXT_MUTED,
             tool_label_color: palette::TEXT_DIM,
-            tool_running_accent: palette::ACCENT_TOOL_LIVE,
-            tool_success_accent: palette::STATUS_SUCCESS,
-            tool_warning_accent: palette::STATUS_WARNING,
-            tool_failed_accent: palette::STATUS_ERROR,
+            tool_running_accent: palette::WHALE_ACTION,
+            tool_success_accent: palette::TEXT_MUTED,
+            tool_warning_accent: palette::WHALE_HUMAN,
+            tool_failed_accent: palette::WHALE_ERROR,
         }
     }
 
@@ -88,8 +88,8 @@ impl Theme {
             tool_title_color: palette::LIGHT_TEXT_SOFT,
             tool_value_color: palette::LIGHT_TEXT_MUTED,
             tool_label_color: palette::LIGHT_TEXT_HINT,
-            tool_running_accent: palette::LIGHT_LIVE,
-            tool_success_accent: palette::LIGHT_SUCCESS_FG,
+            tool_running_accent: palette::LIGHT_ACTION,
+            tool_success_accent: palette::LIGHT_TEXT_MUTED,
             tool_warning_accent: palette::LIGHT_WARNING,
             tool_failed_accent: palette::LIGHT_DANGER,
         }
@@ -110,7 +110,7 @@ impl Theme {
             tool_value_color: palette::SOLARIZED_TEXT_MUTED,
             tool_label_color: palette::SOLARIZED_TEXT_DIM,
             tool_running_accent: palette::SOLARIZED_BLUE,
-            tool_success_accent: palette::SOLARIZED_CYAN,
+            tool_success_accent: palette::SOLARIZED_TEXT_MUTED,
             tool_warning_accent: palette::SOLARIZED_YELLOW,
             tool_failed_accent: palette::SOLARIZED_RED,
         }
@@ -147,13 +147,24 @@ impl Theme {
         }
     }
 
-    /// Pick the right tool accent for a given [`ToolStatus`].
+    /// The one place a tool cell's lifecycle state becomes ink.
+    ///
+    /// Every surface that paints a tool cell — the header glyph, the family
+    /// glyph, the state word, the card rail, and the exploring fan-out dots —
+    /// reads its colour from here, so a running tool reads as running and a
+    /// failed one as failed without any neighbouring row narrating it.
+    /// Modelled on OMP's `output-block.ts`, where a block's `state` drives its
+    /// border colour: in-flight takes the action accent, a settled success
+    /// recedes into muted text, and only warning and failure keep a loud
+    /// colour of their own. `Hydrated` is a stalled "tool loaded — retry
+    /// required", not live work, so it takes the hint colour rather than
+    /// borrowing the running accent and reading as in-flight.
     #[must_use]
     pub const fn tool_status_color(self, status: ToolStatus) -> Color {
         match status {
             ToolStatus::Running => self.tool_running_accent,
             ToolStatus::Success => self.tool_success_accent,
-            ToolStatus::Hydrated => self.tool_running_accent,
+            ToolStatus::Hydrated => self.tool_label_color,
             ToolStatus::Warning => self.tool_warning_accent,
             ToolStatus::Failed => self.tool_failed_accent,
         }
@@ -213,9 +224,9 @@ mod tests {
         assert_eq!(theme.tool_title_color, palette::TEXT_SOFT);
         assert_eq!(theme.tool_value_color, palette::TEXT_MUTED);
         assert_eq!(theme.tool_label_color, palette::TEXT_DIM);
-        assert_eq!(theme.tool_running_accent, palette::ACCENT_TOOL_LIVE);
-        assert_eq!(theme.tool_success_accent, palette::STATUS_SUCCESS);
-        assert_eq!(theme.tool_failed_accent, palette::STATUS_ERROR);
+        assert_eq!(theme.tool_running_accent, palette::WHALE_ACTION);
+        assert_eq!(theme.tool_success_accent, palette::TEXT_MUTED);
+        assert_eq!(theme.tool_failed_accent, palette::WHALE_ERROR);
     }
 
     #[test]
@@ -227,8 +238,8 @@ mod tests {
         assert_eq!(theme.tool_title_color, palette::LIGHT_TEXT_SOFT);
         assert_eq!(theme.tool_value_color, palette::LIGHT_TEXT_MUTED);
         assert_eq!(theme.section_title_color, palette::LIGHT_ACTION);
-        assert_eq!(theme.tool_running_accent, palette::LIGHT_LIVE);
-        assert_eq!(theme.tool_success_accent, palette::LIGHT_SUCCESS_FG);
+        assert_eq!(theme.tool_running_accent, palette::LIGHT_ACTION);
+        assert_eq!(theme.tool_success_accent, palette::LIGHT_TEXT_MUTED);
     }
 
     #[test]
@@ -241,28 +252,70 @@ mod tests {
         assert_eq!(theme.tool_failed_accent, palette::GRAYSCALE_TEXT_BODY);
     }
 
+    /// The whole point of "tool cells carry their own state": every variant
+    /// maps to a distinct WHALE token, so a running card, a failed one and a
+    /// settled one are told apart by ink alone. Asserted against the tokens
+    /// rather than the theme's own fields — a field-to-field assertion passes
+    /// no matter what the fields hold, which is how `Hydrated` sat on the
+    /// running accent and read as live work.
     #[test]
     fn tool_status_color_maps_each_status() {
         let theme = Theme::dark();
-        assert_eq!(
-            theme.tool_status_color(ToolStatus::Running),
-            theme.tool_running_accent
-        );
-        assert_eq!(
-            theme.tool_status_color(ToolStatus::Success),
-            theme.tool_success_accent
-        );
-        assert_eq!(
-            theme.tool_status_color(ToolStatus::Hydrated),
-            theme.tool_running_accent
-        );
-        assert_eq!(
-            theme.tool_status_color(ToolStatus::Warning),
-            theme.tool_warning_accent
-        );
-        assert_eq!(
-            theme.tool_status_color(ToolStatus::Failed),
-            theme.tool_failed_accent
-        );
+        let table = [
+            (ToolStatus::Running, palette::WHALE_ACTION),
+            (ToolStatus::Success, palette::TEXT_MUTED),
+            (ToolStatus::Hydrated, palette::TEXT_DIM),
+            (ToolStatus::Warning, palette::WHALE_HUMAN),
+            (ToolStatus::Failed, palette::WHALE_ERROR),
+        ];
+        for (status, expected) in table {
+            assert_eq!(
+                theme.tool_status_color(status),
+                expected,
+                "dark theme paints {status:?} with the wrong token"
+            );
+        }
+
+        // Nothing in the table may collide: two statuses sharing a colour is
+        // the failure this mapping exists to prevent.
+        for (i, (status, color)) in table.iter().enumerate() {
+            for (other_status, other_color) in &table[i + 1..] {
+                assert_ne!(
+                    color, other_color,
+                    "{status:?} and {other_status:?} paint the same colour"
+                );
+            }
+        }
+    }
+
+    /// The load-bearing separations hold in every palette, not just the active
+    /// one. Grayscale has four greys for five statuses, so full distinctness is
+    /// a dark-theme claim; running / failed / success being told apart is not
+    /// negotiable anywhere.
+    #[test]
+    fn every_palette_separates_running_failed_and_success() {
+        for mode in [
+            crate::palette::PaletteMode::Dark,
+            crate::palette::PaletteMode::Light,
+            crate::palette::PaletteMode::Grayscale,
+            crate::palette::PaletteMode::SolarizedLight,
+        ] {
+            let theme = Theme::for_palette_mode(mode);
+            assert_ne!(
+                theme.tool_status_color(ToolStatus::Running),
+                theme.tool_status_color(ToolStatus::Failed),
+                "{mode:?} paints running and failed alike"
+            );
+            assert_ne!(
+                theme.tool_status_color(ToolStatus::Running),
+                theme.tool_status_color(ToolStatus::Success),
+                "{mode:?} paints running and success alike"
+            );
+            assert_ne!(
+                theme.tool_status_color(ToolStatus::Failed),
+                theme.tool_status_color(ToolStatus::Success),
+                "{mode:?} paints failed and success alike"
+            );
+        }
     }
 }

--- a/crates/tui/src/deepseek_theme.rs
+++ b/crates/tui/src/deepseek_theme.rs
@@ -15,6 +15,7 @@ use ratatui::widgets::{BorderType, Borders, Padding};
 use crate::palette;
 use crate::palette::PaletteMode;
 use crate::tui::history::ToolStatus;
+use crate::tui::widgets::tool_card::ToolFamily;
 
 /// Visual variant exposed by the theme.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -68,7 +69,7 @@ impl Theme {
             tool_value_color: palette::TEXT_MUTED,
             tool_label_color: palette::TEXT_DIM,
             tool_running_accent: palette::WHALE_ACTION,
-            tool_success_accent: palette::TEXT_MUTED,
+            tool_success_accent: palette::STATUS_SUCCESS,
             tool_warning_accent: palette::WHALE_HUMAN,
             tool_failed_accent: palette::WHALE_ERROR,
         }
@@ -89,7 +90,7 @@ impl Theme {
             tool_value_color: palette::LIGHT_TEXT_MUTED,
             tool_label_color: palette::LIGHT_TEXT_HINT,
             tool_running_accent: palette::LIGHT_ACTION,
-            tool_success_accent: palette::LIGHT_TEXT_MUTED,
+            tool_success_accent: palette::LIGHT_SUCCESS_FG,
             tool_warning_accent: palette::LIGHT_WARNING,
             tool_failed_accent: palette::LIGHT_DANGER,
         }
@@ -110,7 +111,7 @@ impl Theme {
             tool_value_color: palette::SOLARIZED_TEXT_MUTED,
             tool_label_color: palette::SOLARIZED_TEXT_DIM,
             tool_running_accent: palette::SOLARIZED_BLUE,
-            tool_success_accent: palette::SOLARIZED_TEXT_MUTED,
+            tool_success_accent: palette::SOLARIZED_CYAN,
             tool_warning_accent: palette::SOLARIZED_YELLOW,
             tool_failed_accent: palette::SOLARIZED_RED,
         }
@@ -147,23 +148,53 @@ impl Theme {
         }
     }
 
-    /// The one place a tool cell's lifecycle state becomes ink.
+    /// Colour of a tool cell's **rail** — the card border.
     ///
-    /// Every surface that paints a tool cell — the header glyph, the family
-    /// glyph, the state word, the card rail, and the exploring fan-out dots —
-    /// reads its colour from here, so a running tool reads as running and a
-    /// failed one as failed without any neighbouring row narrating it.
-    /// Modelled on OMP's `output-block.ts`, where a block's `state` drives its
-    /// border colour: in-flight takes the action accent, a settled success
-    /// recedes into muted text, and only warning and failure keep a loud
-    /// colour of their own. `Hydrated` is a stalled "tool loaded — retry
-    /// required", not live work, so it takes the hint colour rather than
-    /// borrowing the running accent and reading as in-flight.
+    /// This is OMP's `output-block.ts` rule verbatim: a block takes a state and
+    /// its border colour follows it. In-flight takes the action accent, a
+    /// settled success recedes into muted text so finished work stops competing
+    /// for the eye, and only warning and failure keep a loud colour. `Hydrated`
+    /// is a stalled "tool loaded — retry required", not live work, so it takes
+    /// the hint colour instead of borrowing the running accent and reading as
+    /// in-flight.
+    ///
+    /// Deliberately *not* the same function as [`Self::tool_glyph_color`]: the
+    /// border reports lifecycle, the glyph reports identity. They agree
+    /// wherever it matters — running, warning and failure are the same ink in
+    /// both, so the two can never disagree about trouble.
     #[must_use]
-    pub const fn tool_status_color(self, status: ToolStatus) -> Color {
+    pub const fn tool_rail_color(self, status: ToolStatus) -> Color {
         match status {
             ToolStatus::Running => self.tool_running_accent,
-            ToolStatus::Success => self.tool_success_accent,
+            ToolStatus::Success => self.tool_value_color,
+            ToolStatus::Hydrated => self.tool_label_color,
+            ToolStatus::Warning => self.tool_warning_accent,
+            ToolStatus::Failed => self.tool_failed_accent,
+        }
+    }
+
+    /// Colour of a tool cell's **status glyph** and the state word beside it.
+    ///
+    /// Follows the accepted mockup (`tideline-mockups/tideline-01`) rather than
+    /// the border rule: a finished verify row keeps its green `✓`, and a
+    /// finished read or search keeps the family accent that identifies it — the
+    /// blue magnifier in that mockup. A settled card therefore still says *what
+    /// it was* even while its border has receded to muted.
+    ///
+    /// Everything that needs attention reads identically to the rail.
+    #[must_use]
+    pub const fn tool_glyph_color(self, status: ToolStatus, family: ToolFamily) -> Color {
+        match status {
+            ToolStatus::Running => self.tool_running_accent,
+            // Verified work earns Working Green; every other family keeps the
+            // action accent it wore while running, which is what makes a
+            // completed `read` row still read as a read.
+            ToolStatus::Success => match family {
+                ToolFamily::Verify => self.tool_success_accent,
+                _ => self.tool_running_accent,
+            },
+            // A hydrated cell has not succeeded at anything yet, so it never
+            // borrows the verified or family accent.
             ToolStatus::Hydrated => self.tool_label_color,
             ToolStatus::Warning => self.tool_warning_accent,
             ToolStatus::Failed => self.tool_failed_accent,
@@ -178,10 +209,11 @@ impl Theme {
             .add_modifier(Modifier::BOLD)
     }
 
-    /// Right-side status text ("running", "done", "issue") style.
+    /// Right-side status text ("running", "done", "issue") style. Reads as the
+    /// glyph it sits beside, not as the rail.
     #[must_use]
-    pub fn tool_status_style(self, status: ToolStatus) -> Style {
-        Style::default().fg(self.tool_status_color(status))
+    pub fn tool_status_style(self, status: ToolStatus, family: ToolFamily) -> Style {
+        Style::default().fg(self.tool_glyph_color(status, family))
     }
 
     /// Detail label style ("command:", "time:", step markers).
@@ -208,6 +240,7 @@ mod tests {
     use super::{Theme, Variant, active_theme};
     use crate::palette;
     use crate::tui::history::ToolStatus;
+    use crate::tui::widgets::tool_card::ToolFamily;
 
     #[test]
     fn active_theme_returns_dark() {
@@ -225,7 +258,7 @@ mod tests {
         assert_eq!(theme.tool_value_color, palette::TEXT_MUTED);
         assert_eq!(theme.tool_label_color, palette::TEXT_DIM);
         assert_eq!(theme.tool_running_accent, palette::WHALE_ACTION);
-        assert_eq!(theme.tool_success_accent, palette::TEXT_MUTED);
+        assert_eq!(theme.tool_success_accent, palette::STATUS_SUCCESS);
         assert_eq!(theme.tool_failed_accent, palette::WHALE_ERROR);
     }
 
@@ -239,7 +272,7 @@ mod tests {
         assert_eq!(theme.tool_value_color, palette::LIGHT_TEXT_MUTED);
         assert_eq!(theme.section_title_color, palette::LIGHT_ACTION);
         assert_eq!(theme.tool_running_accent, palette::LIGHT_ACTION);
-        assert_eq!(theme.tool_success_accent, palette::LIGHT_TEXT_MUTED);
+        assert_eq!(theme.tool_success_accent, palette::LIGHT_SUCCESS_FG);
     }
 
     #[test]
@@ -252,14 +285,13 @@ mod tests {
         assert_eq!(theme.tool_failed_accent, palette::GRAYSCALE_TEXT_BODY);
     }
 
-    /// The whole point of "tool cells carry their own state": every variant
-    /// maps to a distinct WHALE token, so a running card, a failed one and a
-    /// settled one are told apart by ink alone. Asserted against the tokens
-    /// rather than the theme's own fields — a field-to-field assertion passes
-    /// no matter what the fields hold, which is how `Hydrated` sat on the
-    /// running accent and read as live work.
+    /// The rail is the block's border and follows OMP's rule: every status is a
+    /// distinct WHALE token and a settled success recedes into muted text.
+    /// Asserted against the tokens rather than the theme's own fields — a
+    /// field-to-field assertion passes no matter what the fields hold, which is
+    /// how `Hydrated` sat on the running accent and read as live work.
     #[test]
-    fn tool_status_color_maps_each_status() {
+    fn tool_rail_color_maps_each_status() {
         let theme = Theme::dark();
         let table = [
             (ToolStatus::Running, palette::WHALE_ACTION),
@@ -270,22 +302,89 @@ mod tests {
         ];
         for (status, expected) in table {
             assert_eq!(
-                theme.tool_status_color(status),
+                theme.tool_rail_color(status),
                 expected,
-                "dark theme paints {status:?} with the wrong token"
+                "dark theme borders {status:?} with the wrong token"
             );
         }
 
-        // Nothing in the table may collide: two statuses sharing a colour is
-        // the failure this mapping exists to prevent.
+        // Nothing in the table may collide: two statuses sharing a border
+        // colour is the failure this mapping exists to prevent.
         for (i, (status, color)) in table.iter().enumerate() {
             for (other_status, other_color) in &table[i + 1..] {
                 assert_ne!(
                     color, other_color,
-                    "{status:?} and {other_status:?} paint the same colour"
+                    "{status:?} and {other_status:?} draw the same rail"
                 );
             }
         }
+    }
+
+    /// The glyph follows the accepted mockup, not the border rule: a settled
+    /// verify row keeps Working Green, a settled read keeps the family accent
+    /// that identifies it, and everything needing attention reads exactly as
+    /// the rail does.
+    #[test]
+    fn tool_glyph_color_maps_each_status_and_family() {
+        let theme = Theme::dark();
+        // `STATUS_SUCCESS` is built from `WHALE_WORKING_GREEN_RGB`.
+        let working_green = palette::STATUS_SUCCESS;
+        let table = [
+            (ToolStatus::Running, ToolFamily::Read, palette::WHALE_ACTION),
+            (
+                ToolStatus::Running,
+                ToolFamily::Verify,
+                palette::WHALE_ACTION,
+            ),
+            (ToolStatus::Success, ToolFamily::Verify, working_green),
+            (ToolStatus::Success, ToolFamily::Read, palette::WHALE_ACTION),
+            (ToolStatus::Success, ToolFamily::Find, palette::WHALE_ACTION),
+            (ToolStatus::Success, ToolFamily::Run, palette::WHALE_ACTION),
+            (
+                ToolStatus::Success,
+                ToolFamily::Generic,
+                palette::WHALE_ACTION,
+            ),
+            (ToolStatus::Hydrated, ToolFamily::Verify, palette::TEXT_DIM),
+            (ToolStatus::Hydrated, ToolFamily::Read, palette::TEXT_DIM),
+            (ToolStatus::Warning, ToolFamily::Read, palette::WHALE_HUMAN),
+            (ToolStatus::Failed, ToolFamily::Verify, palette::WHALE_ERROR),
+            (ToolStatus::Failed, ToolFamily::Read, palette::WHALE_ERROR),
+        ];
+        for (status, family, expected) in table {
+            assert_eq!(
+                theme.tool_glyph_color(status, family),
+                expected,
+                "dark theme paints the {status:?}/{family:?} glyph with the wrong token"
+            );
+        }
+    }
+
+    /// The two mappings are separate on purpose, and each half of that claim is
+    /// load-bearing: a settled card must dim its border while keeping an
+    /// identifying glyph, and the two must never disagree about trouble.
+    #[test]
+    fn rail_and_glyph_split_only_where_the_card_has_settled() {
+        let theme = Theme::dark();
+        for family in [ToolFamily::Read, ToolFamily::Verify] {
+            for status in [ToolStatus::Running, ToolStatus::Warning, ToolStatus::Failed] {
+                assert_eq!(
+                    theme.tool_rail_color(status),
+                    theme.tool_glyph_color(status, family),
+                    "{status:?} must read the same on the rail and the glyph"
+                );
+            }
+            assert_ne!(
+                theme.tool_rail_color(ToolStatus::Success),
+                theme.tool_glyph_color(ToolStatus::Success, family),
+                "a settled {family:?} card must dim its border without dimming its glyph"
+            );
+        }
+        assert_ne!(
+            theme.tool_glyph_color(ToolStatus::Success, ToolFamily::Verify),
+            theme.tool_glyph_color(ToolStatus::Success, ToolFamily::Read),
+            "a passed verify and a finished read must not share a glyph colour"
+        );
     }
 
     /// The load-bearing separations hold in every palette, not just the active
@@ -302,18 +401,18 @@ mod tests {
         ] {
             let theme = Theme::for_palette_mode(mode);
             assert_ne!(
-                theme.tool_status_color(ToolStatus::Running),
-                theme.tool_status_color(ToolStatus::Failed),
+                theme.tool_rail_color(ToolStatus::Running),
+                theme.tool_rail_color(ToolStatus::Failed),
                 "{mode:?} paints running and failed alike"
             );
             assert_ne!(
-                theme.tool_status_color(ToolStatus::Running),
-                theme.tool_status_color(ToolStatus::Success),
+                theme.tool_rail_color(ToolStatus::Running),
+                theme.tool_rail_color(ToolStatus::Success),
                 "{mode:?} paints running and success alike"
             );
             assert_ne!(
-                theme.tool_status_color(ToolStatus::Failed),
-                theme.tool_status_color(ToolStatus::Success),
+                theme.tool_rail_color(ToolStatus::Failed),
+                theme.tool_rail_color(ToolStatus::Success),
                 "{mode:?} paints failed and success alike"
             );
         }

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -820,29 +820,7 @@ impl ToolCell {
     pub fn status(&self) -> Option<ToolStatus> {
         match self {
             ToolCell::Exec(cell) => Some(cell.status),
-            ToolCell::Exploring(cell) => {
-                let has_running = cell
-                    .entries
-                    .iter()
-                    .any(|entry| entry.status == ToolStatus::Running);
-                let has_failed = cell
-                    .entries
-                    .iter()
-                    .any(|entry| entry.status == ToolStatus::Failed);
-                let has_warning = cell
-                    .entries
-                    .iter()
-                    .any(|entry| entry.status == ToolStatus::Warning);
-                Some(if has_running {
-                    ToolStatus::Running
-                } else if has_failed {
-                    ToolStatus::Failed
-                } else if has_warning {
-                    ToolStatus::Warning
-                } else {
-                    ToolStatus::Success
-                })
-            }
+            ToolCell::Exploring(cell) => Some(cell.status()),
             ToolCell::PlanUpdate(cell) => Some(cell.status),
             ToolCell::PatchSummary(cell) => Some(cell.status),
             ToolCell::Review(cell) => Some(cell.status),
@@ -1045,7 +1023,7 @@ impl ExecCell {
         // Command, live output, and artifact paths belong in the Activity sidebar
         // and `/jobs` detail surfaces.
         if compact_foreground_wait {
-            return wrap_card_rail(lines);
+            return wrap_card_rail(lines, self.status);
         }
 
         // A successful shell call does not earn its full body in live mode —
@@ -1063,7 +1041,7 @@ impl ExecCell {
                 .is_some_and(is_truncated_output_preview)
         {
             lines.push(render_spillover_annotation(width));
-            return wrap_card_rail(lines);
+            return wrap_card_rail(lines, self.status);
         }
         if mode == RenderMode::Live && self.status == ToolStatus::Success {
             if self.interaction.is_none()
@@ -1086,7 +1064,7 @@ impl ExecCell {
                     width,
                 ));
             }
-            return wrap_card_rail(lines);
+            return wrap_card_rail(lines, self.status);
         }
 
         if self.status == ToolStatus::Success && self.source == ExecSource::User {
@@ -1159,7 +1137,7 @@ impl ExecCell {
             }
         }
 
-        wrap_card_rail(lines)
+        wrap_card_rail(lines, self.status)
     }
 }
 
@@ -1177,6 +1155,32 @@ pub struct ExploringCell {
 }
 
 impl ExploringCell {
+    /// The cell's own lifecycle state, rolled up from its parallel entries.
+    ///
+    /// One derivation, used by the card header, by [`ToolCell::status`], and by
+    /// the Activity surfaces — three copies of this fold had drifted apart, and
+    /// the header's copy could not produce `Failed` at all, so a fan-out with a
+    /// failed read painted itself `done` in the success colour.
+    ///
+    /// Precedence: any entry still running keeps the whole cell running; after
+    /// that the loudest terminal state wins, so a single failure is never
+    /// averaged away by its successful siblings.
+    #[must_use]
+    pub fn status(&self) -> ToolStatus {
+        let any = |wanted: ToolStatus| self.entries.iter().any(|entry| entry.status == wanted);
+        if any(ToolStatus::Running) {
+            ToolStatus::Running
+        } else if any(ToolStatus::Failed) {
+            ToolStatus::Failed
+        } else if any(ToolStatus::Warning) {
+            ToolStatus::Warning
+        } else if any(ToolStatus::Hydrated) {
+            ToolStatus::Hydrated
+        } else {
+            ToolStatus::Success
+        }
+    }
+
     /// Render the exploring cell into lines.
     #[cfg(test)]
     pub fn lines_with_motion(&self, width: u16, low_motion: bool) -> Vec<Line<'static>> {
@@ -1190,29 +1194,8 @@ impl ExploringCell {
         locale: Locale,
     ) -> Vec<Line<'static>> {
         let mut lines = Vec::new();
-        let all_done = self
-            .entries
-            .iter()
-            .all(|entry| entry.status != ToolStatus::Running);
-        let any_hydrated = self
-            .entries
-            .iter()
-            .any(|entry| entry.status == ToolStatus::Hydrated);
-        let any_warning = self
-            .entries
-            .iter()
-            .any(|entry| entry.status == ToolStatus::Warning);
-        let status = if all_done {
-            if any_warning {
-                ToolStatus::Warning
-            } else if any_hydrated {
-                ToolStatus::Hydrated
-            } else {
-                ToolStatus::Success
-            }
-        } else {
-            ToolStatus::Running
-        };
+        let status = self.status();
+        let all_done = status != ToolStatus::Running;
         let header_summary = exploring_header_summary(&self.entries);
         let multi_entry = self.entries.len() > 1;
         let header_state: Cow<'static, str> = if multi_entry {
@@ -1252,28 +1235,33 @@ impl ExploringCell {
                         ToolStatus::Running => (d, r + 1, f),
                         ToolStatus::Failed => (d, r, f + 1),
                     });
-            let dots: String = self
-                .entries
-                .iter()
-                .map(|e| match e.status {
+            // Each dot carries its own entry's state. Painting the strip one
+            // flat colour made a failed parallel read indistinguishable from a
+            // finished one, which is exactly the narration the cell is
+            // supposed to make unnecessary.
+            let mut dot_spans: Vec<Span<'static>> = vec![Span::raw("  ")];
+            dot_spans.extend(self.entries.iter().map(|e| {
+                let glyph = match e.status {
                     ToolStatus::Success | ToolStatus::Hydrated => "\u{25CF}",
                     ToolStatus::Warning => "!",
                     ToolStatus::Running => "\u{25D0}",
                     ToolStatus::Failed => "\u{2715}",
-                })
-                .collect();
+                };
+                Span::styled(glyph, Style::default().fg(tool_state_color(e.status)))
+            }));
             let counts = format!(
-                "{done} done, {running} running{}",
+                "  {done} done, {running} running{}",
                 if failed > 0 {
                     format!(", {failed} failed")
                 } else {
                     String::new()
                 },
             );
-            lines.push(Line::styled(
-                format!("  {dots}  {counts}"),
-                Style::default().fg(palette::WHALE_INFO),
+            dot_spans.push(Span::styled(
+                counts,
+                Style::default().fg(tool_state_color(status)),
             ));
+            lines.push(Line::from(dot_spans));
         }
 
         for entry in &self.entries {
@@ -1759,14 +1747,17 @@ impl GenericToolCell {
         {
             let family = crate::tui::widgets::tool_card::tool_family_for_name(&self.name);
             let summary = truncate_text(output.trim(), 200);
-            return wrap_card_rail(vec![render_tool_header_with_family_and_summary(
-                family,
-                Some(summary.as_str()),
-                tool_status_label(self.status),
+            return wrap_card_rail(
+                vec![render_tool_header_with_family_and_summary(
+                    family,
+                    Some(summary.as_str()),
+                    tool_status_label(self.status),
+                    self.status,
+                    None,
+                    low_motion,
+                )],
                 self.status,
-                None,
-                low_motion,
-            )]);
+            );
         }
 
         // Live mode stays calm: successful tool calls collapse to one header
@@ -1797,7 +1788,7 @@ impl GenericToolCell {
                 if self.spillover_path.is_some() {
                     collapsed.push(render_spillover_annotation(width));
                 }
-                return wrap_card_rail(collapsed);
+                return wrap_card_rail(collapsed, self.status);
             }
         }
 
@@ -1906,7 +1897,7 @@ impl GenericToolCell {
                 lines.push(render_spillover_annotation(width));
             }
         }
-        wrap_card_rail(lines)
+        wrap_card_rail(lines, self.status)
     }
 
     /// If this cell is a checklist/todo write/add/update and the output is
@@ -2020,7 +2011,7 @@ impl GenericToolCell {
                     ));
                 }
             }
-            return Some(wrap_card_rail(lines));
+            return Some(wrap_card_rail(lines, self.status));
         }
 
         use crate::tui::widgets::workflow_panel::{WorkflowHistoryExtras, WorkflowPanel};
@@ -2088,7 +2079,7 @@ impl GenericToolCell {
                 ));
             }
         }
-        Some(wrap_card_rail(lines))
+        Some(wrap_card_rail(lines, self.status))
     }
 }
 
@@ -2189,13 +2180,20 @@ fn render_compact_kv(label: &str, value: &str, style: Style, width: u16) -> Vec<
 /// Wrap rendered tool-card lines with card-rail glyphs (╭ │ ╰).
 /// First non-empty line gets `╭`, middle lines get `│`, last line gets `╰`.
 /// Single-line cards get a single `─` prefix.
-fn wrap_card_rail(mut lines: Vec<Line<'static>>) -> Vec<Line<'static>> {
+///
+/// The rail is the card's border, so it carries the cell's own state: it is
+/// painted with [`tool_state_color`], the single status→ink mapping. A running
+/// card is bordered in the action accent and a failed one in the error colour,
+/// which is what makes a tool cell legible without a neighbouring row
+/// narrating what the card already shows.
+fn wrap_card_rail(mut lines: Vec<Line<'static>>, status: ToolStatus) -> Vec<Line<'static>> {
     let n = lines.len();
     if n == 0 {
         return lines;
     }
+    let rail_style = Style::default().fg(tool_state_color(status));
     if n == 1 {
-        lines[0].spans.insert(0, Span::raw("─ "));
+        lines[0].spans.insert(0, Span::styled("─ ", rail_style));
         return lines;
     }
     for (i, line) in lines.iter_mut().enumerate() {
@@ -2206,7 +2204,7 @@ fn wrap_card_rail(mut lines: Vec<Line<'static>>) -> Vec<Line<'static>> {
         } else {
             "\u{2502} " // │
         };
-        line.spans.insert(0, Span::raw(rail));
+        line.spans.insert(0, Span::styled(rail, rail_style));
     }
     lines
 }

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1247,7 +1247,10 @@ impl ExploringCell {
                     ToolStatus::Running => "\u{25D0}",
                     ToolStatus::Failed => "\u{2715}",
                 };
-                Span::styled(glyph, Style::default().fg(tool_state_color(e.status)))
+                Span::styled(
+                    glyph,
+                    Style::default().fg(tool_glyph_color(e.status, family)),
+                )
             }));
             let counts = format!(
                 "  {done} done, {running} running{}",
@@ -1259,7 +1262,7 @@ impl ExploringCell {
             );
             dot_spans.push(Span::styled(
                 counts,
-                Style::default().fg(tool_state_color(status)),
+                Style::default().fg(tool_glyph_color(status, family)),
             ));
             lines.push(Line::from(dot_spans));
         }
@@ -2182,16 +2185,18 @@ fn render_compact_kv(label: &str, value: &str, style: Style, width: u16) -> Vec<
 /// Single-line cards get a single `─` prefix.
 ///
 /// The rail is the card's border, so it carries the cell's own state: it is
-/// painted with [`tool_state_color`], the single status→ink mapping. A running
-/// card is bordered in the action accent and a failed one in the error colour,
-/// which is what makes a tool cell legible without a neighbouring row
-/// narrating what the card already shows.
+/// painted with [`tool_rail_color`], OMP's border rule. A running card is
+/// bordered in the action accent, a failed one in the error colour, and a
+/// settled one recedes to muted — which is what makes a tool cell legible
+/// without a neighbouring row narrating what the card already shows. The
+/// header glyph inside it follows [`tool_glyph_color`] instead, so a finished
+/// card still says what it was.
 fn wrap_card_rail(mut lines: Vec<Line<'static>>, status: ToolStatus) -> Vec<Line<'static>> {
     let n = lines.len();
     if n == 0 {
         return lines;
     }
-    let rail_style = Style::default().fg(tool_state_color(status));
+    let rail_style = Style::default().fg(tool_rail_color(status));
     if n == 1 {
         lines[0].spans.insert(0, Span::styled("─ ", rail_style));
         return lines;
@@ -2557,18 +2562,16 @@ fn render_tool_header_with_family_and_summary(
     let glyph = crate::tui::widgets::tool_card::family_glyph(family);
     let verb = crate::tui::widgets::tool_card::family_label(family);
 
+    let glyph_style = Style::default().fg(tool_glyph_color(status, family));
     let mut spans = vec![
         Span::styled(
             format!("{} ", status_symbol(started_at, status, low_motion, family)),
-            Style::default().fg(tool_state_color(status)),
+            glyph_style,
         ),
-        Span::styled(
-            format!("{glyph} "),
-            Style::default().fg(tool_state_color(status)),
-        ),
+        Span::styled(format!("{glyph} "), glyph_style),
         Span::styled(verb.to_string(), tool_title_style()),
         Span::styled(" ", Style::default()),
-        Span::styled(state_owned, tool_status_style(status)),
+        Span::styled(state_owned, tool_status_style(status, family)),
     ];
 
     // #4148: don't let the summary echo the verb it sits next to — an
@@ -2681,16 +2684,28 @@ fn tool_title_style() -> Style {
     active_theme().tool_title_style()
 }
 
-fn tool_status_style(status: ToolStatus) -> Style {
-    active_theme().tool_status_style(status)
+fn tool_status_style(
+    status: ToolStatus,
+    family: crate::tui::widgets::tool_card::ToolFamily,
+) -> Style {
+    active_theme().tool_status_style(status, family)
 }
 
 fn tool_detail_label_style() -> Style {
     active_theme().tool_label_style()
 }
 
-fn tool_state_color(status: ToolStatus) -> Color {
-    active_theme().tool_status_color(status)
+/// Card border ink — OMP's border rule. See [`Theme::tool_rail_color`].
+fn tool_rail_color(status: ToolStatus) -> Color {
+    active_theme().tool_rail_color(status)
+}
+
+/// Status-glyph ink — the mockup's reading. See [`Theme::tool_glyph_color`].
+fn tool_glyph_color(
+    status: ToolStatus,
+    family: crate::tui::widgets::tool_card::ToolFamily,
+) -> Color {
+    active_theme().tool_glyph_color(status, family)
 }
 
 fn tool_status_label(status: ToolStatus) -> &'static str {

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -2345,3 +2345,116 @@ fn the_card_helpers_accept_their_documented_forms_and_decline_the_rest() {
         "Line one\nLine two"
     );
 }
+
+/// The card rail is the block's border, so it carries the cell's own state.
+/// Property, not token: every status paints a distinct rail, the rail agrees
+/// with the header glyph beside it, and the rail is never left unstyled — an
+/// unstyled rail is what shipped before, and it made a failed card look
+/// exactly like a finished one from the border in.
+#[test]
+fn card_rail_carries_the_cell_status() {
+    let mut rails = Vec::new();
+    for status in [
+        ToolStatus::Running,
+        ToolStatus::Success,
+        ToolStatus::Hydrated,
+        ToolStatus::Warning,
+        ToolStatus::Failed,
+    ] {
+        let cell = exec_tool("cargo test", status);
+        let lines = cell.render(80, /*low_motion*/ true, RenderMode::Live);
+        let first = &lines[0];
+
+        let rail = first.spans.first().expect("card rail span");
+        assert!(
+            matches!(rail.content.as_ref(), "─ " | "╭ "),
+            "{status:?} lost its card rail: {:?}",
+            rail.content
+        );
+        let rail_color = rail.style.fg.unwrap_or_else(|| {
+            panic!("{status:?} left the card rail unstyled — the border must follow the state")
+        });
+
+        let glyph_color = first.spans[1]
+            .style
+            .fg
+            .expect("header status glyph must be styled");
+        assert_eq!(
+            rail_color, glyph_color,
+            "{status:?} paints its rail and its header glyph differently"
+        );
+
+        rails.push((status, rail_color));
+    }
+
+    for (i, (status, color)) in rails.iter().enumerate() {
+        for (other_status, other_color) in &rails[i + 1..] {
+            assert_ne!(
+                color, other_color,
+                "{status:?} and {other_status:?} draw the same rail"
+            );
+        }
+    }
+}
+
+/// An exploring cell rolls its parallel entries up into one state, and a
+/// single failure is never averaged away by its successful siblings. This is
+/// the fold that used to exist in three places and could not produce `Failed`
+/// in the one that painted the header.
+#[test]
+fn exploring_cell_status_keeps_the_loudest_terminal_state() {
+    use super::{ExploringCell, ExploringEntry};
+
+    let cell = |statuses: &[ToolStatus]| ExploringCell {
+        entries: statuses
+            .iter()
+            .map(|status| ExploringEntry {
+                label: "Reading src/foo.rs".to_string(),
+                status: *status,
+            })
+            .collect(),
+    };
+
+    for (statuses, expected) in [
+        (
+            vec![ToolStatus::Success, ToolStatus::Success],
+            ToolStatus::Success,
+        ),
+        (
+            vec![ToolStatus::Success, ToolStatus::Running],
+            ToolStatus::Running,
+        ),
+        (
+            vec![ToolStatus::Failed, ToolStatus::Running],
+            ToolStatus::Running,
+        ),
+        (
+            vec![ToolStatus::Success, ToolStatus::Failed],
+            ToolStatus::Failed,
+        ),
+        (
+            vec![ToolStatus::Warning, ToolStatus::Failed],
+            ToolStatus::Failed,
+        ),
+        (
+            vec![ToolStatus::Success, ToolStatus::Warning],
+            ToolStatus::Warning,
+        ),
+        (
+            vec![ToolStatus::Success, ToolStatus::Hydrated],
+            ToolStatus::Hydrated,
+        ),
+    ] {
+        assert_eq!(
+            cell(&statuses).status(),
+            expected,
+            "{statuses:?} should roll up to {expected:?}"
+        );
+    }
+
+    // And the cell reports that state through the ToolCell it lives in.
+    assert_eq!(
+        ToolCell::Exploring(cell(&[ToolStatus::Success, ToolStatus::Failed])).status(),
+        Some(ToolStatus::Failed)
+    );
+}

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -2347,10 +2347,11 @@ fn the_card_helpers_accept_their_documented_forms_and_decline_the_rest() {
 }
 
 /// The card rail is the block's border, so it carries the cell's own state.
-/// Property, not token: every status paints a distinct rail, the rail agrees
-/// with the header glyph beside it, and the rail is never left unstyled — an
-/// unstyled rail is what shipped before, and it made a failed card look
-/// exactly like a finished one from the border in.
+/// Property, not token: every status paints a distinct rail, the rail is never
+/// left unstyled — an unstyled rail is what shipped before, and it made a
+/// failed card look exactly like a finished one from the border in — and it
+/// agrees with the glyph beside it on everything that needs attention while
+/// receding on a settled card, which is the whole point of the split.
 #[test]
 fn card_rail_carries_the_cell_status() {
     let mut rails = Vec::new();
@@ -2379,10 +2380,18 @@ fn card_rail_carries_the_cell_status() {
             .style
             .fg
             .expect("header status glyph must be styled");
-        assert_eq!(
-            rail_color, glyph_color,
-            "{status:?} paints its rail and its header glyph differently"
-        );
+        if status == ToolStatus::Success {
+            // A settled card dims its border but keeps an identifying glyph.
+            assert_ne!(
+                rail_color, glyph_color,
+                "a settled card must not dim its glyph along with its rail"
+            );
+        } else {
+            assert_eq!(
+                rail_color, glyph_color,
+                "{status:?} must read the same on the rail and the glyph"
+            );
+        }
 
         rails.push((status, rail_color));
     }
@@ -2395,6 +2404,35 @@ fn card_rail_carries_the_cell_status() {
             );
         }
     }
+}
+
+/// The header glyph reports identity, not just lifecycle: a passed `verify`
+/// card keeps its green tick where a finished `read` keeps the family accent
+/// the mockup draws as a blue magnifier. Relationship, not token — the two must
+/// simply not collapse into one another.
+#[test]
+fn a_settled_verify_glyph_does_not_read_as_a_settled_read() {
+    let verify = generic_tool("run_tests", ToolStatus::Success);
+    let read = generic_tool("read_file", ToolStatus::Success);
+
+    let glyph_color = |cell: &GenericToolCell| {
+        cell.lines_with_mode_and_locale(
+            80,
+            /*low_motion*/ true,
+            RenderMode::Live,
+            crate::localization::Locale::En,
+        )[0]
+        .spans[1]
+            .style
+            .fg
+            .expect("header status glyph must be styled")
+    };
+
+    assert_ne!(
+        glyph_color(&verify),
+        glyph_color(&read),
+        "a passed verify and a finished read must not share a glyph colour"
+    );
 }
 
 /// An exploring cell rolls its parallel entries up into one state, and a

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -668,7 +668,7 @@ fn turn_stall_watchdog_timeout(app: &App) -> Duration {
 fn active_turn_has_running_tool(app: &App) -> bool {
     app.active_cell.as_ref().is_some_and(|active| {
         active.entries().iter().any(|cell| match cell {
-            HistoryCell::Tool(tool) => tool_cell_is_running(tool),
+            HistoryCell::Tool(tool) => tool.is_running(),
             _ => false,
         })
     })

--- a/crates/tui/src/tui/ui/activity_detail.rs
+++ b/crates/tui/src/tui/ui/activity_detail.rs
@@ -234,48 +234,6 @@ fn activity_cell_label(app: &App, cell_index: usize, cell: &HistoryCell) -> Stri
     }
 }
 
-fn tool_status_for_activity(tool: &ToolCell) -> Option<ToolStatus> {
-    match tool {
-        ToolCell::Exec(cell) => Some(cell.status),
-        ToolCell::Exploring(cell) => {
-            if cell
-                .entries
-                .iter()
-                .any(|entry| entry.status == ToolStatus::Running)
-            {
-                Some(ToolStatus::Running)
-            } else if cell
-                .entries
-                .iter()
-                .any(|entry| entry.status == ToolStatus::Failed)
-            {
-                Some(ToolStatus::Failed)
-            } else if cell
-                .entries
-                .iter()
-                .any(|entry| entry.status == ToolStatus::Warning)
-            {
-                Some(ToolStatus::Warning)
-            } else if cell
-                .entries
-                .iter()
-                .any(|entry| entry.status == ToolStatus::Hydrated)
-            {
-                Some(ToolStatus::Hydrated)
-            } else {
-                Some(ToolStatus::Success)
-            }
-        }
-        ToolCell::PlanUpdate(cell) => Some(cell.status),
-        ToolCell::PatchSummary(cell) => Some(cell.status),
-        ToolCell::Review(cell) => Some(cell.status),
-        ToolCell::Mcp(cell) => Some(cell.status),
-        ToolCell::ViewImage(_) => Some(ToolStatus::Success),
-        ToolCell::WebSearch(cell) => Some(cell.status),
-        ToolCell::Generic(cell) => Some(cell.status),
-    }
-}
-
 fn tool_duration_for_activity(tool: &ToolCell) -> Option<u64> {
     match tool {
         ToolCell::Exec(cell) => cell.duration_ms.or_else(|| {
@@ -1232,7 +1190,7 @@ fn turn_timeline_lines(app: &App, start: usize, end: usize) -> Vec<String> {
                 let (kind, summary) = timeline_tool_summary(app, idx, tool);
                 let duration =
                     tool_duration_for_activity(tool).map(crate::elapsed::format_elapsed_ms);
-                let status = tool_status_for_activity(tool).map(activity_status_label);
+                let status = tool.status().map(activity_status_label);
                 let actions = timeline_cell_actions(app, idx, cell);
                 rows.push(timeline_row(
                     kind,

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -739,23 +739,6 @@ pub(crate) fn build_session_snapshot(
     Ok(session)
 }
 
-pub(crate) fn tool_cell_is_running(tool: &ToolCell) -> bool {
-    match tool {
-        ToolCell::Exec(cell) => cell.status == ToolStatus::Running,
-        ToolCell::Exploring(cell) => cell
-            .entries
-            .iter()
-            .any(|entry| entry.status == ToolStatus::Running),
-        ToolCell::PlanUpdate(cell) => cell.status == ToolStatus::Running,
-        ToolCell::PatchSummary(cell) => cell.status == ToolStatus::Running,
-        ToolCell::Review(cell) => cell.status == ToolStatus::Running,
-        ToolCell::Mcp(cell) => cell.status == ToolStatus::Running,
-        ToolCell::ViewImage(_) => false,
-        ToolCell::WebSearch(cell) => cell.status == ToolStatus::Running,
-        ToolCell::Generic(cell) => cell.status == ToolStatus::Running,
-    }
-}
-
 /// Strip ANSI control codes / non-printable bytes from a streaming
 /// text chunk. `pub(super)` because `tui::notifications` consumes it
 /// from `crate::tui::ui` for its per-turn message composition.


### PR DESCRIPTION
## Summary

A running, failed or warned tool now reads as such in the transcript itself, the way oh-my-pi's output blocks do (`output-block.ts`: the block's state drives its border). What was wrong here: `wrap_card_rail` inserted the `╭ │ ╰` rail with `Span::raw`, so the card border carried no state; the exploring fan-out painted every dot flat `WHALE_INFO`, so a failed read looked like a done one; and four copies of the status fold had drifted apart — the card header's copy could not even produce `Failed`, so a fan-out with a failed read rendered `done` in the success colour.

Now there is one fold (`ExploringCell::status`) and two theme functions, both reusing the existing `Theme::tool_status_color` plumbing:

- **Rail / border** (`tool_rail_color`): running `WHALE_ACTION`, success `TEXT_MUTED`, hydrated `TEXT_DIM`, warning `WHALE_HUMAN`, failed `WHALE_ERROR`.
- **Glyph + state word** (`tool_glyph_color`, per family): running action-blue; settled *verify* rows `✓` in `WHALE_WORKING_GREEN`; settled read/find/run/patch rows keep their family accent (the blue magnifier in mockup tideline-01); warning/failed as the rail.

Running, warning and failure use the same ink in both tables by construction, so border and glyph can never disagree about trouble; only success splits, which is the case the accepted mockup cares about. Light and solarized follow the same roles in their own tokens; grayscale is untouched (four greys cannot separate five states, and a test says so rather than papering over it).

Design rationale: codewhale-ops `design/SHELL-DESIGN-20260901.md` §2.1 (OMP paragraph) and §2.5a.

## Testing

- `scripts/dev-test.sh tui tui::history` → `Summary 77 tests run: 77 passed`
- `scripts/dev-test.sh tui deepseek_theme` → `Summary 8 tests run: 8 passed`
- `scripts/dev-test.sh tui tui::` → `Summary 3328 tests run: 3328 passed`
- whole tui lib → `11820 tests run: 11819 passed, 1 failed` — the one failure is `task_manager::tests::forced_idle_timeout_releases_the_worker_for_later_tasks`, a timing test this change does not touch; alone: `1 test run: 1 passed`
- The rail regression test fails without the fix: reverting the two `Span::styled` lines → `panicked at history/tests.rs:2375: Running left the card rail unstyled`
- No goldens changed (text-only goldens; none renders a tool cell)

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-tui` warning-free under the CI allow list
- [x] tui suites above

## Checklist

- [x] This PR adds a new layer/module/abstraction — it names or deletes the layer it replaces (deletes three drifted copies of the status fold)
- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — rendering asserted through the real render path in tests; not eyeballed in a terminal
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdbuqwHAXSDcikPiS6L6Qw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only visual and status-display logic with broad test coverage; no auth, persistence, or API surface changes.
> 
> **Overview**
> Tool transcript cards now **encode lifecycle in the border** and **identity in the header glyph**, aligned with oh-my-pi output blocks and the tideline mockup.
> 
> **Theme** replaces a single `tool_status_color` with **`tool_rail_color`** (running/warning/failed stay loud; success and hydrated recede to muted/dim) and **`tool_glyph_color(status, family)`** (verify success stays green; other families keep the action accent when done). Dark/light running accents shift to action tokens; status text styling is family-aware.
> 
> **Rendering** passes `ToolStatus` into `wrap_card_rail` so `╭│╰` rails are styled, not raw. Headers and exploring fan-out dots use per-entry glyph colors instead of one flat info color.
> 
> **Status rollup** adds `ExploringCell::status()` (running first, then failed/warning/hydrated) and routes `ToolCell::status`, activity timeline, and headers through it—fixing fan-outs that could show `done` when a child failed. Duplicate helpers `tool_cell_is_running` / `tool_status_for_activity` are dropped in favor of `ToolCell::is_running()` / `status()`.
> 
> Tests lock rail distinctness, rail vs glyph split on success, verify vs read glyphs, and exploring precedence across palettes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693f08c03ad8dc09ffa8651c5888df4c159cc40a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->