### PR TITLE
fix(providers): provider neutrality gates (#5588)

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -4215,6 +4215,12 @@ pub(crate) use prepared::{
 };
 pub(crate) use provider_native_search::{ProviderNativeSearchClient, ProviderNativeSearchRequest};
 
+/// Whether a route speaks ordinary `/chat/completions` (not Messages or Responses).
+#[must_use]
+pub(crate) fn provider_speaks_chat_completions(api_provider: ApiProvider) -> bool {
+    provider_default_wire_format(api_provider) == WireFormat::ChatCompletions
+}
+
 pub(crate) fn inspect_prompt_for_request(request: &MessageRequest) -> PromptInspection {
     chat::inspect_prompt_for_request(request)
 }

--- a/crates/tui/src/commands/groups/debug/balance.rs
+++ b/crates/tui/src/commands/groups/debug/balance.rs
@@ -1,28 +1,18 @@
-//! Balance: query the active provider's account balance or credit status.
-//!
-//! Provider-specific network dispatch is still pending. Until that lands, keep
-//! this command explicit about being a scaffold so users do not mistake it for
-//! a live balance lookup.
+//! Balance: query the active provider's remaining prepaid credit.
 
-use crate::config::ApiProvider;
-use crate::tui::app::App;
+use crate::config::provider_has_balance_api;
+use crate::tui::app::{App, AppAction};
 
 use super::CommandResult;
 
 /// Query provider account balance / credits.
 pub fn balance(app: &mut App) -> CommandResult {
     let provider = app.api_provider;
-    match provider {
-        ApiProvider::Deepseek
-        | ApiProvider::DeepseekCN
-        | ApiProvider::Openrouter
-        | ApiProvider::Novita => CommandResult::message(format!(
-            "Balance check for {} is planned, but provider balance network dispatch is not wired in this build yet.",
-            provider.display_name()
-        )),
-        _ => CommandResult::message(format!(
+    if !provider_has_balance_api(provider) {
+        return CommandResult::message(format!(
             "Balance check is not supported for {} yet. Check the provider dashboard for account balance details.",
             provider.display_name()
-        )),
+        ));
     }
+    CommandResult::action(AppAction::FetchBalance)
 }

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -1724,19 +1724,21 @@ mod tests {
     }
 
     #[test]
-    fn balance_command_reports_scaffold_without_claiming_dispatch() {
+    fn balance_command_dispatches_live_fetch_for_prepaid_providers() {
         let mut app = create_test_app();
-        app.api_provider = ApiProvider::Deepseek;
-
-        let result = execute("/balance", &mut app);
-        let msg = result
-            .message
-            .expect("balance scaffold should explain current state");
-
-        assert!(!result.is_error);
-        assert!(msg.contains("DeepSeek"));
-        assert!(msg.contains("not wired"));
-        assert!(!msg.contains("sent"));
+        for provider in [
+            ApiProvider::Deepseek,
+            ApiProvider::Openrouter,
+            ApiProvider::Siliconflow,
+        ] {
+            app.api_provider = provider;
+            let result = execute("/balance", &mut app);
+            assert!(!result.is_error, "{provider:?}");
+            assert!(
+                matches!(result.action, Some(AppAction::FetchBalance)),
+                "{provider:?} should dispatch a live remaining-credit fetch"
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2351,7 +2351,7 @@ pub enum StatusItem {
     RateLimit,
     /// Session token usage: input / cache-hit / output.
     Tokens,
-    /// DeepSeek account balance, refreshed once per turn completion.
+    /// Prepaid remaining credit, refreshed once per turn completion.
     Balance,
     /// Session metrics strip: turns · steps │ LLM · tools │ TTFT · tok/s │
     /// cache │ in — sourced from engine timings and provider usage.
@@ -2466,7 +2466,7 @@ impl StatusItem {
             StatusItem::LastToolElapsed => "ms of the most recent tool call (reserved)",
             StatusItem::RateLimit => "remaining requests in the budget (reserved)",
             StatusItem::Tokens => "input / cache-hit / output token totals",
-            StatusItem::Balance => "topped-up + granted balance from DeepSeek",
+            StatusItem::Balance => "remaining prepaid credit from the active provider",
             StatusItem::SessionMetrics => "turns · steps · LLM/tool time · TTFT · tok/s · input",
         }
     }
@@ -2499,12 +2499,24 @@ impl StatusItem {
     #[must_use]
     pub fn is_available_for(self, provider: ApiProvider) -> bool {
         match self {
-            StatusItem::Balance => {
-                matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
-            }
+            StatusItem::Balance => provider_has_balance_api(provider),
             _ => true,
         }
     }
+}
+
+/// Prepaid providers that publish a remaining-credit endpoint Codewhale
+/// can fetch. Local runtimes and invoice-only vendors stay out.
+#[must_use]
+pub fn provider_has_balance_api(provider: ApiProvider) -> bool {
+    matches!(
+        provider,
+        ApiProvider::Deepseek
+            | ApiProvider::DeepseekCN
+            | ApiProvider::Openrouter
+            | ApiProvider::Siliconflow
+            | ApiProvider::SiliconflowCn
+    )
 }
 
 /// One configurable header item

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -11226,12 +11226,13 @@ fn provider_capability_roundtrip_serialization() {
 }
 
 #[test]
-fn status_item_balance_available_only_for_deepseek_providers() {
-    // Balance item should only be offered for DeepSeek / DeepSeekCN.
+fn status_item_balance_available_for_prepaid_providers() {
     assert!(StatusItem::Balance.is_available_for(ApiProvider::Deepseek));
     assert!(StatusItem::Balance.is_available_for(ApiProvider::DeepseekCN));
-    // Sanity: all other known providers should hide the Balance toggle.
-    assert!(!StatusItem::Balance.is_available_for(ApiProvider::Openrouter));
+    assert!(StatusItem::Balance.is_available_for(ApiProvider::Openrouter));
+    assert!(StatusItem::Balance.is_available_for(ApiProvider::Siliconflow));
+    assert!(StatusItem::Balance.is_available_for(ApiProvider::SiliconflowCn));
+    // Invoice-only, local, and unimplemented prepaid vendors stay hidden.
     assert!(!StatusItem::Balance.is_available_for(ApiProvider::Novita));
     assert!(!StatusItem::Balance.is_available_for(ApiProvider::NvidiaNim));
     assert!(!StatusItem::Balance.is_available_for(ApiProvider::Fireworks));

--- a/crates/tui/src/mcp_server.rs
+++ b/crates/tui/src/mcp_server.rs
@@ -71,6 +71,16 @@ struct ExposedTool {
     internal: String,
 }
 
+fn mcp_request_model(arguments: &Value, default_model: &str) -> String {
+    arguments
+        .get("model")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .unwrap_or(default_model)
+        .to_string()
+}
+
 pub fn run_mcp_server(workspace: PathBuf) -> Result<()> {
     let settings = McpServerSettings::load()?;
     let mut server = McpServer::new(workspace, settings)?;
@@ -188,7 +198,7 @@ impl McpServer {
                                 },
                                 "model": {
                                     "type": "string",
-                                    "description": "Optional model identifier (default: deepseek-v4-pro)"
+                                    "description": "Optional model identifier. When omitted, uses the active provider's default model."
                                 },
                                 "cwd": {
                                     "type": "string",
@@ -345,10 +355,14 @@ impl McpServer {
                 message: "Missing required argument: prompt".to_string(),
             })?;
 
-        let model = arguments
-            .get("model")
-            .and_then(Value::as_str)
-            .unwrap_or("deepseek-v4-pro");
+        // Load config first so an omitted model follows the active provider
+        // default instead of a hardcoded DeepSeek id.
+        let config = Config::load(None, None).map_err(|e| RpcError {
+            code: -32000,
+            message: format!("Failed to load config: {e}"),
+        })?;
+        let default_model = config.default_model();
+        let model = mcp_request_model(arguments, &default_model);
 
         // Resolve thread_id
         let thread_id = if internal_name == "deepseek" {
@@ -365,11 +379,6 @@ impl McpServer {
                 .to_string()
         };
 
-        // Load config and create client
-        let config = Config::load(None, None).map_err(|e| RpcError {
-            code: -32000,
-            message: format!("Failed to load config: {e}"),
-        })?;
         let client = DeepSeekClient::new(&config).map_err(model_client_init_error)?;
 
         // Build message list
@@ -395,9 +404,9 @@ impl McpServer {
 
         // Send the API request (non-streaming for the basic version). Internal
         // chat uses the same resolved output policy as an ordinary turn.
-        let request_route = client.effective_route_envelope(model, chrono::Utc::now());
+        let request_route = client.effective_route_envelope(&model, chrono::Utc::now());
         let request = MessageRequest {
-            model: model.to_string(),
+            model: model.clone(),
             messages: messages.clone(),
             max_tokens: client.effective_max_output_tokens(&request_route.model),
             system: None,
@@ -720,5 +729,36 @@ mod tests {
 
         assert!(!init.message.contains("DeepSeek"));
         assert!(!request.message.contains("DeepSeek"));
+    }
+
+    #[test]
+    fn omitted_mcp_model_follows_the_active_provider_default() {
+        assert_eq!(mcp_request_model(&json!({}), "gpt-5.6"), "gpt-5.6");
+        assert_eq!(
+            mcp_request_model(&json!({ "model": "   " }), "GLM-5.3"),
+            "GLM-5.3"
+        );
+        assert_eq!(
+            mcp_request_model(&json!({ "model": "kimi-k2.5" }), "gpt-5.6"),
+            "kimi-k2.5"
+        );
+    }
+
+    #[test]
+    fn list_tools_does_not_hardcode_a_deepseek_default_model() {
+        let settings = McpServerSettings {
+            expose_tools: vec!["deepseek".to_string()],
+            require_approval: false,
+        };
+        let server = McpServer::new(PathBuf::from("."), settings).expect("build server");
+        let tools = server.list_tools_response();
+        let description = tools["tools"][0]["inputSchema"]["properties"]["model"]["description"]
+            .as_str()
+            .expect("model description");
+        assert!(
+            !description.to_ascii_lowercase().contains("deepseek"),
+            "{description}"
+        );
+        assert!(description.contains("active provider"), "{description}");
     }
 }

--- a/crates/tui/src/pricing.rs
+++ b/crates/tui/src/pricing.rs
@@ -107,9 +107,10 @@ impl CostEstimate {
     }
 }
 
-// === DeepSeek Account Balance ===
+// === Provider Account Balance ===
 
-/// Response from `GET https://api.deepseek.com/user/balance`.
+/// Response from DeepSeek `GET /user/balance`. Other prepaid providers are
+/// mapped onto [`BalanceInfo`] at the fetch seam.
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 pub struct BalanceResponse {
     #[allow(dead_code)]
@@ -117,28 +118,64 @@ pub struct BalanceResponse {
     pub balance_infos: Vec<BalanceInfo>,
 }
 
-/// Per-currency balance entry from the balance API.
+/// Per-currency remaining-credit entry shown by `/balance` and the status chip.
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 pub struct BalanceInfo {
-    // Wire fields of the live `GET /user/balance` response deserialized in
-    // `tui::ui::fetch_deepseek_balance` and parked in `App::balance_cell`.
-    // Nothing renders them today — the footer balance chip went with the
-    // legacy FooterWidget — so `dead_code` cannot see the producer. Kept
-    // because they are the API contract, matching the sibling fields below.
-    #[allow(dead_code)]
     pub currency: String,
     #[serde(default)]
-    #[allow(dead_code)]
     pub total_balance: String,
     #[serde(default)]
-    #[allow(dead_code)]
     pub topped_up_balance: String,
     #[serde(default)]
-    #[allow(dead_code)]
     pub granted_balance: String,
 }
 
-impl BalanceInfo {}
+impl BalanceInfo {
+    /// Compact ledger chip, e.g. `$12.50` or `¥123.45`.
+    #[must_use]
+    pub fn chip_label(&self) -> Option<String> {
+        let amount = self.total_balance.trim();
+        if amount.is_empty() {
+            return None;
+        }
+        Some(format_balance_amount(amount, &self.currency))
+    }
+
+    /// Full `/balance` report for one prepaid provider.
+    #[must_use]
+    pub fn report(&self, provider_name: &str) -> String {
+        let amount = self
+            .chip_label()
+            .unwrap_or_else(|| self.total_balance.trim().to_string());
+        let mut report = if amount.is_empty() {
+            format!("{provider_name} account balance is unknown")
+        } else {
+            format!("{provider_name} account balance: {amount}")
+        };
+        let topped = self.topped_up_balance.trim();
+        let granted = self.granted_balance.trim();
+        if !topped.is_empty() || !granted.is_empty() {
+            let mut parts = Vec::new();
+            if !topped.is_empty() {
+                parts.push(format!("topped up {topped}"));
+            }
+            if !granted.is_empty() {
+                parts.push(format!("granted {granted}"));
+            }
+            report.push_str(&format!(" ({})", parts.join(", ")));
+        }
+        report
+    }
+}
+
+fn format_balance_amount(amount: &str, currency: &str) -> String {
+    match currency.trim().to_ascii_uppercase().as_str() {
+        "CNY" | "RMB" | "¥" => format!("¥{amount}"),
+        "USD" | "US$" | "$" => format!("${amount}"),
+        "" => amount.to_string(),
+        other => format!("{amount} {other}"),
+    }
+}
 
 /// How a hand-sourced row bills cache-creation (cache-write) tokens.
 ///
@@ -4745,5 +4782,33 @@ mod tests {
         assert!(resp.balance_infos.is_empty());
     }
 
-    // ── BalanceInfo::total_balance_f64 ─────────────────────────────
+    #[test]
+    fn balance_info_chip_label_uses_currency_prefix() {
+        let cny = BalanceInfo {
+            currency: "CNY".to_string(),
+            total_balance: "123.45".to_string(),
+            ..BalanceInfo::default()
+        };
+        assert_eq!(cny.chip_label().as_deref(), Some("¥123.45"));
+        let usd = BalanceInfo {
+            currency: "USD".to_string(),
+            total_balance: "12.50".to_string(),
+            ..BalanceInfo::default()
+        };
+        assert_eq!(usd.chip_label().as_deref(), Some("$12.50"));
+        assert_eq!(
+            usd.report("OpenRouter"),
+            "OpenRouter account balance: $12.50"
+        );
+        let deepseek = BalanceInfo {
+            currency: "CNY".to_string(),
+            total_balance: "123.45".to_string(),
+            topped_up_balance: "100.00".to_string(),
+            granted_balance: "23.45".to_string(),
+        };
+        assert_eq!(
+            deepseek.report("DeepSeek"),
+            "DeepSeek account balance: ¥123.45 (topped up 100.00, granted 23.45)"
+        );
+    }
 }

--- a/crates/tui/src/tui/app/types.rs
+++ b/crates/tui/src/tui/app/types.rs
@@ -1108,6 +1108,8 @@ pub enum AppAction {
         title: String,
         content: String,
     },
+    /// Live remaining-credit lookup for prepaid providers (`/balance`).
+    FetchBalance,
     FetchModels,
     /// Force a Models.dev live-catalog refresh into ProviderLake (#4187).
     RefreshModelsDevCatalog,

--- a/crates/tui/src/tui/phase_strip.rs
+++ b/crates/tui/src/tui/phase_strip.rs
@@ -977,3 +977,18 @@ pub(crate) fn tideline_footer_from_app(app: &mut App, width: u16) -> TidelineFoo
 
 #[cfg(test)]
 mod tideline_tests;
+
+#[cfg(test)]
+mod neutrality_tests {
+    #[test]
+    fn session_metrics_strip_is_on_by_default() {
+        assert!(
+            crate::config::StatusItem::default_footer()
+                .contains(&crate::config::StatusItem::SessionMetrics)
+        );
+        assert_eq!(
+            crate::config::StatusItem::from_key("session_metrics"),
+            Some(crate::config::StatusItem::SessionMetrics)
+        );
+    }
+}

--- a/crates/tui/src/tui/prompt_suggestion.rs
+++ b/crates/tui/src/tui/prompt_suggestion.rs
@@ -149,15 +149,14 @@ impl fmt::Debug for SuggestionLaunch {
     }
 }
 
-/// Whether a provider speaks the exact DeepSeek OpenAI-compatible
+/// Whether a provider speaks the ordinary OpenAI-compatible
 /// `/chat/completions` shape [`generate_suggestion`] hardcodes.
 ///
-/// This is deliberately narrow: `DeepseekAnthropic` is a different wire
-/// protocol, and every other provider is out of scope. Widening this set is a
-/// feature change, not a bug fix.
+/// Gate on wire protocol, not a vendor enum: Anthropic Messages and the
+/// OpenAI Responses API are different request shapes and stay out.
 #[must_use]
 pub fn route_is_supported_suggestion_provider(provider: ApiProvider) -> bool {
-    matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
+    crate::client::provider_speaks_chat_completions(provider)
 }
 
 /// Resolve credentials for exactly one configured route identity.
@@ -181,8 +180,8 @@ fn resolve_credentials_for_identity(
     provider_identity: &str,
     model: &str,
 ) -> Option<SuggestionRouteCredentials> {
-    // Belt and braces: callers already gated, but this function must never be
-    // the thing that reads a non-DeepSeek route's credentials.
+    // Belt and braces: callers already gated, but this function must never
+    // read credentials for a wire this helper does not speak.
     if !route_is_supported_suggestion_provider(provider) {
         return None;
     }
@@ -225,9 +224,9 @@ fn resolve_credentials_for_identity(
 /// whatever route config describes *now*, not the route the turn is running on.
 /// The receipt was minted from the installed client itself, so it cannot drift.
 ///
-/// Unsupported providers — every non-DeepSeek route, including
-/// `DeepseekAnthropic` — return `None`, and no credential material of any
-/// provider is inspected on this path at all.
+/// Unsupported providers — Anthropic Messages, Responses, and any other
+/// non-Chat-Completions wire — return `None`, and no credential material
+/// of any provider is inspected on this path at all.
 #[must_use]
 pub fn capture_route_authority(route: &TurnRoute) -> Option<SuggestionRouteAuthority> {
     if !route_is_supported_suggestion_provider(route.provider) {
@@ -261,8 +260,8 @@ pub fn capture_route_authority(route: &TurnRoute) -> Option<SuggestionRouteAutho
 ///
 /// Fail-closed by construction:
 /// - `resolve_route_credentials` is only invoked once every non-credential gate
-///   has passed for a supported DeepSeek route, so a non-DeepSeek completion
-///   never reaches DeepSeek credential material at all.
+///   has passed for a Chat Completions route, so a Messages/Responses
+///   completion never reaches another provider's credentials at all.
 /// - The decision reads only `completed_route`, never live selection state, so
 ///   a later route switch cannot redirect it.
 /// - The route must still resolve to the *same* provider, identity, wire model,
@@ -428,15 +427,21 @@ pub async fn generate_suggestion(
         %model,
         "generating prompt suggestion"
     );
-    let response = match client
+    let mut request = client
         .post(&url)
         .header(AUTHORIZATION, format!("Bearer {api_key}"))
         .header(CONTENT_TYPE, "application/json")
         .timeout(std::time::Duration::from_secs(10))
-        .json(&body)
-        .send()
-        .await
-    {
+        .json(&body);
+    // OpenRouter app attribution: same headers the Chat Completions client
+    // already sends. Infer from the turn's actual endpoint so this helper
+    // does not grow a provider enum of its own.
+    if endpoint_identity(&url).contains("openrouter.ai") {
+        request = request
+            .header("HTTP-Referer", "https://codewhale.net")
+            .header("X-Title", "Codewhale");
+    }
+    let response = match request.send().await {
         Ok(r) => r,
         Err(_) => return None,
     };
@@ -689,9 +694,9 @@ mod tests {
     }
 
     #[test]
-    fn non_deepseek_completion_never_touches_deepseek_credentials() {
-        // A DeepSeek key exists and would resolve fine — the gate must run
-        // before the resolver is ever consulted.
+    fn non_chat_completions_completion_never_touches_foreign_credentials() {
+        // A Chat Completions key exists and would resolve fine — the gate must
+        // run before the resolver is ever consulted.
         let resolver = RecordingResolver::new(vec![(
             ApiProvider::Deepseek,
             "deepseek",
@@ -699,9 +704,7 @@ mod tests {
         )]);
         for (provider, identity, model) in [
             (ApiProvider::Anthropic, "anthropic", "claude-sonnet-4"),
-            (ApiProvider::Openai, "openai", "gpt-4.1"),
-            (ApiProvider::Openrouter, "openrouter", "some/model"),
-            (ApiProvider::Custom, "lm-studio", "local-model"),
+            (ApiProvider::OpenaiCodex, "openai-codex", "gpt-5.4"),
             (
                 ApiProvider::DeepseekAnthropic,
                 "deepseek-anthropic",
@@ -726,6 +729,65 @@ mod tests {
             "credential resolution must never be attempted for unsupported routes, got {:?}",
             resolver.asked()
         );
+    }
+
+    #[test]
+    fn chat_completions_routes_launch_with_their_own_credentials() {
+        for (provider, identity, model, base, key) in [
+            (
+                ApiProvider::Deepseek,
+                "deepseek",
+                "deepseek-chat",
+                DEEPSEEK_BASE,
+                DEEPSEEK_KEY,
+            ),
+            (
+                ApiProvider::Openai,
+                "openai",
+                "gpt-5.6",
+                "https://api.openai.com/v1",
+                "sk-openai",
+            ),
+            (
+                ApiProvider::Openrouter,
+                "openrouter",
+                "some/model",
+                "https://openrouter.ai/api/v1",
+                "sk-or",
+            ),
+            (
+                ApiProvider::Custom,
+                "lm-studio",
+                "local-model",
+                "http://127.0.0.1:1234/v1",
+                "lm-key",
+            ),
+            (
+                ApiProvider::Zai,
+                "zai",
+                "GLM-5.3",
+                "https://api.z.ai/api/paas/v4",
+                "zai-key",
+            ),
+        ] {
+            let resolver =
+                RecordingResolver::new(vec![(provider, identity, credentials(key, base, model))]);
+            let authority = route_authority(provider, identity, model, base, key);
+            let route = SuggestionRouteSnapshot {
+                provider,
+                provider_identity: identity,
+                model,
+                authority: &authority,
+                actual_base_url: Some(base),
+            };
+            let launch =
+                plan_suggestion_launch(true, true, 2, Some(route), |route| resolver.resolve(route))
+                    .unwrap_or_else(|| panic!("{provider:?} Chat Completions route must launch"));
+            assert_eq!(launch.api_key, key, "{provider:?}");
+            assert_eq!(launch.base_url, base, "{provider:?}");
+            assert_eq!(launch.model, model, "{provider:?}");
+            assert_eq!(resolver.asked(), vec![(provider, identity.to_string())]);
+        }
     }
 
     #[test]
@@ -1552,16 +1614,14 @@ mod tests {
     #[test]
     fn config_unsupported_providers_capture_no_authority() {
         let _env = seal_deepseek_env();
-        // A usable DeepSeek credential exists in this config, and each route
-        // below is even handed a DeepSeek-shaped receipt. An unsupported
+        // A usable Chat Completions credential exists in this config, and
+        // each route below is even handed a receipt. A Messages/Responses
         // completed route must still capture nothing.
         let config = deepseek_config(DEEPSEEK_KEY, DEEPSEEK_BASE);
 
         for (provider, identity, model) in [
             (ApiProvider::Anthropic, "anthropic", "claude-sonnet-4"),
-            (ApiProvider::Openai, "openai", "gpt-4.1"),
-            (ApiProvider::Openrouter, "openrouter", "some/model"),
-            (ApiProvider::Custom, "lm-studio", "local-model"),
+            (ApiProvider::OpenaiCodex, "openai-codex", "gpt-5.4"),
             (
                 ApiProvider::DeepseekAnthropic,
                 "deepseek-anthropic",

--- a/crates/tui/src/tui/ui/apply.rs
+++ b/crates/tui/src/tui/ui/apply.rs
@@ -1505,6 +1505,63 @@ pub(crate) async fn apply_command_result(
                     app.status_message = Some(format!("Could not cancel {agent_id}"));
                 }
             }
+            AppAction::FetchBalance => {
+                let provider = app.api_provider;
+                if !crate::config::provider_has_balance_api(provider) {
+                    app.add_message(HistoryCell::System {
+                        content: format!(
+                            "Balance check is not supported for {} yet. Check the provider dashboard for account balance details.",
+                            provider.display_name()
+                        ),
+                    });
+                } else {
+                    let api_key = config.deepseek_api_key().unwrap_or_default();
+                    if api_key.trim().is_empty() {
+                        app.add_message(HistoryCell::System {
+                            content: format!(
+                                "No API key configured for {}.",
+                                provider.display_name()
+                            ),
+                        });
+                    } else {
+                        let base_url = config.deepseek_base_url();
+                        match fetch_provider_balance(provider, &api_key, &base_url).await {
+                            Some(info) => {
+                                if let Ok(mut guard) = app.balance_cell.lock() {
+                                    *guard = Some(info.clone());
+                                }
+                                app.last_balance_fetch = Some(Instant::now());
+                                app.add_message(HistoryCell::System {
+                                    content: info.report(provider.display_name()),
+                                });
+                            }
+                            None => {
+                                let fallback = app
+                                    .balance_cell
+                                    .lock()
+                                    .ok()
+                                    .and_then(|guard| guard.clone())
+                                    .and_then(|info| {
+                                        info.chip_label().map(|amount| {
+                                            format!(
+                                                "Could not refresh {} balance; last known: {amount}",
+                                                provider.display_name()
+                                            )
+                                        })
+                                    });
+                                app.add_message(HistoryCell::System {
+                                    content: fallback.unwrap_or_else(|| {
+                                        format!(
+                                            "Could not fetch {} account balance. Check the provider dashboard.",
+                                            provider.display_name()
+                                        )
+                                    }),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
             AppAction::FetchModels => {
                 app.status_message = Some("Fetching models...".to_string());
                 match fetch_available_models(config).await {
@@ -1603,30 +1660,9 @@ pub(crate) async fn apply_command_result(
             }
             AppAction::SwitchProvider { provider, model } => {
                 switch_provider(app, engine_handle, config, provider, model).await;
-                // Refresh balance after provider switch.
-                let balance_cooldown_expired = app
-                    .last_balance_fetch
-                    .is_none_or(|t| t.elapsed() >= BALANCE_FETCH_COOLDOWN);
-                if balance_cooldown_expired && should_fetch_deepseek_balance(app) {
-                    let cell = app.balance_cell.clone();
-                    let api_key = config.deepseek_api_key().unwrap_or_default();
-                    let base_url = config.deepseek_base_url();
-                    if !api_key.is_empty() {
-                        app.last_balance_fetch = Some(Instant::now());
-                        tokio::spawn(async move {
-                            if let Some(info) = fetch_deepseek_balance(&api_key, &base_url).await
-                                && let Ok(mut guard) = cell.lock()
-                            {
-                                *guard = Some(info);
-                            }
-                        });
-                    }
-                } else {
-                    // Clear balance when switching to a non-DeepSeek provider.
-                    if let Ok(mut guard) = app.balance_cell.lock() {
-                        *guard = None;
-                    }
-                }
+                let api_key = config.deepseek_api_key().unwrap_or_default();
+                let base_url = config.deepseek_base_url();
+                schedule_balance_fetch(app, &api_key, &base_url, false);
             }
             AppAction::SwitchModelRoute { provider, model } => {
                 let previous_model = if app.auto_model {

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -1212,23 +1212,13 @@ pub(crate) async fn run_event_loop(
         }
     }
 
-    // Fire a one-shot initial balance fetch for DeepSeek providers
-    // so the footer chip shows balance on the first frame without
+    // Fire a one-shot initial remaining-credit fetch for prepaid
+    // providers so the footer chip can show on the first frame without
     // waiting for a turn to complete.
-    if !app.balance_initiated && should_fetch_deepseek_balance(app) {
-        let cell = app.balance_cell.clone();
+    if !app.balance_initiated {
         let api_key = config.deepseek_api_key().unwrap_or_default();
         let base_url = config.deepseek_base_url();
-        if !api_key.is_empty() {
-            app.last_balance_fetch = Some(Instant::now());
-            tokio::spawn(async move {
-                if let Some(info) = fetch_deepseek_balance(&api_key, &base_url).await
-                    && let Ok(mut guard) = cell.lock()
-                {
-                    *guard = Some(info);
-                }
-            });
-        }
+        schedule_balance_fetch(app, &api_key, &base_url, false);
         app.balance_initiated = true;
     }
 
@@ -2419,28 +2409,12 @@ pub(crate) async fn run_event_loop(
                         // could not be built or queued, the in-flight
                         // checkpoint survives for startup recovery review.
 
-                        // Refresh DeepSeek account balance after each completed
+                        // Refresh prepaid remaining credit after each completed
                         // turn so the footer balance chip stays current without
                         // adding latency to any request path.
-                        let balance_cooldown_expired = app
-                            .last_balance_fetch
-                            .is_none_or(|t| t.elapsed() >= BALANCE_FETCH_COOLDOWN);
-                        if balance_cooldown_expired && should_fetch_deepseek_balance(app) {
-                            let cell = app.balance_cell.clone();
-                            let api_key = config.deepseek_api_key().unwrap_or_default();
-                            let base_url = config.deepseek_base_url();
-                            if !api_key.is_empty() {
-                                app.last_balance_fetch = Some(Instant::now());
-                                tokio::spawn(async move {
-                                    if let Some(info) =
-                                        fetch_deepseek_balance(&api_key, &base_url).await
-                                        && let Ok(mut guard) = cell.lock()
-                                    {
-                                        *guard = Some(info);
-                                    }
-                                });
-                            }
-                        }
+                        let api_key = config.deepseek_api_key().unwrap_or_default();
+                        let base_url = config.deepseek_base_url();
+                        schedule_balance_fetch(app, &api_key, &base_url, false);
 
                         // Legacy pending-steer recovery. Current keyboard
                         // handling keeps Esc as cancel-only, but older saved

--- a/crates/tui/src/tui/ui/provider_routes.rs
+++ b/crates/tui/src/tui/ui/provider_routes.rs
@@ -157,15 +157,131 @@ pub(crate) fn complete_provider_picker_onboarding_if_switched(
     }
 }
 
-/// Fetch the DeepSeek account balance from the balance API.
+/// How one prepaid provider publishes remaining credit. Each variant is a
+/// distinct wire contract — do not send DeepSeek `/user/balance` to a
+/// provider that does not speak it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BalanceApi {
+    DeepSeekUserBalance,
+    OpenRouterCredits,
+    SiliconFlowUserInfo,
+}
+
+fn balance_api_for(provider: ApiProvider) -> Option<BalanceApi> {
+    match provider {
+        ApiProvider::Deepseek | ApiProvider::DeepseekCN => Some(BalanceApi::DeepSeekUserBalance),
+        ApiProvider::Openrouter => Some(BalanceApi::OpenRouterCredits),
+        ApiProvider::Siliconflow | ApiProvider::SiliconflowCn => {
+            Some(BalanceApi::SiliconFlowUserInfo)
+        }
+        _ => None,
+    }
+}
+
+/// Fetch remaining credit for the active prepaid provider.
 ///
-/// Returns `None` on any error (network, auth, parse) — callers should treat
-/// a `None` return as "balance unknown" and keep the previous value.
-pub(crate) async fn fetch_deepseek_balance(
+/// Returns `None` on any error (network, auth, parse) — callers treat that
+/// as "balance unknown" and keep the previous value.
+pub(crate) async fn fetch_provider_balance(
+    provider: ApiProvider,
+    api_key: &str,
+    base_url: &str,
+) -> Option<crate::pricing::BalanceInfo> {
+    let api_key = api_key.trim();
+    if api_key.is_empty() {
+        return None;
+    }
+    match balance_api_for(provider)? {
+        BalanceApi::DeepSeekUserBalance => fetch_deepseek_user_balance(api_key, base_url).await,
+        BalanceApi::OpenRouterCredits => fetch_openrouter_credits(api_key, base_url).await,
+        BalanceApi::SiliconFlowUserInfo => {
+            fetch_siliconflow_user_info(api_key, base_url, provider).await
+        }
+    }
+}
+
+async fn fetch_deepseek_user_balance(
     api_key: &str,
     base_url: &str,
 ) -> Option<crate::pricing::BalanceInfo> {
     let url = format!("{}/user/balance", base_url.trim_end_matches('/'));
+    let body: crate::pricing::BalanceResponse = balance_get_json(api_key, &url).await?;
+    body.balance_infos.into_iter().next()
+}
+
+#[derive(serde::Deserialize)]
+struct OpenRouterCreditsResponse {
+    data: OpenRouterCreditsData,
+}
+
+#[derive(serde::Deserialize)]
+struct OpenRouterCreditsData {
+    total_credits: f64,
+    total_usage: f64,
+}
+
+fn openrouter_remaining_credits(total_credits: f64, total_usage: f64) -> f64 {
+    (total_credits - total_usage).max(0.0)
+}
+
+async fn fetch_openrouter_credits(
+    api_key: &str,
+    base_url: &str,
+) -> Option<crate::pricing::BalanceInfo> {
+    let url = format!("{}/credits", base_url.trim_end_matches('/'));
+    let body: OpenRouterCreditsResponse = balance_get_json(api_key, &url).await?;
+    let remaining = openrouter_remaining_credits(body.data.total_credits, body.data.total_usage);
+    Some(crate::pricing::BalanceInfo {
+        currency: "USD".to_string(),
+        total_balance: format!("{remaining:.2}"),
+        topped_up_balance: format!("{:.2}", body.data.total_credits),
+        granted_balance: String::new(),
+    })
+}
+
+#[derive(serde::Deserialize)]
+struct SiliconFlowUserInfo {
+    data: Option<SiliconFlowUserData>,
+}
+
+#[derive(serde::Deserialize)]
+struct SiliconFlowUserData {
+    #[serde(default, alias = "totalBalance")]
+    total_balance: Option<String>,
+    #[serde(default, alias = "chargeBalance")]
+    charge_balance: Option<String>,
+    #[serde(default)]
+    balance: Option<String>,
+}
+
+async fn fetch_siliconflow_user_info(
+    api_key: &str,
+    base_url: &str,
+    provider: ApiProvider,
+) -> Option<crate::pricing::BalanceInfo> {
+    let url = format!("{}/user/info", base_url.trim_end_matches('/'));
+    let body: SiliconFlowUserInfo = balance_get_json(api_key, &url).await?;
+    let data = body.data?;
+    let total = data
+        .total_balance
+        .as_deref()
+        .or(data.balance.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let currency = if provider == ApiProvider::SiliconflowCn {
+        "CNY"
+    } else {
+        "USD"
+    };
+    Some(crate::pricing::BalanceInfo {
+        currency: currency.to_string(),
+        total_balance: total.to_string(),
+        topped_up_balance: data.charge_balance.unwrap_or_default(),
+        granted_balance: String::new(),
+    })
+}
+
+async fn balance_get_json<T: serde::de::DeserializeOwned>(api_key: &str, url: &str) -> Option<T> {
     let client = &*BALANCE_CLIENT;
     let response = client
         .get(url)
@@ -181,17 +297,62 @@ pub(crate) async fn fetch_deepseek_balance(
         );
         return None;
     }
-    let body: crate::pricing::BalanceResponse = response.json().await.ok()?;
-    // Return the first balance entry (typically the user's primary currency).
-    body.balance_infos.into_iter().next()
+    response.json().await.ok()
 }
 
-pub(crate) fn should_fetch_deepseek_balance(app: &App) -> bool {
+pub(crate) fn should_fetch_provider_balance(app: &App) -> bool {
     app.status_items.contains(&StatusItem::Balance)
-        && matches!(
-            app.api_provider,
-            ApiProvider::Deepseek | ApiProvider::DeepseekCN
-        )
+        && crate::config::provider_has_balance_api(app.api_provider)
+}
+
+/// Kick a background remaining-credit fetch for the live route.
+///
+/// `force` skips the status-item gate (used by `/balance`). Providers without
+/// a known endpoint clear the parked chip so a previous route cannot linger.
+pub(crate) fn schedule_balance_fetch(app: &mut App, api_key: &str, base_url: &str, force: bool) {
+    if !crate::config::provider_has_balance_api(app.api_provider) {
+        if let Ok(mut guard) = app.balance_cell.lock() {
+            *guard = None;
+        }
+        return;
+    }
+    if !force && !should_fetch_provider_balance(app) {
+        return;
+    }
+    if api_key.trim().is_empty() {
+        return;
+    }
+    let cooldown_ok = force
+        || app
+            .last_balance_fetch
+            .is_none_or(|t| t.elapsed() >= BALANCE_FETCH_COOLDOWN);
+    if !cooldown_ok {
+        return;
+    }
+    app.last_balance_fetch = Some(Instant::now());
+    let cell = app.balance_cell.clone();
+    let provider = app.api_provider;
+    let api_key = api_key.to_string();
+    let base_url = base_url.to_string();
+    tokio::spawn(async move {
+        if let Some(info) = fetch_provider_balance(provider, &api_key, &base_url).await
+            && let Ok(mut guard) = cell.lock()
+        {
+            *guard = Some(info);
+        }
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn openrouter_credits_from_json(json: &str) -> Option<crate::pricing::BalanceInfo> {
+    let body: OpenRouterCreditsResponse = serde_json::from_str(json).ok()?;
+    let remaining = openrouter_remaining_credits(body.data.total_credits, body.data.total_usage);
+    Some(crate::pricing::BalanceInfo {
+        currency: "USD".to_string(),
+        total_balance: format!("{remaining:.2}"),
+        topped_up_balance: format!("{:.2}", body.data.total_credits),
+        granted_balance: String::new(),
+    })
 }
 
 /// Route text from either clipboard transport into the canonical provider

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -21574,7 +21574,7 @@ fn default_footer_excludes_provider_specific_diagnostic_chips() {
     );
     assert!(
         !items.contains(&crate::config::StatusItem::Balance),
-        "balance is DeepSeek-only and should not crowd the default footer for non-DeepSeek users"
+        "balance is an opt-in prepaid chip and should not crowd the default footer"
     );
     assert!(
         items.contains(&crate::config::StatusItem::Cache),
@@ -21589,27 +21589,43 @@ fn default_footer_excludes_provider_specific_diagnostic_chips() {
 // ── Balance footer chip tests ─────────────────────────────────────
 
 #[test]
-fn should_fetch_deepseek_balance_requires_balance_status_item() {
+fn should_fetch_provider_balance_requires_balance_status_item() {
     let mut app = create_test_app();
     app.api_provider = ApiProvider::Deepseek;
     app.status_items = crate::config::StatusItem::default_footer();
 
-    assert!(!should_fetch_deepseek_balance(&app));
+    assert!(!should_fetch_provider_balance(&app));
 
     app.status_items.push(crate::config::StatusItem::Balance);
-    assert!(should_fetch_deepseek_balance(&app));
+    assert!(should_fetch_provider_balance(&app));
 }
 
 #[test]
-fn should_fetch_deepseek_balance_requires_deepseek_provider() {
+fn should_fetch_provider_balance_covers_prepaid_providers() {
     let mut app = create_test_app();
     app.status_items = vec![crate::config::StatusItem::Balance];
 
+    app.api_provider = ApiProvider::Ollama;
+    assert!(!should_fetch_provider_balance(&app));
+
     app.api_provider = ApiProvider::Openrouter;
-    assert!(!should_fetch_deepseek_balance(&app));
+    assert!(should_fetch_provider_balance(&app));
+
+    app.api_provider = ApiProvider::Siliconflow;
+    assert!(should_fetch_provider_balance(&app));
 
     app.api_provider = ApiProvider::DeepseekCN;
-    assert!(should_fetch_deepseek_balance(&app));
+    assert!(should_fetch_provider_balance(&app));
+}
+
+#[test]
+fn openrouter_credits_map_remaining_usd() {
+    let info =
+        openrouter_credits_from_json(r#"{"data":{"total_credits":50.0,"total_usage":12.345}}"#)
+            .expect("openrouter credits JSON");
+    assert_eq!(info.currency, "USD");
+    assert_eq!(info.total_balance, "37.66");
+    assert_eq!(info.chip_label().as_deref(), Some("$37.66"));
 }
 
 /// Regression for issue #244: visible session spend must not decrease.

--- a/crates/tui/src/tui/views/status_picker.rs
+++ b/crates/tui/src/tui/views/status_picker.rs
@@ -406,11 +406,13 @@ mod tests {
     }
 
     #[test]
-    fn balance_excluded_for_non_deepseek_provider() {
+    fn balance_offered_for_prepaid_providers_and_hidden_for_local() {
         let active = StatusItem::default_footer();
-        let view = StatusPickerView::new(&active, ApiProvider::Openrouter, Locale::En);
-        assert!(!view.rows.contains(&StatusItem::Balance));
-        assert!(view.rows.contains(&StatusItem::Mode));
+        let openrouter = StatusPickerView::new(&active, ApiProvider::Openrouter, Locale::En);
+        assert!(openrouter.rows.contains(&StatusItem::Balance));
+        let ollama = StatusPickerView::new(&active, ApiProvider::Ollama, Locale::En);
+        assert!(!ollama.rows.contains(&StatusItem::Balance));
+        assert!(ollama.rows.contains(&StatusItem::Mode));
     }
 
     #[test]


### PR DESCRIPTION
Closes #5588

Re-lands #5588 provider neutrality slice (`9ffec9b90`) from `codex/v0912-integration-20260823`.

- Remaining-credit lookup (`/balance` seam covering DeepSeek /user/balance, OpenRouter /credits, SiliconFlow /user/info)
- Un-gate ghost-text prompt suggestions across wire protocols
- Dispatched default model neutrality for MCP servers

Co-authored-by: Grok 4.6 <grok@x.ai>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds live outbound balance calls and broadens prompt-suggestion credential use to more Chat Completions routes; `/balance` still passes `deepseek_api_key`/`deepseek_base_url` from config, which may not match every prepaid provider’s active route.
> 
> **Overview**
> **Provider-neutral prepaid credit** replaces the DeepSeek-only balance scaffold. `/balance` and the optional footer chip use `provider_has_balance_api` (DeepSeek, OpenRouter, SiliconFlow) and `fetch_provider_balance` with per-vendor endpoints (`/user/balance`, `/credits`, `/user/info`), mapped into shared `BalanceInfo` with `chip_label` / `report` formatting. Background refresh is centralized in `schedule_balance_fetch` and runs on startup, after turns, and on provider switch when the Balance status item is enabled.
> 
> **Prompt suggestions** no longer gate on DeepSeek alone: `provider_speaks_chat_completions` drives eligibility so any Chat Completions wire can launch suggestions (with OpenRouter attribution headers inferred from the endpoint). **MCP** omits a hardcoded default model—`mcp_request_model` falls back to `config.default_model()` and the tool schema text reflects the active provider.
> 
> Docs/tests rename “DeepSeek balance” to **prepaid remaining credit** and extend coverage for OpenRouter credit math and status-picker availability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 879e9263551125041820e220bc4b76a9207807ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->