### PR TITLE
test: restore contributor CI baseline and process lifecycle checks

### DIFF
--- a/crates/tui/src/plugins/marketplace/document.rs
+++ b/crates/tui/src/plugins/marketplace/document.rs
@@ -208,20 +208,17 @@ mod tests {
         assert!(!valid_marketplace_name("a".repeat(65).as_str()));
     }
 
+    #[cfg(unix)]
     #[test]
     fn load_refuses_symlink_documents() {
         let dir = tempfile::tempdir().unwrap();
         let real = dir.path().join("real.json");
         std::fs::write(&real, "{}").unwrap();
         let link = dir.path().join("link.json");
-        #[cfg(unix)]
         std::os::unix::fs::symlink(&real, &link).unwrap();
-        #[cfg(not(unix))]
-        let link = real.clone();
 
         let error = load_catalog_document("test", dir.path(), link.to_str().unwrap())
             .expect_err("symlink document must be refused");
-        #[cfg(unix)]
         assert!(error.contains("symlink"), "{error}");
     }
 

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -11191,6 +11191,7 @@ async fn marketplace_catalog_lifecycle_over_http_lists_installs_and_removes() ->
     Ok(())
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn marketplace_add_rejects_symlink_documents_over_http() -> Result<()> {
     let tmp = tempfile::tempdir()?;
@@ -11203,10 +11204,7 @@ async fn marketplace_add_rejects_symlink_documents_over_http() -> Result<()> {
     let real = catalog_dir.join("real.json");
     fs::write(&real, r#"{"plugins":[]}"#)?;
     let link = catalog_dir.join("link.json");
-    #[cfg(unix)]
     std::os::unix::fs::symlink(&real, &link)?;
-    #[cfg(not(unix))]
-    let link = real;
 
     let Some((addr, handle)) = spawn_plugin_api_server(root, workspace).await? else {
         return Ok(());
@@ -11221,10 +11219,7 @@ async fn marketplace_add_rejects_symlink_documents_over_http() -> Result<()> {
         }))
         .send()
         .await?;
-    #[cfg(unix)]
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    #[cfg(not(unix))]
-    assert!(resp.status().is_success());
 
     handle.abort();
     Ok(())

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -3719,7 +3719,8 @@ async fn wait_for_terminal_turn(
                 | RuntimeTurnStatus::Interrupted
                 | RuntimeTurnStatus::Canceled
         );
-        if terminal {
+        let timed_out = Instant::now() >= deadline;
+        if terminal || timed_out {
             let receipt_is_durable =
                 manager
                     .events_since(&turn.thread_id, None)?
@@ -3727,16 +3728,21 @@ async fn wait_for_terminal_turn(
                     .any(|event| {
                         event.event == "turn.completed" && event.turn_id.as_deref() == Some(turn_id)
                     });
-            let claim_is_clear = manager
+            let active_claim_present = manager
                 .active_turn_flags(&turn.thread_id, turn_id)
                 .await
-                .is_none();
-            if receipt_is_durable && claim_is_clear {
+                .is_some();
+            if terminal && receipt_is_durable && !active_claim_present {
                 return Ok(turn);
             }
-        }
-        if Instant::now() >= deadline {
-            bail!("Timed out waiting for turn {turn_id}");
+            if timed_out {
+                bail!(
+                    "Timed out waiting for turn {turn_id}: status={:?}, \
+                     completion_receipt_present={receipt_is_durable}, \
+                     active_claim_present={active_claim_present}",
+                    turn.status
+                );
+            }
         }
         sleep(Duration::from_millis(20)).await;
     }
@@ -5420,7 +5426,8 @@ async fn monitor_separates_lifecycle_start_from_billing_dispatch_and_child_usage
         })
         .await?;
 
-    let completed = wait_for_terminal_turn(&manager, &turn.id, Duration::from_secs(2)).await?;
+    let completed =
+        wait_for_terminal_turn(&manager, &turn.id, TURN_SETTLEMENT_DEADLOCK_TIMEOUT).await?;
     assert_eq!(completed.effective_provider.as_deref(), Some("stepfun"));
     assert_eq!(
         completed.effective_provider_id.as_deref(),

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -722,7 +722,7 @@ impl App {
                 selected_attachment_index: None,
                 slash_menu_selected: 0,
                 slash_menu_hidden: false,
-                    mention_menu_selected: 0,
+                mention_menu_selected: 0,
                 mention_menu_hidden: false,
                 mention_completion_cache: None,
                 mention_discovery: crate::tui::mention_completion::MentionDiscovery::default(),

--- a/crates/tui/src/tui/mouse_ui.rs
+++ b/crates/tui/src/tui/mouse_ui.rs
@@ -337,9 +337,6 @@ fn handle_plugin_cta_mouse(app: &mut App, mouse: MouseEvent) -> Option<Vec<ViewE
     Some(Vec::new())
 }
 
-/// Handle mouse events within the composer area.
-/// Returns true if the event was consumed.
-
 /// Slash-autocomplete rows painted inside the composer. Click selects
 /// (second click on the same row applies, matching the command palette);
 /// wheel moves the highlight. Returns true when the event was consumed so
@@ -349,12 +346,13 @@ fn handle_slash_autocomplete_mouse(app: &mut App, mouse: MouseEvent) -> bool {
     if hitboxes.is_empty() {
         return false;
     }
-    let over_row = hitboxes.iter().find_map(|(idx, rect)| {
-        mouse_hits_rect(mouse, Some(*rect)).then_some(*idx)
-    });
+    let over_row = hitboxes
+        .iter()
+        .find_map(|(idx, rect)| mouse_hits_rect(mouse, Some(*rect)).then_some(*idx));
     let over_menu = over_row.is_some()
         || hitboxes.iter().any(|(_, rect)| {
-            mouse.row >= rect.y && mouse.row < rect.y.saturating_add(rect.height)
+            mouse.row >= rect.y
+                && mouse.row < rect.y.saturating_add(rect.height)
                 && mouse.column >= rect.x
                 && mouse.column < rect.x.saturating_add(rect.width)
         });
@@ -405,6 +403,8 @@ fn handle_slash_autocomplete_mouse(app: &mut App, mouse: MouseEvent) -> bool {
     }
 }
 
+/// Handle mouse events within the composer area.
+/// Returns true if the event was consumed.
 pub(crate) fn handle_composer_mouse(app: &mut App, mouse: MouseEvent) -> bool {
     // Use outer area for hit-testing (includes border).
     let Some(area) = app.viewport.last_composer_area else {
@@ -1973,8 +1973,6 @@ mod tests {
         crate::tui::hover_layer::clear_pointer();
     }
 
-
-
     #[test]
     fn slash_autocomplete_click_selects_and_second_click_applies() {
         let mut app = create_test_app();
@@ -1986,18 +1984,22 @@ mod tests {
         app.slash_menu_selected = 0;
         // Simulate two painted rows from ComposerWidget.
         app.viewport.last_composer_area = Some(Rect::new(0, 18, 80, 6));
-        *app.viewport.last_slash_menu_hitboxes.borrow_mut() = vec![
-            (0, Rect::new(1, 20, 78, 1)),
-            (1, Rect::new(1, 21, 78, 1)),
-        ];
+        *app.viewport.last_slash_menu_hitboxes.borrow_mut() =
+            vec![(0, Rect::new(1, 20, 78, 1)), (1, Rect::new(1, 21, 78, 1))];
 
         assert!(
             handle_composer_mouse(&mut app, left_click(5, 21)),
             "slash row click must be consumed by the composer"
         );
-        assert_eq!(app.slash_menu_selected, 1, "click on another row highlights it");
+        assert_eq!(
+            app.slash_menu_selected, 1,
+            "click on another row highlights it"
+        );
         let before = app.input.clone();
-        assert_eq!(before, "/he", "select-only click must not rewrite the composer");
+        assert_eq!(
+            before, "/he",
+            "select-only click must not rewrite the composer"
+        );
 
         assert!(handle_composer_mouse(&mut app, left_click(5, 21)));
         assert_ne!(app.input, before, "click on the highlighted row applies it");
@@ -2018,10 +2020,8 @@ mod tests {
         app.slash_menu_hidden = false;
         app.slash_menu_selected = 0;
         app.viewport.last_composer_area = Some(Rect::new(0, 18, 80, 6));
-        *app.viewport.last_slash_menu_hitboxes.borrow_mut() = vec![
-            (0, Rect::new(1, 20, 78, 1)),
-            (1, Rect::new(1, 21, 78, 1)),
-        ];
+        *app.viewport.last_slash_menu_hitboxes.borrow_mut() =
+            vec![(0, Rect::new(1, 20, 78, 1)), (1, Rect::new(1, 21, 78, 1))];
         let entries = crate::tui::slash_menu::visible_slash_menu_entries(&app, 128);
         assert!(entries.len() >= 2, "prefix must offer multiple entries");
 
@@ -2047,7 +2047,6 @@ mod tests {
         ));
         assert_eq!(app.slash_menu_selected, 0);
     }
-
 
     #[test]
     fn send_click_matches_the_keyboard_submit_and_focus_never_leaves_the_composer() {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4927,7 +4927,10 @@ fn paste_burst_does_not_leak_into_composer_while_a_modal_owns_keys() {
         &mut app,
         now + crate::tui::paste_burst::PasteBurst::recommended_flush_delay(),
     );
-    assert!(!flushed, "modal-owned keys must not flush into the composer");
+    assert!(
+        !flushed,
+        "modal-owned keys must not flush into the composer"
+    );
     assert!(
         app.input.is_empty() || app.input == "/",
         "composer must not gain leaked burst text under a modal: {:?}",

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1359,7 +1359,11 @@ impl Renderable for ComposerWidget<'_> {
     fn render(&self, area: Rect, buf: &mut Buffer) {
         // Slash rows are re-recorded below; clear first so a closed or
         // resized menu cannot keep stale hitboxes from the prior frame.
-        self.app.viewport.last_slash_menu_hitboxes.borrow_mut().clear();
+        self.app
+            .viewport
+            .last_slash_menu_hitboxes
+            .borrow_mut()
+            .clear();
         let background = Style::default().bg(self.app.ui_theme.composer_bg);
         let has_panel = self.has_panel(area);
         let inner_area = self.inner_area(area);
@@ -1826,10 +1830,7 @@ impl Renderable for ComposerWidget<'_> {
                         .viewport
                         .last_slash_menu_hitboxes
                         .borrow_mut()
-                        .push((
-                            idx,
-                            Rect::new(inner_area.x, row_y, inner_area.width, 1),
-                        ));
+                        .push((idx, Rect::new(inner_area.x, row_y, inner_area.width, 1)));
                 }
 
                 if name_was_truncated || description_was_truncated {

--- a/crates/tui/tests/cucumber/active_composer_pointer_pty.rs
+++ b/crates/tui/tests/cucumber/active_composer_pointer_pty.rs
@@ -341,9 +341,13 @@ fn assert_startup_contract(frame: &Frame, rows: u16, cols: u16, size: &str) {
 
 fn assert_live_shell_contract(frame: &Frame, cols: u16, size: &str) {
     let text = frame.text();
+    // The bottom metrics row owns the model; repository state belongs to
+    // the launch header and git view. This sealed offline session uses the
+    // default model, which must remain visible even at 40 columns.
+    let metrics = frame.row(frame.rows().saturating_sub(1));
     assert!(
-        text.contains("no git"),
-        "{size}: live shell misses the info line\n{}",
+        metrics.contains("deepseek-v4-pro"),
+        "{size}: live shell misses the model in the metrics line\n{}",
         frame.debug_dump()
     );
     // The shell advertises one help route per surface: the info line's

--- a/crates/tui/tests/cucumber/plugin_e2e_acceptance.rs
+++ b/crates/tui/tests/cucumber/plugin_e2e_acceptance.rs
@@ -693,19 +693,22 @@ fn review_confirmation_in_text(text: &str) -> Option<String> {
     // The confirmation is `/plugin trust demo <64-hex>.<64-hex>` (129 chars).
     // Transcript cards wrap well before that, so a single rendered line no
     // longer holds the token. Join trimmed lines and recover the two digests.
+    // The transcript may also retain an earlier partial command, so scan every
+    // marker instead of rejecting after the first malformed candidate.
     let joined: String = text.lines().map(str::trim).collect();
     let marker = "/plugin trust demo ";
-    let start = joined.find(marker)?;
-    let token: String = joined[start + marker.len()..]
-        .chars()
-        .take_while(|ch| ch.is_ascii_hexdigit() || *ch == '.')
-        .collect();
-    let (content, capability) = token.split_once('.')?;
-    (content.len() == 64
-        && capability.len() == 64
-        && content.chars().all(|ch| ch.is_ascii_hexdigit())
-        && capability.chars().all(|ch| ch.is_ascii_hexdigit()))
-    .then(|| format!("{marker}{content}.{capability}"))
+    joined.match_indices(marker).find_map(|(start, _)| {
+        let token: String = joined[start + marker.len()..]
+            .chars()
+            .take_while(|ch| ch.is_ascii_hexdigit() || *ch == '.')
+            .collect();
+        let (content, capability) = token.split_once('.')?;
+        (content.len() == 64
+            && capability.len() == 64
+            && content.chars().all(|ch| ch.is_ascii_hexdigit())
+            && capability.chars().all(|ch| ch.is_ascii_hexdigit()))
+        .then(|| format!("{marker}{content}.{capability}"))
+    })
 }
 
 #[cfg(all(unix, feature = "long-running-tests"))]
@@ -970,11 +973,11 @@ async fn plugin_toml_binary_lifecycle_skill_and_stdio_mcp_acceptance() {
 
 #[cfg(all(unix, feature = "long-running-tests"))]
 #[test]
-fn review_confirmation_survives_transcript_wrap() {
+fn review_confirmation_skips_partial_candidates_and_survives_transcript_wrap() {
     let content = "a".repeat(64);
     let capability = "b".repeat(64);
     let wrapped = format!(
-        "  /plugin trust demo {head}\n  {mid}\n  {tail}\n",
+        "/plugin trust demo partial\n  /plugin trust demo {head}\n  {mid}\n  {tail}\n",
         head = &format!("{content}.{capability}")[..40],
         mid = &format!("{content}.{capability}")[40..90],
         tail = &format!("{content}.{capability}")[90..],

--- a/crates/tui/tests/integration/exec_persistent_service.rs
+++ b/crates/tui/tests/integration/exec_persistent_service.rs
@@ -18,7 +18,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock, mpsc};
 use std::time::{Duration, Instant};
 
 async fn serialize_persistent_service_tests() -> tokio::sync::MutexGuard<'static, ()> {
@@ -129,13 +129,14 @@ fn json_response(value: Value) -> ResponseTemplate {
 }
 
 /// Sequential provider: first POST stages the service; later POSTs get the
-/// scenario's second turn. An optional delay on the second turn holds the
-/// exec mid-turn for the signal scenario.
+/// scenario's second turn. The failure scenario waits for explicit service
+/// readiness; an optional delay holds the exec mid-turn for the signal case.
 struct SequentialTurns {
     requests: Arc<AtomicUsize>,
     stage_command: String,
     second_turn: String,
     second_turn_delay: Option<Duration>,
+    second_turn_ready: Option<Mutex<mpsc::Receiver<()>>>,
 }
 
 impl Respond for SequentialTurns {
@@ -144,6 +145,17 @@ impl Respond for SequentialTurns {
         if call == 0 {
             sse_response(stage_service_sse(&self.stage_command))
         } else {
+            if call == 1
+                && let Some(ready) = &self.second_turn_ready
+                && ready
+                    .lock()
+                    .expect("service readiness receiver")
+                    .recv_timeout(RUN_TIMEOUT)
+                    .is_err()
+            {
+                return ResponseTemplate::new(504)
+                    .set_body_string("test did not confirm service readiness");
+            }
             let response = sse_response(self.second_turn.clone());
             match self.second_turn_delay {
                 Some(delay) => response.set_delay(delay),
@@ -157,6 +169,7 @@ async fn start_mock_llm(
     stage_command: &str,
     second_turn: String,
     second_turn_delay: Option<Duration>,
+    second_turn_ready: Option<mpsc::Receiver<()>>,
 ) -> MockServer {
     let server = MockServer::start().await;
 
@@ -176,6 +189,7 @@ async fn start_mock_llm(
             stage_command: stage_command.to_string(),
             second_turn,
             second_turn_delay,
+            second_turn_ready: second_turn_ready.map(Mutex::new),
         })
         .mount(&server)
         .await;
@@ -299,26 +313,20 @@ fn kill_process_group(pid: i32) {
     }
 }
 
-fn wait_for_pid_file(path: &Path) -> i32 {
-    // Staging latency is setup, not the assertion under test, and 30s was
-    // tuned against a lightly loaded host. On a machine running the whole
-    // 14k-test suite at once, staging a real child process past 30s is
-    // ordinary, and the suite reported it as "service pid file never
-    // appeared" -- a product failure that was not one. Bound it to the same
-    // budget the run itself uses so a service that genuinely never starts is
-    // still a failure, and load alone is not.
+fn wait_for_pid_file(path: &Path) -> Result<i32, String> {
     let deadline = Instant::now() + RUN_TIMEOUT;
     loop {
         if let Ok(contents) = std::fs::read_to_string(path)
             && let Ok(pid) = contents.trim().parse::<i32>()
         {
-            return pid;
+            return Ok(pid);
         }
-        assert!(
-            Instant::now() < deadline,
-            "service pid file never appeared at {}",
-            path.display()
-        );
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "service pid file never appeared at {}",
+                path.display()
+            ));
+        }
         std::thread::sleep(Duration::from_millis(50));
     }
 }
@@ -340,7 +348,7 @@ const SERVICE_COMMAND: &str = "echo $$ > service.pid; exec sleep 600";
 #[tokio::test(flavor = "multi_thread")]
 async fn successful_exec_releases_persisted_service() {
     let _serial = serialize_persistent_service_tests().await;
-    let server = start_mock_llm(SERVICE_COMMAND, final_answer_sse(), None).await;
+    let server = start_mock_llm(SERVICE_COMMAND, final_answer_sse(), None, None).await;
     let workspace = TempDir::new().expect("workspace tempdir");
     let home = TempDir::new().expect("home tempdir");
 
@@ -360,7 +368,8 @@ async fn successful_exec_releases_persisted_service() {
     let stdout = join_pipe(stdout_reader, "stdout");
     let stderr = join_pipe(stderr_reader, "stderr");
 
-    let service_pid = wait_for_pid_file(&workspace.path().join("service.pid"));
+    let service_pid = wait_for_pid_file(&workspace.path().join("service.pid"))
+        .unwrap_or_else(|error| panic!("{error}\nstdout:\n{stdout}\nstderr:\n{stderr}"));
     let events = stream_events(&stdout);
     let released = events
         .iter()
@@ -393,7 +402,14 @@ async fn successful_exec_releases_persisted_service() {
 #[tokio::test(flavor = "multi_thread")]
 async fn failed_exec_kills_pending_service_and_exits_nonzero() {
     let _serial = serialize_persistent_service_tests().await;
-    let server = start_mock_llm(SERVICE_COMMAND, incomplete_answer_sse(), None).await;
+    let (service_ready, service_ready_receiver) = mpsc::channel();
+    let server = start_mock_llm(
+        SERVICE_COMMAND,
+        incomplete_answer_sse(),
+        None,
+        Some(service_ready_receiver),
+    )
+    .await;
     let workspace = TempDir::new().expect("workspace tempdir");
     let home = TempDir::new().expect("home tempdir");
 
@@ -403,18 +419,42 @@ async fn failed_exec_kills_pending_service_and_exits_nonzero() {
     let stdout_reader = read_pipe_in_background(child.stdout.take().expect("stdout pipe"));
     let stderr_reader = read_pipe_in_background(child.stderr.take().expect("stderr pipe"));
 
-    // Observe the pid file while the exec is still running, exactly as
-    // `terminating_signal_kills_pending_service_and_exits_nonzero` does. Read
-    // after the wait, this raced the very teardown under test: a failing exec
-    // kills its pending service on the way out, so the file could be gone (or
-    // never written) by the time the process had exited. Isolated, staging won
-    // the race; under a loaded CI host it lost, and the suite reported
-    // "service pid file never appeared" as a product failure.
-    //
-    // The order also states the precondition properly: this case is about
-    // killing a service that *was* pending, so the staging must be observed
-    // before the exit, not inferred after it.
-    let service_pid = wait_for_pid_file(&workspace.path().join("service.pid"));
+    // Spawning a background process does not mean its first instruction ran.
+    // Hold the deliberate model failure until the real service is ready, so
+    // cancellation cannot kill it before it writes the PID we need to check.
+    let service_pid = match wait_for_pid_file(&workspace.path().join("service.pid")) {
+        Ok(pid) => pid,
+        Err(error) => {
+            drop(service_ready);
+            // Let the host clean up its managed services before forcing exit.
+            // SAFETY: direct child of this test.
+            unsafe {
+                libc::kill(
+                    i32::try_from(child.id()).expect("child pid fits i32"),
+                    libc::SIGTERM,
+                );
+            }
+            if child
+                .wait_timeout(Duration::from_secs(5))
+                .ok()
+                .flatten()
+                .is_none()
+            {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            let stdout = join_pipe(stdout_reader, "stdout");
+            let stderr = join_pipe(stderr_reader, "stderr");
+            panic!("{error}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        }
+    };
+    assert!(
+        pid_is_alive(service_pid),
+        "service must be alive before the model fails"
+    );
+    service_ready
+        .send(())
+        .expect("release the deliberate model failure");
 
     let status = match child.wait_timeout(RUN_TIMEOUT).expect("wait for exec") {
         Some(status) => status,
@@ -449,6 +489,7 @@ async fn terminating_signal_kills_pending_service_and_exits_nonzero() {
         SERVICE_COMMAND,
         final_answer_sse(),
         Some(Duration::from_secs(300)),
+        None,
     )
     .await;
     let workspace = TempDir::new().expect("workspace tempdir");
@@ -461,7 +502,8 @@ async fn terminating_signal_kills_pending_service_and_exits_nonzero() {
     let stderr_reader = read_pipe_in_background(child.stderr.take().expect("stderr pipe"));
 
     // The pid file proves the service was staged before the signal.
-    let service_pid = wait_for_pid_file(&workspace.path().join("service.pid"));
+    let service_pid = wait_for_pid_file(&workspace.path().join("service.pid"))
+        .unwrap_or_else(|error| panic!("{error}"));
     assert!(pid_is_alive(service_pid));
 
     // SAFETY: direct child of this test.

--- a/scripts/mobile-smoke.sh
+++ b/scripts/mobile-smoke.sh
@@ -165,44 +165,27 @@ assert_status GET "/v1/threads/summary" 200
 
 stop_server
 
-# ── Test Group 3: Binding warnings ──────────────────────────────────────────
+# ── Test Group 3: Non-loopback binding rejection ────────────────────────────
 
 PORT=$(pick_port)
 
-log "=== Test Group 3: Binding warnings (0.0.0.0 default) ==="
-STDOUT_FILE=$(mktemp)
-"$BINARY" serve --port "$PORT" --mobile --insecure > "$STDOUT_FILE" 2>&1 &
-SERVER_PID=$!
-SERVER_READY=0
-for _ in $(seq 1 30); do
-    if curl -sf --max-time 2 "http://127.0.0.1:${PORT}/health" > /dev/null 2>&1; then
-        SERVER_READY=1
-        break
-    fi
-    sleep 0.3
-done
-if [[ "$SERVER_READY" -ne 1 ]]; then
-    rm -f "$STDOUT_FILE"
-    fail "Server did not become ready on port $PORT"
-    cleanup
-    exit 1
-fi
-STDOUT=$(cat "$STDOUT_FILE")
-rm -f "$STDOUT_FILE"
+log "=== Test Group 3: Reject non-loopback mobile binding ==="
+set +e
+BIND_OUTPUT=$("$BINARY" serve --host 0.0.0.0 --port "$PORT" --mobile --insecure 2>&1)
+BIND_STATUS=$?
+set -e
 
-if echo "$STDOUT" | grep -q "0.0.0.0"; then
-    pass "stdout/stderr contains 0.0.0.0 binding warning"
+if [[ "$BIND_STATUS" -ne 0 ]]; then
+    pass "mobile rejects a 0.0.0.0 binding"
 else
-    fail "stdout/stderr missing 0.0.0.0 binding warning"
+    fail "mobile unexpectedly accepted a 0.0.0.0 binding"
 fi
 
-if echo "$STDOUT" | grep -qi "mobile"; then
-    pass "stdout contains mobile URL hint"
+if echo "$BIND_OUTPUT" | grep -qi "loopback-only"; then
+    pass "rejection explains the loopback-only boundary"
 else
-    fail "stdout missing mobile URL hint"
+    fail "rejection missing loopback-only guidance"
 fi
-
-stop_server
 
 # ── summary ──────────────────────────────────────────────────────────────────
 

--- a/scripts/mobile-smoke.sh
+++ b/scripts/mobile-smoke.sh
@@ -171,11 +171,39 @@ PORT=$(pick_port)
 
 log "=== Test Group 3: Reject non-loopback mobile binding ==="
 set +e
-BIND_OUTPUT=$("$BINARY" serve --host 0.0.0.0 --port "$PORT" --mobile --insecure 2>&1)
+BIND_OUTPUT=$(python3 - "$BINARY" "$PORT" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+probe = subprocess.Popen(
+    [sys.argv[1], "serve", "--host", "0.0.0.0", "--port", sys.argv[2], "--mobile", "--insecure"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    start_new_session=True,
+)
+try:
+    output, _ = probe.communicate(timeout=10)
+except subprocess.TimeoutExpired:
+    try:
+        os.killpg(probe.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    output, _ = probe.communicate()
+    sys.stdout.buffer.write(output)
+    print("Non-loopback rejection probe timed out; terminated and reaped its process group.")
+    sys.exit(124)
+sys.stdout.buffer.write(output)
+sys.exit(probe.returncode)
+PY
+)
 BIND_STATUS=$?
 set -e
 
-if [[ "$BIND_STATUS" -ne 0 ]]; then
+if [[ "$BIND_STATUS" -eq 124 ]]; then
+    fail "mobile did not reject a 0.0.0.0 binding within 10 seconds"
+elif [[ "$BIND_STATUS" -ne 0 ]]; then
     pass "mobile rejects a 0.0.0.0 binding"
 else
     fail "mobile unexpectedly accepted a 0.0.0.0 binding"


### PR DESCRIPTION
Restore contributor CI so unrelated PRs can be evaluated against a working baseline. Plugin lifecycle fixtures now supply the required trust token, Unix symlink tests stay off Windows, the pointer assertion uses the current compact footer, and formatting/doc comments match the compiler and formatter.

Process fixtures wait for observable readiness and remain bounded: the deliberately failing persistent service must publish its PID before the model error; the mobile non-loopback refusal probe kills and reaps an unexpectedly surviving child. The monitor receipt fixture uses the existing ten-second settlement watchdog because its former two-second deadline was shorter than the event store's valid five-second transaction-lock allowance. Timeout output reports status, completion-receipt presence and active-claim presence; every route, billing, usage and cleanup assertion remains.

No-Issue: repairs failures reproduced on public main and this PR's hosted CI. Includes Paulo Aboim Pinto's original commits with authorship and GitHub-linked co-author credit preserved.

Validation:

- Public repair base `3dafb52`: macOS workspace/all-feature nextest CI profile **14,229 passed, 0 failed, 15 skipped**; CI-flags workspace Clippy and formatting passed. Real pointer acceptance passed at five terminal sizes.
- Mobile probe correction `6046ed7`: actual smoke **9 passed, 0 failed**. Controlled invalid-bind acceptance produced the expected **8 passed, 1 failed**, nonzero exit within the deadline, and reaped the child.
- Current monitor correction `59cc5eb`: related runtime-thread tests **157 passed, 0 failed**, retries disabled; focused fixture **1 passed, 0 failed**. Formatting and diff checks passed. A bounded old-binary load check passed 24/24 and did not reproduce the hosted timeout; the exact Windows host cause remains unproved.
- Root `npm test && npm run check:web` is unavailable in this Rust repository (`Missing script: test`; zero npm tests). No claim is made that these commands passed.

Hosted Linux, lint, mobile and Buildkite checks passed at `6046ed7`. Its Windows run had **13,880 passed, 1 failed, 14 skipped**; the failed monitor fixture is addressed above. Full hosted checks must pass on current head before merge.
