### PR TITLE
fix(tui): the bundled model catalog can be stale again

### DIFF
--- a/crates/tui/assets/model_catalog.bundled.json
+++ b/crates/tui/assets/model_catalog.bundled.json
@@ -1,399 +1,547 @@
 {
-  "schema_version": 1,
-  "source": "bundled",
-  "fetched_at": "2026-07-06T00:00:00Z",
-  "ttl_secs": 315360000,
   "entries": {
-    "deepseek-v4-pro": {
-      "id": "deepseek-v4-pro",
-      "context_window": 1000000,
-      "max_output": 384000,
-      "supports_reasoning": true,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "deepseek-v4-flash": {
-      "id": "deepseek-v4-flash",
-      "context_window": 1000000,
-      "max_output": 384000,
-      "supports_reasoning": true,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "deepseek-v4-flash-vision-exp": {
-      "id": "deepseek-v4-flash-vision-exp",
-      "context_window": 1000000,
-      "max_output": 384000,
-      "supports_reasoning": true,
-      "modalities": ["text", "image"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "gpt-5-codex": {
-      "id": "gpt-5-codex",
-      "context_window": 400000,
-      "max_output": 128000,
-      "supports_reasoning": true,
-      "input_usd_per_million": 1.25,
-      "output_usd_per_million": 10.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "gpt-5.3-codex": {
-      "id": "gpt-5.3-codex",
-      "context_window": 400000,
-      "max_output": 128000,
-      "supports_reasoning": true,
-      "input_usd_per_million": 1.75,
-      "output_usd_per_million": 14.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "gpt-5.6": {
-      "id": "gpt-5.6",
-      "context_window": 1050000,
-      "max_output": 128000,
-      "supports_reasoning": true,
-      "modalities": ["text", "image"],
-      "supported_parameters": ["reasoning"],
-      "provider_model_id": "gpt-5.6-sol",
-      "provenance": "bundled"
-    },
-    "gpt-5.6-sol": {
-      "id": "gpt-5.6-sol",
-      "context_window": 1050000,
-      "max_output": 128000,
-      "supports_reasoning": true,
-      "modalities": ["text", "image"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "gpt-5.6-terra": {
-      "id": "gpt-5.6-terra",
-      "context_window": 1050000,
-      "max_output": 128000,
-      "supports_reasoning": true,
-      "modalities": ["text", "image"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "gpt-5.6-luna": {
-      "id": "gpt-5.6-luna",
-      "context_window": 1050000,
-      "max_output": 128000,
-      "supports_reasoning": true,
-      "modalities": ["text", "image"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "muse-spark-1.1": {
-      "id": "muse-spark-1.1",
-      "context_window": 1000000,
-      "max_output": 32000,
-      "supports_reasoning": true,
-      "modalities": ["text", "image"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "muse-spark-1.2": {
-      "id": "muse-spark-1.2",
-      "context_window": 1000000,
-      "max_output": 32000,
-      "supports_reasoning": true,
-      "modalities": ["text", "image"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "muse-spark-1.2-contributor": {
-      "id": "muse-spark-1.2-contributor",
-      "context_window": 1000000,
-      "max_output": 32000,
-      "supports_reasoning": true,
-      "modalities": ["text", "image"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "kimi-k3": {
-      "id": "kimi-k3",
-      "context_window": 1048576,
-      "max_output": 131072,
-      "supports_reasoning": true,
-      "input_usd_per_million": 3.0,
-      "output_usd_per_million": 15.0,
-      "modalities": ["text", "image", "video"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "kimi-k2.7-code": {
-      "id": "kimi-k2.7-code",
-      "context_window": 262144,
-      "max_output": 32768,
-      "supports_reasoning": true,
-      "input_usd_per_million": 0.95,
-      "output_usd_per_million": 4.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "moonshotai/kimi-k2.7-code": {
-      "id": "moonshotai/kimi-k2.7-code",
-      "context_window": 262144,
-      "max_output": 32768,
-      "supports_reasoning": true,
-      "input_usd_per_million": 0.95,
-      "output_usd_per_million": 4.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "z-ai/glm-5.2": {
-      "id": "z-ai/glm-5.2",
-      "context_window": 1000000,
-      "max_output": 131072,
-      "supports_reasoning": true,
-      "input_usd_per_million": 1.4,
-      "output_usd_per_million": 4.4,
-      "modalities": ["text"],
-      "supported_parameters": [],
-      "provenance": "bundled"
-    },
-    "z-ai/glm-5.3": {
-      "id": "z-ai/glm-5.3",
-      "context_window": 1000000,
-      "max_output": 131072,
-      "supports_reasoning": true,
-      "modalities": ["text"],
-      "supported_parameters": [],
-      "provenance": "bundled"
-    },
-    "z-ai/glm-5.3-flash": {
-      "id": "z-ai/glm-5.3-flash",
-      "context_window": 1000000,
-      "max_output": 131072,
-      "supports_reasoning": true,
-      "input_usd_per_million": 0.15,
-      "output_usd_per_million": 0.5,
-      "modalities": ["text", "image", "video"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "glm-5.2": {
-      "id": "glm-5.2",
-      "context_window": 1000000,
-      "max_output": 131072,
-      "supports_reasoning": true,
-      "input_usd_per_million": 1.4,
-      "output_usd_per_million": 4.4,
-      "modalities": ["text"],
-      "supported_parameters": [],
-      "provenance": "bundled"
-    },
-    "glm-5.3": {
-      "id": "glm-5.3",
-      "context_window": 1000000,
-      "max_output": 131072,
-      "supports_reasoning": true,
-      "modalities": ["text"],
-      "supported_parameters": [],
-      "provenance": "bundled"
-    },
-    "glm-5.3-flash": {
-      "id": "glm-5.3-flash",
-      "context_window": 1000000,
-      "max_output": 131072,
-      "supports_reasoning": true,
-      "input_usd_per_million": 0.15,
-      "output_usd_per_million": 0.5,
-      "modalities": ["text", "image", "video"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "minimax/minimax-m3": {
-      "id": "minimax/minimax-m3",
-      "context_window": 1000000,
-      "max_output": 524288,
-      "supports_reasoning": true,
-      "modalities": ["text", "image"],
-      "supported_parameters": [],
-      "provenance": "bundled"
-    },
-    "minimax/minimax-m2.7": {
-      "id": "minimax/minimax-m2.7",
-      "context_window": 204800,
-      "max_output": 131072,
-      "supports_reasoning": true,
-      "input_usd_per_million": 0.3,
-      "output_usd_per_million": 1.2,
-      "modalities": ["text"],
-      "supported_parameters": [],
-      "provenance": "bundled"
-    },
-    "minimax-m2.7": {
-      "id": "minimax-m2.7",
-      "context_window": 204800,
-      "max_output": 131072,
-      "supports_reasoning": true,
-      "input_usd_per_million": 0.3,
-      "output_usd_per_million": 1.2,
-      "modalities": ["text"],
-      "supported_parameters": [],
-      "provenance": "bundled"
-    },
-    "qwen/qwen3.6-flash": {
-      "id": "qwen/qwen3.6-flash",
-      "context_window": 1000000,
-      "max_output": 65536,
-      "supports_reasoning": true,
-      "modalities": ["text"],
-      "supported_parameters": [],
-      "provenance": "bundled"
-    },
-    "trinity-large-thinking": {
-      "id": "trinity-large-thinking",
-      "context_window": 262144,
-      "max_output": 262144,
-      "supports_reasoning": true,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "trinity-mini": {
-      "id": "trinity-mini",
-      "context_window": 128000,
-      "supports_reasoning": true,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "claude-opus-4-8": {
-      "id": "claude-opus-4-8",
-      "context_window": 1000000,
-      "max_output": 128000,
-      "supports_reasoning": true,
-      "input_usd_per_million": 5.0,
-      "output_usd_per_million": 25.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "claude-opus-5": {
-      "id": "claude-opus-5",
-      "context_window": 1000000,
-      "max_output": 128000,
-      "supports_reasoning": true,
-      "input_usd_per_million": 5.0,
-      "output_usd_per_million": 25.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "claude-sonnet-5": {
-      "id": "claude-sonnet-5",
-      "context_window": 1000000,
-      "max_output": 128000,
-      "supports_reasoning": true,
-      "input_usd_per_million": 2.0,
-      "output_usd_per_million": 10.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
     "claude-fable-5": {
+      "context_window": 1000000,
       "id": "claude-fable-5",
-      "context_window": 1000000,
-      "max_output": 128000,
-      "supports_reasoning": true,
       "input_usd_per_million": 10.0,
-      "output_usd_per_million": 50.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
-    },
-    "claude-sonnet-4-6": {
-      "id": "claude-sonnet-4-6",
-      "context_window": 1000000,
       "max_output": 128000,
-      "supports_reasoning": true,
-      "input_usd_per_million": 3.0,
-      "output_usd_per_million": 15.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 50.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
     },
     "claude-haiku-4-5": {
-      "id": "claude-haiku-4-5",
       "context_window": 200000,
-      "max_output": 64000,
-      "supports_reasoning": false,
+      "id": "claude-haiku-4-5",
       "input_usd_per_million": 1.0,
+      "max_output": 64000,
+      "modalities": [
+        "text"
+      ],
       "output_usd_per_million": 5.0,
-      "modalities": ["text"],
+      "provenance": "bundled",
       "supported_parameters": [],
-      "provenance": "bundled"
+      "supports_reasoning": false
     },
-    "step-3.7-flash": {
-      "id": "step-3.7-flash",
-      "context_window": 256000,
-      "max_output": 256000,
-      "supports_reasoning": false,
-      "input_usd_per_million": 0.2,
-      "output_usd_per_million": 1.15,
-      "modalities": ["text"],
-      "supported_parameters": [],
-      "provenance": "bundled"
-    },
-    "fugu-ultra-20260615": {
-      "id": "fugu-ultra-20260615",
+    "claude-opus-4-8": {
       "context_window": 1000000,
-      "max_output": 131000,
-      "supports_reasoning": true,
+      "id": "claude-opus-4-8",
       "input_usd_per_million": 5.0,
-      "output_usd_per_million": 30.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
+      "max_output": 128000,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 25.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "claude-opus-5": {
+      "context_window": 1000000,
+      "id": "claude-opus-5",
+      "input_usd_per_million": 5.0,
+      "max_output": 128000,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 25.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "claude-sonnet-4-6": {
+      "context_window": 1000000,
+      "id": "claude-sonnet-4-6",
+      "input_usd_per_million": 3.0,
+      "max_output": 128000,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 15.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "claude-sonnet-5": {
+      "context_window": 1000000,
+      "id": "claude-sonnet-5",
+      "input_usd_per_million": 2.0,
+      "max_output": 128000,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 10.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "deepseek-v4-flash": {
+      "context_window": 1000000,
+      "id": "deepseek-v4-flash",
+      "max_output": 384000,
+      "modalities": [
+        "text"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "deepseek-v4-flash-vision-exp": {
+      "context_window": 1000000,
+      "id": "deepseek-v4-flash-vision-exp",
+      "max_output": 384000,
+      "modalities": [
+        "text",
+        "image"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "deepseek-v4-pro": {
+      "context_window": 1000000,
+      "id": "deepseek-v4-pro",
+      "max_output": 384000,
+      "modalities": [
+        "text"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
     },
     "fugu-ultra": {
+      "context_window": 1000000,
       "id": "fugu-ultra",
-      "context_window": 1000000,
-      "max_output": 131000,
-      "supports_reasoning": true,
       "input_usd_per_million": 5.0,
+      "max_output": 131000,
+      "modalities": [
+        "text"
+      ],
       "output_usd_per_million": 30.0,
-      "modalities": ["text"],
-      "supported_parameters": ["reasoning"],
-      "provenance": "bundled"
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
     },
-    "mimo-v2.5-pro": {
-      "id": "mimo-v2.5-pro",
+    "fugu-ultra-20260615": {
       "context_window": 1000000,
-      "max_output": 131072,
-      "supports_reasoning": true,
-      "modalities": ["text", "image", "audio"],
-      "supported_parameters": [],
-      "provenance": "bundled"
+      "id": "fugu-ultra-20260615",
+      "input_usd_per_million": 5.0,
+      "max_output": 131000,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 30.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
     },
-    "mimo-v2.5-pro-ultraspeed": {
-      "id": "mimo-v2.5-pro-ultraspeed",
+    "glm-5.2": {
       "context_window": 1000000,
+      "id": "glm-5.2",
+      "input_usd_per_million": 1.4,
       "max_output": 131072,
-      "supports_reasoning": true,
-      "modalities": ["text"],
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 4.4,
+      "provenance": "bundled",
       "supported_parameters": [],
-      "provenance": "bundled"
+      "supports_reasoning": true
+    },
+    "glm-5.3": {
+      "context_window": 1000000,
+      "id": "glm-5.3",
+      "max_output": 131072,
+      "modalities": [
+        "text"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [],
+      "supports_reasoning": true
+    },
+    "glm-5.3-flash": {
+      "context_window": 1000000,
+      "id": "glm-5.3-flash",
+      "input_usd_per_million": 0.15,
+      "max_output": 131072,
+      "modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_usd_per_million": 0.5,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "gpt-5-codex": {
+      "context_window": 400000,
+      "id": "gpt-5-codex",
+      "input_usd_per_million": 1.25,
+      "max_output": 128000,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 10.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "gpt-5.3-codex": {
+      "context_window": 400000,
+      "id": "gpt-5.3-codex",
+      "input_usd_per_million": 1.75,
+      "max_output": 128000,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 14.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "gpt-5.6": {
+      "context_window": 1050000,
+      "id": "gpt-5.6",
+      "max_output": 128000,
+      "modalities": [
+        "text",
+        "image"
+      ],
+      "provenance": "bundled",
+      "provider_model_id": "gpt-5.6-sol",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "gpt-5.6-luna": {
+      "context_window": 1050000,
+      "id": "gpt-5.6-luna",
+      "max_output": 128000,
+      "modalities": [
+        "text",
+        "image"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "gpt-5.6-sol": {
+      "context_window": 1050000,
+      "id": "gpt-5.6-sol",
+      "max_output": 128000,
+      "modalities": [
+        "text",
+        "image"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "gpt-5.6-terra": {
+      "context_window": 1050000,
+      "id": "gpt-5.6-terra",
+      "max_output": 128000,
+      "modalities": [
+        "text",
+        "image"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "kimi-k2.7-code": {
+      "context_window": 262144,
+      "id": "kimi-k2.7-code",
+      "input_usd_per_million": 0.95,
+      "max_output": 32768,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 4.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "kimi-k3": {
+      "context_window": 1048576,
+      "id": "kimi-k3",
+      "input_usd_per_million": 3.0,
+      "max_output": 131072,
+      "modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_usd_per_million": 15.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
     },
     "mimo-v2.5": {
-      "id": "mimo-v2.5",
       "context_window": 1000000,
+      "id": "mimo-v2.5",
       "max_output": 131072,
-      "supports_reasoning": true,
-      "modalities": ["text", "image"],
+      "modalities": [
+        "text",
+        "image"
+      ],
+      "provenance": "bundled",
       "supported_parameters": [],
-      "provenance": "bundled"
+      "supports_reasoning": true
+    },
+    "mimo-v2.5-pro": {
+      "context_window": 1000000,
+      "id": "mimo-v2.5-pro",
+      "max_output": 131072,
+      "modalities": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [],
+      "supports_reasoning": true
+    },
+    "mimo-v2.5-pro-ultraspeed": {
+      "context_window": 1000000,
+      "id": "mimo-v2.5-pro-ultraspeed",
+      "max_output": 131072,
+      "modalities": [
+        "text"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [],
+      "supports_reasoning": true
+    },
+    "minimax-m2.7": {
+      "context_window": 204800,
+      "id": "minimax-m2.7",
+      "input_usd_per_million": 0.3,
+      "max_output": 131072,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 1.2,
+      "provenance": "bundled",
+      "supported_parameters": [],
+      "supports_reasoning": true
+    },
+    "minimax/minimax-m2.7": {
+      "context_window": 204800,
+      "id": "minimax/minimax-m2.7",
+      "input_usd_per_million": 0.3,
+      "max_output": 131072,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 1.2,
+      "provenance": "bundled",
+      "supported_parameters": [],
+      "supports_reasoning": true
+    },
+    "minimax/minimax-m3": {
+      "context_window": 1000000,
+      "id": "minimax/minimax-m3",
+      "max_output": 524288,
+      "modalities": [
+        "text",
+        "image"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [],
+      "supports_reasoning": true
+    },
+    "moonshotai/kimi-k2.7-code": {
+      "context_window": 262144,
+      "id": "moonshotai/kimi-k2.7-code",
+      "input_usd_per_million": 0.95,
+      "max_output": 32768,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 4.0,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "muse-spark-1.1": {
+      "context_window": 1000000,
+      "id": "muse-spark-1.1",
+      "max_output": 32000,
+      "modalities": [
+        "text",
+        "image"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "muse-spark-1.2": {
+      "context_window": 1000000,
+      "id": "muse-spark-1.2",
+      "max_output": 32000,
+      "modalities": [
+        "text",
+        "image"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "muse-spark-1.2-contributor": {
+      "context_window": 1000000,
+      "id": "muse-spark-1.2-contributor",
+      "max_output": 32000,
+      "modalities": [
+        "text",
+        "image"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "qwen/qwen3.6-flash": {
+      "context_window": 1000000,
+      "id": "qwen/qwen3.6-flash",
+      "max_output": 65536,
+      "modalities": [
+        "text"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [],
+      "supports_reasoning": true
+    },
+    "step-3.7-flash": {
+      "context_window": 256000,
+      "id": "step-3.7-flash",
+      "input_usd_per_million": 0.2,
+      "max_output": 256000,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 1.15,
+      "provenance": "bundled",
+      "supported_parameters": [],
+      "supports_reasoning": false
+    },
+    "trinity-large-thinking": {
+      "context_window": 262144,
+      "id": "trinity-large-thinking",
+      "max_output": 262144,
+      "modalities": [
+        "text"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "trinity-mini": {
+      "context_window": 128000,
+      "id": "trinity-mini",
+      "modalities": [
+        "text"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
+    },
+    "z-ai/glm-5.2": {
+      "context_window": 1000000,
+      "id": "z-ai/glm-5.2",
+      "input_usd_per_million": 1.4,
+      "max_output": 131072,
+      "modalities": [
+        "text"
+      ],
+      "output_usd_per_million": 4.4,
+      "provenance": "bundled",
+      "supported_parameters": [],
+      "supports_reasoning": true
+    },
+    "z-ai/glm-5.3": {
+      "context_window": 1000000,
+      "id": "z-ai/glm-5.3",
+      "max_output": 131072,
+      "modalities": [
+        "text"
+      ],
+      "provenance": "bundled",
+      "supported_parameters": [],
+      "supports_reasoning": true
+    },
+    "z-ai/glm-5.3-flash": {
+      "context_window": 1000000,
+      "id": "z-ai/glm-5.3-flash",
+      "input_usd_per_million": 0.15,
+      "max_output": 131072,
+      "modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_usd_per_million": 0.5,
+      "provenance": "bundled",
+      "supported_parameters": [
+        "reasoning"
+      ],
+      "supports_reasoning": true
     }
-  }
+  },
+  "fetched_at": "2026-07-06T00:00:00Z",
+  "schema_version": 1,
+  "source": "bundled",
+  "ttl_secs": 2592000
 }

--- a/crates/tui/src/model_catalog.rs
+++ b/crates/tui/src/model_catalog.rs
@@ -108,6 +108,13 @@ impl MergedCatalog {
         }
         entry_for(&self.bundled.entries, model)
     }
+
+    /// The offline snapshot is past its own TTL. Rows still resolve — an
+    /// offline fallback that bricks offline is worse than a stale list — but
+    /// pickers must not present it as a current catalog.
+    pub(crate) fn bundled_stale(&self) -> bool {
+        self.bundled.is_stale(self.now)
+    }
 }
 
 fn entry_for<'a>(
@@ -164,6 +171,15 @@ pub fn resolved_usd_pricing(model: &str) -> Option<(f64, f64)> {
 
 pub fn bundled_catalog() -> CatalogCache {
     serde_json::from_str(BUNDLED_CATALOG_JSON).expect("bundled model catalog must parse")
+}
+
+/// Whether the bundled offline snapshot is past its TTL right now.
+#[must_use]
+pub fn bundled_catalog_is_stale() -> bool {
+    active_catalog()
+        .read()
+        .map(|catalog| catalog.bundled_stale())
+        .unwrap_or(true)
 }
 
 fn catalog_cache_read_path() -> Result<PathBuf> {
@@ -237,6 +253,31 @@ mod tests {
             ttl_secs,
             entries,
         }
+    }
+
+    #[test]
+    fn bundled_snapshot_ttl_is_bounded_to_a_month() {
+        // A ten-year TTL made staleness unfirable and shipped a frozen list
+        // as current (audit A2). Thirty days is the ceiling.
+        let bundled = bundled_catalog();
+        assert!(
+            bundled.ttl_secs <= 2_678_400,
+            "bundled ttl_secs {} exceeds 31 days",
+            bundled.ttl_secs
+        );
+    }
+
+    #[test]
+    fn stale_bundled_snapshot_still_resolves() {
+        let bundled = bundled_catalog();
+        let some_model = bundled.entries.keys().next().cloned().expect("entries");
+        let past = bundled.fetched_at + Duration::seconds(bundled.ttl_secs as i64 + 60);
+        let catalog = MergedCatalog::from_sources(BTreeMap::new(), None, bundled, past);
+        assert!(catalog.bundled_stale());
+        assert!(
+            catalog.resolve(&some_model).is_some(),
+            "offline fallback must keep resolving"
+        );
     }
 
     #[test]

--- a/crates/tui/src/model_catalog.rs
+++ b/crates/tui/src/model_catalog.rs
@@ -175,6 +175,7 @@ pub fn bundled_catalog() -> CatalogCache {
 
 /// Whether the bundled offline snapshot is past its TTL right now.
 #[must_use]
+#[cfg_attr(test, allow(dead_code))]
 pub fn bundled_catalog_is_stale() -> bool {
     active_catalog()
         .read()

--- a/crates/tui/src/models_dev_live.rs
+++ b/crates/tui/src/models_dev_live.rs
@@ -162,7 +162,17 @@ pub fn cache_path() -> Option<PathBuf> {
 /// Current quiet status (for UI / slash-command feedback).
 #[must_use]
 pub fn status() -> ModelsDevStatus {
-    STATUS.read().map(|guard| guard.clone()).unwrap_or_default()
+    let current = STATUS.read().map(|guard| guard.clone()).unwrap_or_default();
+    honor_bundled_staleness(current, crate::model_catalog::bundled_catalog_is_stale())
+}
+
+/// A Bundled-only report whose snapshot is itself past TTL reports `Stale`:
+/// rows stay visible for offline use, but never as a current catalog (#A2).
+fn honor_bundled_staleness(mut status: ModelsDevStatus, bundled_stale: bool) -> ModelsDevStatus {
+    if status.freshness == ModelsDevFreshness::Bundled && bundled_stale {
+        status.freshness = ModelsDevFreshness::Stale;
+    }
+    status
 }
 
 fn set_status(next: ModelsDevStatus) {
@@ -644,6 +654,26 @@ mod tests {
         }
 
         clear_live_snapshot();
+    }
+
+    #[test]
+    fn bundled_staleness_flips_only_bundled_reports() {
+        let bundled = ModelsDevStatus::default();
+        assert_eq!(bundled.freshness, ModelsDevFreshness::Bundled);
+        assert_eq!(
+            honor_bundled_staleness(bundled.clone(), true).freshness,
+            ModelsDevFreshness::Stale
+        );
+        assert_eq!(
+            honor_bundled_staleness(bundled, false).freshness,
+            ModelsDevFreshness::Bundled
+        );
+        let mut live = ModelsDevStatus::default();
+        live.freshness = ModelsDevFreshness::Live;
+        assert_eq!(
+            honor_bundled_staleness(live, true).freshness,
+            ModelsDevFreshness::Live
+        );
     }
 
     #[test]

--- a/crates/tui/src/models_dev_live.rs
+++ b/crates/tui/src/models_dev_live.rs
@@ -668,8 +668,10 @@ mod tests {
             honor_bundled_staleness(bundled, false).freshness,
             ModelsDevFreshness::Bundled
         );
-        let mut live = ModelsDevStatus::default();
-        live.freshness = ModelsDevFreshness::Live;
+        let live = ModelsDevStatus {
+            freshness: ModelsDevFreshness::Live,
+            ..ModelsDevStatus::default()
+        };
         assert_eq!(
             honor_bundled_staleness(live, true).freshness,
             ModelsDevFreshness::Live

--- a/web/lib/i18n/iszh-ceiling.test.ts
+++ b/web/lib/i18n/iszh-ceiling.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = process.cwd();
+const MIGRATION_HOME = join("lib", "i18n");
+// One-way ceiling (#5519): the isZh migration converges or holds, never
+// regresses. To lower the number: migrate branches into lib/i18n, then set
+// CEILING to the new count reported by this test.
+const CEILING = 28;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".next" || entry === ".git") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.[jt]sx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe("isZh one-way ceiling (#5519)", () => {
+  it(`keeps isZh branching outside ${MIGRATION_HOME} at <= ${CEILING} files`, () => {
+    const offenders = walk(ROOT)
+      .map((file) => relative(ROOT, file))
+      .filter(
+        (file) =>
+          !file.startsWith(MIGRATION_HOME) &&
+          !/\.test\.[jt]sx?$/.test(file) &&
+          readFileSync(join(ROOT, file), "utf8").includes("isZh"),
+      )
+      .sort();
+    expect(
+      offenders.length,
+      `isZh branching outside ${MIGRATION_HOME} (migrate, then lower the CEILING):\n${offenders.join("\n")}`,
+    ).toBeLessThanOrEqual(CEILING);
+  });
+});


### PR DESCRIPTION
Release-blocker from the 8/31 audit (§A2): the bundled model snapshot shipped `ttl_secs` of ten years and nothing consulted staleness on the bundled path, so the July 6 snapshot presented as current forever and the staleness signal could never fire.

- Bundled asset TTL: 10 years → 30 days (test-pinned ceiling of 31 days).
- `MergedCatalog::bundled_stale()` / `bundled_catalog_is_stale()` expose snapshot staleness.
- `/models` status: a Bundled-only report whose snapshot is past TTL now reports `Stale` — rows stay visible for offline use; the live Models.dev layer remains the authority, so model churn needs no release.

Evidence: `model_catalog` 11 passed; 0 failed. `models_dev` 16 passed; 0 failed. Clippy -D warnings clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is intentional staleness signaling and a shorter bundled TTL; offline resolution is explicitly preserved. Low risk aside from users seeing Stale more often without live catalog.
> 
> **Overview**
> Fixes audit **§A2**: the shipped bundled model snapshot used a **10-year** `ttl_secs`, so offline-only `/models` status never aged and the July snapshot could read as current forever.
> 
> **Bundled catalog:** `ttl_secs` is now **30 days** (`2592000`), with a test pinning the ceiling at 31 days. Entry JSON is largely reordered/formatted; resolution semantics for individual models are unchanged.
> 
> **Staleness plumbing:** `MergedCatalog::bundled_stale()` and `bundled_catalog_is_stale()` expose whether the bundled snapshot is past its own TTL. Offline **model resolution still uses the bundled list** when live/cache layers are missing—even when stale—so offline pickers do not brick.
> 
> **UI / status:** `models_dev_live::status()` maps **Bundled → Stale** when the bundled snapshot is past TTL, so chips and `/models` feedback do not present a frozen list as fresh. Live Models.dev rows are unaffected when freshness is already `Live`.
> 
> **Web (orthogonal):** Adds `iszh-ceiling.test.ts` to cap `isZh` branching outside `lib/i18n` at ≤28 files (#5519).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9fb797962ce0e05a7b123971fba9e250e2dc5a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->