### PR TITLE
fix(tui): the posture bar states how long the session has been working (#5914)

### DIFF
--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -1294,7 +1294,7 @@
   "LaunchMcpNeedsSignInMany": "{count} need sign-in",
   "PhaseIdle": "idle",
   "PhaseDraft": "draft",
-  "PhaseWorking": "in the current",
+  "PhaseWorking": "working",
   "PhaseReasoning": "reasoning",
   "PhaseReading": "reading",
   "PhaseUsingTool": "using tool",

--- a/crates/tui/src/tui/goldens/footer_100x30.txt
+++ b/crates/tui/src/tui/goldens/footer_100x30.txt
@@ -27,4 +27,4 @@
                                                                                                     
                                                                                                     
                                                                                                     
-▶▶ ask (Shift+Tab) · work (Tab) · 2 agents · Esc to interrupt                                       
+▶▶ ask (Shift+Tab) · work (Tab) · working 1m 15s · 2 agents · worked 41m 12s · Esc to interrupt     

--- a/crates/tui/src/tui/goldens/footer_120x32.txt
+++ b/crates/tui/src/tui/goldens/footer_120x32.txt
@@ -29,4 +29,4 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
-▶▶ ask (Shift+Tab) · work (Tab) · 2 agents · Esc to interrupt                                                           
+▶▶ ask (Shift+Tab) · work (Tab) · working 1m 15s · 2 agents · worked 41m 12s · Esc to interrupt                         

--- a/crates/tui/src/tui/goldens/footer_160x40.txt
+++ b/crates/tui/src/tui/goldens/footer_160x40.txt
@@ -37,4 +37,4 @@
                                                                                                                                                                 
                                                                                                                                                                 
                                                                                                                                                                 
-▶▶ ask (Shift+Tab) · work (Tab) · 2 agents · Esc to interrupt                                                                                                   
+▶▶ ask (Shift+Tab) · work (Tab) · working 1m 15s · 2 agents · worked 41m 12s · Esc to interrupt                                                                 

--- a/crates/tui/src/tui/goldens/footer_80x24.txt
+++ b/crates/tui/src/tui/goldens/footer_80x24.txt
@@ -21,4 +21,4 @@
                                                                                 
                                                                                 
                                                                                 
-▶▶ ask (Shift+Tab) · work (Tab) · 2 agents · Esc to interrupt                   
+▶▶ ask (Shift+Tab) · work (Tab) · 2 agents · worked 41m 12s · Esc to interrupt  

--- a/crates/tui/src/tui/phase_strip.rs
+++ b/crates/tui/src/tui/phase_strip.rs
@@ -11,9 +11,11 @@
 //! changes text inside fixed rows and never displaces the composer.
 //!
 //! One owner per fact: the context reading and the price are the metrics
-//! line's; mode and permission are this bar's. The module name is the
-//! historical one — the phase word it painted now lives in the transcript's
-//! active row.
+//! line's; mode, permission and the working clock are this bar's. The module
+//! name is the historical one — the phase word it painted also lives in the
+//! transcript's active row, but the bar keeps its own copy beside the clock
+//! (#5914): a bare duration cannot say whether the session is producing
+//! tokens or parked waiting on a tool, a sub-agent, or you.
 
 use ratatui::{
     buffer::Buffer,
@@ -35,10 +37,6 @@ pub fn height() -> u16 {
     1
 }
 
-/// Compact working detail for the phase band: `×N` for tools or `1m 15s`
-/// while the model is thinking.
-/// Kept quieter than the classic footer's verbose tool-status line so the
-/// transcript owns the ledger and the strip only names the live pulse.
 /// Route identity for a rail or info line segment, shed field by field until it
 /// fits `budget`.
 ///
@@ -526,12 +524,21 @@ mod tests {
 //
 //   ▶▶ full access (Shift+Tab) · work (Tab) · 2 agents, 1 task · Esc to interrupt      rc connected
 //
-// permission chip first (never sheds, #5796), the mode, the live counts,
-// then the one hint that applies right now; the remote-control state or a
-// live notice pinned right. No phase word, no elapsed, no cost: the
-// transcript's active row owns the pulse, the roster owns per-agent
-// elapsed, and the metrics line owns the price. The context reading is the
-// metrics line's; this row only says what to do about it at the cap.
+// permission chip first (never sheds, #5796), the mode, the turn clock, the
+// live counts, the session clock, then the one hint that applies right now;
+// the remote-control state or a live notice pinned right. No cost: the
+// roster owns per-agent elapsed and the metrics line owns the price. The
+// context reading is the metrics line's; this row only says what to do about
+// it at the cap.
+//
+// The clock came back in #5914. It was the `worked Nm Ss` chip on the
+// classic footer until `146ab7f756` deleted that path, and the phase band's
+// `working_detail` until `329960fcbf` (the 0.9.12 mega shell) merged the
+// bands and left the elapsed reading to the transcript's active row. A
+// multi-hour operate session scrolls that row out of sight, so the founder
+// looking straight at the screen had no way to tell how long the session had
+// been working or whether the current turn was stuck. The fixed row is where
+// a glancing user looks; the clock lives here.
 // ---------------------------------------------------------------------------
 
 /// The context cap warning at ≥80% (spec §5a/§5e). The reading itself lives
@@ -557,9 +564,18 @@ pub struct TidelineFooter<'a> {
     pub mode_chip: Option<(&'a str, crate::palette::ChromeInk)>,
     /// The chord that cycles the mode, when the binding is live (`Tab`).
     pub mode_key: Option<&'a str>,
+    /// The turn half of the working clock (`working 1m 15s`): what the
+    /// session is doing right now and for how long. `None` between turns.
+    pub turn_clock: Option<(&'a str, crate::palette::ChromeInk)>,
     /// Live counts (`2 agents`, `1 task`) in their own inks, joined with
     /// `, `.
     pub counts: &'a [(String, ChromeInk)],
+    /// The session half of the working clock (`worked 41m 12s`): how long
+    /// this session has actually worked — the reading the founder went
+    /// looking for and could not find (#5914). Outlives the turn half, and
+    /// sheds before the hint and the counts. `None` until the session has
+    /// worked a minute.
+    pub session_clock: Option<(&'a str, crate::palette::ChromeInk)>,
     /// The one hint that applies right now (`Esc to interrupt`).
     pub hint: Option<(&'a str, crate::palette::ChromeInk)>,
     /// Context window percentage 0–100. The metrics line paints the reading;
@@ -584,7 +600,9 @@ impl<'a> TidelineFooter<'a> {
             permission_key: None,
             mode_chip: None,
             mode_key: None,
+            turn_clock: None,
             counts: &[],
+            session_clock: None,
             hint: None,
             context_percent: 0,
             right: None,
@@ -607,6 +625,18 @@ impl<'a> TidelineFooter<'a> {
     #[must_use]
     pub fn mode_key(mut self, key: Option<&'a str>) -> Self {
         self.mode_key = key;
+        self
+    }
+
+    #[must_use]
+    pub fn turn_clock(mut self, clock: Option<(&'a str, crate::palette::ChromeInk)>) -> Self {
+        self.turn_clock = clock;
+        self
+    }
+
+    #[must_use]
+    pub fn session_clock(mut self, clock: Option<(&'a str, crate::palette::ChromeInk)>) -> Self {
+        self.session_clock = clock;
         self
     }
 
@@ -657,11 +687,18 @@ impl<'a> TidelineFooter<'a> {
             .collect()
     }
 
+    /// Whether the context window is full enough that the bar owes the cap
+    /// warning. It replaces the hint and, unlike a hint, outranks the clock
+    /// and the counts on the shed ladder.
+    fn at_context_cap(&self) -> bool {
+        self.context_percent.clamp(0, 100) >= 80
+    }
+
     /// The hint the left run ends on: the cap warning outranks whatever the
     /// caller passed, because a full context is the one thing that stops the
     /// next turn.
     fn effective_hint(&self) -> Option<(String, ChromeInk)> {
-        if self.context_percent.clamp(0, 100) >= 80 {
+        if self.at_context_cap() {
             return Some((
                 format!("{} {}", self.sym("▲"), self.sym(DEPTH_WARN)),
                 ChromeInk::Attention,
@@ -691,10 +728,33 @@ struct PostureItem {
     count_index: Option<usize>,
 }
 
-/// Shed ladder for the left run, most expendable first: the hint, the
-/// counts, the mode key, the mode, the permission key. The permission chip
-/// itself never sheds (#5796): a silently missing `full access` is the bar
-/// under-reporting the authority the session actually holds.
+/// Shed rungs for the left run, most expendable first. The permission chip
+/// itself has no rung: it never sheds (#5796), because a silently missing
+/// `full access` is the bar under-reporting the authority the session
+/// actually holds.
+///
+/// The two halves of the working clock shed apart, and both go first
+/// (#5914). The clock is what a *glance* wants; at the narrowest widths the
+/// row's other facts are what a *keystroke* wants — the counts name work you
+/// can open, the hint names a chord you can press right now (`Esc to
+/// interrupt`, `Enter again to send now`). An 80-column row carrying the
+/// filesystem-scope notice cannot hold all of it, and losing the affordance
+/// to keep the stopwatch is the wrong trade. The turn half goes before the
+/// session half: the transcript's active row and the spinner also show the
+/// turn is alive, while the session total is stated nowhere else. Above
+/// them the context-cap warning, which is not a hint but the reason the
+/// next turn will not start at all.
+const SHED_TURN_CLOCK: u8 = 1;
+const SHED_SESSION_CLOCK: u8 = 2;
+const SHED_HINT: u8 = 3;
+const SHED_COUNTS: u8 = 4;
+const SHED_CAP_WARNING: u8 = 5;
+const SHED_MODE_KEY: u8 = 6;
+const SHED_MODE: u8 = 7;
+const SHED_PERMISSION_KEY: u8 = 8;
+/// The most-shed rung: everything gone but the permission chip.
+const MAX_SHED: u8 = SHED_PERMISSION_KEY;
+
 fn posture_items(footer: &TidelineFooter<'_>, shed: u8) -> Vec<PostureItem> {
     let chip = |text: &str, key: Option<&str>| -> String {
         match key {
@@ -705,23 +765,35 @@ fn posture_items(footer: &TidelineFooter<'_>, shed: u8) -> Vec<PostureItem> {
     let mut items = vec![PostureItem {
         text: chip(
             &footer.sym(footer.permission_chip.0),
-            footer.permission_key.filter(|_| shed < 5),
+            footer.permission_key.filter(|_| shed < SHED_PERMISSION_KEY),
         ),
         ink: footer.permission_chip.1,
         bold: true,
         joined: false,
         count_index: None,
     }];
-    if let Some((mode, ink)) = footer.mode_chip.filter(|_| shed < 4) {
+    if let Some((mode, ink)) = footer.mode_chip.filter(|_| shed < SHED_MODE) {
         items.push(PostureItem {
-            text: chip(&footer.sym(mode), footer.mode_key.filter(|_| shed < 3)),
+            text: chip(
+                &footer.sym(mode),
+                footer.mode_key.filter(|_| shed < SHED_MODE_KEY),
+            ),
             ink,
             bold: true,
             joined: false,
             count_index: None,
         });
     }
-    if shed < 2 {
+    if let Some((clock, ink)) = footer.turn_clock.filter(|_| shed < SHED_TURN_CLOCK) {
+        items.push(PostureItem {
+            text: footer.sym(clock),
+            ink,
+            bold: false,
+            joined: false,
+            count_index: None,
+        });
+    }
+    if shed < SHED_COUNTS {
         for (index, (count, ink)) in footer.counts.iter().enumerate() {
             items.push(PostureItem {
                 text: footer.sym(count),
@@ -732,7 +804,24 @@ fn posture_items(footer: &TidelineFooter<'_>, shed: u8) -> Vec<PostureItem> {
             });
         }
     }
-    if shed < 1
+    if let Some((clock, ink)) = footer.session_clock.filter(|_| shed < SHED_SESSION_CLOCK) {
+        items.push(PostureItem {
+            text: footer.sym(clock),
+            ink,
+            bold: false,
+            joined: false,
+            count_index: None,
+        });
+    }
+    // The cap warning is not a hint: it sheds after the counts and both
+    // clock halves, because a full context is the one thing that stops the
+    // next turn from starting at all.
+    let hint_rung = if footer.at_context_cap() {
+        SHED_CAP_WARNING
+    } else {
+        SHED_HINT
+    };
+    if shed < hint_rung
         && let Some((text, ink)) = footer.effective_hint()
     {
         items.push(PostureItem {
@@ -791,7 +880,7 @@ pub fn render_tideline_footer(
 
     // The permission chip alone is the floor; the right slot takes what is
     // left after it, and the rest of the left run sheds against the slot.
-    let floor = left_run_width(&mark, &posture_items(footer, 5));
+    let floor = left_run_width(&mark, &posture_items(footer, MAX_SHED));
     let right = footer.right.map(|(text, ink)| {
         let budget = width.saturating_sub(floor + 1);
         (truncate_owned(&footer.sym(text), budget), ink)
@@ -801,10 +890,10 @@ pub fn render_tideline_footer(
         .map(|(text, _)| text.width() + 1)
         .unwrap_or(0);
     let left_budget = width.saturating_sub(right_width);
-    let items = (0..=5u8)
+    let items = (0..=MAX_SHED)
         .map(|shed| posture_items(footer, shed))
         .find(|items| left_run_width(&mark, items) <= left_budget)
-        .unwrap_or_else(|| posture_items(footer, 5));
+        .unwrap_or_else(|| posture_items(footer, MAX_SHED));
 
     let permission_ink = footer.permission_chip.1;
     let mut x = usize::from(area.x);
@@ -821,12 +910,16 @@ pub fn render_tideline_footer(
     x += mark.width() + 1;
     for (index, item) in items.iter().enumerate() {
         if index > 0 {
-            let separator = separator_before(item);
+            // Projected like every other glyph on the row: an ascii-safe
+            // terminal that cannot draw `·` must not get one here either,
+            // least of all next to a clock reading whose own separator was
+            // projected.
+            let separator = footer.sym(separator_before(item));
             tput(
                 buf,
                 x as u16,
                 area.y,
-                &clip(x, separator),
+                &clip(x, &separator),
                 tchrome(theme, ChromeInk::MetadataDim),
             );
             x += separator.width();
@@ -878,7 +971,9 @@ pub(crate) struct TidelineFooterFacts {
     pub permission_key: Option<&'static str>,
     pub mode_chip: Option<(String, crate::palette::ChromeInk)>,
     pub mode_key: Option<&'static str>,
+    pub turn_clock: ClockReading,
     pub counts: Vec<(String, ChromeInk)>,
+    pub session_clock: ClockReading,
     /// The dock view each entry of `counts` opens when clicked — same
     /// length, same order.
     pub count_panels: Vec<crate::tui::work_surface::RailPanel>,
@@ -904,12 +999,76 @@ impl TidelineFooterFacts {
         .permission_key(self.permission_key)
         .mode_chip(borrow(&self.mode_chip))
         .mode_key(self.mode_key)
+        .turn_clock(borrow(&self.turn_clock))
         .counts(&self.counts)
+        .session_clock(borrow(&self.session_clock))
         .hint(borrow(&self.hint))
         .context_percent(self.context_percent)
         .right(borrow(&self.right))
         .ascii_safe(ascii_safe)
     }
+}
+
+/// The session has to have worked this long before the bar states a total.
+/// A fresh launch that says `worked 4s` is furniture, not information; the
+/// classic footer's `worked` chip used the same floor (#448).
+const CLOCK_SESSION_FLOOR_SECS: u64 = 60;
+
+/// One half of the working clock: its text and the ink that says whether the
+/// clock is running. `None` when that half has nothing true to say.
+pub(crate) type ClockReading = Option<(String, ChromeInk)>;
+
+/// The working clock (#5914), as its two halves — `(turn, session)`.
+///
+/// * the **turn** reading is `{phase_label} {elapsed}` — the phase word is
+///   the transcript's own, so `working 1m 15s` and `waiting on you 1m 15s`
+///   and `sub-agents underway 1m 15s` all say what the clock is counting.
+///   A duration alone cannot distinguish a session producing tokens from one
+///   parked on a tool, a sub-agent, or an unanswered prompt. `None` between
+///   turns: there is no turn to time.
+/// * the **session** reading is the classic `worked {elapsed}` chip (#448):
+///   `App::cumulative_turn_duration` (the sum of finished turns) plus the
+///   live turn, so it ticks continuously and never jumps at `TurnComplete`.
+///   It is model work, not wall clock since launch — an idle TUI does not
+///   claim to have been working. Quiet ink while no turn is running, because
+///   the clock is stopped.
+pub(crate) fn working_clock(
+    app: &App,
+    phase: ShellPhase,
+    phase_label: &str,
+) -> (ClockReading, ClockReading) {
+    let turn = app.turn_started_at.map(|started| started.elapsed());
+    let ink = match phase {
+        ShellPhase::Waiting | ShellPhase::Approval => ChromeInk::Waiting,
+        ShellPhase::Failed => ChromeInk::Attention,
+        _ => ChromeInk::Active,
+    };
+    let turn_clock = turn.map(|turn| {
+        (
+            format!(
+                "{phase_label} {}",
+                crate::elapsed::format_elapsed_secs(turn.as_secs())
+            ),
+            ink,
+        )
+    });
+    let worked = app
+        .cumulative_turn_duration
+        .saturating_add(turn.unwrap_or_default());
+    let session_clock = (worked.as_secs() >= CLOCK_SESSION_FLOOR_SECS).then(|| {
+        (
+            tr(app.ui_locale, MessageId::FooterWorkedChip).replace(
+                "{duration}",
+                &crate::elapsed::format_elapsed_secs(worked.as_secs()),
+            ),
+            if turn.is_some() {
+                ink
+            } else {
+                ChromeInk::MetadataValue
+            },
+        )
+    });
+    (turn_clock, session_clock)
 }
 
 /// Context window percentage — the snapshot the metrics line's reading
@@ -1091,6 +1250,7 @@ pub(crate) fn tideline_footer_from_app(app: &mut App, width: u16) -> TidelineFoo
                 .map(|word| (format!("/rc {word}"), ChromeInk::Info))
         });
 
+    let (turn_clock, session_clock) = working_clock(app, phase, &phase_label);
     let (counts, count_panels) = live_counts(app, tier);
     TidelineFooterFacts {
         permission_chip,
@@ -1107,7 +1267,9 @@ pub(crate) fn tideline_footer_from_app(app: &mut App, width: u16) -> TidelineFoo
                 crate::tui::footer_hints::MODE_CYCLE,
             )
         }),
+        turn_clock,
         counts,
+        session_clock,
         count_panels,
         hint,
         context_percent: context_percent_from_app(app),

--- a/crates/tui/src/tui/phase_strip/tideline_tests.rs
+++ b/crates/tui/src/tui/phase_strip/tideline_tests.rs
@@ -15,7 +15,9 @@ struct Fixture {
     permission_key: Option<&'static str>,
     mode: Option<(&'static str, ChromeInk)>,
     mode_key: Option<&'static str>,
+    turn_clock: Option<(&'static str, ChromeInk)>,
     counts: Vec<(String, ChromeInk)>,
+    session_clock: Option<(&'static str, ChromeInk)>,
     hint: Option<(&'static str, ChromeInk)>,
     context_percent: u8,
     right: Option<(&'static str, ChromeInk)>,
@@ -28,7 +30,9 @@ fn working() -> Fixture {
         permission_key: Some("Shift+Tab"),
         mode: Some(("work", ChromeInk::PolicyAct)),
         mode_key: Some("Tab"),
+        turn_clock: Some(("working 1m 15s", ChromeInk::Active)),
         counts: vec![("2 agents".to_string(), ChromeInk::Active)],
+        session_clock: Some(("worked 41m 12s", ChromeInk::Active)),
         hint: Some(("Esc to interrupt", ChromeInk::MetadataHint)),
         context_percent: 61,
         right: None,
@@ -41,7 +45,9 @@ impl Fixture {
             .permission_key(self.permission_key)
             .mode_chip(self.mode)
             .mode_key(self.mode_key)
+            .turn_clock(self.turn_clock)
             .counts(&self.counts)
+            .session_clock(self.session_clock)
             .hint(self.hint)
             .context_percent(self.context_percent)
             .right(self.right)
@@ -69,30 +75,34 @@ fn footer_matches_goldens_at_blocker_sizes() {
 }
 
 /// Claude Code's grammar: mark, permission chip with its cycle key, mode
-/// with its cycle key, live counts, then the one hint that applies now.
+/// with its cycle key, the working clock, live counts, then the one hint
+/// that applies now.
 #[test]
-fn posture_bar_reads_permission_mode_counts_hint() {
-    let text = draw(100, 30, &working().widget(&UI_THEME));
+fn posture_bar_reads_permission_mode_clock_counts_hint() {
+    let text = draw(120, 30, &working().widget(&UI_THEME));
     let band = text.lines().last().unwrap_or_default().trim_end();
     assert_eq!(
         band,
-        "▶▶ ask (Shift+Tab) · work (Tab) · 2 agents · Esc to interrupt"
+        "▶▶ ask (Shift+Tab) · work (Tab) · working 1m 15s · 2 agents · worked 41m 12s · Esc to interrupt"
     );
 }
 
-/// The bar carries no phase word, no elapsed, no cost and no context
-/// reading: the transcript, the roster and the metrics line own those.
+/// The bar carries no cost and no context reading: the metrics line owns
+/// both. The elapsed reading is this bar's again (#5914) — a fixed row is
+/// the only place a glancing user can find it during a multi-hour session —
+/// so it is asserted here rather than excluded.
 #[test]
-fn posture_bar_states_no_phase_cost_or_context_reading() {
+fn posture_bar_states_no_cost_or_context_reading() {
     for pct in [0u8, 12, 61, 79] {
         let mut fixture = working();
         fixture.context_percent = pct;
         let text = draw(120, 32, &fixture.widget(&UI_THEME));
         assert!(!text.contains(&format!("{pct}%")), "{pct}: {text}");
-        assert!(!text.contains("thinking"), "{text}");
         assert!(!text.contains("<·>"), "{text}");
         assert!(!text.contains('$'), "{text}");
-        assert!(!text.contains("1m 15s"), "{text}");
+        assert!(text.contains("working 1m 15s"), "{text}");
+        assert!(text.contains("worked 41m 12s"), "{text}");
+        assert!(text.contains("2 agents"), "{text}");
     }
 }
 
@@ -106,6 +116,28 @@ fn posture_bar_warns_at_eighty_percent_cap() {
     assert!(text.contains("▲ surface soon — /compact"), "{text}");
     assert!(!text.contains("Esc to interrupt"), "{text}");
     assert!(!text.contains("83%"), "{text}");
+}
+
+/// The cap warning outranks the clock: a working session that cannot start
+/// its next turn needs the instruction more than it needs the stopwatch.
+#[test]
+fn cap_warning_outranks_the_clock_when_only_one_fits() {
+    let mut fixture = working();
+    fixture.context_percent = 83;
+    let mut saw_warning_alone = false;
+    for width in 8..=160u16 {
+        let text = draw(width, 12, &fixture.widget(&UI_THEME));
+        let warning = text.contains("surface soon");
+        let clock = text.contains("worked 41m 12s");
+        assert!(
+            !(clock && !warning),
+            "width {width} kept the clock and shed the cap warning: {text}"
+        );
+        if warning && !clock {
+            saw_warning_alone = true;
+        }
+    }
+    assert!(saw_warning_alone, "no width shed the clock alone");
 }
 
 /// The right slot is the notice when one is owed, else the remote-control
@@ -131,27 +163,39 @@ fn posture_bar_pins_notice_or_remote_control_right() {
     assert!(narrow.contains("▶▶ ask"), "{narrow}");
 }
 
-/// Shed ladder, most expendable first: hint, counts, mode key, mode,
-/// permission key. The permission chip never sheds (#5796).
+/// Shed ladder, most expendable first: the turn clock, the session clock,
+/// the hint, the counts, mode key, mode, permission key. The permission chip
+/// never sheds (#5796); the clock is what a glance wants and the hint and
+/// counts are what a keystroke wants, so on a row too narrow for both the
+/// clock goes (#5914).
 #[test]
-fn posture_bar_sheds_hint_counts_mode_key_mode_then_permission_key() {
+fn posture_bar_sheds_the_clocks_then_the_hint_counts_and_posture_chips() {
     let fixture = working();
     let narrowest_showing = |needle: &str| -> u16 {
-        (8..=120u16)
+        (8..=160u16)
             .filter(|w| draw(*w, 3, &fixture.widget(&UI_THEME)).contains(needle))
             .min()
             .unwrap_or_else(|| panic!("{needle} never painted"))
     };
+    let turn_clock = narrowest_showing("working 1m 15s");
+    let session_clock = narrowest_showing("worked 41m 12s");
     let hint = narrowest_showing("Esc to interrupt");
     let counts = narrowest_showing("2 agents");
+    // `work` alone would also match `working`, so measure the mode chip by
+    // a needle only the mode paints.
     let mode_key = narrowest_showing("work (Tab)");
-    let mode = narrowest_showing("work");
+    let mode = narrowest_showing("· work ");
     let permission_key = narrowest_showing("(Shift+Tab)");
     assert!(
-        hint > counts && counts > mode_key && mode_key > mode && mode > permission_key,
-        "hint@{hint} counts@{counts} mode_key@{mode_key} mode@{mode} permission_key@{permission_key}"
+        turn_clock > session_clock
+            && session_clock > hint
+            && hint > counts
+            && counts > mode_key
+            && mode_key > mode
+            && mode > permission_key,
+        "turn_clock@{turn_clock} session_clock@{session_clock} hint@{hint} counts@{counts} mode_key@{mode_key} mode@{mode} permission_key@{permission_key}"
     );
-    for w in 8..=120u16 {
+    for w in 8..=160u16 {
         let text = draw(w, 3, &fixture.widget(&UI_THEME));
         assert!(
             text.contains("ask"),
@@ -195,8 +239,11 @@ fn posture_bar_prints_cycle_keys_only_when_live() {
     let mut fixture = working();
     fixture.mode_key = None;
     fixture.permission_key = None;
-    let text = draw(100, 30, &fixture.widget(&UI_THEME));
-    assert!(text.contains("▶▶ ask · work · 2 agents"), "{text}");
+    let text = draw(120, 30, &fixture.widget(&UI_THEME));
+    assert!(
+        text.contains("▶▶ ask · work · working 1m 15s · 2 agents · worked 41m 12s"),
+        "{text}"
+    );
     assert!(!text.contains('('), "{text}");
 }
 
@@ -378,4 +425,175 @@ fn agent_arrow_hints_show_at_zero_and_one_use_and_clear_at_two() {
 
     set_uses(&mut app, AGENT_ARROWS, 2);
     assert!(tideline_footer_from_app(&mut app, 120).hint.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// The working clock (#5914). The founder watching a multi-hour operate
+// session could not find how long the thing had been working: the classic
+// footer's `worked` chip went with the legacy footer path (146ab7f756) and
+// the phase band's `working_detail` went with the 0.9.12 merged shell
+// (329960fcbf). These pin what came back — both readings, the state word
+// that says what the clock is counting, and its place in the shed ladder.
+// ---------------------------------------------------------------------------
+
+use std::time::{Duration, Instant};
+
+use super::{ShellPhase, working_clock};
+
+/// A live turn states both readings: what the session is doing now and for
+/// how long, then how long it has worked in total.
+#[test]
+fn live_turn_clock_states_the_turn_and_the_session() {
+    let mut app = session_app();
+    app.ui_locale = crate::localization::Locale::En;
+    app.is_loading = true;
+    app.turn_started_at = Some(Instant::now() - Duration::from_secs(75));
+    app.cumulative_turn_duration = Duration::from_secs(2_400);
+
+    let facts = tideline_footer_from_app(&mut app, 160);
+    let (turn, turn_ink) = facts.turn_clock.expect("a live turn states its elapsed");
+    assert_eq!(turn, "working 1m 15s");
+    assert_eq!(turn_ink, ChromeInk::Active);
+    let (session, session_ink) = facts
+        .session_clock
+        .expect("a working session states its total");
+    assert_eq!(session, "worked 41m 15s");
+    assert_eq!(session_ink, ChromeInk::Active);
+}
+
+/// The session reading is model work, not wall clock: it is the sum of
+/// finished turns plus the live one, so it never jumps at `TurnComplete`.
+#[test]
+fn session_reading_carries_finished_turns_plus_the_live_one() {
+    let mut app = session_app();
+    app.ui_locale = crate::localization::Locale::En;
+    app.cumulative_turn_duration = Duration::from_secs(3_600);
+
+    // Turn in flight: the finished total plus this turn.
+    app.is_loading = true;
+    app.turn_started_at = Some(Instant::now() - Duration::from_secs(30));
+    let (_, live) = working_clock(&app, ShellPhase::Working, "working");
+    assert_eq!(live.expect("live session clock").0, "worked 60m 30s");
+
+    // Turn done: the engine folded it into the cumulative total, so the
+    // reading is unchanged and the clock stops.
+    app.is_loading = false;
+    app.turn_started_at = None;
+    app.cumulative_turn_duration = Duration::from_secs(3_630);
+    let facts = tideline_footer_from_app(&mut app, 160);
+    assert!(facts.turn_clock.is_none(), "no turn, no turn clock");
+    let (idle, ink) = facts
+        .session_clock
+        .expect("an idle session still states its total");
+    assert_eq!(idle, "worked 60m 30s");
+    assert_eq!(ink, ChromeInk::MetadataValue, "a stopped clock reads quiet");
+}
+
+/// Actively working, waiting on a sub-agent, and waiting on you are three
+/// different readings — a bare duration cannot tell them apart.
+#[test]
+fn clock_distinguishes_working_from_waiting_on_something() {
+    let mut app = session_app();
+    app.ui_locale = crate::localization::Locale::En;
+    app.is_loading = true;
+    app.turn_started_at = Some(Instant::now() - Duration::from_secs(75));
+    app.cumulative_turn_duration = Duration::from_secs(2_400);
+
+    let working = tideline_footer_from_app(&mut app, 160)
+        .turn_clock
+        .expect("working clock");
+    assert_eq!(working.0, "working 1m 15s");
+    assert_eq!(working.1, ChromeInk::Active);
+
+    // A live sub-agent: the parent turn's clock keeps running, but the word
+    // says what it is waiting on (#5906 is the same founder session).
+    app.agent_progress
+        .insert("agent-a".to_string(), "reading".to_string());
+    let subagents = tideline_footer_from_app(&mut app, 160)
+        .turn_clock
+        .expect("sub-agent clock");
+    assert_eq!(subagents.0, "sub-agents underway 1m 15s");
+    app.agent_progress.clear();
+
+    // Waiting on the user parks the clock in the waiting ink.
+    app.pending_user_input_prompt = Some((
+        "tool-call-1".to_string(),
+        crate::tools::user_input::UserInputRequest {
+            questions: Vec::new(),
+        },
+    ));
+    let waiting = tideline_footer_from_app(&mut app, 160)
+        .turn_clock
+        .expect("waiting clock");
+    assert_eq!(waiting.0, "waiting on you 1m 15s");
+    assert_eq!(waiting.1, ChromeInk::Waiting);
+    assert_ne!(waiting.1, working.1, "waiting must not read as working");
+}
+
+/// A fresh session says nothing: no turn has run, so there is no clock to
+/// state, and a sub-minute total stays quiet rather than rendering a noisy
+/// `worked 4s` that immediately ticks.
+#[test]
+fn a_session_that_has_not_worked_states_no_clock() {
+    let mut app = session_app();
+    app.ui_locale = crate::localization::Locale::En;
+    let facts = tideline_footer_from_app(&mut app, 160);
+    assert!(facts.turn_clock.is_none());
+    assert!(facts.session_clock.is_none());
+
+    app.cumulative_turn_duration = Duration::from_secs(42);
+    assert!(
+        tideline_footer_from_app(&mut app, 160)
+            .session_clock
+            .is_none(),
+        "under a minute the session total stays quiet"
+    );
+
+    // A live turn states its own elapsed from the first second, though — the
+    // whole point is telling a stuck turn from a working one.
+    app.is_loading = true;
+    app.turn_started_at = Some(Instant::now() - Duration::from_secs(3));
+    let facts = tideline_footer_from_app(&mut app, 160);
+    assert_eq!(
+        facts.turn_clock.expect("a live turn always times itself").0,
+        "working 3s"
+    );
+    assert!(
+        facts.session_clock.is_none(),
+        "the sub-minute total is still quiet"
+    );
+}
+
+/// Narrow terminals shed both clock halves before the hint and the counts,
+/// the turn half before the session half, and neither reading is ever
+/// painted half-truncated.
+#[test]
+fn narrow_widths_shed_the_clocks_before_the_hint_and_counts() {
+    let fixture = working();
+    for w in 8..=160u16 {
+        let text = draw(w, 3, &fixture.widget(&UI_THEME));
+        let turn = text.contains("working 1m 15s");
+        let session = text.contains("worked 41m 12s");
+        assert!(
+            !turn || session,
+            "{w} kept the turn clock and dropped the session clock: {text}"
+        );
+        assert!(
+            !session || text.contains("Esc to interrupt"),
+            "{w} kept the session clock and dropped the hint: {text}"
+        );
+        assert!(
+            !text.contains("Esc to interrupt") || text.contains("2 agents"),
+            "{w} kept the hint and dropped the counts: {text}"
+        );
+        // Whole readings or none: a clipped duration is a lie.
+        assert!(
+            !text.contains("working 1m") || turn,
+            "{w} painted a half-truncated turn clock: {text}"
+        );
+        assert!(
+            !text.contains("worked 41m") || session,
+            "{w} painted a half-truncated session clock: {text}"
+        );
+    }
 }

--- a/crates/tui/src/tui/ui/frame/one_owner_tests.rs
+++ b/crates/tui/src/tui/ui/frame/one_owner_tests.rs
@@ -26,6 +26,15 @@ fn frame_app() -> App {
     app.onboarding = crate::tui::app::OnboardingState::None;
     app.launch.visible = false;
     app.ui_locale = crate::localization::Locale::En;
+    // The posture bar's permission chip carries the filesystem-scope notice
+    // (`files: workspace (unenforced)`) whenever no sandbox backend can
+    // actually enforce the policy — true on default Linux and all Windows,
+    // false on macOS, which resolves seatbelt. That is 30 columns of chip
+    // that appears or not depending on which machine runs the test, and it
+    // decides what an 80-column shed ladder can still hold: these tests
+    // passed locally and failed on both CI legs until it was pinned. Force
+    // the wider, unenforced reading so every host asserts the same row.
+    app.sandbox_backend = None;
     app
 }
 
@@ -105,9 +114,13 @@ fn count_rows_containing(rows: &[String], needle: &str) -> usize {
 /// Every chrome fact paints in exactly one row of the composed default
 /// frame: the context reading, the mode and permission chips, the model,
 /// the cost, the agent count, and the help hint.
+///
+/// 160 columns joins the blocker sizes so the working clock's two halves
+/// are asserted at a width that holds both; at 80 and 120 they shed by
+/// design (#5914) and the row is asserted for what it does keep.
 #[test]
 fn composed_frame_paints_each_fact_in_exactly_one_row() {
-    for (width, height) in [(80u16, 24u16), (120, 32)] {
+    for (width, height) in [(80u16, 24u16), (120, 32), (160, 40)] {
         let mut app = working_app();
         let rows = draw(&mut app, width, height);
         let pct = super::info_context_percent(&app);
@@ -173,10 +186,34 @@ fn composed_frame_paints_each_fact_in_exactly_one_row() {
             "posture bar is row 1 under the composer"
         );
         assert_eq!(metrics, posture + 1, "metrics line is row 2");
-        // The bar carries no phase word and no elapsed; the metrics line no
-        // repository, branch or provider.
-        assert!(!rows[posture].contains("underway"), "{}", rows[posture]);
-        assert!(!rows[posture].contains("1m 15s"), "{}", rows[posture]);
+        // The scope notice is pinned on, not inherited from the host: if
+        // this ever goes quiet the widths below stop meaning what they say.
+        assert!(
+            rows[posture].contains("files: workspace (unenforced)"),
+            "{width}x{height}: the fixture must pin the scope notice: {}",
+            rows[posture]
+        );
+        // The bar carries the working clock (#5914) — how long the current
+        // turn has been doing what it is doing, and how long the session has
+        // worked. Both halves shed before the hint and the counts, so a
+        // narrow row keeps the affordances and drops the stopwatch: the
+        // session half needs 120 columns here, the turn half 160. Each
+        // paints in exactly one row wherever it paints. The metrics line
+        // carries no repository, branch or provider.
+        let clock_facts: &[(u16, &str)] =
+            &[(120, "worked 1m 15s"), (160, "sub-agents underway 1m 15s")];
+        for (needs, needle) in clock_facts {
+            if width < *needs {
+                continue;
+            }
+            assert!(rows[posture].contains(needle), "{}", rows[posture]);
+            assert_eq!(
+                count_rows_containing(&rows, needle),
+                1,
+                "{width}x{height}: {needle:?} paints in exactly one row:\n{}",
+                rows.join("\n")
+            );
+        }
         assert!(!rows[metrics].contains('⑂'), "{}", rows[metrics]);
         // No dead key hints anywhere in the frame.
         for row in &rows {
@@ -234,11 +271,9 @@ fn context_cap_warns_once_in_the_posture_bar() {
         context_tokens: Some(60),
         ..Default::default()
     });
-    // 140 columns: on a backend-less platform (linux CI) the filesystem
-    // scope notice paints `files: workspace (unenforced)` and the shed
-    // ladder drops the hint first; the width keeps the hint inside the
-    // budget with the notice present, so the warning is asserted on every
-    // platform.
+    // 140 columns: the fixture always paints the filesystem scope notice
+    // (`frame_app` pins `sandbox_backend = None`), so the width has to hold
+    // the warning with the notice present. The clock halves shed first.
     let rows = draw(&mut app, 140, 32);
     let pct = super::info_context_percent(&app);
     assert!(pct >= 80, "fixture must sit at the cap: {pct}");
@@ -256,7 +291,10 @@ fn context_cap_warns_once_in_the_posture_bar() {
     );
 }
 
-/// The double-tap window advertises itself in the posture bar's hint slot.
+/// The double-tap window advertises itself in the posture bar's hint slot,
+/// and keeps it: both halves of the working clock shed before the hint does
+/// (#5914), so the steer stays reachable on a 120-column row that cannot
+/// also hold the stopwatch.
 #[test]
 fn double_tap_window_shows_the_send_now_hint() {
     let mut app = working_app();


### PR DESCRIPTION
Closes #5914

## What the founder saw

"it does seem kinda weird that we don't show how long the overall thing has been working anymore? just looking at the screen" — during a multi-hour operate session with sub-agents, nothing on a fixed row said how long the session had been working, how long the current turn had been running, or whether anything was parked.

## What lost it

Two commits, and the second one is the one that finished the job:

- **`146ab7f756` "refactor(tui): delete the legacy FooterWidget rendering path"** removed `crates/tui/src/tui/widgets/footer.rs` whole, and with it `footer_worked_chip` — the `worked Nm Ss` indicator built from `App::cumulative_turn_duration` (#448).
- **`329960fcbf` "feat: Codewhale 0.9.12 shell, brand, fleet, and Operate (mega)" (#5826)** merged the activity and identity bands into the posture bar and deleted `phase_strip::working_detail`, which had painted the current turn's elapsed. Its stated rationale was "the phase word it painted now lives in the transcript's active row" — true, and true only until the transcript scrolls, which is what a long session does. (That commit also left `working_detail`'s doc comment orphaned above the next function; this PR removes it.)

`App::cumulative_turn_duration` has been accruing the whole time with no reader.

## Restore, not replace

The posture bar (row 1 under the composer — the line the founder's screenshot shows) now paints a two-part working clock:

```
▶▶ ask (Shift+Tab) · work (Tab) · working 1m 15s · 2 agents · worked 41m 12s · Esc to interrupt
```

- **Turn half** — `{phase label} {elapsed}`. The phase word comes from `phase_marker_with_activity`, the shell's existing single owner, so the reading is `working 1m 15s`, `using tool 1m 15s`, `sub-agents underway 1m 15s` or `waiting on you 1m 15s`. A bare duration cannot distinguish a session producing tokens from one parked on a tool, a sub-agent, or an unanswered prompt; waiting phases also paint in the Waiting ink.
- **Session half** — the classic `worked {elapsed}` chip: `cumulative_turn_duration` (finished turns) plus the live turn, so it ticks continuously and never jumps at `TurnComplete`. It is model work, not wall clock since launch, and it stays silent under a minute exactly as #448 specified.

Both durations go through `crate::elapsed::format_elapsed_secs`. No second formatter, no new state, no new `MessageId` (the session half reuses `FooterWorkedChip`, which survived in all 15 locale packs).

## Shed ladder (narrow terminals)

Most expendable first: **turn clock → session clock → hint → counts → context-cap warning → mode key → mode → permission key**. The permission chip still never sheds (#5796).

Both clock halves go before the hint and the counts. The clock is what a *glance* wants, but at the narrowest widths the row's other facts are what a *keystroke* wants — the counts name work you can open, the hint names a chord you can press right now (`Esc to interrupt`, `Enter again to send now`) — and an 80-column row carrying the filesystem-scope notice cannot hold all of it. The turn half goes first: the transcript's active row and the spinner also show the turn is alive, while the session total is stated nowhere else, so the session reading is the longer-lived of the two and survives to about 100 columns.

The context-cap warning was **promoted above both clocks and the counts**: it is not a hint, it is the reason the next turn will not start. Previously it shed first, with the hint.

## The environment-dependent chip that broke CI

`one_owner_tests` passed on macOS and failed deterministically on both the ubuntu and windows legs. The cause was not the clock: `underwater::filesystem_scope_notice` appends `files: workspace (unenforced)` to the permission chip whenever `App::sandbox_backend` is `None` — true on default Linux and all Windows, false on macOS, which resolves seatbelt. That is ~30 columns of chip that appears or not depending on the host, and it decides what an 80-column shed ladder can still hold.

`frame_app()` now pins `sandbox_backend = None`, and the test asserts the notice is actually present, so if the pin ever stops working the test says so instead of silently going back to host-dependent. `composed_frame_paints_each_fact_in_exactly_one_row` gained a 160-column row so both clock halves are asserted at a width that holds them, and the clock assertions are gated on the width that each half needs (120 for the session half, 160 for the turn half). `double_tap_window_shows_the_send_now_hint` is back at its original 120 columns — with the reordered ladder the steer survives there.

## Two adjacent defects fixed because this code paints them

- `en.json` `PhaseWorking` read **"in the current"** — a corrupted find/replace. Every other locale says "working" / "arbeitet" / "trabajando". This is the word the clock paints, so it is fixed here. (The same corruption survives as a literal string in `footer_hints.rs::friendly_subagent_progress`; left alone as out of scope.)
- Ascii-safe mode painted the row's `·` separators raw while projecting every other glyph, which would have put a projected `.` inside the clock next to unprojected `·` separators. Separators are now projected too.

## Tests

Changed behaviour, so two tests that encoded the old decision were changed with it:

- `tideline_tests::posture_bar_states_no_phase_cost_or_context_reading` → `posture_bar_states_no_cost_or_context_reading`. It still pins that the bar carries no price and no context reading; it now asserts the elapsed readings instead of forbidding them.
- `one_owner_tests::composed_frame_paints_each_fact_in_exactly_one_row` asserted the posture bar contains no `underway` and no `1m 15s`. It now asserts the clock is there **and paints in exactly one row** — the one-owner contract is kept, the owner moved.

New:

- `live_turn_clock_states_the_turn_and_the_session` — both readings and both inks.
- `session_reading_carries_finished_turns_plus_the_live_one` — continuity across `TurnComplete`, and the stopped clock's quiet ink.
- `clock_distinguishes_working_from_waiting_on_something` — working vs `sub-agents underway` vs `waiting on you`, driven end-to-end through `tideline_footer_from_app` with real `App` state.
- `a_session_that_has_not_worked_states_no_clock` — the sub-minute floor, and that a live turn still times itself from the first second.
- `narrow_widths_shed_the_clocks_before_the_hint_and_counts` — over every width 8..=160: the turn clock never survives without the session clock, the session clock never without the hint, the hint never without the counts, and neither reading is ever painted half-truncated.
- `cap_warning_outranks_the_clock_when_only_one_fits`.
- `posture_bar_sheds_the_clocks_then_the_hint_counts_and_posture_chips` — the full ladder, by narrowest width at which each fact appears.

Of the four `footer_{w}x{h}` goldens, only `footer_80x24` shows a shed change (it keeps the hint and the counts and drops the turn clock); 100/120/160 carry the full band. The settings-stage goldens are untouched (the preview's footer area is too narrow for a clock, so it does not get one).

## Verified

| Command | Result |
| --- | --- |
| `cargo fmt -p codewhale-tui` | clean |
| `cargo check -p codewhale-tui` | clean |
| `cargo clippy -p codewhale-tui --all-targets` | clean |
| `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib` | **11690 passed, 0 failed, 12 ignored** |
| `... --lib -- tui::ui::frame tui::phase_strip tui::footer` | 45 passed, 0 failed |
| `... --lib -- tui::phase_strip` | 30 passed, 0 failed |
| `... --lib -- tui::ui::frame` | 12 passed, 0 failed |
| `... --lib -- tui::footer` | 3 passed, 0 failed |
| `... --lib -- localization` | 49 passed, 0 failed |
| `... --lib -- elapsed` | 20 passed, 0 failed |

No stack-overflow aborts locally. Three flakes seen across full-suite runs, each passing in isolation and on the next run, none touching this change: `session_control_acceptance::tests::tui_and_api_listings_agree`, `client::tests::deepseek_anthropic_translate_uses_messages_endpoint`, `tui::clipboard::tests::tmux_load_buffer_w_reaches_attached_client_with_default_passthrough_disabled`.

## Not verified

- No run against a real provider, a real multi-hour session, or a real terminal. All evidence here is buffer-level: rendered `TestBackend` buffers and unit tests. Nobody has watched the clock tick in a live operate session.
- The 14 non-English locale packs are unchanged. The session half reuses their existing `FooterWorkedChip` translation; the turn half reuses their existing phase words. The `PhaseWorking` fix is English-only because English was the only pack that was wrong.
- `#5906` (sub-agents parked as "waiting for input" with no cleanup path), reported in the same session, is not addressed here. This PR only makes the parked time visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XYyJaw9Mh9uSrqQBoqhm