### PR TITLE
fix(web): make the homepage terminal preview more compact

### DIFF
--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -97,7 +97,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
               alt={d.screenshotAlt}
               width={2760}
               height={1494}
-              sizes="(max-width: 1280px) calc(100vw - 2rem), 1248px"
+              sizes="(max-width: 928px) calc(100vw - 2rem), 896px"
               priority
             />
             <figcaption>

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -97,7 +97,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
               alt={d.screenshotAlt}
               width={2760}
               height={1494}
-              sizes="(max-width: 928px) calc(100vw - 2rem), 896px"
+              sizes="(max-width: 58rem) calc(100vw - 2rem), 56rem"
               priority
             />
             <figcaption>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4065,14 +4065,14 @@ html[data-theme="dark"] .docs-theme {
   font-size: 1.4rem;
 }
 
-/* The terminal is the main product image, at a readable full-column scale. */
+/* Keep the terminal centered and compact beneath the introductory copy. */
 .folio-hero-grid { grid-template-columns: minmax(0, 1fr); grid-template-rows: auto auto auto; row-gap: 2rem; }
 .folio-hero-copy { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); column-gap: clamp(2rem, 5vw, 5rem); max-width: none; grid-column: 1; grid-row: 1; padding-bottom: 0; }
 .folio-hero-copy .folio-kicker { grid-column: 1 / -1; }
 .folio-hero-copy h1 { grid-column: 1; grid-row: 2 / 4; font-size: clamp(2.75rem, 5vw, 4.5rem); }
 .folio-hero-copy .folio-lede { grid-column: 2; grid-row: 2; margin-top: 0; align-self: end; }
 .folio-hero-copy .folio-actions { grid-column: 2; grid-row: 3; align-self: start; margin-top: 1.25rem; }
-.folio-shot { grid-column: 1; grid-row: 2; width: 100%; margin-top: 0; }
+.folio-shot { grid-column: 1; grid-row: 2; width: min(100%, 56rem); justify-self: center; margin-top: 0; }
 .folio-chapter { grid-column: 1; grid-row: 3; justify-self: start; }
 .product-install-grid > div, .product-composer, .product-composer > div { min-width: 0; }
 @media (max-width: 760px) {


### PR DESCRIPTION
## Summary

The homepage terminal stretched across the full desktop content column and overwhelmed the introduction. Cap it at 896px and center it; keep mobile full width and preserve the screenshot's aspect ratio. Match the responsive image sizes to the rendered width.

## Testing

- Website `npm test`: 407 passed, 0 failed across 47 files.
- Website `npm run lint`: no errors; two existing image warnings in untouched navigation/footer components.
- Browser verified at 1280px (896px terminal) and 390px (343px terminal, no horizontal overflow).

No-Issue: direct founder request to reduce the homepage terminal preview size.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only homepage CSS and responsive image hints; no auth, data, or routing changes.
> 
> **Overview**
> The homepage hero terminal no longer spans the full content column on desktop. **CSS** caps `.folio-shot` at **56rem** (~896px), centers it under the intro copy, and keeps it **full width** below **760px**. The hero grid comment now describes a compact, centered shot rather than a full-column product image.
> 
> The **Next.js `Image` `sizes`** attribute is updated to match (**58rem** breakpoint, **56rem** max) so the browser picks appropriately sized assets for the smaller rendered width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e0355128b4c4cc5304dcd51affed0bf3c7372e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->