### PR TITLE
ci(release): give the parity job room for its cache save

### DIFF
--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -665,7 +665,9 @@ for (const job of ["bundle", "windows-installer", "assemble", "smoke"]) {
 }
 assert.equal(jobTimeout(nightly, "build"), 90);
 assert.equal(jobTimeout(release, "resolve"), 10);
-assert.equal(jobTimeout(release, "parity"), 20);
+// The v0.9.12 tag push finished every parity step and was then cancelled at
+// 20 minutes inside rust-cache's post-run save; 45 keeps that margin.
+assert.equal(jobTimeout(release, "parity"), 45);
 
 console.log(
   "Workflow contracts OK: 6-target/12-asset single-runtime nightly and exact-head 7-target/34-asset release candidate.",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         run: node scripts/release/ensure-release-assets-absent.js "${GITHUB_REPOSITORY}" "${TAG}"
 
   parity:
-    timeout-minutes: 20
+    timeout-minutes: 45
     needs: resolve
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The v0.9.12 tag push ran release.yml parity to a clean pass on every step and was then cancelled at the 20-minute job timeout during the rust-cache post-run save, skipping artifacts/release/npm/docker/homebrew. This raises the parity bound to 45 minutes. Workflow-only change; release-workflows contract test passes.

No-Issue: CI hardening found during the v0.9.12 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bs5x11yXAg3sJ4giZf4krF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow timeout-only change with no application or release-logic edits; it reduces false timeouts on tag releases.
> 
> **Overview**
> Raises the **release** workflow **`parity`** job limit from **20 to 45 minutes** so the job can finish **`rust-cache`**’s post-run cache save after the Rust gates complete.
> 
> The contract test in **`release-workflows.test.js`** now expects **45 minutes**, with a note that **v0.9.12** hit the old cap during cache save even though every parity step had already passed—downstream **artifacts**, **release**, **npm**, **docker**, and **homebrew** never ran.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aa6bc952d31cd4416922a668478f7f735880c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->