### PR TITLE
fix(mcp): show startup progress as each server connects

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -6484,18 +6484,19 @@ impl Engine {
             async move {
                 let mut remaining: Vec<String> =
                     pending.iter().map(|(name, _)| name.clone()).collect();
-                let results = McpPool::connect_pending_concurrently(
+                let mut connects = McpPool::spawn_pending_connects(
                     pending,
                     timeouts,
                     network_policy,
                     catalog_generation,
-                )
-                .await;
+                );
                 let mut connection_errors = HashMap::new();
-                {
-                    let mut pool = pool_for_task.lock().await;
-                    for (name, result) in results {
-                        remaining.retain(|pending_name| pending_name != &name);
+                while let Some(joined) = connects.join_next().await {
+                    let (name, result) = joined
+                        .unwrap_or_else(|error| ("connection task".to_string(), Err(error.into())));
+                    remaining.retain(|pending_name| pending_name != &name);
+                    {
+                        let mut pool = pool_for_task.lock().await;
                         match result {
                             Ok(connection) => pool.store_ready_connection(name, connection),
                             Err(error) => {
@@ -6504,13 +6505,16 @@ impl Engine {
                                     .insert(name, crate::mcp::format_mcp_error_for_display(&error));
                             }
                         }
-                        let _ = progress_tx.send(McpBootUpdate::Progress {
-                            generation,
-                            authority_errors: Arc::clone(&authority_errors),
-                            connection_errors: connection_errors.clone(),
-                            connecting: remaining.clone(),
-                        });
                     }
+                    let _ = progress_tx.send(McpBootUpdate::Progress {
+                        generation,
+                        authority_errors: Arc::clone(&authority_errors),
+                        connection_errors: connection_errors.clone(),
+                        connecting: remaining.clone(),
+                    });
+                }
+                {
+                    let pool = pool_for_task.lock().await;
                     let mut required = Vec::new();
                     pool.push_required_server_errors(&mut required);
                     for (name, error) in required {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -6329,6 +6329,7 @@ impl Engine {
                 }
                 self.mcp_event_generation = generation;
                 self.replace_mcp_boot_errors(&authority_errors, connection_errors);
+                self.session.pending_prefix_change_reason = Some("mcp-session-boot".to_string());
                 if let Ok(snapshot) = self.mcp_session_snapshot().await {
                     let _ = self.tx_event.try_send(Event::McpSessionBoot {
                         generation,
@@ -6382,6 +6383,8 @@ impl Engine {
                     }
                     self.mcp_event_generation = generation;
                     self.replace_mcp_boot_errors(&authority_errors, connection_errors);
+                    self.session.pending_prefix_change_reason =
+                        Some("mcp-session-boot".to_string());
                 }
                 McpBootUpdate::Finished {
                     generation,
@@ -6497,13 +6500,30 @@ impl Engine {
                     remaining.retain(|pending_name| pending_name != &name);
                     {
                         let mut pool = pool_for_task.lock().await;
-                        match result {
-                            Ok(connection) => pool.store_ready_connection(name, connection),
-                            Err(error) => {
-                                pool.note_connect_failure(&name, &error);
-                                connection_errors
-                                    .insert(name, crate::mcp::format_mcp_error_for_display(&error));
+                        // A turn may have reloaded the pool while these handshakes
+                        // were in flight. Never let their old authority or failures
+                        // overwrite the newly installed configuration.
+                        let reload = pool.reload_if_config_changed().await;
+                        if reload.is_err()
+                            || pool.current_catalog_generation() != catalog_generation
+                        {
+                            connects.abort_all();
+                            connection_errors.clear();
+                            if let Err(error) = reload {
+                                connection_errors.insert(
+                                    "configuration".to_string(),
+                                    crate::mcp::format_mcp_error_for_display(&error),
+                                );
                             }
+                            break;
+                        }
+                        let result = result.and_then(|connection| {
+                            pool.store_ready_connection(name.clone(), connection)
+                        });
+                        if let Err(error) = result {
+                            pool.note_connect_failure(&name, &error);
+                            connection_errors
+                                .insert(name, crate::mcp::format_mcp_error_for_display(&error));
                         }
                     }
                     let _ = progress_tx.send(McpBootUpdate::Progress {
@@ -6613,8 +6633,9 @@ impl Engine {
         if self.mcp_boot_in_flight {
             // Optional servers are still connecting in the background. Snapshot
             // currently-ready tools so the first LLM call is not serialized
-            // behind the slowest handshake. The catalog refreshes on a later
-            // turn once boot settles (KV-cache prefix re-pin: mcp-session-boot).
+            // behind the slowest handshake. Declare the refresh here as well
+            // as on Progress: a ready connection can precede its mailbox update.
+            self.session.pending_prefix_change_reason = Some("mcp-session-boot".to_string());
             return pool.lock().await.to_api_tools();
         }
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -20770,7 +20770,7 @@ async fn assert_incremental_mcp_boot(invalidate_config: bool) {
         .output()
         .is_err()
     {
-        eprintln!("skipping MCP stdio fixture because node is unavailable");
+        tracing::warn!("skipping MCP stdio fixture because node is unavailable");
         return;
     }
     let tmp = tempdir().expect("tempdir");

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -20756,6 +20756,23 @@ async fn reload_mcp_op_recovers_from_invalid_initial_config_in_process() {
 
 #[tokio::test]
 async fn mcp_boot_reports_ready_server_before_stalled_server_finishes() {
+    assert_incremental_mcp_boot(false).await;
+}
+
+#[tokio::test]
+async fn mcp_boot_does_not_restore_servers_removed_during_handshake() {
+    assert_incremental_mcp_boot(true).await;
+}
+
+async fn assert_incremental_mcp_boot(invalidate_config: bool) {
+    if std::process::Command::new("node")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping MCP stdio fixture because node is unavailable");
+        return;
+    }
     let tmp = tempdir().expect("tempdir");
     let server = tmp.path().join("server.mjs");
     let release = tmp.path().join("release-slow");
@@ -20794,14 +20811,15 @@ lines.on('line', async (line) => {
         .expect("config JSON"),
     )
     .expect("MCP config");
-    let (engine, handle) = Engine::new(
+    let (mut engine, handle) = Engine::new(
         EngineConfig {
             workspace: tmp.path().to_path_buf(),
-            mcp_config_path: config_path,
+            mcp_config_path: config_path.clone(),
             ..Default::default()
         },
         &Config::default(),
     );
+    let pool = engine.ensure_mcp_pool().await.expect("engine pool");
     let task = tokio::spawn(async move { engine.run().await });
     let mut events = handle.rx_event.write().await;
     let progress = tokio::time::timeout(Duration::from_secs(10), async {
@@ -20820,6 +20838,19 @@ lines.on('line', async (line) => {
         panic!("engine event channel closed");
     })
     .await;
+    let ready_tools = pool.lock().await.to_api_tools();
+    if invalidate_config {
+        std::fs::write(
+            &config_path,
+            r#"{"servers":{"slow":{"command":"node","disabled":true}}}"#,
+        )
+        .expect("remove servers");
+        pool.lock()
+            .await
+            .reload_if_config_changed()
+            .await
+            .expect("reload config");
+    }
     // Release and shut down even when testing the old batch-buffered behavior.
     std::fs::write(&release, "continue").expect("release stalled fixture");
     let finished = tokio::time::timeout(Duration::from_secs(10), async {
@@ -20852,13 +20883,17 @@ lines.on('line', async (line) => {
             .iter()
             .any(|row| row.name == "slow" && !row.connected)
     );
-    assert!(
-        finished
-            .expect("finished boot")
-            .servers
-            .iter()
-            .all(|row| row.connected)
-    );
+    assert!(ready_tools.iter().any(|tool| tool.name == "mcp_fast_ready"));
+    assert!(!ready_tools.iter().any(|tool| tool.name == "mcp_slow_ready"));
+    let finished = finished.expect("finished boot");
+    if invalidate_config {
+        assert_eq!(finished.servers.len(), 1);
+        assert!(!finished.servers[0].enabled);
+        assert!(!finished.servers[0].connected);
+        assert!(pool.lock().await.to_api_tools().is_empty());
+    } else {
+        assert!(finished.servers.iter().all(|row| row.connected));
+    }
 }
 
 #[tokio::test]
@@ -20906,6 +20941,10 @@ async fn mcp_boot_updates_preserve_authority_errors_and_replace_ordinary_errors(
         ])
     );
     assert!(!engine.mcp_connection_errors.contains_key("stale-transport"));
+    assert_eq!(
+        engine.session.pending_prefix_change_reason.as_deref(),
+        Some("mcp-session-boot")
+    );
 
     engine.mcp_connection_errors.insert(
         "stale-between-updates".to_string(),
@@ -20933,6 +20972,42 @@ async fn mcp_boot_updates_preserve_authority_errors_and_replace_ordinary_errors(
                 "final connection failure".to_string(),
             ),
         ])
+    );
+}
+
+#[tokio::test]
+async fn mcp_boot_catalog_refresh_declares_prefix_before_mailbox_delivery() {
+    let tmp = tempdir().expect("tempdir");
+    let (mut engine, _handle) = Engine::new(
+        EngineConfig {
+            workspace: tmp.path().to_path_buf(),
+            ..Default::default()
+        },
+        &Config::default(),
+    );
+    engine.mcp_boot_generation = Some(1);
+    engine.mcp_boot_in_flight = true;
+    engine.session.pending_prefix_change_reason = None;
+    let _tools = engine.mcp_tools().await;
+    assert_eq!(
+        engine.session.pending_prefix_change_reason.as_deref(),
+        Some("mcp-session-boot")
+    );
+
+    engine.session.pending_prefix_change_reason = None;
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    engine.mcp_boot_rx = Some(rx);
+    tx.send(McpBootUpdate::Progress {
+        generation: 1,
+        authority_errors: Arc::new(HashMap::new()),
+        connection_errors: HashMap::new(),
+        connecting: vec!["slow".to_string()],
+    })
+    .expect("queue progress");
+    engine.drain_mcp_boot_updates().await;
+    assert_eq!(
+        engine.session.pending_prefix_change_reason.as_deref(),
+        Some("mcp-session-boot")
     );
 }
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -20755,6 +20755,113 @@ async fn reload_mcp_op_recovers_from_invalid_initial_config_in_process() {
 }
 
 #[tokio::test]
+async fn mcp_boot_reports_ready_server_before_stalled_server_finishes() {
+    let tmp = tempdir().expect("tempdir");
+    let server = tmp.path().join("server.mjs");
+    let release = tmp.path().join("release-slow");
+    std::fs::write(
+        &server,
+        r#"import fs from 'node:fs';
+import readline from 'node:readline';
+const lines = readline.createInterface({ input: process.stdin });
+lines.on('line', async (line) => {
+  const request = JSON.parse(line);
+  if (request.id === undefined) return;
+  if (process.argv[2] === 'slow' && request.method === 'initialize') {
+    while (!fs.existsSync(process.argv[3])) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+  const result = request.method === 'initialize'
+    ? { protocolVersion: '2024-11-05', capabilities: { tools: {} },
+        serverInfo: { name: process.argv[2], version: '1' } }
+    : { tools: [{ name: 'ready', inputSchema: { type: 'object' } }] };
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result }) + '\n');
+});
+"#,
+    )
+    .expect("server fixture");
+    let config_path = tmp.path().join("mcp.json");
+    std::fs::write(
+        &config_path,
+        serde_json::to_vec(&serde_json::json!({
+            "timeouts": { "connect_timeout": 30 },
+            "servers": {
+                "fast": { "command": "node", "args": [server, "fast", release] },
+                "slow": { "command": "node", "args": [server, "slow", release] }
+            }
+        }))
+        .expect("config JSON"),
+    )
+    .expect("MCP config");
+    let (engine, handle) = Engine::new(
+        EngineConfig {
+            workspace: tmp.path().to_path_buf(),
+            mcp_config_path: config_path,
+            ..Default::default()
+        },
+        &Config::default(),
+    );
+    let task = tokio::spawn(async move { engine.run().await });
+    let mut events = handle.rx_event.write().await;
+    let progress = tokio::time::timeout(Duration::from_secs(10), async {
+        while let Some(event) = events.recv().await {
+            if let Event::McpSessionBoot {
+                snapshot,
+                connecting,
+                finished: false,
+                ..
+            } = event
+                && connecting == ["slow"]
+            {
+                return snapshot;
+            }
+        }
+        panic!("engine event channel closed");
+    })
+    .await;
+    // Release and shut down even when testing the old batch-buffered behavior.
+    std::fs::write(&release, "continue").expect("release stalled fixture");
+    let finished = tokio::time::timeout(Duration::from_secs(10), async {
+        while let Some(event) = events.recv().await {
+            if let Event::McpSessionBoot {
+                snapshot,
+                finished: true,
+                ..
+            } = event
+            {
+                return snapshot;
+            }
+        }
+        panic!("engine event channel closed");
+    })
+    .await;
+    drop(events);
+    handle.send(Op::Shutdown).await.expect("shutdown");
+    task.await.expect("engine task");
+    let progress = progress.expect("fast server must be visible before slow server is released");
+    assert!(
+        progress
+            .servers
+            .iter()
+            .any(|row| row.name == "fast" && row.connected)
+    );
+    assert!(
+        progress
+            .servers
+            .iter()
+            .any(|row| row.name == "slow" && !row.connected)
+    );
+    assert!(
+        finished
+            .expect("finished boot")
+            .servers
+            .iter()
+            .all(|row| row.connected)
+    );
+}
+
+#[tokio::test]
 async fn mcp_boot_updates_preserve_authority_errors_and_replace_ordinary_errors() {
     let tmp = tempdir().expect("tempdir");
     let engine_config = EngineConfig {

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -3094,15 +3094,12 @@ impl McpPool {
     /// Handshake the pending servers concurrently without holding the pool
     /// lock. Callers insert results under a short lock so a live turn can
     /// snapshot ready tools while optional servers are still connecting.
-    pub(crate) async fn connect_pending_concurrently(
+    pub(crate) fn spawn_pending_connects(
         pending: Vec<McpPendingConnect>,
         timeouts: McpTimeouts,
         network_policy: Option<NetworkPolicyDecider>,
         catalog_generation: u64,
-    ) -> Vec<(String, Result<McpConnection, anyhow::Error>)> {
-        if pending.is_empty() {
-            return Vec::new();
-        }
+    ) -> tokio::task::JoinSet<(String, Result<McpConnection, anyhow::Error>)> {
         let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(Self::CONNECT_CONCURRENCY));
         let mut joins: tokio::task::JoinSet<(String, Result<McpConnection, anyhow::Error>)> =
             tokio::task::JoinSet::new();
@@ -3126,20 +3123,7 @@ impl McpPool {
             });
         }
 
-        let mut results = Vec::new();
-        while let Some(joined) = joins.join_next().await {
-            match joined {
-                Ok(result) => results.push(result),
-                // A panicked connect task loses its server name in the
-                // JoinError; attribute generically. The sequential loop
-                // would have propagated the panic and taken the whole
-                // pool down with it, so this is strictly better.
-                Err(join_error) => {
-                    results.push(("connection task".to_string(), Err(join_error.into())));
-                }
-            }
-        }
-        results
+        joins
     }
 
     /// Connect to all enabled servers, returning errors for failed connections.
@@ -3197,14 +3181,15 @@ impl McpPool {
                 break;
             }
 
-            let results = Self::connect_pending_concurrently(
+            let mut connects = Self::spawn_pending_connects(
                 pending,
                 self.config.timeouts,
                 self.network_policy.clone(),
                 self.catalog_generation.load(Ordering::SeqCst),
-            )
-            .await;
-            for (name, result) in results {
+            );
+            while let Some(joined) = connects.join_next().await {
+                let (name, result) = joined
+                    .unwrap_or_else(|error| ("connection task".to_string(), Err(error.into())));
                 match result {
                     Ok(connection) => self.store_ready_connection(name, connection),
                     Err(error) => {

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -16,6 +16,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use futures_util::FutureExt;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
@@ -2864,7 +2865,7 @@ impl McpPool {
         };
         connection.catalog_generation = self.catalog_generation.load(Ordering::SeqCst);
 
-        self.store_ready_connection(server_name.to_string(), connection);
+        self.store_ready_connection(server_name.to_string(), connection)?;
         self.connections
             .get_mut(server_name)
             .ok_or_else(|| anyhow::anyhow!("Failed to store MCP connection for {server_name}"))
@@ -2913,7 +2914,7 @@ impl McpPool {
             anyhow::bail!("Failed to connect MCP server '{server_name}': server is disabled");
         }
 
-        let connection = match McpConnection::connect_with_policy(
+        let mut connection = match McpConnection::connect_with_policy(
             server_name.to_string(),
             server_config,
             &self.config.timeouts,
@@ -2927,14 +2928,25 @@ impl McpPool {
                 return Err(error);
             }
         };
-        self.store_ready_connection(server_name.to_string(), connection);
+        connection.catalog_generation = self.current_catalog_generation();
+        self.store_ready_connection(server_name.to_string(), connection)?;
         self.connections
             .get_mut(server_name)
             .ok_or_else(|| anyhow::anyhow!("Failed to store MCP connection for {server_name}"))
     }
 
-    pub(crate) fn store_ready_connection(&mut self, name: String, mut connection: McpConnection) {
-        connection.catalog_generation = self.catalog_generation.load(Ordering::SeqCst);
+    pub(crate) fn store_ready_connection(
+        &mut self,
+        name: String,
+        connection: McpConnection,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            connection.catalog_generation == self.current_catalog_generation(),
+            "MCP configuration changed while connecting {name}; retry against the current config"
+        );
+        if let Some(source) = connection.config().reviewed_plugin.as_ref() {
+            source.validate_before_use(&name, "use")?;
+        }
         // A successful connect settles the auth question for this server,
         // and the cooldown with it.
         self.connect_backoff.remove(&name);
@@ -2942,6 +2954,7 @@ impl McpPool {
             self.needs_auth_generation = self.needs_auth_generation.wrapping_add(1);
         }
         self.connections.insert(name, connection);
+        Ok(())
     }
 
     /// Record a connect failure's auth classification. When the failure looks
@@ -3107,18 +3120,23 @@ impl McpPool {
             let permit = semaphore.clone();
             let network_policy = network_policy.clone();
             joins.spawn(async move {
-                let _permit = permit.acquire_owned().await;
-                let connection = McpConnection::connect_with_policy(
-                    name.clone(),
-                    config,
-                    &timeouts,
-                    network_policy.as_ref(),
-                )
+                let connection = std::panic::AssertUnwindSafe(async {
+                    let _permit = permit.acquire_owned().await;
+                    McpConnection::connect_with_policy(
+                        name.clone(),
+                        config,
+                        &timeouts,
+                        network_policy.as_ref(),
+                    )
+                    .await
+                    .map(|mut connection| {
+                        connection.catalog_generation = catalog_generation;
+                        connection
+                    })
+                })
+                .catch_unwind()
                 .await
-                .map(|mut connection| {
-                    connection.catalog_generation = catalog_generation;
-                    connection
-                });
+                .unwrap_or_else(|_| Err(anyhow::anyhow!("MCP connection task panicked")));
                 (name, connection)
             });
         }
@@ -3190,12 +3208,11 @@ impl McpPool {
             while let Some(joined) = connects.join_next().await {
                 let (name, result) = joined
                     .unwrap_or_else(|error| ("connection task".to_string(), Err(error.into())));
-                match result {
-                    Ok(connection) => self.store_ready_connection(name, connection),
-                    Err(error) => {
-                        self.note_connect_failure(&name, &error);
-                        errors.push((name, error));
-                    }
+                let result = result
+                    .and_then(|connection| self.store_ready_connection(name.clone(), connection));
+                if let Err(error) = result {
+                    self.note_connect_failure(&name, &error);
+                    errors.push((name, error));
                 }
             }
 

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -2914,6 +2914,27 @@ async fn reload_if_config_changed_swaps_config_on_content_change() {
 }
 
 #[tokio::test]
+async fn stale_handshake_cannot_be_restamped_after_config_reload() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("mcp.json");
+    std::fs::write(&path, r#"{"servers":{"local":{"command":"node"}}}"#).unwrap();
+    let mut pool = McpPool::from_config_path(&path).unwrap();
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut connection = test_connection(Box::new(DropCountingTransport {
+        drops: drops.clone(),
+    }));
+    connection.catalog_generation = pool.current_catalog_generation();
+    std::fs::write(&path, r#"{"servers":{}}"#).unwrap();
+    pool.reload_from_config_sources(true).unwrap();
+    let error = pool
+        .store_ready_connection("local".to_string(), connection)
+        .unwrap_err();
+    assert!(error.to_string().contains("configuration changed"));
+    assert!(!pool.connections.contains_key("local"));
+    assert_eq!(drops.load(AtomicOrdering::SeqCst), 1);
+}
+
+#[tokio::test]
 async fn reload_if_config_changed_drops_live_connections() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("mcp.json");


### PR DESCRIPTION
Startup buffered every MCP connection result until the slowest batch finished, so the TUI could keep showing “20 connecting” even after individual servers were ready. Ready tools were also unavailable in the pool during that wait.

Consume each owned connection task as it completes, update the engine-owned pool under a short lock, and emit per-server progress immediately. Both startup and explicit connect-all use the same bounded task set. Preserve the eight-connection limit, catalog generations, plugin-authority validation, required-server errors, and cancellation when the task set is dropped.

Fixes #5887. The deterministic fixture proves this startup batching defect; it does not reproduce every server in the founder’s private configuration.

Validation: 157/157 focused MCP and engine nextest tests passed with the documented 16 MiB test stack; cargo check, Clippy with -D warnings, and formatting pass. A real engine event-loop fixture holds one stdio server until a release file is written and verifies that the other server is already visible and the connecting count has dropped before that release. Boot completion, retry ownership, stale-generation handling, catalog and authority tests pass.

An initial broad libtest substring filter also selected an unrelated setup test and aborted on its default-stack overflow; the focused run uses the repository’s documented stack setting. Full workspace tests were not run locally.

Based on the bundle relocation in #5890. This PR is v0.9.13 work and does not retag or republish v0.9.12.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP connection lifecycle, config reload races during concurrent boot, and LLM tool-catalog/prefix pinning timing—important for correctness but covered by focused integration tests.
> 
> **Overview**
> MCP session boot no longer waits for the slowest handshake before updating the UI or tool catalog. The engine now consumes **`spawn_pending_connects`** tasks as each finishes, stores ready connections under a short pool lock, and emits **`McpSessionBoot`** progress with an updated connecting list after every completion instead of buffering until the batch ends.
> 
> Ready tools are exposed while optional servers are still connecting, and **`pending_prefix_change_reason`** is set to **`mcp-session-boot`** on progress, finished boot, and early **`mcp_tools()`** snapshots so the KV prefix refresh is scheduled even when a connection becomes ready before its mailbox event.
> 
> **`store_ready_connection`** now returns **`Result`** and rejects connections whose catalog generation no longer matches the pool (with plugin validation on store). Mid-boot config reloads call **`reload_if_config_changed`**, abort remaining connect tasks, and avoid letting stale handshakes overwrite the new configuration. Connect tasks are wrapped with panic catching via **`FutureExt`**.
> 
> New engine and pool tests cover incremental boot visibility, config invalidation during handshake, and prefix-change ordering relative to progress events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d716c0c8aa0c45b44ed966f6d64e57c9ee5516bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->