### PR TITLE
feat(tui): tool output keeps its colours

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-to-tui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
+dependencies = [
+ "nom 8.0.0",
+ "ratatui-core",
+ "smallvec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1048,7 @@ name = "codewhale-tui"
 version = "0.9.11"
 dependencies = [
  "ahash",
+ "ansi-to-tui",
  "anyhow",
  "arboard",
  "async-stream",

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -71,6 +71,7 @@ rmcp = { version = "2.2.0", default-features = false, features = ["auth", "clien
 rustls.workspace = true
 qrcode = { version = "0.14", default-features = false }
 similar = "3"
+ansi-to-tui = { version = "8.0.1", default-features = false }
 syntect = { version = "5.2", default-features = false, features = ["default-fancy"] }
 serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -2662,6 +2662,54 @@ fn render_card_detail_line(
     lines
 }
 
+/// `render_card_detail_line` for a row whose text carries its own SGR
+/// colours: every segment's style is patched over `value_style`, so the
+/// tool's colour wins where it set one and the cell's own ink (dim, state,
+/// file:line emphasis) shows through where it did not. Wraps to `width`
+/// along the same boundaries as the plain path.
+fn render_card_detail_line_styled(
+    label: Option<&str>,
+    segments: &[tool_output::StyledSegment],
+    value_style: Style,
+    width: u16,
+) -> Vec<Line<'static>> {
+    let label_text = label.map(|text| format!("{text}:"));
+    let prefix_width = UnicodeWidthStr::width(TRANSCRIPT_RAIL)
+        + label_text.as_deref().map_or(0, UnicodeWidthStr::width)
+        + usize::from(label.is_some());
+    let content_width = usize::from(width).saturating_sub(prefix_width).max(1);
+
+    let full: String = segments.iter().map(|(text, _)| text.as_str()).collect();
+    let parts = wrap_text(&full, content_width);
+    let split = tool_output::split_segments(segments.to_vec(), &parts);
+
+    let mut lines = Vec::new();
+    for (idx, part) in split.into_iter().enumerate() {
+        let mut spans = vec![Span::styled(
+            TRANSCRIPT_RAIL.to_string(),
+            Style::default().fg(palette::TEXT_DIM),
+        )];
+        if idx == 0 {
+            if let Some(label_text) = label_text.as_deref() {
+                spans.push(Span::styled(
+                    label_text.to_string(),
+                    tool_detail_label_style(),
+                ));
+                spans.push(Span::raw(" "));
+            }
+        } else if let Some(label_text) = label_text.as_deref() {
+            spans.push(Span::raw(
+                " ".repeat(UnicodeWidthStr::width(label_text) + 1),
+            ));
+        }
+        for (text, style) in part {
+            spans.push(Span::styled(text, value_style.patch(style)));
+        }
+        lines.push(Line::from(spans));
+    }
+    lines
+}
+
 fn render_card_detail_line_single(
     label: Option<&str>,
     value: &str,

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -2665,10 +2665,12 @@ fn render_card_detail_line(
 /// `render_card_detail_line` for a row whose text carries its own SGR
 /// colours: every segment's style is patched over `value_style`, so the
 /// tool's colour wins where it set one and the cell's own ink (dim, state,
-/// file:line emphasis) shows through where it did not. Wraps to `width`
-/// along the same boundaries as the plain path.
+/// file:line emphasis) shows through where it did not. `text` is the row's
+/// plain text (what the segments concatenate to); wrapping follows the same
+/// boundaries as the plain path.
 fn render_card_detail_line_styled(
     label: Option<&str>,
+    text: &str,
     segments: &[tool_output::StyledSegment],
     value_style: Style,
     width: u16,
@@ -2679,9 +2681,8 @@ fn render_card_detail_line_styled(
         + usize::from(label.is_some());
     let content_width = usize::from(width).saturating_sub(prefix_width).max(1);
 
-    let full: String = segments.iter().map(|(text, _)| text.as_str()).collect();
-    let parts = wrap_text(&full, content_width);
-    let split = tool_output::split_segments(segments.to_vec(), &parts);
+    let parts = wrap_text(text, content_width);
+    let split = tool_output::split_segments(segments, &parts);
 
     let mut lines = Vec::new();
     for (idx, part) in split.into_iter().enumerate() {
@@ -2708,6 +2709,23 @@ fn render_card_detail_line_styled(
         lines.push(Line::from(spans));
     }
     lines
+}
+
+/// `render_card_detail_line_single` for a coloured row: one line, never
+/// wrapped, so an intact path or URL keeps the same hitbox with or without
+/// colour.
+fn render_card_detail_line_single_styled(
+    label: Option<&str>,
+    segments: &[tool_output::StyledSegment],
+    value_style: Style,
+) -> Line<'static> {
+    let mut line = render_card_detail_line_single(label, "", value_style);
+    line.spans.pop();
+    for (text, style) in segments {
+        line.spans
+            .push(Span::styled(text.clone(), value_style.patch(*style)));
+    }
+    line
 }
 
 fn render_card_detail_line_single(

--- a/crates/tui/src/tui/history/tool_output.rs
+++ b/crates/tui/src/tui/history/tool_output.rs
@@ -10,7 +10,8 @@ use crate::palette;
 use super::constants::{TOOL_OUTPUT_HEAD_LINES, TOOL_OUTPUT_TAIL_LINES, TOOL_TEXT_LIMIT};
 use super::{
     RenderMode, details_affordance_line, looks_like_file_path, render_card_detail_line,
-    render_card_detail_line_single, tool_value_style, truncate_text,
+    render_card_detail_line_single, render_card_detail_line_styled, tool_value_style,
+    truncate_text,
 };
 
 pub(super) fn render_tool_output_mode(
@@ -35,7 +36,17 @@ pub(super) fn render_exec_output_mode(
 pub struct OutputRow {
     pub text: String,
     pub intact: bool,
+    /// SGR-styled segments of `text` when the source line carried colour
+    /// (`cargo`, `git`, `gh` with colour forced on, anything run through a
+    /// PTY). Concatenated they equal `text`; `None` for plain rows so the
+    /// common path allocates nothing extra.
+    pub styled: Option<Vec<StyledSegment>>,
 }
+
+/// One run of `OutputRow::text` with the style the tool's own SGR codes
+/// asked for. Only what is painted keeps the colour: the model, the session
+/// store, the pager, clipboard and exports still see stripped text.
+pub type StyledSegment = (String, Style);
 
 /// Heuristic: does the output look like a unified diff? Returns true when
 /// the output contains at least one hunk header (`@@`) or a `diff --git`
@@ -423,17 +434,24 @@ fn output_rows(output: &str, width: u16) -> Vec<OutputRow> {
     for line in output.lines() {
         sanitized.clear();
         crate::tui::osc8::strip_ansi_into(line, &mut sanitized);
+        let styled = styled_segments(line, &sanitized);
         let intact = is_path_or_url_like(&sanitized);
         if intact {
             rows.push(OutputRow {
                 text: sanitized.clone(),
                 intact: true,
+                styled,
             });
         } else {
-            for wrapped in wrap_text(&sanitized, wrap_width) {
+            let parts = wrap_text(&sanitized, wrap_width);
+            let mut styled_parts = styled.map(|segments| split_segments(segments, &parts));
+            for (idx, wrapped) in parts.into_iter().enumerate() {
                 rows.push(OutputRow {
                     text: wrapped,
                     intact: false,
+                    styled: styled_parts
+                        .as_mut()
+                        .map(|split| std::mem::take(&mut split[idx])),
                 });
             }
         }
@@ -442,9 +460,92 @@ fn output_rows(output: &str, width: u16) -> Vec<OutputRow> {
         rows.push(OutputRow {
             text: String::new(),
             intact: false,
+            styled: None,
         });
     }
     rows
+}
+
+/// Parse the SGR codes in `line` into styled segments whose text
+/// concatenates to `plain` (the fully stripped line). Returns `None` when the
+/// line carries no escape at all, when nothing in it sets a style, or when
+/// the parse disagrees with the plain strip — the plain path is then the
+/// truth, exactly as before.
+fn styled_segments(line: &str, plain: &str) -> Option<Vec<StyledSegment>> {
+    use ansi_to_tui::IntoText;
+
+    if !line.contains('\x1b') {
+        return None;
+    }
+    let mut kept = String::with_capacity(line.len());
+    crate::tui::osc8::strip_ansi_keep_sgr_into(line, &mut kept);
+    let text = kept.into_text().ok()?;
+    let mut segments: Vec<StyledSegment> = Vec::new();
+    for parsed in text.lines {
+        for span in parsed.spans {
+            if span.content.is_empty() {
+                continue;
+            }
+            let style = tool_style(span.style);
+            match segments.last_mut() {
+                Some((last, last_style)) if *last_style == style => {
+                    last.push_str(&span.content);
+                }
+                _ => segments.push((span.content.into_owned(), style)),
+            }
+        }
+    }
+    let round_trip: String = segments.iter().map(|(text, _)| text.as_str()).collect();
+    if round_trip != plain || segments.iter().all(|(_, style)| *style == Style::default()) {
+        return None;
+    }
+    Some(segments)
+}
+
+/// What the tool asked for, expressed relative to the cell's own ink. A
+/// tool's *reset* (`ESC[0m`, or `Color::Reset`) means "back to the
+/// terminal default", and in the transcript that default is the value style
+/// the cell already paints — so resets become "nothing set" instead of a
+/// `Style::reset()` that would wipe the cell's dim/state colour when
+/// patched over it. Only positive requests (a colour, bold, underline)
+/// survive.
+fn tool_style(style: Style) -> Style {
+    let keep = |colour: Option<ratatui::style::Color>| {
+        colour.filter(|c| *c != ratatui::style::Color::Reset)
+    };
+    let mut out = Style::default().add_modifier(style.add_modifier);
+    if let Some(fg) = keep(style.fg) {
+        out = out.fg(fg);
+    }
+    if let Some(bg) = keep(style.bg) {
+        out = out.bg(bg);
+    }
+    out
+}
+
+/// Re-split styled segments along the boundaries `wrap_text` chose, so each
+/// wrapped part keeps the colours of the characters it holds. `parts` must
+/// concatenate to the segments' text (which is how `wrap_text` splits).
+pub(super) fn split_segments(
+    segments: Vec<StyledSegment>,
+    parts: &[String],
+) -> Vec<Vec<StyledSegment>> {
+    let mut chars = segments
+        .iter()
+        .flat_map(|(text, style)| text.chars().map(move |ch| (ch, *style)));
+    parts
+        .iter()
+        .map(|part| {
+            let mut out: Vec<StyledSegment> = Vec::new();
+            for (ch, style) in chars.by_ref().take(part.chars().count()) {
+                match out.last_mut() {
+                    Some((last, last_style)) if *last_style == style => last.push(ch),
+                    _ => out.push((ch.to_string(), style)),
+                }
+            }
+            out
+        })
+        .collect()
 }
 
 fn selected_output_indices(rows: &[OutputRow], line_limit: usize) -> Vec<usize> {
@@ -589,7 +690,14 @@ fn render_output_row(
     let diff_style = diff_line_style(&row.text);
     let file_style = file_line_style(&row.text);
     let value_style = diff_style.or(file_style).unwrap_or_else(tool_value_style);
-    if row.intact {
+    if let Some(segments) = &row.styled {
+        lines.extend(render_card_detail_line_styled(
+            label,
+            segments,
+            value_style,
+            width,
+        ));
+    } else if row.intact {
         lines.push(render_card_detail_line_single(
             label,
             &row.text,
@@ -646,5 +754,106 @@ pub(super) fn wrap_text(text: &str, width: usize) -> Vec<String> {
         vec![String::new()]
     } else {
         lines
+    }
+}
+
+#[cfg(test)]
+mod ansi_colour_tests {
+    use super::*;
+    use ratatui::style::{Color, Modifier};
+
+    fn styled_text(rows: &[OutputRow]) -> Vec<String> {
+        rows.iter()
+            .map(|row| {
+                row.styled
+                    .as_ref()
+                    .map(|segments| segments.iter().map(|(t, _)| t.as_str()).collect())
+                    .unwrap_or_default()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn plain_line_carries_no_styled_segments() {
+        let rows = output_rows("   Compiling codewhale v0.9.12", 80);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].text, "   Compiling codewhale v0.9.12");
+        assert!(rows[0].styled.is_none());
+    }
+
+    #[test]
+    fn cargo_style_line_keeps_its_green_bold_verb() {
+        let line = "\x1b[1m\x1b[32m   Compiling\x1b[0m codewhale v0.9.12";
+        let rows = output_rows(line, 80);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].text, "   Compiling codewhale v0.9.12");
+        let segments = rows[0]
+            .styled
+            .as_ref()
+            .expect("coloured line keeps segments");
+        assert_eq!(segments[0].0, "   Compiling");
+        assert_eq!(segments[0].1.fg, Some(Color::Green));
+        assert!(segments[0].1.add_modifier.contains(Modifier::BOLD));
+        assert_eq!(segments[1].0, " codewhale v0.9.12");
+        assert_eq!(segments[1].1, Style::default());
+        assert_eq!(styled_text(&rows), vec![rows[0].text.clone()]);
+    }
+
+    #[test]
+    fn osc8_link_is_stripped_while_its_sgr_colour_survives() {
+        let line =
+            "see \x1b]8;;https://example.com/x\x1b\\\x1b[31mthe docs\x1b[0m\x1b]8;;\x1b\\ now";
+        let rows = output_rows(line, 80);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].text, "see the docs now");
+        let segments = rows[0]
+            .styled
+            .as_ref()
+            .expect("SGR inside an OSC 8 wrapper");
+        assert_eq!(segments[0], ("see ".to_string(), Style::default()));
+        assert_eq!(segments[1].0, "the docs");
+        assert_eq!(segments[1].1.fg, Some(Color::Red));
+        assert_eq!(segments[2], (" now".to_string(), Style::default()));
+    }
+
+    #[test]
+    fn wrapped_rows_split_the_colour_along_wrap_boundaries() {
+        let line = format!("\x1b[33m{}\x1b[0m{}", "y".repeat(10), "p".repeat(10));
+        // width 12 → wrap width 8: rows of 8/8/4 characters.
+        let rows = output_rows(&line, 12);
+        assert_eq!(rows.len(), 3);
+        assert_eq!(
+            styled_text(&rows),
+            rows.iter().map(|r| r.text.clone()).collect::<Vec<_>>()
+        );
+        let second = rows[1].styled.as_ref().unwrap();
+        assert_eq!(
+            second[0],
+            ("yy".to_string(), Style::default().fg(Color::Yellow))
+        );
+        assert_eq!(second[1], ("pppppp".to_string(), Style::default()));
+    }
+
+    #[test]
+    fn painted_span_patches_tool_colour_over_the_cell_style() {
+        let rows = output_rows("\x1b[31merror\x1b[0m: boom", 80);
+        let mut lines = Vec::new();
+        render_output_row(&mut lines, Some("output"), &rows[0], 80);
+        assert_eq!(lines.len(), 1);
+        let spans = &lines[0].spans;
+        // rail, label, gap, "error", ": boom"
+        assert_eq!(spans[3].content, "error");
+        assert_eq!(spans[3].style.fg, Some(Color::Red));
+        assert_eq!(spans[4].content, ": boom");
+        assert_eq!(spans[4].style, tool_value_style());
+        let plain: String = spans[3..].iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(plain, "error: boom");
+    }
+
+    #[test]
+    fn a_line_that_only_resets_stays_on_the_plain_path() {
+        let rows = output_rows("done\x1b[0m", 80);
+        assert_eq!(rows[0].text, "done");
+        assert!(rows[0].styled.is_none());
     }
 }

--- a/crates/tui/src/tui/history/tool_output.rs
+++ b/crates/tui/src/tui/history/tool_output.rs
@@ -10,8 +10,8 @@ use crate::palette;
 use super::constants::{TOOL_OUTPUT_HEAD_LINES, TOOL_OUTPUT_TAIL_LINES, TOOL_TEXT_LIMIT};
 use super::{
     RenderMode, details_affordance_line, looks_like_file_path, render_card_detail_line,
-    render_card_detail_line_single, render_card_detail_line_styled, tool_value_style,
-    truncate_text,
+    render_card_detail_line_single, render_card_detail_line_single_styled,
+    render_card_detail_line_styled, tool_value_style, truncate_text,
 };
 
 pub(super) fn render_tool_output_mode(
@@ -444,7 +444,7 @@ fn output_rows(output: &str, width: u16) -> Vec<OutputRow> {
             });
         } else {
             let parts = wrap_text(&sanitized, wrap_width);
-            let mut styled_parts = styled.map(|segments| split_segments(segments, &parts));
+            let mut styled_parts = styled.map(|segments| split_segments(&segments, &parts));
             for (idx, wrapped) in parts.into_iter().enumerate() {
                 rows.push(OutputRow {
                     text: wrapped,
@@ -527,7 +527,7 @@ fn tool_style(style: Style) -> Style {
 /// wrapped part keeps the colours of the characters it holds. `parts` must
 /// concatenate to the segments' text (which is how `wrap_text` splits).
 pub(super) fn split_segments(
-    segments: Vec<StyledSegment>,
+    segments: &[StyledSegment],
     parts: &[String],
 ) -> Vec<Vec<StyledSegment>> {
     let mut chars = segments
@@ -691,12 +691,21 @@ fn render_output_row(
     let file_style = file_line_style(&row.text);
     let value_style = diff_style.or(file_style).unwrap_or_else(tool_value_style);
     if let Some(segments) = &row.styled {
-        lines.extend(render_card_detail_line_styled(
-            label,
-            segments,
-            value_style,
-            width,
-        ));
+        if row.intact {
+            lines.push(render_card_detail_line_single_styled(
+                label,
+                segments,
+                value_style,
+            ));
+        } else {
+            lines.extend(render_card_detail_line_styled(
+                label,
+                &row.text,
+                segments,
+                value_style,
+                width,
+            ));
+        }
     } else if row.intact {
         lines.push(render_card_detail_line_single(
             label,
@@ -848,6 +857,44 @@ mod ansi_colour_tests {
         assert_eq!(spans[4].style, tool_value_style());
         let plain: String = spans[3..].iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(plain, "error: boom");
+    }
+
+    #[test]
+    fn coloured_intact_path_stays_on_one_line_with_the_plain_hitbox() {
+        let path = "crates/tui/src/tui/history/tool_output.rs:812";
+        let coloured = format!("\x1b[35m{path}\x1b[0m");
+        let plain_rows = output_rows(path, 20);
+        let styled_rows = output_rows(&coloured, 20);
+        assert_eq!(plain_rows.len(), 1);
+        assert_eq!(styled_rows.len(), 1);
+        assert!(plain_rows[0].intact && styled_rows[0].intact);
+        assert!(styled_rows[0].styled.is_some());
+
+        let mut plain = Vec::new();
+        render_output_row(&mut plain, Some("output"), &plain_rows[0], 20);
+        let mut styled = Vec::new();
+        render_output_row(&mut styled, Some("output"), &styled_rows[0], 20);
+        assert_eq!(plain.len(), 1, "plain intact row is one line");
+        assert_eq!(styled.len(), 1, "coloured intact row is one line too");
+        let text = |line: &Line<'static>| {
+            line.spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>()
+        };
+        assert_eq!(text(&styled[0]), text(&plain[0]));
+        // Same prefix (rail + label + gap), so the click region is identical.
+        assert_eq!(
+            styled[0].spans[..3]
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<Vec<_>>(),
+            plain[0].spans[..3]
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(styled[0].spans[3].style.fg, Some(Color::Magenta));
     }
 
     #[test]

--- a/crates/tui/src/tui/osc8.rs
+++ b/crates/tui/src/tui/osc8.rs
@@ -245,6 +245,19 @@ pub fn take_frame_links() -> Vec<LinkRegion> {
 /// PM, APC, and standalone two-byte ESC sequences. OSC 8 hyperlink wrappers
 /// (`ESC ] 8 ; … BEL` / `ESC \`) are stripped along with the rest.
 pub fn strip_ansi_into(s: &str, out: &mut String) {
+    strip_ansi_impl(s, out, false);
+}
+
+/// Like [`strip_ansi_into`], but SGR sequences (`ESC [ … m`: colour, bold,
+/// underline, reset) pass through untouched so a renderer that understands
+/// them can paint the output as the tool emitted it. Everything else — OSC
+/// (including OSC 8 hyperlink wrappers), cursor movement, DCS, lone control
+/// bytes — is still removed; only the styling survives.
+pub fn strip_ansi_keep_sgr_into(s: &str, out: &mut String) {
+    strip_ansi_impl(s, out, true);
+}
+
+fn strip_ansi_impl(s: &str, out: &mut String, keep_sgr: bool) {
     let bytes = s.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -254,13 +267,21 @@ pub fn strip_ansi_into(s: &str, out: &mut String) {
                 // CSI: ESC [ ... <final byte 0x40..=0x7E>
                 b'[' => {
                     let mut j = i + 2;
+                    let mut final_byte = 0u8;
                     while j < bytes.len() {
                         let b = bytes[j];
                         if (0x40..=0x7e).contains(&b) {
+                            final_byte = b;
                             j += 1;
                             break;
                         }
                         j += 1;
+                    }
+                    if keep_sgr
+                        && final_byte == b'm'
+                        && let Ok(seq) = std::str::from_utf8(&bytes[i..j])
+                    {
+                        out.push_str(seq);
                     }
                     i = j;
                     continue;
@@ -441,6 +462,19 @@ mod tests {
     fn strip_ansi_removes_csi_sgr_and_keeps_text() {
         let coloured = "526   \x1b[1;32mOPEN\x1b[0m  bug fix";
         assert_eq!(strip_ansi(coloured), "526   OPEN  bug fix");
+    }
+
+    #[test]
+    fn strip_keep_sgr_keeps_colour_and_drops_everything_else() {
+        let mut out = String::new();
+        strip_ansi_keep_sgr_into(
+            "\x1b]8;;https://x\x07\x1b[1;32mok\x1b[0m\x1b]8;;\x07\x1b[2K\x1b[?25l tail",
+            &mut out,
+        );
+        assert_eq!(out, "\x1b[1;32mok\x1b[0m tail");
+        let mut plain = String::new();
+        strip_ansi_into(&out, &mut plain);
+        assert_eq!(plain, "ok tail");
     }
 
     #[test]

--- a/crates/tui/src/tui/output_rows_cache.rs
+++ b/crates/tui/src/tui/output_rows_cache.rs
@@ -259,6 +259,7 @@ mod tests {
         OutputRow {
             text: text.to_string(),
             intact: false,
+            styled: None,
         }
     }
 


### PR DESCRIPTION
No-Issue: internal 0.9.12 shell wave slice.

Rendering wave R4 (0.9.12 runlog): preserve ANSI colour in tool output instead of stripping it.

**What changed for the user.** When a shell tool's output carries colour — `cargo` build lines, `git`/`gh` with colour forced on, anything run through a PTY — the transcript now paints it as the tool emitted it: the green bold `Compiling`, red `error`, yellow warnings. Plain output looks exactly as before.

**Why.** Every coloured line was flattened to one ink, so the reader lost the tool's own emphasis and had to re-read output the terminal would have shown at a glance.

**How.** Each `OutputRow` now also carries styled segments parsed with `ansi-to-tui` (MIT, 8.0.1; depends on `ratatui-core` 0.1 already in the lockfile; default features off). Only the painted cell keeps the colour — the model, session store, pager, clipboard and exports still see stripped text; rows without an escape take the old path with no extra allocation. A tool's reset (`ESC[0m`, `Color::Reset`) is normalised to "nothing set" before being patched over the cell's value style, so the cell's own dim/state/file:line ink (#5799) shows through wherever the tool set nothing. Wrapped rows are split along the same boundaries `wrap_text` chose. OSC 8 wrappers are still stripped; links keep resolving from the visible text (`osc8::strip_ansi_keep_sgr_into` is the new helper).

**Evidence.**
- `ansi_colour_tests` (plain stays plain; cargo green bold verb; OSC 8 + SGR mix; wrap boundaries; span patched over the cell style; reset-only stays plain): `Summary 6 tests run: 6 passed`
- `strip_keep_sgr_keeps_colour_and_drops_everything_else`: `Summary 1 test run: 1 passed`
- `scripts/dev-test.sh tui`: `Summary 11858 tests run: 11858 passed, 13 skipped`
- `cargo clippy --workspace --all-targets` with CI flags: clean. `cargo fmt`: clean.

**Not in this PR.** Live PTY panes (R3) and word-level diff emphasis (R5) are separate slices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only TUI rendering change with fallback to the plain path when parsing fails; no auth, persistence, or model-facing text changes.
> 
> **Overview**
> **Coloured shell tool output** (`cargo`, `git`, PTY runs, etc.) is now painted in the transcript with the tool’s SGR emphasis instead of a single flat ink. Plain lines behave as before with no extra allocation.
> 
> **How it works:** `OutputRow` optionally carries parsed `StyledSegment`s built with `ansi-to-tui` after `strip_ansi_keep_sgr_into` keeps only `ESC [ … m` sequences while still stripping OSC 8, cursor controls, and other escapes. Display-only rendering patches those styles over the existing cell ink (diff/file:line/dim); resets are normalized so they don’t wipe cell styling. Wrapped rows split colours along the same `wrap_text` boundaries; intact paths stay one line for unchanged click hitboxes.
> 
> **Dependency:** `ansi-to-tui` 8.0.1 (default features off) on `codewhale-tui`. Session store, model, pager, clipboard, and exports still use fully stripped text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661c87702133b1943794c155d04c6bf9d83ce553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->