### PR TITLE
chore(tui): one definition per constant; drop a dead fleet settings entry

### DIFF
--- a/crates/tui/src/tui/approval/previews.rs
+++ b/crates/tui/src/tui/approval/previews.rs
@@ -6,6 +6,9 @@
 
 use std::borrow::Cow;
 
+/// Cap on rows previewed per approval card.
+const PREVIEW_LIMIT: usize = 7;
+
 use serde_json::Value;
 
 use crate::localization::{Locale, MessageId, tr};
@@ -176,8 +179,6 @@ fn append_preview_truncation(lines: &mut Vec<String>, line: String, limit: usize
 }
 
 pub(super) fn apply_patch_preview_lines(patch: &str) -> Option<Vec<String>> {
-    const PREVIEW_LIMIT: usize = 7;
-
     let mut lines = Vec::new();
     let mut omitted = 0usize;
     for line in patch.lines().filter(|line| !line.trim().is_empty()) {
@@ -219,8 +220,6 @@ pub(super) fn apply_patch_preview_lines(patch: &str) -> Option<Vec<String>> {
 }
 
 fn changes_preview_lines(changes: &[Value]) -> Option<Vec<String>> {
-    const PREVIEW_LIMIT: usize = 7;
-
     let mut lines = Vec::new();
     let mut rendered_changes = 0usize;
     for (idx, change) in changes.iter().enumerate() {

--- a/crates/tui/src/tui/ui/handlers.rs
+++ b/crates/tui/src/tui/ui/handlers.rs
@@ -5,6 +5,10 @@
 
 use super::*;
 
+/// How long a spawned constitution draft may run before the loop gives up
+/// (#3757 review: never await it inline on the event loop).
+const DRAFT_TIMEOUT: Duration = Duration::from_secs(20);
+
 /// Persist a `# foo` quick-add through the native memory store and surface
 /// a status note to the user. Errors land in the same status channel so a
 /// missing memory directory becomes visible without crashing the composer.
@@ -225,7 +229,6 @@ pub(crate) async fn handle_setup_constitution_model_draft(
     // Spawn the draft off the event loop (same pattern as the fleet drafter,
     // #3757 review): awaiting it inline parked the whole TUI for up to the
     // timeout. The loop polls constitution_draft_cell and delivers the result.
-    const DRAFT_TIMEOUT: Duration = Duration::from_secs(20);
     let model_label = app.model_display_label();
     let client = match DeepSeekClient::new(config) {
         Ok(client) => client,
@@ -301,7 +304,6 @@ pub(crate) async fn handle_fleet_profile_model_draft(
     // TUI for up to the timeout (#3757 review). Spawn it into the shared
     // fleet_draft_cell and let the loop poll + deliver the result, keeping
     // the wizard interactive with a drafting status.
-    const DRAFT_TIMEOUT: Duration = Duration::from_secs(20);
     let model_label = app.model_display_label();
     let client = match DeepSeekClient::new(config) {
         Ok(client) => client,

--- a/crates/tui/src/tui/underwater.rs
+++ b/crates/tui/src/tui/underwater.rs
@@ -486,7 +486,7 @@ impl RunningToolFacts {
 }
 
 const WORKING_BUBBLE_FRAMES: [&str; 8] = ["⠀", "⢀", "⣀", "⣄", "⣤", "⣦", "⣶", "⣿"];
-const COMPLETION_BREATH_MS: u128 = 800;
+use super::ocean::COMPLETION_BREATH_MS;
 const COMPLETION_RELEASE_MS: u128 = 560;
 // The idle whale portrait rows (IDLE_WHALE_ROWS / UWU_IDLE_WHALE_ROWS) and
 // their caustic shimmer were deleted per the 2026-08-29 founder directive:

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -3558,7 +3558,6 @@ fn config_integer_key(key: &str) -> bool {
             | "thinking_preview_lines"
             | "auto_compact_threshold_percent"
             | "max_history"
-            | "fleet.exec.max_spawn_depth"
     )
 }
 

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -62,7 +62,6 @@ pub fn redacted_identifier_for_log(identifier: &str) -> String {
     format!("<redacted:{hash:016x}>")
 }
 
-#[cfg(windows)]
 /// Win32 process-creation flag: detach the child from the console so helper
 /// exes don't flash a terminal window. One definition for every Command type.
 #[cfg(windows)]

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -63,11 +63,18 @@ pub fn redacted_identifier_for_log(identifier: &str) -> String {
 }
 
 #[cfg(windows)]
+/// Win32 process-creation flag: detach the child from the console so helper
+/// exes don't flash a terminal window. One definition for every Command type.
+#[cfg(windows)]
+mod win32 {
+    pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+}
+
+#[cfg(windows)]
 pub(crate) fn suppress_console_window(cmd: &mut Command) {
     use std::os::windows::process::CommandExt;
 
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-    cmd.creation_flags(CREATE_NO_WINDOW);
+    cmd.creation_flags(win32::CREATE_NO_WINDOW);
 }
 
 #[cfg(not(windows))]
@@ -75,8 +82,7 @@ pub(crate) fn suppress_console_window(_cmd: &mut Command) {}
 
 #[cfg(windows)]
 pub(crate) fn suppress_tokio_console_window(cmd: &mut tokio::process::Command) {
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-    cmd.creation_flags(CREATE_NO_WINDOW);
+    cmd.creation_flags(win32::CREATE_NO_WINDOW);
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
Zero-risk hygiene from the slop audit: duplicate constants collapsed to one definition (COMPLETION_BREATH_MS, DRAFT_TIMEOUT, PREVIEW_LIMIT, CREATE_NO_WINDOW) and the unreachable `fleet.exec.max_spawn_depth` integer-table entry dropped (its row is read-only; meta() short-circuits before the table runs).

Evidence: `cargo test -p codewhale-tui --lib -- preview underwater ocean draft` — 343 passed; 0 failed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors duplicate literals and removes one config integer-table entry; no auth, persistence, or approval logic changes.
> 
> **Overview**
> Hygiene PR that **deduplicates constants** so each value is defined once and reused: approval preview row cap (`PREVIEW_LIMIT` in `previews.rs`), constitution/fleet model draft timeout (`DRAFT_TIMEOUT` in `handlers.rs`), underwater completion timing (`COMPLETION_BREATH_MS` imported from `ocean`), and Win32 `CREATE_NO_WINDOW` (shared `win32` module in `utils.rs` for std and tokio `Command` helpers).
> 
> Also **drops `fleet.exec.max_spawn_depth` from the config integer-key matcher** in `views/mod.rs`, so that setting is no longer routed through the editable integer-table path (the row remains read-only elsewhere).
> 
> No intended behavior change beyond config UI routing for that fleet key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a6a2f4809052294c553a9a2b54537c1055049bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->