### PR TITLE
web(i18n): one-way ceiling on isZh branching (#5519)

### DIFF
--- a/web/lib/i18n/iszh-ceiling.test.ts
+++ b/web/lib/i18n/iszh-ceiling.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = process.cwd();
+const MIGRATION_HOME = join("lib", "i18n");
+// One-way ceiling (#5519): the isZh migration converges or holds, never
+// regresses. To lower the number: migrate branches into lib/i18n, then set
+// CEILING to the new count reported by this test.
+const CEILING = 28;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".next" || entry === ".git") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.[jt]sx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe("isZh one-way ceiling (#5519)", () => {
+  it(`keeps isZh branching outside ${MIGRATION_HOME} at <= ${CEILING} files`, () => {
+    const offenders = walk(ROOT)
+      .map((file) => relative(ROOT, file))
+      .filter(
+        (file) =>
+          !file.startsWith(MIGRATION_HOME) &&
+          !/\.test\.[jt]sx?$/.test(file) &&
+          readFileSync(join(ROOT, file), "utf8").includes("isZh"),
+      )
+      .sort();
+    expect(
+      offenders.length,
+      `isZh branching outside ${MIGRATION_HOME} (migrate, then lower the CEILING):\n${offenders.join("\n")}`,
+    ).toBeLessThanOrEqual(CEILING);
+  });
+});


### PR DESCRIPTION
Adds the ceiling test #5519 asked for: files branching on `isZh` outside `web/lib/i18n` must never exceed 28 (the count on main today). Migration work lowers the count; the constant ratchets down with it.

`vitest run lib/i18n/iszh-ceiling.test.ts` — 1 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a regression test only; no runtime or product behavior changes.
> 
> **Overview**
> Adds a **Vitest guard** for the `isZh` → `lib/i18n` migration: it scans the `web` tree for `.js`/`.ts`/`.jsx`/`.tsx` files that contain `isZh` while excluding `lib/i18n` and test files, and **fails if that count exceeds 28** (today’s baseline on main).
> 
> The test is documented as a **one-way ratchet**—migration should shrink the offender list; **`CEILING` is only lowered** after branches move into `lib/i18n`, so new scattered `isZh` branching cannot creep back in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 015e1770ef6fc91309f48d3addd8661abf95f36d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->