### PR TITLE
feat(runtime-api): rehydrate persisted goals and run host-managed continuation loop (re-land of #5711)

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -4842,10 +4842,14 @@ impl Engine {
             .await
             .as_ref()?;
 
-        // This within-turn hook is the only goal-continuation dispatch site
-        // for every session, so the configured between-continuation quiet
-        // period is awaited right here unconditionally — non-host-managed
-        // sessions (e.g. `codewhale resume --last`) must honor the delay too.
+        // There are exactly two goal-continuation dispatchers, split by
+        // scope: this within-turn hook owns the intra-turn passes for every
+        // session (bounded by the step budget), and the runtime host's
+        // `RuntimeThreadManager::settle_thread_goal_after_turn` owns the
+        // cross-turn re-arm for host-managed engines, which never
+        // self-continue. The configured between-continuation quiet period is
+        // awaited right here unconditionally — non-host-managed sessions
+        // (e.g. `codewhale resume --last`) must honor the delay too.
         // The wait is cancellable: the cancel token (Esc) wins biased over the
         // timer, and a pause/clear or terminal update_goal observed after the
         // wait cancels the pending pass before anything is recorded or

--- a/crates/tui/src/goal_loop.rs
+++ b/crates/tui/src/goal_loop.rs
@@ -217,8 +217,11 @@ pub const fn continuation_wait(delay_seconds: u64) -> Option<Duration> {
 /// Wait out the between-continuation quiet period, honoring cancellation.
 /// `None` resolves to `Elapsed` immediately so callers have a single dispatch
 /// gate. Cancellation is biased and always wins over a racing expiry — the
-/// same semantics as the interactive cadence (#5508) for host-managed turns,
-/// where the turn loop is the only continuation dispatcher.
+/// same semantics as the interactive cadence (#5508). Two dispatchers await
+/// this gate: the turn loop's intra-turn passes (every session), and the
+/// runtime host's cross-turn re-arm for host-managed engines
+/// (`RuntimeThreadManager::spawn_goal_continuation`), which never
+/// self-continue.
 pub async fn await_continuation_wait(
     wait: Option<Duration>,
     cancel_token: &tokio_util::sync::CancellationToken,

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -4647,6 +4647,12 @@ async fn upsert_thread_goal(
         .runtime_threads
         .emit_goal_updated_event(&id, goal.clone())
         .await;
+    // Inject the goal into a cached engine (if any) and dispatch the kickoff
+    // turn while the thread is idle. Errors are advisory: the goal record is
+    // already durable and a subsequent turn still carries it.
+    if let Err(err) = state.runtime_threads.activate_thread_goal(&id).await {
+        tracing::warn!("failed to activate goal for thread '{id}': {err}");
+    }
     Ok((status_code, Json(goal)))
 }
 
@@ -4670,6 +4676,10 @@ async fn delete_thread_goal(
         return Err(ApiError::not_found(format!("thread '{id}' has no goal")));
     }
     let _ = state.runtime_threads.emit_goal_cleared_event(&id).await;
+    state
+        .runtime_threads
+        .sync_engine_goal_status(&id, crate::tools::goal::GoalStatus::Active, true)
+        .await;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -4711,6 +4721,10 @@ async fn complete_thread_goal(
     let _ = state
         .runtime_threads
         .emit_goal_updated_event(&id, updated.clone())
+        .await;
+    state
+        .runtime_threads
+        .sync_engine_goal_status(&id, crate::tools::goal::GoalStatus::Complete, false)
         .await;
     Ok(Json(updated))
 }
@@ -4754,6 +4768,10 @@ async fn block_thread_goal(
     let _ = state
         .runtime_threads
         .emit_goal_updated_event(&id, updated.clone())
+        .await;
+    state
+        .runtime_threads
+        .sync_engine_goal_status(&id, crate::tools::goal::GoalStatus::Blocked, false)
         .await;
     Ok(Json(updated))
 }

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2303,6 +2303,13 @@ enum RuntimeTurnInputSource {
         message_id: String,
         persisted_summary: String,
     },
+    /// A host-driven goal pass (kickoff or continuation). The runtime host,
+    /// not the engine, owns the durable goal loop: host-managed engines
+    /// never self-continue, so each pass is claimed here with the same
+    /// durable-turn machinery as any other input.
+    GoalContinuation {
+        continuation_index: u32,
+    },
 }
 
 impl RuntimeTurnInputSource {
@@ -2310,6 +2317,7 @@ impl RuntimeTurnInputSource {
         match self {
             Self::ExternalUser => crate::core::ops::UserInputProvenance::ExternalUser,
             Self::AgentMail { .. } => crate::core::ops::UserInputProvenance::AgentMail,
+            Self::GoalContinuation { .. } => crate::core::ops::UserInputProvenance::Runtime,
         }
     }
 
@@ -2317,6 +2325,7 @@ impl RuntimeTurnInputSource {
         match self {
             Self::ExternalUser => None,
             Self::AgentMail { message_id, .. } => Some(message_id),
+            Self::GoalContinuation { .. } => None,
         }
     }
 
@@ -2329,16 +2338,26 @@ impl RuntimeTurnInputSource {
             Self::AgentMail {
                 persisted_summary, ..
             } => Some(persisted_summary.clone()),
+            // Continuation prompts embed goal JSON and engine framing, so the
+            // same rule applies: persist a bounded marker, not the projection.
+            Self::GoalContinuation { continuation_index } => Some(format!(
+                "Goal continuation pass #{continuation_index} (host-driven)"
+            )),
         }
     }
 
     fn item_metadata(&self) -> Option<Value> {
-        self.mail_message_id().map(|message_id| {
-            json!({
+        match self {
+            Self::ExternalUser => None,
+            Self::AgentMail { message_id, .. } => Some(json!({
                 "input_provenance": "agent_mail",
                 "agent_mail_message_id": message_id,
-            })
-        })
+            })),
+            Self::GoalContinuation { continuation_index } => Some(json!({
+                "input_provenance": "goal_continuation",
+                "goal_continuation_index": continuation_index,
+            })),
+        }
     }
 }
 
@@ -4177,6 +4196,236 @@ impl RuntimeThreadManager {
         tokio::task::spawn_blocking(move || store.delete_goal(&thread_id))
             .await
             .context("goal delete task panicked")?
+    }
+
+    /// Activate a persisted `Active` goal: make sure the engine carries the
+    /// goal state, then dispatch the kickoff turn while the thread is idle.
+    /// A busy thread is left alone — the running turn already carries the
+    /// persisted goal, and its terminal settlement arms the next pass.
+    pub async fn activate_thread_goal(&self, thread_id: &str) -> Result<()> {
+        let Some(goal) = self.store.load_goal(thread_id)? else {
+            return Ok(());
+        };
+        if !matches!(goal.status, codewhale_protocol::ThreadGoalStatus::Active) {
+            return Ok(());
+        }
+        {
+            let active = self.active.lock().await;
+            if let Some(state) = active.engines.get(thread_id)
+                && state.active_turn.is_some()
+            {
+                return Ok(());
+            }
+        }
+        let objective = goal.objective.trim().to_string();
+        if objective.is_empty() {
+            return Ok(());
+        }
+        self.start_goal_turn(thread_id, objective, 0).await?;
+        Ok(())
+    }
+
+    /// Push a durable goal lifecycle transition into a cached engine so its
+    /// prompt surface and tool gates follow the store. Engines are not
+    /// loaded for this; a later load re-derives the state from the record.
+    pub async fn sync_engine_goal_status(
+        &self,
+        thread_id: &str,
+        status: crate::tools::goal::GoalStatus,
+        clear: bool,
+    ) {
+        let engine = {
+            let active = self.active.lock().await;
+            active
+                .engines
+                .get(thread_id)
+                .map(|state| state.engine.clone())
+        };
+        if let Some(engine) = engine {
+            let _ = engine.try_send(Op::SetGoalStatus { status, clear });
+        }
+    }
+
+    /// Claim one host-driven goal turn with the standard durable machinery.
+    /// The caller renders the prompt (kickoff objective or continuation
+    /// frame); `continuation_index` is 0 for the kickoff pass.
+    async fn start_goal_turn(
+        &self,
+        thread_id: &str,
+        prompt: String,
+        continuation_index: u32,
+    ) -> Result<TurnRecord> {
+        let req = StartTurnRequest {
+            prompt,
+            operation_key: None,
+            input_summary: Some(if continuation_index == 0 {
+                "goal kickoff".to_string()
+            } else {
+                format!("goal continuation pass #{continuation_index}")
+            }),
+            model: None,
+            reasoning_effort: None,
+            allowed_tools: None,
+            mode: None,
+            permission_posture: None,
+            allow_shell: None,
+            trust_mode: None,
+            auto_approve: None,
+            dynamic_tools: Vec::new(),
+            environment_id: None,
+        };
+        self.start_turn_with_source(
+            thread_id,
+            req,
+            RuntimeTurnInputSource::GoalContinuation { continuation_index },
+            None,
+        )
+        .await
+    }
+
+    /// Terminal goal settlement for one finished turn.
+    ///
+    /// Host-managed runtime engines never self-continue (the interactive
+    /// sibling schedules `Op::ContinueGoal` in-process), so the runtime host
+    /// owns the durable loop here: turn usage is written back to the goal
+    /// record, the model's terminal decision (`update_goal` complete/blocked)
+    /// is mirrored from the engine snapshot, and the next pass is armed after
+    /// the configured quiet period while the goal is still Active.
+    async fn settle_thread_goal_after_turn(
+        &self,
+        thread_id: &str,
+        turn: &TurnRecord,
+        engine_goal: Option<crate::tools::goal::GoalSnapshot>,
+    ) {
+        let mut goal = match self.store.load_goal(thread_id) {
+            Ok(Some(goal)) => goal,
+            Ok(None) => return,
+            Err(err) => {
+                tracing::warn!("failed to load goal for {thread_id} after turn: {err}");
+                return;
+            }
+        };
+
+        // Accrue this turn's provider spend onto the durable counters. The
+        // engine tracks the same totals in memory; the record is the
+        // cross-restart authority.
+        let token_delta = turn
+            .usage
+            .as_ref()
+            .map(|usage| i64::from(usage.input_tokens) + i64::from(usage.output_tokens))
+            .unwrap_or(0);
+        let time_delta_seconds = turn.duration_ms.map(|ms| (ms / 1000) as i64).unwrap_or(0);
+        if token_delta > 0 || time_delta_seconds > 0 {
+            goal.tokens_used = goal.tokens_used.saturating_add(token_delta);
+            goal.time_used_seconds = goal.time_used_seconds.saturating_add(time_delta_seconds);
+            goal.updated_at = chrono::Utc::now().timestamp();
+        }
+
+        // Mirror the model's terminal decision into the durable record so a
+        // restarted host does not resume a goal the verifier already closed.
+        if matches!(goal.status, codewhale_protocol::ThreadGoalStatus::Active)
+            && let Some(snapshot) = engine_goal.as_ref()
+            && let Some(projected) = match snapshot.status.as_str() {
+                "complete" => Some(codewhale_protocol::ThreadGoalStatus::Complete),
+                "blocked" => Some(codewhale_protocol::ThreadGoalStatus::Blocked),
+                "paused" => match snapshot.pause_reason {
+                    // Pause reasons that map to the protocol's limit states
+                    // keep their distinct reason; a user pause stays Paused.
+                    Some(crate::tools::goal::GoalPauseReason::UsageLimit) => {
+                        Some(codewhale_protocol::ThreadGoalStatus::UsageLimited)
+                    }
+                    Some(crate::tools::goal::GoalPauseReason::BudgetLimit) => {
+                        Some(codewhale_protocol::ThreadGoalStatus::BudgetLimited)
+                    }
+                    _ => Some(codewhale_protocol::ThreadGoalStatus::Paused),
+                },
+                _ => None,
+            }
+        {
+            goal.status = projected;
+            goal.updated_at = chrono::Utc::now().timestamp();
+        }
+
+        // Only a cleanly completed pass continues the loop. Failed or
+        // interrupted passes leave the goal Active for an explicit resume
+        // (PUT, or the next user turn).
+        let mut continue_after: Option<u64> = None;
+        if turn.status == RuntimeTurnStatus::Completed
+            && matches!(goal.status, codewhale_protocol::ThreadGoalStatus::Active)
+        {
+            let max_continuations = i64::from(self.read_config().goal_max_continuations());
+            if max_continuations != 0 && goal.continuation_count >= max_continuations {
+                tracing::info!(
+                    "goal for {thread_id} reached the continuation cap ({}); stopping",
+                    goal.continuation_count
+                );
+            } else {
+                goal.continuation_count = goal.continuation_count.saturating_add(1);
+                goal.updated_at = chrono::Utc::now().timestamp();
+                continue_after = Some(self.read_config().goal_continuation_delay_seconds());
+            }
+        }
+
+        if let Err(err) = self.store.save_goal(&goal) {
+            tracing::warn!("failed to record goal progress for {thread_id}: {err}");
+            return;
+        }
+        if let Err(err) = self.emit_goal_updated_event(thread_id, goal.clone()).await {
+            tracing::warn!("failed to emit goal update for {thread_id}: {err}");
+        }
+        if let Some(delay_seconds) = continue_after {
+            self.spawn_goal_continuation(thread_id.to_string(), delay_seconds);
+        }
+    }
+
+    fn spawn_goal_continuation(&self, thread_id: String, delay_seconds: u64) {
+        let manager = self.clone();
+        tokio::spawn(async move {
+            // Quiet period between passes, mirroring the interactive
+            // engine's `goal_continuation_delay_seconds` behavior (#5508).
+            if delay_seconds > 0 {
+                tokio::time::sleep(std::time::Duration::from_secs(delay_seconds)).await;
+            }
+            if let Err(err) = manager.run_goal_continuation(&thread_id).await {
+                tracing::warn!("goal continuation for {thread_id} failed: {err}");
+            }
+        });
+    }
+
+    /// Dispatch one goal continuation pass after the quiet period. Every
+    /// guard re-reads durable state: the goal may have been paused, cleared,
+    /// completed, or capped while the timer ran.
+    async fn run_goal_continuation(&self, thread_id: &str) -> Result<()> {
+        let Some(goal) = self.store.load_goal(thread_id)? else {
+            return Ok(());
+        };
+        if !matches!(goal.status, codewhale_protocol::ThreadGoalStatus::Active) {
+            return Ok(());
+        }
+        {
+            let active = self.active.lock().await;
+            if let Some(state) = active.engines.get(thread_id)
+                && state.active_turn.is_some()
+            {
+                return Ok(());
+            }
+        }
+        let max_continuations = i64::from(self.read_config().goal_max_continuations());
+        if max_continuations != 0 && goal.continuation_count >= max_continuations {
+            return Ok(());
+        }
+        if goal
+            .token_budget
+            .is_some_and(|budget| goal.tokens_used >= budget)
+        {
+            return Ok(());
+        }
+        let continuation_index = u32::try_from(goal.continuation_count.max(1)).unwrap_or(u32::MAX);
+        let snapshot = crate::tools::goal::GoalSnapshot::from_thread_goal(&goal);
+        let prompt = crate::tools::goal::render_continuation_prompt(&snapshot, continuation_index);
+        self.start_goal_turn(thread_id, prompt, continuation_index)
+            .await?;
+        Ok(())
     }
 
     /// Persist one canonical Agent Mail envelope in the runtime store. The
@@ -6980,14 +7229,36 @@ impl RuntimeThreadManager {
         };
         turn.item_ids.push(user_item_id.clone());
 
+        // Every turn carries the persisted goal alongside its message. The
+        // engine's `handle_send_message` installs these fields into its
+        // host-surface projection unconditionally, so passing `None` here
+        // would clear an injected goal on any ordinary message. Passing the
+        // durable record keeps the engine aligned with the store; a replaced
+        // objective (PUT) still resets counters through the same sync path.
+        let turn_goal = self.store.load_goal(thread_id).ok().flatten();
+        let turn_goal_objective = turn_goal
+            .as_ref()
+            .map(|goal| goal.objective.trim().to_string())
+            .filter(|objective| !objective.is_empty());
+        let turn_goal_token_budget = turn_goal
+            .as_ref()
+            .and_then(|goal| goal.token_budget)
+            .and_then(|value| u32::try_from(value.max(0)).ok());
+        let turn_goal_status = turn_goal
+            .as_ref()
+            .map(|goal| {
+                crate::tools::goal::thread_goal_status_projection(goal.status.clone()).0
+            })
+            .unwrap_or(crate::tools::goal::GoalStatus::Active);
+
         let op = Op::SendMessage {
             content: prompt,
             mode,
             route: Box::new(route),
             compaction: Box::new(compaction),
-            goal_objective: None,
-            goal_token_budget: None,
-            goal_status: crate::tools::goal::GoalStatus::Active,
+            goal_objective: turn_goal_objective,
+            goal_token_budget: turn_goal_token_budget,
+            goal_status: turn_goal_status,
             reasoning_effort,
             reasoning_effort_auto: auto_controls_reasoning,
             auto_model,
@@ -7589,6 +7860,63 @@ impl RuntimeThreadManager {
                         .map(|registry| registry.rediscover_for_workspace(&thread.workspace))
                 })
                 .flatten();
+            // Rehydrate the persisted thread goal into the engine so the
+            // goal loop, prompt surface, and `update_goal` tool operate on
+            // the durable record from the first turn. Usage and continuation
+            // counters are preserved; `sync_from_host_status` would reset
+            // them because the fresh state's objective "changed".
+            let persisted_goal = self.store.load_goal(&thread.id).unwrap_or_else(|err| {
+                tracing::warn!(
+                    "failed to load persisted goal for thread {}: {err}",
+                    thread.id
+                );
+                None
+            });
+            let (goal_objective, goal_token_budget, goal_status, goal_state) = match &persisted_goal
+            {
+                Some(goal) => {
+                    let objective = goal.objective.trim();
+                    if objective.is_empty() {
+                        (
+                            None,
+                            None,
+                            crate::tools::goal::GoalStatus::Active,
+                            crate::tools::goal::new_shared_goal_state(),
+                        )
+                    } else {
+                        let (status, pause_reason) =
+                            crate::tools::goal::thread_goal_status_projection(goal.status.clone());
+                        let tokens_used =
+                            u64::try_from(goal.tokens_used.max(0)).unwrap_or(u64::MAX);
+                        let time_used_seconds =
+                            u64::try_from(goal.time_used_seconds.max(0)).unwrap_or(u64::MAX);
+                        let continuation_count =
+                            u32::try_from(goal.continuation_count.max(0)).unwrap_or(u32::MAX);
+                        (
+                            Some(objective.to_string()),
+                            goal.token_budget
+                                .and_then(|value| u32::try_from(value.max(0)).ok()),
+                            status,
+                            crate::tools::goal::new_shared_goal_state_from_persisted(
+                                objective,
+                                goal.token_budget
+                                    .and_then(|value| u32::try_from(value.max(0)).ok()),
+                                status,
+                                pause_reason,
+                                tokens_used,
+                                time_used_seconds,
+                                continuation_count,
+                            ),
+                        )
+                    }
+                }
+                None => (
+                    None,
+                    None,
+                    crate::tools::goal::GoalStatus::Active,
+                    crate::tools::goal::new_shared_goal_state(),
+                ),
+            };
             let engine_cfg = EngineConfig {
                 model: route_model.clone(),
                 active_route_limits: route_limits,
@@ -7628,7 +7956,7 @@ impl RuntimeThreadManager {
                 compaction,
                 todos: new_shared_todo_list(),
                 plan_state: new_shared_plan_state(),
-                goal_state: crate::tools::goal::new_shared_goal_state(),
+                goal_state,
                 max_spawn_depth: cfg.subagent_max_spawn_depth_for_provider(provider),
                 subagent_token_budget: cfg.subagent_token_budget_for_provider(provider),
                 network_policy,
@@ -7696,9 +8024,9 @@ impl RuntimeThreadManager {
                     .then(|| cfg.vision_model_config())
                     .flatten(),
                 strict_tool_mode: cfg.strict_tool_mode.unwrap_or(false),
-                goal_objective: None,
-                goal_token_budget: None,
-                goal_status: crate::tools::goal::GoalStatus::Active,
+                goal_objective,
+                goal_token_budget,
+                goal_status,
                 goal_max_continuations: cfg.goal_max_continuations(),
                 goal_continuation_delay_seconds: cfg.goal_continuation_delay_seconds(),
                 allowed_tools: isolated_chat.then(Vec::new),
@@ -8039,6 +8367,11 @@ impl RuntimeThreadManager {
         let mut engine_turn_id: Option<String> = None;
         let mut pending_event: Option<EngineEvent> = None;
         let mut event_channel_closed = false;
+        // Latest engine-side goal snapshot observed during this turn. The
+        // model's `update_goal` decision (complete/blocked/paused) lands here
+        // before TurnComplete, so terminal settlement can mirror it into the
+        // durable goal record instead of continuing to spend.
+        let mut latest_goal_snapshot: Option<crate::tools::goal::GoalSnapshot> = None;
 
         loop {
             let event = if let Some(event) = pending_event.take() {
@@ -9084,6 +9417,9 @@ impl RuntimeThreadManager {
                     }
                     break;
                 }
+                EngineEvent::GoalUpdated { snapshot } => {
+                    latest_goal_snapshot = Some(snapshot);
+                }
                 _ => {}
             }
         }
@@ -9243,6 +9579,13 @@ impl RuntimeThreadManager {
             }
             touch_lru(&mut active.lru, &thread_id);
         }
+
+        // The same terminal boundary settles the durable goal loop: usage is
+        // written back, the model's terminal decision is mirrored, and the
+        // next pass is armed while the goal is still Active. Runs after the
+        // active-turn cleanup above so an armed pass sees an idle thread.
+        self.settle_thread_goal_after_turn(&thread_id, &turn, latest_goal_snapshot)
+            .await;
 
         // A terminal turn is the declared safe boundary. Wake at most the
         // oldest eligible envelope; its own terminal boundary may advance the

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2340,6 +2340,11 @@ impl RuntimeTurnInputSource {
             } => Some(persisted_summary.clone()),
             // Continuation prompts embed goal JSON and engine framing, so the
             // same rule applies: persist a bounded marker, not the projection.
+            // Index 0 is the kickoff pass, not a continuation; the summary
+            // must not call it one.
+            Self::GoalContinuation {
+                continuation_index: 0,
+            } => Some("Goal kickoff (host-driven)".to_string()),
             Self::GoalContinuation { continuation_index } => Some(format!(
                 "Goal continuation pass #{continuation_index} (host-driven)"
             )),
@@ -4296,6 +4301,7 @@ impl RuntimeThreadManager {
         thread_id: &str,
         turn: &TurnRecord,
         engine_goal: Option<crate::tools::goal::GoalSnapshot>,
+        turn_tool_catalog: Option<&[codewhale_core::request::Tool]>,
     ) {
         let mut goal = match self.store.load_goal(thread_id) {
             Ok(Some(goal)) => goal,
@@ -4319,6 +4325,21 @@ impl RuntimeThreadManager {
             goal.tokens_used = goal.tokens_used.saturating_add(token_delta);
             goal.time_used_seconds = goal.time_used_seconds.saturating_add(time_delta_seconds);
             goal.updated_at = chrono::Utc::now().timestamp();
+        }
+
+        // The engine snapshot is the authority for the continuation counter:
+        // `record_continuation` counts every intra-turn pass the turn actually
+        // ran, while a flat per-turn increment here would diverge (one turn
+        // with N intra-turn passes would count as 1) and could keep arming
+        // passes the engine's own `ContinuationLimit` gate then refuses.
+        // A rehydrated engine starts from the durable count, so this only
+        // ever moves the record forward.
+        if let Some(snapshot) = engine_goal.as_ref() {
+            let engine_count = i64::from(snapshot.continuation_count);
+            if engine_count > goal.continuation_count {
+                goal.continuation_count = engine_count;
+                goal.updated_at = chrono::Utc::now().timestamp();
+            }
         }
 
         // Mirror the model's terminal decision into the durable record so a
@@ -4354,14 +4375,45 @@ impl RuntimeThreadManager {
             && matches!(goal.status, codewhale_protocol::ThreadGoalStatus::Active)
         {
             let max_continuations = i64::from(self.read_config().goal_max_continuations());
+            // The engine stops its own intra-turn loop at this cap with only
+            // a status line (`goal_continuation_allowed` → Stop), so a
+            // snapshot at or beyond the cap means the engine already refused
+            // the next pass. Mirror that stop as a host-side pause instead of
+            // arming passes that can only trip the same gate; an explicit
+            // PUT resumes the goal.
+            let engine_hit_cap = engine_goal.as_ref().is_some_and(|snapshot| {
+                max_continuations != 0
+                    && i64::from(snapshot.continuation_count) >= max_continuations
+            });
+            // A turn whose catalog lacked `update_goal` (an `allowed_tools`
+            // restriction, or an `isolated_chat` engine) has no tool with
+            // which the model could ever report complete/blocked, so the
+            // engine's own continuation hook skips such turns
+            // (`goal_continuation_message_if_needed`). The host mirrors that
+            // precondition: re-arming would spend one provider call per pass
+            // with no terminal path. A missing catalog means the turn never
+            // reached the request seam, so the same conservative gate holds.
+            let update_goal_available = turn_tool_catalog
+                .is_some_and(|catalog| catalog.iter().any(|tool| tool.name == "update_goal"));
             if max_continuations != 0 && goal.continuation_count >= max_continuations {
                 tracing::info!(
                     "goal for {thread_id} reached the continuation cap ({}); stopping",
                     goal.continuation_count
                 );
-            } else {
-                goal.continuation_count = goal.continuation_count.saturating_add(1);
+                goal.status = codewhale_protocol::ThreadGoalStatus::Paused;
                 goal.updated_at = chrono::Utc::now().timestamp();
+            } else if engine_hit_cap {
+                tracing::info!(
+                    "goal for {thread_id} hit the engine continuation cap ({}); pausing",
+                    goal.continuation_count
+                );
+                goal.status = codewhale_protocol::ThreadGoalStatus::Paused;
+                goal.updated_at = chrono::Utc::now().timestamp();
+            } else if !update_goal_available {
+                tracing::info!(
+                    "goal for {thread_id} stays parked: the finished turn's catalog lacked update_goal"
+                );
+            } else {
                 continue_after = Some(self.read_config().goal_continuation_delay_seconds());
             }
         }
@@ -4378,6 +4430,11 @@ impl RuntimeThreadManager {
         }
     }
 
+    /// Arm one goal continuation pass to run after the quiet period. The
+    /// sleep is deliberately never cancelled: a pause, clear, completion, or
+    /// cap that lands while the timer runs is honored by the re-read inside
+    /// `run_goal_continuation`, which is the cancellation path — `DELETE
+    /// /goal` and status syncs therefore do not need to interrupt this task.
     fn spawn_goal_continuation(&self, thread_id: String, delay_seconds: u64) {
         let manager = self.clone();
         tokio::spawn(async move {
@@ -8372,6 +8429,10 @@ impl RuntimeThreadManager {
         // before TurnComplete, so terminal settlement can mirror it into the
         // durable goal record instead of continuing to spend.
         let mut latest_goal_snapshot: Option<crate::tools::goal::GoalSnapshot> = None;
+        // Tool definitions of the finished turn's request surface, from the
+        // final TurnComplete receipt. Goal settlement uses it to mirror the
+        // engine's own `update_goal` precondition for continuation.
+        let mut turn_tool_catalog: Option<Vec<codewhale_core::request::Tool>> = None;
 
         loop {
             let event = if let Some(event) = pending_event.take() {
@@ -9391,9 +9452,13 @@ impl RuntimeThreadManager {
                     usage,
                     status,
                     error,
+                    tool_catalog,
                     ..
                 } => {
                     turn_usage = Some(usage);
+                    if tool_catalog.is_some() {
+                        turn_tool_catalog = tool_catalog;
+                    }
                     let reported_status = match status {
                         TurnOutcomeStatus::Completed => RuntimeTurnStatus::Completed,
                         TurnOutcomeStatus::Interrupted => RuntimeTurnStatus::Interrupted,
@@ -9583,9 +9648,17 @@ impl RuntimeThreadManager {
         // The same terminal boundary settles the durable goal loop: usage is
         // written back, the model's terminal decision is mirrored, and the
         // next pass is armed while the goal is still Active. Runs after the
-        // active-turn cleanup above so an armed pass sees an idle thread.
-        self.settle_thread_goal_after_turn(&thread_id, &turn, latest_goal_snapshot)
-            .await;
+        // active-turn cleanup above so an armed pass sees an idle thread. A
+        // goal pass and the mail wake below can race for the same durable
+        // claim; a goal pass that loses the race simply re-arms after the
+        // mail turn's own settlement, so no arbitration is needed here.
+        self.settle_thread_goal_after_turn(
+            &thread_id,
+            &turn,
+            latest_goal_snapshot,
+            turn_tool_catalog.as_deref(),
+        )
+        .await;
 
         // A terminal turn is the declared safe boundary. Wake at most the
         // oldest eligible envelope; its own terminal boundary may advance the

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -6498,6 +6498,378 @@ async fn multi_turn_continuity_same_thread() -> Result<()> {
     Ok(())
 }
 
+/// A minimal tool definition for `TurnComplete.tool_catalog` receipts in
+/// mock-engine goal tests.
+fn catalog_tool(name: &str) -> codewhale_core::request::Tool {
+    codewhale_core::request::Tool {
+        tool_type: None,
+        name: name.to_string(),
+        description: String::new(),
+        input_schema: serde_json::json!({ "type": "object" }),
+        allowed_callers: None,
+        defer_loading: None,
+        input_examples: None,
+        strict: None,
+        cache_control: None,
+    }
+}
+
+fn active_test_goal(thread_id: &str, goal_id: &str) -> codewhale_protocol::ThreadGoal {
+    codewhale_protocol::ThreadGoal {
+        thread_id: thread_id.to_string(),
+        goal_id: goal_id.to_string(),
+        objective: "ship the goal loop".to_string(),
+        status: codewhale_protocol::ThreadGoalStatus::Active,
+        token_budget: None,
+        tokens_used: 0,
+        time_used_seconds: 0,
+        continuation_count: 0,
+        created_at: 0,
+        updated_at: 0,
+    }
+}
+
+async fn wait_for_goal_status(
+    manager: &RuntimeThreadManager,
+    thread_id: &str,
+    expected: codewhale_protocol::ThreadGoalStatus,
+    timeout: Duration,
+) -> Result<codewhale_protocol::ThreadGoal> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let goal = manager
+            .store
+            .load_goal(thread_id)?
+            .ok_or_else(|| anyhow::anyhow!("goal record missing for {thread_id}"))?;
+        if goal.status == expected {
+            return Ok(goal);
+        }
+        if Instant::now() > deadline {
+            anyhow::bail!("goal did not reach {expected:?} in time: {goal:?}");
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// Wait until the thread has `expected` terminal turns in the durable store.
+async fn wait_for_terminal_turn_count(
+    manager: &RuntimeThreadManager,
+    thread_id: &str,
+    expected: usize,
+    timeout: Duration,
+) -> Result<Vec<TurnRecord>> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let turns = manager.store.list_turns_for_thread(thread_id)?;
+        let terminal = turns
+            .iter()
+            .filter(|turn| {
+                matches!(
+                    turn.status,
+                    RuntimeTurnStatus::Completed
+                        | RuntimeTurnStatus::Failed
+                        | RuntimeTurnStatus::Interrupted
+                        | RuntimeTurnStatus::Canceled
+                )
+            })
+            .count();
+        if terminal == expected {
+            return Ok(turns);
+        }
+        if Instant::now() > deadline {
+            anyhow::bail!("expected {expected} terminal turns, saw {terminal}: {turns:?}");
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn host_goal_loop_kickoff_arms_one_continuation_and_parks_at_engine_cap() -> Result<()> {
+    let config = Config {
+        goal: Some(crate::config::GoalConfig {
+            max_continuations: Some(2),
+            continuation_delay_seconds: None,
+        }),
+        ..Config::default()
+    };
+    let manager = RuntimeThreadManager::open(
+        config,
+        PathBuf::from("."),
+        test_manager_config(test_runtime_dir()),
+    )?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    manager
+        .store
+        .save_goal(&active_test_goal(&thread.id, "goal_cap"))?;
+
+    let harness = install_mock_engine(&manager, &thread.id).await;
+    let mut rx_op = harness.rx_op;
+    let tx_event = harness.tx_event;
+    let passes = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
+    let counter = passes.clone();
+    tokio::spawn(async move {
+        while let Some(op) = rx_op.recv().await {
+            if !matches!(op, Op::SendMessage { .. }) {
+                continue;
+            }
+            let pass = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            // Mirror the real engine: emit_goal_updated lands right before
+            // TurnComplete, so settlement sees the final snapshot.
+            let snapshot = crate::tools::goal::GoalSnapshot {
+                objective: Some("ship the goal loop".to_string()),
+                status: "active".to_string(),
+                // The kickoff runs pass 0; the armed continuation is pass 2,
+                // already at the configured cap.
+                continuation_count: if pass == 1 { 0 } else { 2 },
+                ..Default::default()
+            };
+            let _ = tx_event.send(EngineEvent::GoalUpdated { snapshot }).await;
+            let _ = tx_event
+                .send(EngineEvent::TurnStarted {
+                    turn_id: format!("engine_goal_{pass}"),
+                    created_at: chrono::Utc::now(),
+                    route: None,
+                })
+                .await;
+            let _ = tx_event
+                .send(EngineEvent::MessageStarted { index: 0 })
+                .await;
+            let _ = tx_event
+                .send(EngineEvent::MessageDelta {
+                    index: 0,
+                    content: format!("pass {pass}"),
+                })
+                .await;
+            let _ = tx_event
+                .send(EngineEvent::MessageComplete { index: 0 })
+                .await;
+            let _ = tx_event
+                .send(EngineEvent::TurnComplete {
+                    usage: Usage {
+                        input_tokens: 10,
+                        output_tokens: 10,
+                        ..Usage::default()
+                    },
+                    status: TurnOutcomeStatus::Completed,
+                    error: None,
+                    tool_catalog: Some(vec![catalog_tool("update_goal")]),
+                    base_url: None,
+                })
+                .await;
+        }
+    });
+
+    manager.activate_thread_goal(&thread.id).await?;
+
+    // Kickoff plus exactly one armed continuation, then the engine cap
+    // parks the goal instead of arming a third pass.
+    let turns =
+        wait_for_terminal_turn_count(&manager, &thread.id, 2, TURN_SETTLEMENT_DEADLOCK_TIMEOUT)
+            .await?;
+    assert_eq!(turns.len(), 2);
+    assert!(
+        turns
+            .iter()
+            .all(|turn| turn.status == RuntimeTurnStatus::Completed)
+    );
+    assert_eq!(turns[0].input_summary, "goal kickoff");
+    assert_eq!(turns[1].input_summary, "goal continuation pass #1");
+
+    let goal = wait_for_goal_status(
+        &manager,
+        &thread.id,
+        codewhale_protocol::ThreadGoalStatus::Paused,
+        TURN_SETTLEMENT_DEADLOCK_TIMEOUT,
+    )
+    .await?;
+    // Snapshot authority: the record keeps the engine's counter (2), and
+    // both turns' usage was accrued.
+    assert_eq!(goal.continuation_count, 2);
+    assert_eq!(goal.tokens_used, 40);
+
+    // Grace window for an (incorrect) third pass with delay 0.
+    sleep(Duration::from_millis(400)).await;
+    assert_eq!(
+        passes.load(std::sync::atomic::Ordering::SeqCst),
+        2,
+        "no pass may be armed after the engine cap parked the goal"
+    );
+
+    // Transcripts must read the kickoff as a kickoff, not "pass #0".
+    let detail = manager.get_thread_detail(&thread.id).await?;
+    assert!(detail.items.iter().any(|item| {
+        item.kind == TurnItemKind::UserMessage
+            && item.detail.as_deref() == Some("Goal kickoff (host-driven)")
+    }));
+    assert!(detail.items.iter().any(|item| {
+        item.kind == TurnItemKind::UserMessage
+            && item.detail.as_deref() == Some("Goal continuation pass #1 (host-driven)")
+    }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn host_goal_loop_skips_rearm_without_update_goal_and_after_failed_pass() -> Result<()> {
+    // Scenario A: a completed pass whose catalog lacks `update_goal` has no
+    // terminal path, so the host must not arm another pass.
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    manager
+        .store
+        .save_goal(&active_test_goal(&thread.id, "goal_no_update"))?;
+    let harness = install_mock_engine(&manager, &thread.id).await;
+    let mut rx_op = harness.rx_op;
+    let tx_event = harness.tx_event;
+    let passes = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
+    let counter = passes.clone();
+    tokio::spawn(async move {
+        while let Some(op) = rx_op.recv().await {
+            if !matches!(op, Op::SendMessage { .. }) {
+                continue;
+            }
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let snapshot = crate::tools::goal::GoalSnapshot {
+                objective: Some("ship the goal loop".to_string()),
+                status: "active".to_string(),
+                ..Default::default()
+            };
+            let _ = tx_event.send(EngineEvent::GoalUpdated { snapshot }).await;
+            let _ = tx_event
+                .send(EngineEvent::TurnStarted {
+                    turn_id: "engine_goal_no_update".to_string(),
+                    created_at: chrono::Utc::now(),
+                    route: None,
+                })
+                .await;
+            let _ = tx_event
+                .send(EngineEvent::MessageStarted { index: 0 })
+                .await;
+            let _ = tx_event
+                .send(EngineEvent::MessageDelta {
+                    index: 0,
+                    content: "work without the goal tool".to_string(),
+                })
+                .await;
+            let _ = tx_event
+                .send(EngineEvent::MessageComplete { index: 0 })
+                .await;
+            let _ = tx_event
+                .send(EngineEvent::TurnComplete {
+                    usage: Usage {
+                        input_tokens: 10,
+                        output_tokens: 10,
+                        ..Usage::default()
+                    },
+                    status: TurnOutcomeStatus::Completed,
+                    error: None,
+                    tool_catalog: Some(vec![catalog_tool("read")]),
+                    base_url: None,
+                })
+                .await;
+        }
+    });
+    manager.activate_thread_goal(&thread.id).await?;
+    wait_for_terminal_turn_count(&manager, &thread.id, 1, TURN_SETTLEMENT_DEADLOCK_TIMEOUT).await?;
+    // Settlement must have accrued usage before deciding; once visible, the
+    // arming decision has been made.
+    let deadline = Instant::now() + TURN_SETTLEMENT_DEADLOCK_TIMEOUT;
+    let goal = loop {
+        let goal = manager
+            .store
+            .load_goal(&thread.id)?
+            .ok_or_else(|| anyhow::anyhow!("goal record missing"))?;
+        if goal.tokens_used >= 20 || Instant::now() > deadline {
+            break goal;
+        }
+        sleep(Duration::from_millis(20)).await;
+    };
+    assert_eq!(goal.status, codewhale_protocol::ThreadGoalStatus::Active);
+    sleep(Duration::from_millis(400)).await;
+    assert_eq!(
+        passes.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "no pass may be armed without update_goal in the catalog"
+    );
+
+    // Scenario B: a failed kickoff pass leaves the goal Active without
+    // arming anything.
+    let failed_thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    manager
+        .store
+        .save_goal(&active_test_goal(&failed_thread.id, "goal_failed_pass"))?;
+    let failed_harness = install_mock_engine(&manager, &failed_thread.id).await;
+    let mut failed_rx_op = failed_harness.rx_op;
+    let failed_tx_event = failed_harness.tx_event;
+    let failed_passes = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
+    let failed_counter = failed_passes.clone();
+    tokio::spawn(async move {
+        while let Some(op) = failed_rx_op.recv().await {
+            if !matches!(op, Op::SendMessage { .. }) {
+                continue;
+            }
+            failed_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let snapshot = crate::tools::goal::GoalSnapshot {
+                objective: Some("ship the goal loop".to_string()),
+                status: "active".to_string(),
+                ..Default::default()
+            };
+            let _ = failed_tx_event
+                .send(EngineEvent::GoalUpdated { snapshot })
+                .await;
+            let _ = failed_tx_event
+                .send(EngineEvent::TurnStarted {
+                    turn_id: "engine_goal_failed".to_string(),
+                    created_at: chrono::Utc::now(),
+                    route: None,
+                })
+                .await;
+            let _ = failed_tx_event
+                .send(EngineEvent::TurnComplete {
+                    usage: Usage {
+                        input_tokens: 5,
+                        output_tokens: 5,
+                        ..Usage::default()
+                    },
+                    status: TurnOutcomeStatus::Failed,
+                    error: Some("provider exploded".to_string()),
+                    tool_catalog: Some(vec![catalog_tool("update_goal")]),
+                    base_url: None,
+                })
+                .await;
+        }
+    });
+    manager.activate_thread_goal(&failed_thread.id).await?;
+    let failed_turns = wait_for_terminal_turn_count(
+        &manager,
+        &failed_thread.id,
+        1,
+        TURN_SETTLEMENT_DEADLOCK_TIMEOUT,
+    )
+    .await?;
+    assert_eq!(failed_turns[0].status, RuntimeTurnStatus::Failed);
+    sleep(Duration::from_millis(400)).await;
+    assert_eq!(
+        failed_passes.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "a failed pass must not arm a continuation"
+    );
+    let failed_goal = manager
+        .store
+        .load_goal(&failed_thread.id)?
+        .ok_or_else(|| anyhow::anyhow!("failed-pass goal record missing"))?;
+    assert_eq!(
+        failed_goal.status,
+        codewhale_protocol::ThreadGoalStatus::Active
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn get_thread_detail_batches_items_by_turn_without_losing_order() -> Result<()> {
     let manager = test_manager(test_runtime_dir())?;

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -6871,6 +6871,98 @@ async fn host_goal_loop_skips_rearm_without_update_goal_and_after_failed_pass() 
 }
 
 #[tokio::test]
+async fn host_goal_loop_mirrors_terminal_snapshot_and_does_not_rearm() -> Result<()> {
+    // A completed pass whose engine snapshot says `complete` (or `blocked`)
+    // is mirrored into the durable record and arms nothing more: a restarted
+    // host must not resume a goal the verifier already closed.
+    let manager = test_manager(test_runtime_dir())?;
+    for (goal_id, engine_status, expected) in [
+        (
+            "goal_complete",
+            "complete",
+            codewhale_protocol::ThreadGoalStatus::Complete,
+        ),
+        (
+            "goal_blocked",
+            "blocked",
+            codewhale_protocol::ThreadGoalStatus::Blocked,
+        ),
+    ] {
+        let thread = manager
+            .create_thread(CreateThreadRequest::default())
+            .await?;
+        manager
+            .store
+            .save_goal(&active_test_goal(&thread.id, goal_id))?;
+        let harness = install_mock_engine(&manager, &thread.id).await;
+        let mut rx_op = harness.rx_op;
+        let tx_event = harness.tx_event;
+        let passes = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
+        let counter = passes.clone();
+        let status = engine_status.to_string();
+        tokio::spawn(async move {
+            while let Some(op) = rx_op.recv().await {
+                if !matches!(op, Op::SendMessage { .. }) {
+                    continue;
+                }
+                counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let snapshot = crate::tools::goal::GoalSnapshot {
+                    objective: Some("ship the goal loop".to_string()),
+                    status: status.clone(),
+                    continuation_count: 1,
+                    ..Default::default()
+                };
+                let _ = tx_event.send(EngineEvent::GoalUpdated { snapshot }).await;
+                let _ = tx_event
+                    .send(EngineEvent::TurnStarted {
+                        turn_id: format!("engine_{status}"),
+                        created_at: chrono::Utc::now(),
+                        route: None,
+                    })
+                    .await;
+                let _ = tx_event
+                    .send(EngineEvent::TurnComplete {
+                        usage: Usage {
+                            input_tokens: 7,
+                            output_tokens: 3,
+                            ..Usage::default()
+                        },
+                        status: TurnOutcomeStatus::Completed,
+                        error: None,
+                        tool_catalog: Some(vec![catalog_tool("update_goal")]),
+                        base_url: None,
+                    })
+                    .await;
+            }
+        });
+        manager.activate_thread_goal(&thread.id).await?;
+        let goal = wait_for_goal_status(
+            &manager,
+            &thread.id,
+            expected,
+            TURN_SETTLEMENT_DEADLOCK_TIMEOUT,
+        )
+        .await?;
+        // Usage and the engine's continuation counter landed on the record.
+        assert_eq!(goal.tokens_used, 10);
+        assert_eq!(goal.continuation_count, 1);
+        sleep(Duration::from_millis(400)).await;
+        assert_eq!(
+            passes.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a terminal snapshot must not arm another pass ({engine_status})"
+        );
+        let turns = manager.store.list_turns_for_thread(&thread.id)?;
+        assert_eq!(
+            turns.len(),
+            1,
+            "exactly the kickoff turn ran ({engine_status})"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn get_thread_detail_batches_items_by_turn_without_losing_order() -> Result<()> {
     let manager = test_manager(test_runtime_dir())?;
     let thread = manager

--- a/crates/tui/src/tools/goal.rs
+++ b/crates/tui/src/tools/goal.rs
@@ -38,6 +38,30 @@ pub fn new_shared_goal_state_from_host_status(
     Arc::new(Mutex::new(state))
 }
 
+/// Create shared state restored from a persisted goal record, keeping the
+/// accumulated usage and continuation counters. See
+/// [`GoalState::from_persisted`].
+#[must_use]
+pub fn new_shared_goal_state_from_persisted(
+    objective: &str,
+    token_budget: Option<u32>,
+    status: GoalStatus,
+    pause_reason: Option<GoalPauseReason>,
+    tokens_used: u64,
+    time_used_seconds: u64,
+    continuation_count: u32,
+) -> SharedGoalState {
+    Arc::new(Mutex::new(GoalState::from_persisted(
+        objective,
+        token_budget,
+        status,
+        pause_reason,
+        tokens_used,
+        time_used_seconds,
+        continuation_count,
+    )))
+}
+
 /// A goal declaration stated in ordinary user prose rather than as a leading
 /// `/goal <objective>` command.
 ///
@@ -338,6 +362,44 @@ impl GoalState {
         self.last_gap_fingerprint = None;
         self.repeated_gap_count = 0;
         Ok(())
+    }
+
+    /// Restore goal state from a persisted runtime goal, keeping the
+    /// accumulated usage and continuation counters.
+    ///
+    /// Unlike [`Self::sync_from_host_status`], which resets the counters
+    /// whenever the objective changes, this constructor treats the persisted
+    /// values as the authoritative history: the durable store owns them and
+    /// the engine is rehydrating, not re-declaring, the goal. Evidence,
+    /// blockers, and review notes are runtime-only and start empty; the
+    /// durable loop re-derives them on the next pass.
+    #[must_use]
+    pub fn from_persisted(
+        objective: &str,
+        token_budget: Option<u32>,
+        status: GoalStatus,
+        pause_reason: Option<GoalPauseReason>,
+        tokens_used: u64,
+        time_used_seconds: u64,
+        continuation_count: u32,
+    ) -> Self {
+        Self {
+            objective: Some(objective.to_string()),
+            token_budget,
+            status: Some(status),
+            tokens_used,
+            time_used_seconds,
+            continuation_count,
+            started_at: Some(Instant::now()),
+            finished_at: (status != GoalStatus::Active).then(Instant::now),
+            evidence: None,
+            blocker: None,
+            pause_reason,
+            completion_verification: None,
+            advisories: Vec::new(),
+            last_gap_fingerprint: None,
+            repeated_gap_count: 0,
+        }
     }
 
     pub fn record_usage(&mut self, token_delta: u64, time_delta_seconds: u64) {

--- a/crates/tui/src/tools/goal.rs
+++ b/crates/tui/src/tools/goal.rs
@@ -1780,4 +1780,56 @@ mod tests {
         let update = UpdateGoalTool::new(new_shared_goal_state());
         assert!(update.description().contains("requires user input"));
     }
+
+    #[test]
+    fn from_persisted_keeps_counters_that_sync_from_host_status_resets() {
+        // Rehydration treats the durable record as history: the counters
+        // survive, evidence starts empty, and only a terminal status carries
+        // a finish time.
+        let restored = GoalState::from_persisted(
+            "ship the goal loop",
+            Some(50_000),
+            GoalStatus::Active,
+            None,
+            1_234,
+            56,
+            3,
+        );
+        assert_eq!(restored.objective.as_deref(), Some("ship the goal loop"));
+        assert_eq!(restored.token_budget, Some(50_000));
+        assert_eq!(restored.status, Some(GoalStatus::Active));
+        assert_eq!(restored.tokens_used, 1_234);
+        assert_eq!(restored.time_used_seconds, 56);
+        assert_eq!(restored.continuation_count, 3);
+        assert!(restored.started_at.is_some());
+        assert!(restored.finished_at.is_none());
+        assert!(restored.evidence.is_none());
+        assert!(restored.blocker.is_none());
+        assert!(restored.advisories.is_empty());
+
+        let blocked = GoalState::from_persisted(
+            "ship the goal loop",
+            None,
+            GoalStatus::Blocked,
+            None,
+            0,
+            0,
+            0,
+        );
+        assert!(blocked.finished_at.is_some());
+
+        // The same objective through the host-status path keeps the counters
+        // (it is not a re-declaration)…
+        let mut state = restored;
+        state.sync_from_host_status(Some("ship the goal loop"), Some(50_000), GoalStatus::Active);
+        assert_eq!(state.tokens_used, 1_234);
+        assert_eq!(state.continuation_count, 3);
+
+        // …while a changed objective resets them — the contrast that makes
+        // `from_persisted` necessary for rehydration.
+        state.sync_from_host_status(Some("a different objective"), None, GoalStatus::Active);
+        assert_eq!(state.tokens_used, 0);
+        assert_eq!(state.time_used_seconds, 0);
+        assert_eq!(state.continuation_count, 0);
+    }
 }


### PR DESCRIPTION
No-Issue: internal 0.9.12 shell wave slice.

## What changed for the user

A goal set on a runtime thread survives a host restart and keeps going. \`PUT /v1/threads/{id}/goal\` now injects the goal into the cached engine and dispatches a kickoff turn while the thread is idle (it used to only persist the record), and after every completed pass the host re-arms one continuation, honouring the configured cap and quiet period, until the model reports complete or blocked. Failed or interrupted passes leave the goal Active for an explicit resume.

**Contract change, stated up front:** \`PUT /v1/threads/{id}/goal\` on an idle thread now spends tokens (it starts a turn). Existing runtime-API callers that only wanted to persist a record should expect that turn.

## Why

Goals were engine-only state: a persisted goal was rehydrated with zeroed counters, and nothing on the host side continued the loop across turns, so a headless runtime lost its goal on restart and stalled after one pass.

## One-scheduler contract

The host loop goes through the standard \`start_turn_with_source\` durable-turn path and never drives the engine directly. It cannot race the engine's in-process \`ContinueGoal\` scheduler because runtime engines never self-continue: the turn loop owns intra-turn passes (bounded by the step budget) and \`settle_thread_goal_after_turn\` owns the cross-turn re-arm; both await the same quiet-period gate. The comments in \`core/engine/turn_loop.rs\` and \`goal_loop.rs\` now say so.

## Review notes from #5711, addressed

1. **Tests** — the contributor's second commit added two host-loop tests (kickoff arms exactly one continuation and parks at the engine cap; no re-arm without \`update_goal\` in the catalog, and none after a failed pass). This re-land adds the two the review still asked for: \`GoalState::from_persisted\` keeps the persisted counters where \`sync_from_host_status\` resets them, and settlement mirrors a complete/blocked snapshot into the store without arming another pass.
2. **Receipts** — clippy and the full TUI area, below.
3. **Contract change** — called out above.
4. **One-scheduler** — explained above.

The original head's Windows Test failure was a runner cancellation at 1h30 (\`The operation was canceled\` after 12k passing tests), not a test failure.

## Evidence

\`\`\`
scripts/dev-test.sh tui runtime_threads::tests::host_goal tools::goal::tests
Summary [   1.701s] 28 tests run: 28 passed, 11840 skipped

RUST_MIN_STACK=16777216 scripts/dev-test.sh tui
Summary [  85.838s] 11855 tests run: 11855 passed, 13 skipped

cargo clippy -p codewhale-tui --all-targets -- -D warnings -A clippy::too_many_arguments -A clippy::uninlined_format_args -A clippy::unnecessary_map_or
Finished; exit 0
\`\`\`

Author credit: @gaord (commits preserved: \`26a5a1e85\`, \`e1510884c\`). Supersedes #5711, which conflicts only because main moved. The CHANGELOG receipt from the earlier integration branch was dropped; receipts are written on main at the wave's end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autonomous turn scheduling and API semantics (PUT goal spends tokens), with durable state sync between store and engine; logic is heavily guarded but affects long-running agent behavior and billing-related counters.
> 
> **Overview**
> **Runtime threads now own the cross-turn goal loop** for host-managed engines: persisted goals are rehydrated into cached engines (usage and continuation counters preserved via `GoalState::from_persisted`), every turn carries the durable goal on `SendMessage`, and after each terminal turn **`settle_thread_goal_after_turn`** writes usage, mirrors the engine’s `update_goal` outcome into the store, and optionally schedules the next pass after the configured quiet period.
> 
> **`PUT /v1/threads/{id}/goal`** on an idle thread now **starts a kickoff turn** (`activate_thread_goal`), not only persists the record. **DELETE / complete / block** push matching status into a cached engine via `sync_engine_goal_status`. Continuations use a new **`GoalContinuation`** turn input source with bounded persisted summaries and metadata.
> 
> **Continuation gating** matches the interactive engine: no re-arm without `update_goal` in the turn catalog, after failed passes, when the snapshot is complete/blocked, or when continuation caps are hit (host may pause the durable goal). Comments in the turn loop and `goal_loop` document the split between intra-turn dispatch and host cross-turn re-arm.
> 
> **Tests** cover kickoff + one continuation then cap parking, skip re-arm without `update_goal` / after failure, terminal snapshot mirroring, and `from_persisted` counter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 719cb4807d265f4bb06abbc3eac1fae3448d8a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->