### PR TITLE
feat(tui): the work surface sits under the composer by default

### DIFF
--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -602,11 +602,12 @@ pub fn sidebar(app: &mut App, arg: Option<&str>) -> CommandResult {
         [value] => {
             let value = value.to_ascii_lowercase();
             // Legacy focus words map onto the closest rail concept so muscle
-            // memory keeps working: "on" restores the default top rail,
+            // memory keeps working: "on" restores the default bottom rail,
             // "off" hides it, panel names select panels.
             let placement = match value.as_str() {
-                "top" | "on" | "show" | "visible" => {
-                    Some(crate::tui::work_surface::WorkSurfacePlacement::Top)
+                "top" => Some(crate::tui::work_surface::WorkSurfacePlacement::Top),
+                "bottom" | "on" | "show" | "visible" => {
+                    Some(crate::tui::work_surface::WorkSurfacePlacement::Bottom)
                 }
                 "left" => Some(crate::tui::work_surface::WorkSurfacePlacement::Left),
                 "right" => Some(crate::tui::work_surface::WorkSurfacePlacement::Right),
@@ -671,7 +672,8 @@ fn rail_status_message(app: &App) -> String {
 
     let placement = app.work_surface.placement;
     if placement == WorkSurfacePlacement::Off {
-        return "Rail is off — no panel renders (/rail top|left|right to show it)".to_string();
+        return "Rail is off — no panel renders (/rail bottom|top|left|right to show it)"
+            .to_string();
     }
     let panel = app.work_surface.panel;
     let mut message = format!(
@@ -3492,7 +3494,7 @@ mod tests {
     }
 
     #[test]
-    fn work_surface_config_applies_live_and_rejects_bottom() {
+    fn work_surface_config_applies_live_and_accepts_bottom() {
         let mut app = create_test_app();
 
         let result = set_config_value(&mut app, "work_surface_placement", "left", false);
@@ -3508,15 +3510,15 @@ mod tests {
         );
 
         let result = set_config_value(&mut app, "work_surface_placement", "bottom", false);
-        assert!(result.is_error);
+        assert!(!result.is_error, "{:?}", result.message);
         assert_eq!(
             app.work_surface.placement,
-            crate::tui::work_surface::WorkSurfacePlacement::Left
+            crate::tui::work_surface::WorkSurfacePlacement::Bottom
         );
     }
 
     #[test]
-    fn rail_command_on_restores_default_top_placement() {
+    fn rail_command_on_restores_default_bottom_placement() {
         let mut app = create_test_app();
         app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::Off;
 
@@ -3525,10 +3527,10 @@ mod tests {
         assert!(!result.is_error);
         assert_eq!(
             app.work_surface.placement,
-            crate::tui::work_surface::WorkSurfacePlacement::Top
+            crate::tui::work_surface::WorkSurfacePlacement::Bottom
         );
         let message = result.message.unwrap_or_default();
-        assert!(message.contains("top placement"), "got: {message}");
+        assert!(message.contains("bottom placement"), "got: {message}");
     }
 
     #[test]

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -1411,8 +1411,8 @@ mod tests {
         assert!(!result.is_error);
         assert_eq!(
             app.work_surface.placement,
-            WorkSurfacePlacement::Top,
-            "on restores the default top rail"
+            WorkSurfacePlacement::Bottom,
+            "on restores the default bottom rail (round 3)"
         );
 
         let result = execute("/sidebar none", &mut app);

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -567,9 +567,10 @@ impl Default for Settings {
             // painted over every terminal the user brings.
             ocean_treatment: "flat".to_string(),
             focus_texture: "off".to_string(),
-            // Side rail on spacious terminals; the typed layout falls back to
-            // the compact top strip before it steals transcript width.
-            work_surface_placement: "left".to_string(),
+            // Round 3 (2026-09-01): the bar's information lives under the
+            // composer. Side rails are opt-in and fall back to the top strip
+            // on narrow terminals.
+            work_surface_placement: "bottom".to_string(),
             // Cap, not fixed height: the top strip auto-fits its rows and
             // only grows to this many lines (user request, 2026-07-23).
             work_surface_top_height: 8,
@@ -655,10 +656,14 @@ fn normalize_ocean_treatment(value: &str) -> &'static str {
 
 fn normalize_work_surface_placement(value: &str) -> &'static str {
     match value.trim().to_ascii_lowercase().as_str() {
+        "top" => "top",
+        "bottom" => "bottom",
         "left" => "left",
         "right" => "right",
         "off" => "off",
-        _ => "top",
+        // Round 3 (2026-09-01): unknown values fall back to the product
+        // default — the bar lives under the composer.
+        _ => "bottom",
     }
 }
 
@@ -1345,9 +1350,12 @@ impl Settings {
             }
             "work_surface_placement" | "work_surface" | "work_rail" => {
                 let normalized = value.trim().to_ascii_lowercase();
-                if !matches!(normalized.as_str(), "top" | "left" | "right" | "off") {
+                if !matches!(
+                    normalized.as_str(),
+                    "top" | "bottom" | "left" | "right" | "off"
+                ) {
                     anyhow::bail!(
-                        "Failed to update setting: invalid work surface placement '{value}'. Expected: top, left, right, or off."
+                        "Failed to update setting: invalid work surface placement '{value}'. Expected: top, bottom, left, right, or off."
                     );
                 }
                 self.work_surface_placement = normalized;
@@ -1770,7 +1778,7 @@ impl Settings {
             ),
             (
                 "work_surface_placement",
-                "Ocean Tasks/To-do/Workers rail placement: top/left/right",
+                "Ocean Tasks/To-do/Workers rail placement: bottom (default)/top/left/right",
             ),
             (
                 "work_surface_top_height",
@@ -3163,11 +3171,13 @@ mod tests {
     }
 
     #[test]
-    fn work_surface_placement_persists_top_left_right_and_off() {
+    fn work_surface_placement_persists_all_placements_with_bottom_default() {
         let mut settings = Settings::default();
-        assert_eq!(settings.work_surface_placement, "left");
+        // Round 3 (2026-09-01): the bar's information lives under the
+        // composer, so Bottom is the default.
+        assert_eq!(settings.work_surface_placement, "bottom");
 
-        for placement in ["left", "right", "top", "off"] {
+        for placement in ["bottom", "top", "left", "right", "off"] {
             settings
                 .set("work_surface_placement", placement)
                 .expect("valid placement");
@@ -3178,9 +3188,9 @@ mod tests {
         }
 
         let err = settings
-            .set("work_surface_placement", "bottom")
-            .expect_err("bottom is owned by composer/footer");
-        assert!(err.to_string().contains("top, left, right, or off"));
+            .set("work_surface_placement", "diagonal")
+            .expect_err("nonsense placement");
+        assert!(err.to_string().contains("top, bottom, left, right, or off"));
         assert_eq!(settings.work_surface_placement, "off");
     }
 
@@ -3591,14 +3601,15 @@ mod tests {
         migrate_sidebar_settings_to_rail(&mut explicit);
         assert_eq!(explicit.rail_panel, "tasks");
         // Placement panels keep their placement when the rail hides.
-        let mut left = Settings {
+        let mut bottom = Settings {
             sidebar_focus: "hidden".to_string(),
-            work_surface_placement: "left".to_string(),
+            work_surface_placement: "bottom".to_string(),
             work_surface_placement_explicit: true,
             ..Settings::default()
         };
-        migrate_sidebar_settings_to_rail(&mut left);
-        assert_eq!(left.work_surface_placement, "left");
+        migrate_sidebar_settings_to_rail(&mut bottom);
+        // Bottom is a valid explicit placement now, so migration keeps it.
+        assert_eq!(bottom.work_surface_placement, "bottom");
     }
 
     #[test]
@@ -5089,7 +5100,7 @@ mod tests {
         // A settings.toml that only names `sidebar_focus = "auto"` — the
         // shipped default — must not silently earn an always-on rail strip.
         assert_eq!(loaded.rail_panel, "tasks");
-        assert_eq!(loaded.work_surface_placement, "left");
+        assert_eq!(loaded.work_surface_placement, "bottom");
     }
 
     #[test]

--- a/crates/tui/src/tui/hotbar/actions.rs
+++ b/crates/tui/src/tui/hotbar/actions.rs
@@ -1026,8 +1026,8 @@ impl HotbarAction for AppHotbarAction {
                 if app.work_surface.placement == crate::tui::work_surface::WorkSurfacePlacement::Off
                 {
                     app.work_surface.placement =
-                        crate::tui::work_surface::WorkSurfacePlacement::Top;
-                    app.status_message = Some("Rail: top placement".to_string());
+                        crate::tui::work_surface::WorkSurfacePlacement::Bottom;
+                    app.status_message = Some("Rail: bottom placement".to_string());
                 } else {
                     app.work_surface.placement =
                         crate::tui::work_surface::WorkSurfacePlacement::Off;
@@ -2597,7 +2597,8 @@ mod tests {
         sidebar.dispatch(&mut app).expect("dispatch rail show");
         assert_eq!(
             app.work_surface.placement,
-            crate::tui::work_surface::WorkSurfacePlacement::Top
+            crate::tui::work_surface::WorkSurfacePlacement::Bottom,
+            "toggling the rail back on restores the round-3 default"
         );
         assert!(sidebar.is_active(&app));
     }

--- a/crates/tui/src/tui/mouse_ui.rs
+++ b/crates/tui/src/tui/mouse_ui.rs
@@ -1864,7 +1864,10 @@ mod tests {
         let options = TuiOptions {
             ..crate::test_support::test_tui_options(PathBuf::from("."))
         };
-        App::new(options, &Config::default())
+        let mut app = App::new(options, &Config::default());
+        // Legacy strip geometry (see ui.rs); Bottom default has its own tests.
+        app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::Top;
+        app
     }
 
     fn hover_row(row_y: u16, action: Option<&str>) -> SidebarHoverRow {

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1250,7 +1250,10 @@ mod tests {
         let options = TuiOptions {
             ..crate::test_support::test_tui_options(PathBuf::from("."))
         };
-        App::new(options, &Config::default())
+        let mut app = App::new(options, &Config::default());
+        // Legacy strip geometry (see ui.rs); Bottom default has its own tests.
+        app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::Top;
+        app
     }
 
     fn lines_to_text(lines: &[Line<'static>]) -> Vec<String> {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1319,6 +1319,10 @@ mod provider_key_validation_tests {
             ..crate::test_support::test_tui_options(PathBuf::from("."))
         };
         let mut app = App::new(options, &Config::default());
+        // These suites assert legacy strip geometry (work surface above the
+        // transcript). The Bottom default (round 3, 2026-09-01) has its own
+        // coverage in work_surface::rail_panels_render_in_all_placements.
+        app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::Top;
         app.api_provider = ApiProvider::Deepseek;
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;

--- a/crates/tui/src/tui/ui/apply.rs
+++ b/crates/tui/src/tui/ui/apply.rs
@@ -119,13 +119,13 @@ pub(crate) fn apply_alt_4_shortcut(app: &mut App, _modifiers: KeyModifiers) {
 }
 
 pub(crate) fn apply_alt_0_shortcut(app: &mut App, modifiers: KeyModifiers) {
-    // Ctrl+Alt+0 toggles the rail off and back to the default top
+    // Ctrl+Alt+0 toggles the rail off and back to the default bottom
     // placement. Plain Alt+0 is unbound: it used to select the retired
     // auto-collapse mode.
     if modifiers.contains(KeyModifiers::CONTROL) {
         if app.work_surface.placement == crate::tui::work_surface::WorkSurfacePlacement::Off {
-            app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::Top;
-            app.status_message = Some("Rail: top placement".to_string());
+            app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::Bottom;
+            app.status_message = Some("Rail: bottom placement".to_string());
         } else {
             app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::Off;
             app.status_message = Some("Rail is off".to_string());

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -1219,23 +1219,51 @@ pub(crate) fn render(f: &mut Frame, app: &mut App, _config: &Config) -> Option<(
     // failure, and cancellation rewrites text inside a fixed row — the
     // composer is never displaced. The freed activity row above the composer
     // was reclaimed by the stage (`Min(1)` chat slot).
+    // Round 3 (2026-09-01): the work surface lives BELOW the composer by
+    // default — scrolling up is intentional history — while `top` placement
+    // keeps the strip above the transcript. The strip slot moves; everything
+    // else keeps its order.
+    let strip_below =
+        app.work_surface.placement == crate::tui::work_surface::WorkSurfacePlacement::Bottom;
+    let (constraints, strip_slot, composer_slot, footer_slot) = if strip_below {
+        (
+            vec![
+                Constraint::Min(1),                        // Chat area
+                Constraint::Length(workflow_panel_height), // Workflow panel (#4121)
+                Constraint::Length(preview_height),        // Pending input preview (0 if empty)
+                Constraint::Length(indicator_height), // Background-work chip (#5286, 0 if idle)
+                Constraint::Length(plugin_cta_height), // Live plugin CTA (0 unless matched)
+                Constraint::Length(composer_height),  // Composer
+                Constraint::Length(top_work_strip_height), // Tasks + To-do below composer
+                Constraint::Length(footer_height),    // Merged Tideline footer (slots 6+8)
+            ],
+            6usize,
+            5usize,
+            7usize,
+        )
+    } else {
+        (
+            vec![
+                Constraint::Length(top_work_strip_height), // Tasks + To-do above transcript
+                Constraint::Min(1),                        // Chat area
+                Constraint::Length(workflow_panel_height), // Workflow panel (#4121)
+                Constraint::Length(preview_height),        // Pending input preview (0 if empty)
+                Constraint::Length(indicator_height), // Background-work chip (#5286, 0 if idle)
+                Constraint::Length(plugin_cta_height), // Live plugin CTA (0 unless matched)
+                Constraint::Length(composer_height),  // Composer
+                Constraint::Length(footer_height),    // Merged Tideline footer (slots 6+8)
+            ],
+            0usize,
+            6usize,
+            7usize,
+        )
+    };
     let body_chunks = Layout::default()
         .direction(Direction::Vertical)
         .flex(ratatui::layout::Flex::Start)
-        .constraints([
-            Constraint::Length(top_work_strip_height), // Tasks + To-do above transcript
-            Constraint::Min(1),                        // Chat area
-            Constraint::Length(workflow_panel_height), // Workflow panel (#4121)
-            Constraint::Length(preview_height),        // Pending input preview (0 if empty)
-            Constraint::Length(indicator_height),      // Background-work chip (#5286, 0 if idle)
-            Constraint::Length(plugin_cta_height),     // Live plugin CTA (0 unless matched)
-            Constraint::Length(composer_height),       // Composer
-            Constraint::Length(footer_height),         // Merged Tideline footer (slots 6+8)
-        ])
+        .constraints(constraints)
         .split(body_area);
-    let plugin_cta_slot = 5;
-    let composer_slot = 6;
-    let footer_slot = 7;
+    let plugin_cta_slot = composer_slot.saturating_sub(1);
 
     let (work_chat_area, side_work_area) = if mini && !mini_cfg.keep_sidebar {
         // Mini mode without the side rail: the transcript takes the whole
@@ -1246,7 +1274,7 @@ pub(crate) fn render(f: &mut Frame, app: &mut App, _config: &Config) -> Option<(
     };
 
     if top_work_strip_height > 0 {
-        crate::tui::work_surface::render(f, body_chunks[0], app);
+        crate::tui::work_surface::render(f, body_chunks[strip_slot], app);
     } else if let Some(work_area) = side_work_area {
         crate::tui::work_surface::render(f, work_area, app);
     }
@@ -1471,7 +1499,11 @@ pub(crate) fn render(f: &mut Frame, app: &mut App, _config: &Config) -> Option<(
         column.paint_matching(size, f.buffer_mut(), app.ui_theme.surface_bg);
         column.paint_matching(header_area, f.buffer_mut(), app.ui_theme.header_bg);
         if top_work_strip_height > 0 {
-            column.paint_matching(body_chunks[0], f.buffer_mut(), app.ui_theme.surface_bg);
+            column.paint_matching(
+                body_chunks[strip_slot],
+                f.buffer_mut(),
+                app.ui_theme.surface_bg,
+            );
         }
         if let Some(side_area) = side_work_area {
             column.paint_matching(side_area, f.buffer_mut(), app.ui_theme.surface_bg);

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -1221,49 +1221,38 @@ pub(crate) fn render(f: &mut Frame, app: &mut App, _config: &Config) -> Option<(
     // was reclaimed by the stage (`Min(1)` chat slot).
     // Round 3 (2026-09-01): the work surface lives BELOW the composer by
     // default — scrolling up is intentional history — while `top` placement
-    // keeps the strip above the transcript. The strip slot moves; everything
-    // else keeps its order.
+    // keeps the strip above the transcript. The strip owns a slot at each
+    // end and only one has height, so every other slot keeps its index in
+    // both placements (the stage, preview and indicator are addressed by
+    // position below).
+    // Bottom never falls back (only side rails do), so the configured
+    // placement is the effective one here.
     let strip_below =
         app.work_surface.placement == crate::tui::work_surface::WorkSurfacePlacement::Bottom;
-    let (constraints, strip_slot, composer_slot, footer_slot) = if strip_below {
-        (
-            vec![
-                Constraint::Min(1),                        // Chat area
-                Constraint::Length(workflow_panel_height), // Workflow panel (#4121)
-                Constraint::Length(preview_height),        // Pending input preview (0 if empty)
-                Constraint::Length(indicator_height), // Background-work chip (#5286, 0 if idle)
-                Constraint::Length(plugin_cta_height), // Live plugin CTA (0 unless matched)
-                Constraint::Length(composer_height),  // Composer
-                Constraint::Length(top_work_strip_height), // Tasks + To-do below composer
-                Constraint::Length(footer_height),    // Merged Tideline footer (slots 6+8)
-            ],
-            6usize,
-            5usize,
-            7usize,
-        )
+    let (strip_above_height, strip_below_height) = if strip_below {
+        (0, top_work_strip_height)
     } else {
-        (
-            vec![
-                Constraint::Length(top_work_strip_height), // Tasks + To-do above transcript
-                Constraint::Min(1),                        // Chat area
-                Constraint::Length(workflow_panel_height), // Workflow panel (#4121)
-                Constraint::Length(preview_height),        // Pending input preview (0 if empty)
-                Constraint::Length(indicator_height), // Background-work chip (#5286, 0 if idle)
-                Constraint::Length(plugin_cta_height), // Live plugin CTA (0 unless matched)
-                Constraint::Length(composer_height),  // Composer
-                Constraint::Length(footer_height),    // Merged Tideline footer (slots 6+8)
-            ],
-            0usize,
-            6usize,
-            7usize,
-        )
+        (top_work_strip_height, 0)
     };
     let body_chunks = Layout::default()
         .direction(Direction::Vertical)
         .flex(ratatui::layout::Flex::Start)
-        .constraints(constraints)
+        .constraints([
+            Constraint::Length(strip_above_height), // Tasks + To-do above transcript (`top`)
+            Constraint::Min(1),                     // Chat area
+            Constraint::Length(workflow_panel_height), // Workflow panel (#4121)
+            Constraint::Length(preview_height),     // Pending input preview (0 if empty)
+            Constraint::Length(indicator_height),   // Background-work chip (#5286, 0 if idle)
+            Constraint::Length(plugin_cta_height),  // Live plugin CTA (0 unless matched)
+            Constraint::Length(composer_height),    // Composer
+            Constraint::Length(strip_below_height), // Tasks + To-do under composer (`bottom`)
+            Constraint::Length(footer_height),      // Merged Tideline footer (slots 6+8)
+        ])
         .split(body_area);
-    let plugin_cta_slot = composer_slot.saturating_sub(1);
+    let strip_slot = if strip_below { 7 } else { 0 };
+    let plugin_cta_slot = 5;
+    let composer_slot = 6;
+    let footer_slot = 8;
 
     let (work_chat_area, side_work_area) = if mini && !mini_cfg.keep_sidebar {
         // Mini mode without the side rail: the transcript takes the whole

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4452,6 +4452,49 @@ fn bottom_placement_draws_the_work_strip_under_the_composer() {
 }
 
 #[test]
+fn bottom_placement_keeps_the_stage_and_queued_preview_at_twelve_rows() {
+    // Regression (#5809 Buildkite 1535): the Bottom layout reordered the
+    // frame slots, so the stage, preview and background chip — addressed by
+    // slot index — drew into zero-height slots: a blank transcript and a
+    // queued message with no `Queued #1:` preview at 40x12.
+    let mut app = create_test_app();
+    app.onboarding_workspace_trust_gate = false;
+    app.onboarding = OnboardingState::None;
+    app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::Bottom;
+    app.add_message(HistoryCell::User {
+        content: "stage row survives bottom".to_string(),
+    });
+    app.queue_message(crate::tui::app::QueuedMessage::new(
+        "qa pointer draft 40x12".to_string(),
+        None,
+    ));
+    let config = Config::default();
+    let mut terminal = Terminal::new(TestBackend::new(40, 12)).expect("test terminal");
+    terminal
+        .draw(|frame| {
+            let _ = render(frame, &mut app, &config);
+        })
+        .expect("render frame");
+    let buffer = terminal.backend().buffer();
+    let text = (0..buffer.area.height)
+        .map(|y| {
+            (0..buffer.area.width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        text.contains("Queued #1: qa pointer draft"),
+        "queued preview must render under Bottom at 40x12; got:\n{text}"
+    );
+    assert!(
+        text.contains("stage row survives bottom"),
+        "transcript must render under Bottom at 40x12; got:\n{text}"
+    );
+}
+
+#[test]
 fn wide_underwater_canvas_carries_the_ocean_to_both_terminal_edges() {
     let mut app = create_test_app();
     app.ui_theme = crate::palette::UI_THEME;

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3829,13 +3829,18 @@ fn tool_path_relevance_extracts_paths_from_command_text() {
 }
 
 fn create_test_app() -> App {
-    crate::test_support::test_app_with_options(TuiOptions {
+    let mut app = crate::test_support::test_app_with_options(TuiOptions {
         // Keep UI tests independent from the developer's saved
         // `default_mode` setting.
         start_in_agent_mode: true,
         skip_onboarding: false,
         ..crate::test_support::test_tui_options(PathBuf::from("."))
-    })
+    });
+    // These suites assert legacy strip geometry (work surface above the
+    // transcript). The Bottom default (round 3, 2026-09-01) has dedicated
+    // coverage in work_surface::rail_panels_render_in_all_placements.
+    app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::Top;
+    app
 }
 
 #[test]
@@ -4401,6 +4406,49 @@ fn failed_mcp_is_a_footer_chip_not_multiline_chat_boot_output() {
     );
     assert!(!rendered.contains("alpha · failed"), "{rendered}");
     assert!(!rendered.contains("/mcp retry alpha"), "{rendered}");
+}
+
+#[test]
+fn bottom_placement_draws_the_work_strip_under_the_composer() {
+    // Round 3 (2026-09-01): the bar's information lives under the composer.
+    // `top` keeps the strip above the transcript; `bottom` (the default)
+    // moves the same strip below the composer and above the footer.
+    for (placement, below) in [
+        (crate::tui::work_surface::WorkSurfacePlacement::Bottom, true),
+        (crate::tui::work_surface::WorkSurfacePlacement::Top, false),
+    ] {
+        let mut app = create_test_app();
+        app.onboarding_workspace_trust_gate = false;
+        app.onboarding = OnboardingState::None;
+        app.work_surface.placement = placement;
+        app.goal.objective = Some("ship the release".to_string());
+        let config = Config::default();
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                let _ = render(frame, &mut app, &config);
+            })
+            .expect("render frame");
+        let strip = app
+            .work_surface
+            .last_area
+            .expect("a live goal draws a strip in every strip placement");
+        let composer = app
+            .viewport
+            .last_composer_area
+            .expect("frame records the composer area");
+        if below {
+            assert!(
+                strip.y >= composer.bottom(),
+                "bottom strip must sit under the composer: strip {strip:?}, composer {composer:?}"
+            );
+        } else {
+            assert!(
+                strip.bottom() <= composer.y,
+                "top strip must sit above the composer: strip {strip:?}, composer {composer:?}"
+            );
+        }
+    }
 }
 
 #[test]
@@ -11816,7 +11864,7 @@ fn ctrl_alt_0_turns_rail_off() {
 }
 
 #[test]
-fn ctrl_alt_0_restores_top_rail_when_already_off() {
+fn ctrl_alt_0_restores_bottom_rail_when_already_off() {
     let mut app = create_test_app();
     app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::Off;
 
@@ -11824,9 +11872,12 @@ fn ctrl_alt_0_restores_top_rail_when_already_off() {
 
     assert_eq!(
         app.work_surface.placement,
-        crate::tui::work_surface::WorkSurfacePlacement::Top
+        crate::tui::work_surface::WorkSurfacePlacement::Bottom
     );
-    assert_eq!(app.status_message.as_deref(), Some("Rail: top placement"));
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("Rail: bottom placement")
+    );
 }
 
 #[test]

--- a/crates/tui/src/tui/work_surface/input.rs
+++ b/crates/tui/src/tui/work_surface/input.rs
@@ -167,6 +167,9 @@ pub fn handle_mouse(app: &mut App, mouse: MouseEvent) -> MouseOutcome {
                 && mouse.column >= area.x
                 && mouse.column < area.right()
         }
+        WorkSurfacePlacement::Bottom => {
+            mouse.row == area.y && mouse.column >= area.x && mouse.column < area.right()
+        }
         WorkSurfacePlacement::Left => {
             mouse.column == area.right().saturating_sub(1)
                 && mouse.row >= area.y
@@ -196,7 +199,7 @@ pub fn handle_mouse(app: &mut App, mouse: MouseEvent) -> MouseOutcome {
             app.work_surface.resize_anchor_column = mouse.column;
             app.work_surface.resize_anchor_row = mouse.row;
             app.work_surface.resize_anchor_size = match placement {
-                WorkSurfacePlacement::Top => area.height,
+                WorkSurfacePlacement::Top | WorkSurfacePlacement::Bottom => area.height,
                 WorkSurfacePlacement::Left | WorkSurfacePlacement::Right => area.width,
                 WorkSurfacePlacement::Off => area.width,
             };
@@ -212,6 +215,15 @@ pub fn handle_mouse(app: &mut App, mouse: MouseEvent) -> MouseOutcome {
                 WorkSurfacePlacement::Top => {
                     let delta =
                         i32::from(mouse.row) - i32::from(app.work_surface.resize_anchor_row);
+                    app.work_surface.top_height = (anchor + delta)
+                        .clamp(i32::from(TOP_HEIGHT_MIN), i32::from(TOP_HEIGHT_MAX))
+                        as u16;
+                }
+                // The bottom strip's divider is its TOP edge: dragging up
+                // grows the strip, so the delta is inverted from Top.
+                WorkSurfacePlacement::Bottom => {
+                    let delta =
+                        i32::from(app.work_surface.resize_anchor_row) - i32::from(mouse.row);
                     app.work_surface.top_height = (anchor + delta)
                         .clamp(i32::from(TOP_HEIGHT_MIN), i32::from(TOP_HEIGHT_MAX))
                         as u16;

--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -1883,6 +1883,7 @@ mod tests {
             super::RailPanel::Pinned,
         ] {
             for placement in [
+                super::WorkSurfacePlacement::Bottom,
                 super::WorkSurfacePlacement::Top,
                 super::WorkSurfacePlacement::Left,
                 super::WorkSurfacePlacement::Right,
@@ -1929,6 +1930,12 @@ mod tests {
                     .expect("draw");
                 let text = terminal_text(&terminal);
                 match placement {
+                    super::WorkSurfacePlacement::Bottom => {
+                        assert!(
+                            strip > 0,
+                            "{panel:?} on Bottom should auto-fit a content strip; got height 0"
+                        );
+                    }
                     super::WorkSurfacePlacement::Top => {
                         assert!(
                             strip > 0,

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -26,11 +26,25 @@ use crate::work_graph::{
 /// outright (rail unification, 0.9.4).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum WorkSurfacePlacement {
+    /// Under the composer — the default (round 3, 2026-09-01: the bar's
+    /// information lives below the composer, so scrolling up reads as
+    /// intentional history).
     #[default]
+    Bottom,
     Top,
     Left,
     Right,
     Off,
+}
+
+impl WorkSurfacePlacement {
+    /// Strip placements render as a horizontal band; side placements as a
+    /// rail. Bottom shares Top's auto-fit height math — only its position
+    /// in the frame differs.
+    #[must_use]
+    pub const fn is_strip(self) -> bool {
+        matches!(self, Self::Top | Self::Bottom)
+    }
 }
 
 /// Which panel the rail shows. Orthogonal to placement: the user picks
@@ -85,16 +99,18 @@ impl WorkSurfacePlacement {
     #[must_use]
     pub fn parse(value: &str) -> Self {
         match value.trim().to_ascii_lowercase().as_str() {
+            "top" => Self::Top,
             "left" => Self::Left,
             "right" => Self::Right,
             "off" => Self::Off,
-            _ => Self::Top,
+            _ => Self::Bottom,
         }
     }
 
     #[must_use]
     pub const fn as_setting(self) -> &'static str {
         match self {
+            Self::Bottom => "bottom",
             Self::Top => "top",
             Self::Left => "left",
             Self::Right => "right",
@@ -278,7 +294,7 @@ pub struct WorkSurfaceState {
 
 impl Default for WorkSurfaceState {
     fn default() -> Self {
-        Self::with_placement(WorkSurfacePlacement::Top)
+        Self::with_placement(WorkSurfacePlacement::Bottom)
     }
 }
 
@@ -569,7 +585,7 @@ pub(super) fn project(app: &mut App) -> Vec<WorkRow> {
 /// visible in the common case.
 pub(super) fn project_visible(app: &mut App) -> Vec<WorkRow> {
     let rows = project(app);
-    if app.work_surface.effective_placement != WorkSurfacePlacement::Top {
+    if !app.work_surface.effective_placement.is_strip() {
         return rows;
     }
 
@@ -734,7 +750,7 @@ pub(super) fn visible_rows_for_panel(app: &mut App) -> Vec<WorkRow> {
             // On Top the goal is already the strip title; a side column
             // repeats it as its first row so the durable goal home survives
             // in every placement.
-            if app.work_surface.effective_placement != WorkSurfacePlacement::Top
+            if !app.work_surface.effective_placement.is_strip()
                 && let Some((objective, paused)) =
                     crate::tui::footer_ui::active_goal_chip_state(app)
             {

--- a/crates/tui/src/tui/work_surface/render/layout.rs
+++ b/crates/tui/src/tui/work_surface/render/layout.rs
@@ -18,7 +18,13 @@ fn effective_placement(configured: WorkSurfacePlacement, host_width: u16) -> Wor
     if configured == WorkSurfacePlacement::Off {
         return WorkSurfacePlacement::Off;
     }
-    if host_width < SIDE_RAIL_MIN_HOST_WIDTH {
+    // Only the side rails need width; strip placements work at any host
+    // width, and a narrow host keeps the user's Bottom default.
+    if matches!(
+        configured,
+        WorkSurfacePlacement::Left | WorkSurfacePlacement::Right
+    ) && host_width < SIDE_RAIL_MIN_HOST_WIDTH
+    {
         WorkSurfacePlacement::Top
     } else {
         configured
@@ -51,7 +57,7 @@ pub fn height(app: &mut App, width: u16, terminal_height: u16, rail_budget: u16)
     // to-do or finished sub-agent still occupies a row.) Side placements
     // reserve via `split_chat` and take no top strip.
     if app.work_surface.panel == RailPanel::Context {
-        if app.work_surface.effective_placement != WorkSurfacePlacement::Top {
+        if !app.work_surface.effective_placement.is_strip() {
             return 0;
         }
         if !panels::panel_has_useful_content(app, app.work_surface.panel) {
@@ -85,10 +91,8 @@ pub fn height(app: &mut App, width: u16, terminal_height: u16, rail_budget: u16)
     }
 
     let rows = visible_rows_for_panel(app);
-    let goal_rows = u16::from(
-        app.work_surface.effective_placement == WorkSurfacePlacement::Top
-            && top_goal_title(app).is_some(),
-    );
+    let goal_rows =
+        u16::from(app.work_surface.effective_placement.is_strip() && top_goal_title(app).is_some());
     if rows.is_empty() {
         // A live goal alone still deserves a strip: title + divider.
         if goal_rows == 0 {
@@ -99,7 +103,7 @@ pub fn height(app: &mut App, width: u16, terminal_height: u16, rail_budget: u16)
             app.work_surface.scroll_offset = 0;
             return 0;
         }
-        if app.work_surface.effective_placement != WorkSurfacePlacement::Top {
+        if !app.work_surface.effective_placement.is_strip() {
             return 0;
         }
         let cap = top_cap(app, terminal_height, rail_budget);
@@ -109,7 +113,7 @@ pub fn height(app: &mut App, width: u16, terminal_height: u16, rail_budget: u16)
         }
         return (goal_rows.saturating_add(1)).clamp(model::TOP_HEIGHT_MIN, cap);
     }
-    if app.work_surface.effective_placement != WorkSurfacePlacement::Top {
+    if !app.work_surface.effective_placement.is_strip() {
         return 0;
     }
     // The strip auto-fits its content: the literal selectable list plus the
@@ -248,7 +252,9 @@ pub fn split_chat(app: &mut App, area: Rect, min_chat_width: u16) -> (Rect, Opti
                 ..area
             }),
         ),
-        WorkSurfacePlacement::Top | WorkSurfacePlacement::Off => (area, None),
+        WorkSurfacePlacement::Top | WorkSurfacePlacement::Bottom | WorkSurfacePlacement::Off => {
+            (area, None)
+        }
     }
 }
 

--- a/crates/tui/src/tui/work_surface/render/mod.rs
+++ b/crates/tui/src/tui/work_surface/render/mod.rs
@@ -59,7 +59,14 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         return;
     }
     let body_area = match placement {
+        // Bottom mirrors Top's body/divider split; only the divider edge
+        // differs (below-content for Top, above-content for Bottom).
         WorkSurfacePlacement::Top => Rect {
+            height: area.height.saturating_sub(1),
+            ..area
+        },
+        WorkSurfacePlacement::Bottom => Rect {
+            y: area.y.saturating_add(1),
             height: area.height.saturating_sub(1),
             ..area
         },
@@ -86,22 +93,21 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     }
 
     let mut rows = visible_rows_for_panel(app);
-    if placement == WorkSurfacePlacement::Top {
+    if placement.is_strip() {
         // Literal work list only: selectable to-dos/agents plus the
         // GrokBuild-style `▾ Subagents N` group header. Generic graph chrome
         // from the side/inspector projection stays out.
         rows.retain(|row| row.selectable || row.id.0.starts_with("section:"));
     }
-    let todo_ordinals = if placement == WorkSurfacePlacement::Top {
+    let todo_ordinals = if placement.is_strip() {
         todo_ordinals(&rows)
     } else {
         HashMap::new()
     };
     let ordinal_width = todo_ordinals.len().max(1).to_string().len();
-    let goal_title = (placement == WorkSurfacePlacement::Top)
-        .then(|| top_goal_title(app))
-        .flatten();
-    let todo_progress = (placement == WorkSurfacePlacement::Top)
+    let goal_title = placement.is_strip().then(|| top_goal_title(app)).flatten();
+    let todo_progress = placement
+        .is_strip()
         .then(|| top_todo_progress(app, &rows))
         .flatten();
     // Pin goal title, then progress receipt, above the scrollable rows.
@@ -221,7 +227,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         let hovered = app.work_surface.hovered.as_ref() == Some(&row.id);
         let opened = app.work_surface.opened.as_ref() == Some(&row.id);
         let style = row_style(app, row, selected, hovered, opened);
-        let compact_owner = if placement == WorkSurfacePlacement::Top {
+        let compact_owner = if placement.is_strip() {
             todo_ordinals
                 .get(&row.id.0)
                 .map(|ordinal| format!("{ordinal:>ordinal_width$} · "))
@@ -454,11 +460,9 @@ fn render_panel(frame: &mut Frame, area: Rect, body_area: Rect, app: &mut App) {
         .render(area, frame.buffer_mut());
 
     // Title row policy:
-    // - Top: only an active goal (`Goal: …`). Never panel chrome ("Pinned").
+    // - Top/Bottom: only an active goal (`Goal: …`). Never panel chrome ("Pinned").
     // - Left/Right: muted panel name — a full-height column needs naming.
-    let goal = (placement == WorkSurfacePlacement::Top)
-        .then(|| top_goal_title(app))
-        .flatten();
+    let goal = placement.is_strip().then(|| top_goal_title(app)).flatten();
     let side_panel_title = matches!(
         placement,
         WorkSurfacePlacement::Left | WorkSurfacePlacement::Right
@@ -633,6 +637,15 @@ fn render_divider(frame: &mut Frame, area: Rect, placement: WorkSurfacePlacement
         WorkSurfacePlacement::Off => {}
         WorkSurfacePlacement::Top => {
             let y = area.bottom().saturating_sub(1);
+            for x in area.left()..area.right() {
+                frame.buffer_mut()[(x, y)]
+                    .set_symbol(if active { "━" } else { "─" })
+                    .set_fg(color)
+                    .set_bg(app.ui_theme.surface_bg);
+            }
+        }
+        WorkSurfacePlacement::Bottom => {
+            let y = area.top();
             for x in area.left()..area.right() {
                 frame.buffer_mut()[(x, y)]
                     .set_symbol(if active { "━" } else { "─" })


### PR DESCRIPTION
**What changed for the user.** The tasks / agents / to-do strip now sits **under the composer** by default instead of above the transcript (or as a left rail). `/rail on`, the rail hotbar toggle and Ctrl+Alt+0 restore that bottom placement; `/config work_surface_placement bottom` is accepted; `top`, `left`, `right`, `off` still work as before.

**Why.** Round 3 of the shell design (`codewhale-ops/design/SHELL-DESIGN-20260901.md` §2.0): the bar's information — posture, agent roster, to-do — lives under the composer so scrolling up reads as intentional history and nothing paints above the stage in the default working shell. This slice is only the placement + default; the launch header and the braille mark are separate slices.

**How.** `WorkSurfacePlacement::Bottom` is a strip placement sharing Top's auto-fit height math (`is_strip()`) and row machinery; only its frame slot differs (after the composer, before the footer). Its divider is the strip's top edge (drag delta inverted vs Top) and the body starts one row below it so row hitboxes stay honest. Narrow terminals keep Bottom; only the side rails still fall back to Top under the side-rail width.

**Upgrade note.** The default for `work_surface_placement` changes from `left` to `bottom`. Users who set it explicitly are untouched.

**Goldens.** None re-blessed: the startup goldens carry no work rows, so the strip is zero-height in both placements. Legacy ui/sidebar/mouse test fixtures pin `Top` because they assert the old geometry; Bottom has its own coverage (`bottom_placement_draws_the_work_strip_under_the_composer`; `rail_panels_render_in_all_placements` now includes Bottom).

**Evidence.**
```
scripts/dev-test.sh tui  (cargo test -p codewhale-tui --lib)
test result: FAILED. 11848 passed; 3 failed; 13 ignored; 0 measured; 0 filtered out; finished in 271.13s
  # the 3 (runtime_api::omitted_runtime_models_use_the_active_provider_default,
  #   runtime_threads::approval_required_awaits_external_decision_allow,
  #   sandbox::seatbelt::file_provider_synthetic_operations_are_independent_under_seatbelt)
  # are unrelated to this diff and pass in isolation:
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 11861 filtered out; finished in 2.68s
focused rerun after the last edits:
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 11854 filtered out; finished in 0.60s
cargo clippy --workspace --all-targets -- -D warnings (CI's -A flags): clean
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TUI frame layout and persisted defaults, so wrong slot indexing could break transcript/composer rendering; scope is mostly placement and settings with broad test updates.
> 
> **Overview**
> **Round 3 shell change:** the tasks/agents rail defaults to **`bottom`** (under the composer, above the footer) instead of a left rail or top strip. New **`WorkSurfacePlacement::Bottom`** shares top-strip auto-fit and row rendering via **`is_strip()`**; only frame slot order and divider edge differ.
> 
> **User-facing behavior:** `/rail on`, sidebar hotbar toggle, and **Ctrl+Alt+0** restore **bottom** placement. **`/config work_surface_placement bottom`** is valid; **`top` / `left` / `right` / `off`** unchanged. Narrow terminals keep **bottom**; only side rails still fall back to top when too narrow.
> 
> **Layout fix:** vertical body constraints gain a slot below the composer so stage, preview, and queued message rows keep non-zero height at small sizes (regression **#5809**). Bottom-strip resize uses inverted drag delta on the strip’s top divider.
> 
> **Defaults & tests:** fresh **`work_surface_placement`** default moves from **`left`** to **`bottom`**; unknown placement normalizes to bottom. Legacy UI tests pin **`Top`** geometry; new tests assert strip vs composer ordering and 40×12 queued preview under bottom placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5077aa844a644702232bbdb370ea2d06830aaf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->