### PR TITLE
fix(fleet): stop parked and vanished write claims from blocking spawns

### DIFF
--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -2381,6 +2381,7 @@ async fn agent_runs_runtime_api_exposes_persisted_worker_receipts() -> Result<()
         result_summary: Some("receipt complete".to_string()),
         error: None,
         steps_taken: 2,
+        parked_at_turn_end: false,
         events: VecDeque::from([AgentWorkerEvent {
             seq: 1,
             worker_id: "agent_receipt".to_string(),

--- a/crates/tui/src/tools/subagent/coord/ledger.rs
+++ b/crates/tui/src/tools/subagent/coord/ledger.rs
@@ -154,6 +154,42 @@ pub struct PersistedWriteClaim {
     pub sequence: u64,
     #[serde(default)]
     pub isolated_worktree: bool,
+    /// Which of this claim's roots/exact files existed on disk when it was
+    /// registered (#5906).
+    ///
+    /// Recorded because "the claimed path is gone" and "the claimed path does
+    /// not exist yet" look identical from a later `exists()` call and mean
+    /// opposite things. A claim on a worktree that has since been removed
+    /// describes work nobody can be doing and must stop refusing claimants; a
+    /// claim on a directory its owner is about to create is exactly the
+    /// forward-looking reservation the ledger exists to honor, and disarming
+    /// that would let two writers into the same new tree.
+    ///
+    /// Empty for claims persisted before this field existed and for claims
+    /// that named nothing on disk at the time — both mean "no evidence of
+    /// disappearance", so neither is ever treated as stale.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub present_at_claim: Vec<String>,
+}
+
+impl PersistedWriteClaim {
+    /// Whether every path this claim was recorded as actually covering has
+    /// since disappeared from disk (#5906).
+    ///
+    /// Isolated-worktree claims are excluded because they never contend at
+    /// all — the answer would be unused, and their paths are not resolved
+    /// against the coordination root.
+    pub fn names_only_vanished_paths<F>(&self, mut path_exists: F) -> bool
+    where
+        F: FnMut(&str) -> bool,
+    {
+        !self.isolated_worktree
+            && !self.present_at_claim.is_empty()
+            && !self
+                .present_at_claim
+                .iter()
+                .any(|path| path_exists(path.as_str()))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -470,6 +506,14 @@ impl CoordinationLedger {
         Ok(decision.clone())
     }
 
+    /// Register a bounded write claim.
+    ///
+    /// `owner_is_active` is the caller's whole answer to "may this existing
+    /// claim refuse a new claimant" — liveness and, since #5906, whether the
+    /// claim's recorded paths still exist. The ledger has no filesystem of its
+    /// own; [`super::SubAgentManager::admissible_coordination_owners`] resolves
+    /// both before calling, and stamps
+    /// [`PersistedWriteClaim::present_at_claim`] on the record afterwards.
     pub fn register_claim<F>(
         &mut self,
         mut claim: WriteScopeClaim,
@@ -540,11 +584,12 @@ impl CoordinationLedger {
             self.contentions.push(receipt);
             trim_front(&mut self.contentions, COORDINATION_RECORD_LIMIT);
             return Err(format!(
-                "write-scope contention with {} (roots: {:?}, files: {:?}, contracts: {:?}); serialize the work, narrow the claim, or use worktree isolation",
+                "write-scope contention with {} (roots: {:?}, files: {:?}, contracts: {:?}); serialize the work, narrow the claim, use worktree isolation, or — if that owner has already settled — clear its claim with agent(action=\"release\", agent_id=\"{}\")",
                 existing.claim.owner,
                 existing.claim.roots,
                 existing.claim.exact_files,
-                existing.claim.contracts
+                existing.claim.contracts,
+                existing.claim.owner
             ));
         }
         self.write_claims
@@ -553,6 +598,8 @@ impl CoordinationLedger {
             claim,
             sequence: self.next_sequence(),
             isolated_worktree,
+            // Stamped by the caller, which owns the filesystem.
+            present_at_claim: Vec::new(),
         };
         for contention in &mut self.contentions {
             if contention.claimant == record.claim.owner

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -827,6 +827,12 @@ pub struct AgentWorkerRecord {
     pub error: Option<String>,
     #[serde(default)]
     pub steps_taken: u32,
+    /// This worker settled by being *parked* at the parent's turn end, not by
+    /// asking a question (#5906). See
+    /// [`SubAgentCheckpoint::parked_at_turn_end`]; the coordination liveness
+    /// predicate reads this flag, and re-dispatching the record clears it.
+    #[serde(default)]
+    pub parked_at_turn_end: bool,
     #[serde(default)]
     pub events: VecDeque<AgentWorkerEvent>,
 }
@@ -874,6 +880,7 @@ impl AgentWorkerRecord {
             result_summary: None,
             error: None,
             steps_taken: 0,
+            parked_at_turn_end: false,
             events: VecDeque::new(),
         }
     }
@@ -1838,6 +1845,20 @@ pub struct SubAgentCheckpoint {
     /// budget. `0` for records written before v0.8.67 (serde default).
     #[serde(default, skip_serializing_if = "is_zero")]
     pub omitted_messages: usize,
+    /// This checkpoint was written because the parent's turn ended while the
+    /// child was still working — not because the child asked anyone anything
+    /// (#5906).
+    ///
+    /// Both cases land on `AgentWorkerStatus::WaitingForUser` (the projection
+    /// keys off `continuable`), and coordination has to tell them apart: a
+    /// child that asked a question keeps its write claim, because a user can
+    /// still answer it and the child will write again. A parked child is
+    /// waiting for nothing — it is resumed as a *new* agent through
+    /// `resume_from`, which registers a claim of its own — so its claim must
+    /// stop gating peers the moment it parks. Carried on the checkpoint rather
+    /// than sniffed out of the reason string, which would be a guess.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub parked_at_turn_end: bool,
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
@@ -3919,11 +3940,7 @@ impl SubAgentManager {
                 claim.contracts.push(contract);
             }
         }
-        let active_owners = self.active_coordination_owners();
-        self.coordination
-            .register_claim(claim, existing.isolated_worktree, |candidate| {
-                active_owners.contains(candidate)
-            })
+        self.register_claim_with_presence(claim, existing.isolated_worktree)
     }
 
     /// Release write claims whose owner is no longer a live claimant.
@@ -4004,6 +4021,11 @@ impl SubAgentManager {
             .iter()
             .filter(|record| record.claim.owner != owner && !record.isolated_worktree)
             .filter(|record| self.is_live_coordination_owner(&record.claim.owner))
+            // A claim whose every named path is gone cannot describe a peer
+            // still writing here, so it must not gate command execution
+            // either (#5906) — the reported incident lost a whole session's
+            // shell to a claim on a deleted worktree.
+            .filter(|record| !self.claim_names_only_missing_paths(record))
             .map(|record| record.claim.owner.clone())
             .collect()
     }
@@ -4613,7 +4635,7 @@ impl SubAgentManager {
         if !isolated_worktree {
             self.ensure_coordination_process_lock()?;
         }
-        let active_owners = self.active_coordination_owners();
+        let active_owners = self.admissible_coordination_owners();
         let mut probe = self.coordination.clone();
         match probe.register_claim(claim.clone(), isolated_worktree, |owner| {
             active_owners.contains(owner)
@@ -4624,11 +4646,7 @@ impl SubAgentManager {
                 // remains visible after restart. Invalid/schema failures do
                 // not mutate either ledger.
                 let coordination_before = self.coordination.clone();
-                let _ = self
-                    .coordination
-                    .register_claim(claim, isolated_worktree, |owner| {
-                        active_owners.contains(owner)
-                    });
+                let _ = self.register_claim_with_presence(claim, isolated_worktree);
                 if let Err(persist_error) = self.persist_state_synchronously() {
                     self.coordination = coordination_before;
                     return Err(format!(
@@ -4660,11 +4678,7 @@ impl SubAgentManager {
         let previous_coordination = self.coordination.clone();
         let persisted_claim = claim
             .map(|(claim, isolated_worktree)| {
-                let active_owners = self.active_coordination_owners();
-                self.coordination
-                    .register_claim(claim, isolated_worktree, |owner| {
-                        active_owners.contains(owner)
-                    })
+                self.register_claim_with_presence(claim, isolated_worktree)
             })
             .transpose()?;
 
@@ -4756,11 +4770,102 @@ impl SubAgentManager {
                 // and the child will write again.
                 && !(record.status == AgentWorkerStatus::WaitingForUser
                     && !self.agents.contains_key(id))
+                // A child parked at its parent's turn end is not a child that
+                // asked a question (#5906). Nothing will answer it: the
+                // recovery path is `resume_from`, which starts a *new* agent
+                // that registers its own claim. Counting the parked record
+                // live left its claim standing forever — refusing the resume
+                // itself, every later write-capable spawn overlapping the
+                // scope, and (through the shared-checkout peer gate) all
+                // command execution for those peers.
+                && !record.parked_at_turn_end
                 && !self
                     .agents
                     .get(id)
                     .is_some_and(|agent| self.is_from_prior_session(agent))
         })
+    }
+
+    /// Resolve a normalized claim path against this manager's coordination
+    /// root. The ledger owns no workspace, so it asks through this.
+    fn coordination_claim_path_exists(workspace: &Path, path: &str) -> bool {
+        // `.` is the coordination root itself and is always present.
+        path == "." || workspace.join(path).exists()
+    }
+
+    /// Whether a standing claim's every recorded path is gone from disk.
+    ///
+    /// A claim on a deleted worktree cannot describe work anyone is still
+    /// doing, yet it kept refusing every overlapping claimant (#5906): the
+    /// reported incident claimed a worktree later removed with
+    /// `git worktree remove`, and the claim outlived the checkout it named.
+    /// See [`PersistedWriteClaim::present_at_claim`] for why the answer is
+    /// "vanished since", not "absent now".
+    fn claim_names_only_missing_paths(&self, record: &PersistedWriteClaim) -> bool {
+        record.names_only_vanished_paths(|path| {
+            Self::coordination_claim_path_exists(&self.workspace, path)
+        })
+    }
+
+    /// Register a write claim against the live admission set and stamp which
+    /// of its paths existed at that moment.
+    ///
+    /// The one door every production claim goes through, so the admission
+    /// answer and the presence stamp cannot drift apart: the ledger has no
+    /// filesystem, and a record registered without the stamp would silently
+    /// opt out of vanished-path staleness forever (#5906).
+    fn register_claim_with_presence(
+        &mut self,
+        claim: WriteScopeClaim,
+        isolated_worktree: bool,
+    ) -> Result<PersistedWriteClaim, String> {
+        let admissible = self.admissible_coordination_owners();
+        let mut record = self
+            .coordination
+            .register_claim(claim, isolated_worktree, |owner| admissible.contains(owner))?;
+        let owner = record.claim.owner.clone();
+        if !isolated_worktree {
+            record.present_at_claim = record
+                .claim
+                .roots
+                .iter()
+                .chain(record.claim.exact_files.iter())
+                .filter(|path| Self::coordination_claim_path_exists(&self.workspace, path))
+                .cloned()
+                .collect();
+        }
+        if let Some(persisted) = self
+            .coordination
+            .write_claims
+            .iter_mut()
+            .find(|persisted| persisted.claim.owner == owner)
+        {
+            persisted
+                .present_at_claim
+                .clone_from(&record.present_at_claim);
+        }
+        Ok(record)
+    }
+
+    /// The owners whose standing claims may refuse a new claimant: live by
+    /// [`Self::is_live_coordination_owner`] *and* still naming something that
+    /// exists on disk.
+    ///
+    /// Admission only. [`Self::active_coordination_owners`] stays the answer
+    /// for `coordinate release`, which *deletes* records — a live owner whose
+    /// tree is merely not created yet must not lose its claim permanently to
+    /// a sweep it never asked for.
+    fn admissible_coordination_owners(&self) -> std::collections::HashSet<String> {
+        let mut owners = self.active_coordination_owners();
+        owners.retain(|owner| {
+            !self
+                .coordination
+                .write_claims
+                .iter()
+                .filter(|record| record.claim.owner == *owner)
+                .any(|record| self.claim_names_only_missing_paths(record))
+        });
+        owners
     }
 
     // Worker records carry no boot id of their own, so the per-id predicate
@@ -5201,6 +5306,19 @@ impl SubAgentManager {
         {
             record.started_at_ms = Some(now_ms);
         }
+        // A worker that is executing again is not parked, whatever it was
+        // before. Re-dispatch under the same id therefore restores its claim's
+        // standing without a second authority deciding that (#5906).
+        if matches!(
+            status,
+            AgentWorkerStatus::Queued
+                | AgentWorkerStatus::Starting
+                | AgentWorkerStatus::Running
+                | AgentWorkerStatus::ModelWait
+                | AgentWorkerStatus::RunningTool
+        ) {
+            record.parked_at_turn_end = false;
+        }
         if matches!(
             status,
             AgentWorkerStatus::Completed
@@ -5252,6 +5370,12 @@ impl SubAgentManager {
         if let Some(record) = self.worker_records.get_mut(worker_id) {
             record.result_summary = result.result.clone();
             record.steps_taken = result.steps_taken;
+            // #5906: carry the park/ask distinction from the checkpoint onto
+            // the durable record, which is what coordination reads.
+            record.parked_at_turn_end = result
+                .checkpoint
+                .as_ref()
+                .is_some_and(|checkpoint| checkpoint.parked_at_turn_end);
             if let SubAgentStatus::Failed(err) = &result.status {
                 record.error = Some(err.clone());
             }
@@ -5279,7 +5403,14 @@ impl SubAgentManager {
                 .agents
                 .get(&agent_id)
                 .ok_or_else(|| anyhow!("Agent {agent_id} not found"))?;
-            if agent.status != SubAgentStatus::Running || agent.completion_claimed {
+            if agent.status != SubAgentStatus::Running {
+                let snapshot = agent.snapshot();
+                return Ok(self.terminalize_settled_worker_on_cancel(&agent_id, snapshot));
+            }
+            if agent.completion_claimed {
+                // Still running, with its terminal transition already claimed:
+                // mid-flight, not settled. Stealing it here would record a
+                // second terminal outcome for one child.
                 return Ok(agent.snapshot());
             }
             agent.snapshot()
@@ -5291,6 +5422,48 @@ impl SubAgentManager {
             return self.get_result(&agent_id);
         }
         self.get_result(&agent_id)
+    }
+
+    /// Terminalize a child that already left `Running` but whose worker record
+    /// never reached a terminal status — a child parked at the parent's turn
+    /// end, or one waiting on an answer the parent has now decided not to give
+    /// (#5906).
+    ///
+    /// Cancel is the release path the contention refusal names, and before
+    /// this it was a no-op on exactly the records that leak: `cancel_agent`
+    /// returned the snapshot untouched because the agent was no longer
+    /// `Running`, so the non-terminal worker record kept the write claim
+    /// standing and every overlapping spawn stayed refused. Terminalizing the
+    /// record releases the claim through the one liveness predicate rather
+    /// than reaching into the ledger behind its back.
+    fn terminalize_settled_worker_on_cancel(
+        &mut self,
+        agent_id: &str,
+        snapshot: SubAgentResult,
+    ) -> SubAgentResult {
+        let already_terminal = self
+            .worker_records
+            .get(agent_id)
+            .is_none_or(|record| record.status.is_terminal());
+        if already_terminal {
+            return snapshot;
+        }
+        if let Some(agent) = self.agents.get_mut(agent_id) {
+            // The question is withdrawn with the work: leaving it would keep
+            // offering a resume the operator just declined.
+            agent.needs_input = None;
+        }
+        self.record_worker_event(
+            agent_id,
+            AgentWorkerStatus::Cancelled,
+            Some("cancelled by parent while parked or awaiting input".to_string()),
+            None,
+            None,
+        );
+        self.persist_state_best_effort();
+        self.agents
+            .get(agent_id)
+            .map_or(snapshot, |agent| agent.snapshot())
     }
 
     pub(crate) fn cancel_agent_for_session(
@@ -6382,11 +6555,7 @@ impl SubAgentManager {
                             claim,
                         )?
                     };
-                    let active_owners = self.active_coordination_owners();
-                    self.coordination
-                        .register_claim(claim, options.isolated_worktree, |owner| {
-                            active_owners.contains(owner)
-                        })
+                    self.register_claim_with_presence(claim, options.isolated_worktree)
                 })
                 .transpose()
         } else {
@@ -8082,6 +8251,15 @@ enum AgentToolAction {
     /// so retiring that tool from the catalog without this action would have
     /// left fail-closed write enforcement with no in-band way to satisfy it.
     Claim,
+    /// Clear write claims whose owner is no longer a live claimant (#5906).
+    ///
+    /// The contention refusal and the shared-checkout peer gate both told the
+    /// caller to run `agents/coordinate action=release`, a tool that is no
+    /// longer in any catalog — so the one remediation named by the only error
+    /// that needs it was unreachable from the surface that raised it. Like
+    /// `claim`, this adds no authority: `release_stale_write_claims` never
+    /// removes a live claimant's claim, whoever asks.
+    Release,
 }
 
 fn parse_agent_tool_action(input: &Value) -> Result<AgentToolAction, ToolError> {
@@ -8099,8 +8277,9 @@ fn parse_agent_tool_action(input: &Value) -> Result<AgentToolAction, ToolError> 
         "wait" | "join" | "await" | "block" => Ok(AgentToolAction::Wait),
         "cancel" | "stop" | "abort" => Ok(AgentToolAction::Cancel),
         "claim" => Ok(AgentToolAction::Claim),
+        "release" | "release_claim" => Ok(AgentToolAction::Release),
         other => Err(ToolError::invalid_input(format!(
-            "Invalid agent action '{other}'. Use start, roster, status, peek, message, followup, interrupt, wait, claim, or cancel."
+            "Invalid agent action '{other}'. Use start, roster, status, peek, message, followup, interrupt, wait, claim, release, or cancel."
         ))),
     }
 }
@@ -8225,6 +8404,7 @@ impl ToolSpec for AgentTool {
             "Prefer type=builder for write work and type=verifier (or the Run tool with action=\"verifiers\") after writes settle — dispatch is not completion. ",
             "Coordinate through this same tool: action=message queues a note without waking the child; action=followup delivers queued notes and wakes a running child for its next user-provenance turn; action=interrupt stops the current child turn while preserving its checkpoint; action=wait blocks without changing child state, and until=\"all\" joins a whole fan-out in one call. ",
             "action=claim widens your own enforced write scope: pass write_roots (and optionally exact_files, coordination_contracts) before mutating anything a fail-closed write refusal named. It records a durable claim receipt and fails on contention with a peer claim; it never touches another agent's scope. ",
+            "action=release clears write claims whose owner is no longer running — the fix a write-scope contention or blocking-peers refusal names. Pass agent_id for one, omit it to sweep; a live claim is never removed. ",
             "Action contract: start requires prompt; message/followup require a target and message; peek/interrupt/cancel require a target; claim requires at least one scope entry; roster, status, and wait are unscoped. ",
             "This is the whole model-facing sub-agent surface; there is no second transport. ",
             "In Operate, use detached=true only for independent or long work that must outlive the active turn; a write-capable root start defaults write scope to the parent workspace unless narrowed with write_roots; arbitrary shell remains gated. ",
@@ -8256,8 +8436,8 @@ impl ToolSpec for AgentTool {
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["start", "roster", "status", "peek", "message", "followup", "interrupt", "wait", "claim", "cancel"],
-                    "description": "start launches a turn-owned worker and returns immediately. roster lists the Fleet roles and their descriptions. status/peek inspect running or retained workers. message queues a note without waking a running child. followup delivers queued notes and wakes a running child for its next user-provenance model turn. interrupt stops the current turn while preserving the child checkpoint. wait only observes; see until. claim widens your own enforced write scope (see write_roots). cancel permanently cancels a running child."
+                    "enum": ["start", "roster", "status", "peek", "message", "followup", "interrupt", "wait", "claim", "release", "cancel"],
+                    "description": "start launches a turn-owned worker and returns immediately. roster lists the Fleet roles and their descriptions. status/peek inspect running or retained workers. message queues a note without waking a running child. followup delivers queued notes and wakes a running child for its next user-provenance model turn. interrupt stops the current turn while preserving the child checkpoint. wait only observes; see until. claim widens your own enforced write scope (see write_roots). release clears write claims whose owner is no longer running — the remediation a write-scope contention refusal names; pass agent_id to clear one, omit it to sweep. cancel permanently cancels a running child."
                 },
                 "until": {
                     "type": "string",
@@ -8359,6 +8539,14 @@ impl ToolSpec for AgentTool {
                             "properties": {"action": {"const": "claim"}}
                         },
                         {
+                            // `release` names no *required* target: with
+                            // `agent_id` it clears that one stale claim, and
+                            // without it sweeps every claim whose owner is no
+                            // longer live. Neither form can touch a live
+                            // claimant's claim.
+                            "properties": {"action": {"const": "release"}}
+                        },
+                        {
                             "properties": {"action": {"const": "cancel"}},
                             "anyOf": target_required
                         }
@@ -8407,6 +8595,11 @@ impl ToolSpec for AgentTool {
             // Authority is unchanged: `claim` can only widen the *caller's
             // own* scope, and contention with a peer claim still fails.
             Ok(AgentToolAction::Claim) => ApprovalRequirement::Auto,
+            // Same reasoning, and the same bounded authority: `release` only
+            // drops claims whose owner is already not a live claimant, and a
+            // child that is refused every write until a dead claim clears
+            // cannot raise a modal in a parent UI nobody is watching (#5906).
+            Ok(AgentToolAction::Release) => ApprovalRequirement::Auto,
             _ => ApprovalRequirement::Required,
         }
     }
@@ -8523,6 +8716,28 @@ impl ToolSpec for AgentTool {
                     self.runtime.parent_agent_id.clone(),
                 )
                 .execute(agent_claim_coordinate_input(&input)?, context)
+                .await;
+            }
+            AgentToolAction::Release => {
+                let mut coordinate_input = json!({"action": "release"});
+                if let Some(agent_ref) = parse_agent_ref(&input)? {
+                    // Targeted release accepts a session name like every other
+                    // targeted action; the ledger keys claims by agent id, and
+                    // a headless worker id that resolves to no agent row is
+                    // passed through unchanged.
+                    let owner = {
+                        let manager = self.manager.read().await;
+                        manager
+                            .resolve_agent_ref(&agent_ref)
+                            .unwrap_or_else(|_| agent_ref.clone())
+                    };
+                    coordinate_input["owner"] = json!(owner);
+                }
+                return AgentsCoordinateTool::new(
+                    self.manager.clone(),
+                    self.runtime.parent_agent_id.clone(),
+                )
+                .execute(coordinate_input, context)
                 .await;
             }
         }
@@ -10582,6 +10797,7 @@ fn build_subagent_checkpoint(
         created_at_ms,
         messages: bounded_messages,
         omitted_messages,
+        parked_at_turn_end: false,
     }
 }
 
@@ -11008,7 +11224,10 @@ fn subagent_cancellation_projection(
         let reason = format!(
             "Parent turn ended before this turn-owned child settled. Work was parked instead of discarded; resume with agent(action=\"start\", prompt=\"Continue the parked assignment.\", resume_from=\"{agent_id}\")."
         );
-        let checkpoint = build_subagent_checkpoint(agent_id, &reason, messages, steps, true);
+        let mut checkpoint = build_subagent_checkpoint(agent_id, &reason, messages, steps, true);
+        // Parked, not asking: nothing will answer this child, and its write
+        // claim must stop gating peers immediately (#5906).
+        checkpoint.parked_at_turn_end = true;
         let needs_input = SubAgentNeedsInput {
             question: format!(
                 "Resume this parked child with agent(action=\"start\", prompt=\"Continue the parked assignment.\", resume_from=\"{agent_id}\")."
@@ -14657,7 +14876,10 @@ impl SubAgentToolRegistry {
     /// action, so a ceiling written against `agents/coordinate` keeps meaning
     /// what it meant.
     fn agent_action_permitted(&self, action: &str) -> bool {
-        if action != "claim" {
+        // `release` (#5906) carried the same `agents/coordinate` authority as
+        // `claim` and is gated identically: a read-only role has no write
+        // scope, so no contention refusal to remediate.
+        if !matches!(action, "claim" | "release") {
             return true;
         }
         !self.write_is_denied() && !self.is_tool_denied("agents/coordinate")
@@ -14992,7 +15214,7 @@ impl SubAgentToolRegistry {
                     manager.live_peer_shared_write_claim_owners(&self.owner_agent_id);
                 if !blocking_peers.is_empty() {
                     return Err(anyhow!(
-                        "Tool {name} cannot prove a bounded file target, and another child is writing in this shared checkout (blocking peers: {}). Wait for the peer to finish, ask the parent to cancel it, run agents/coordinate action=release to clear a stale claim, or relaunch the children with worktree isolation.",
+                        "Tool {name} cannot prove a bounded file target, and another child is writing in this shared checkout (blocking peers: {}). Wait for the peer to finish, ask the parent to cancel it with agent(action=\"cancel\", agent_id=\"<peer>\"), run agent(action=\"release\") to clear a stale claim, or relaunch the children with worktree isolation.",
                         blocking_peers.join(", ")
                     ));
                 }

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -11339,9 +11339,24 @@ async fn contended_shared_writer_refusal_names_blocking_peer_and_remediation() {
         err.contains("agent_b"),
         "refusal must name the blocking peer: {err}"
     );
+    // #5906: the remediation must name a surface that exists from here.
+    // `agents/coordinate` left the catalog, so the refusal pointed at a tool
+    // the refused child could not reach.
     assert!(
-        err.contains("agents/coordinate action=release") && err.contains("worktree isolation"),
+        err.contains(r#"agent(action="release")"#) && err.contains("worktree isolation"),
         "refusal must state concrete remediation: {err}"
+    );
+    assert!(
+        AgentTool::new(
+            new_shared_subagent_manager(tmp.path().to_path_buf(), 1),
+            stub_runtime(),
+        )
+        .input_schema()["properties"]["action"]["enum"]
+            .as_array()
+            .expect("action enum")
+            .iter()
+            .any(|action| action == "release"),
+        "the remediation the refusal names must be a real action on this tool"
     );
     assert!(
         !tmp.path().join("src/a2.txt").exists(),
@@ -11471,6 +11486,214 @@ fn waiting_for_user_headless_worker_is_not_a_live_coordination_owner() {
         manager.is_live_coordination_owner(&paired),
         "an interactive child waiting on the user stays live"
     );
+}
+
+/// Register a shared-checkout write claim for `owner` the way production does,
+/// so the presence stamp (#5906) is recorded rather than defaulted away.
+fn claim_shared_root(manager: &mut SubAgentManager, owner: &str, root: &str) -> Result<(), String> {
+    manager
+        .register_claim_with_presence(
+            WriteScopeClaim {
+                owner: owner.to_string(),
+                roots: vec![root.to_string()],
+                exact_files: Vec::new(),
+                contracts: Vec::new(),
+            },
+            false,
+        )
+        .map(|_| ())
+}
+
+/// Commit the exact terminal projection the runtime writes when a parent turn
+/// ends before a turn-owned child settles.
+fn park_child_at_turn_end(manager: &mut SubAgentManager, agent_id: &str) {
+    let parking = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let messages = vec![text_message("user", "Continue the parked assignment.")];
+    let (status, reason, checkpoint, needs_input, _, _) =
+        subagent_cancellation_projection(agent_id, &messages, 0, None, Some(&parking));
+    let mut terminal = manager.get_result(agent_id).expect("running child");
+    terminal.status = status;
+    terminal.result = reason;
+    terminal.checkpoint = checkpoint;
+    terminal.needs_input = needs_input;
+    assert!(
+        manager.finish_terminal_result(agent_id, terminal, true, false),
+        "the parked projection must own the terminal transition"
+    );
+}
+
+/// #5906: a child parked because its parent's turn ended is not a child that
+/// asked a question. Nothing will answer it — the recovery path starts a *new*
+/// agent through `resume_from` — so holding its write claim open refused the
+/// resume itself and every later writer overlapping the scope.
+#[tokio::test]
+async fn a_parked_child_stops_holding_its_write_claim() {
+    let tmp = tempdir().expect("tempdir");
+    let workspace = tmp.path().canonicalize().expect("canonical workspace");
+    std::fs::create_dir_all(workspace.join("src/shared")).expect("claimed tree");
+    let mut manager = SubAgentManager::new(workspace.clone(), 8);
+
+    let parked = manager.insert_test_running_agent("parked", &workspace);
+    claim_shared_root(&mut manager, &parked, "src/shared").expect("initial claim");
+    assert!(
+        manager.is_live_coordination_owner(&parked),
+        "a running writer holds its claim"
+    );
+    claim_shared_root(&mut manager, "agent_resume", "src/shared")
+        .expect_err("a live writer's overlapping scope must still contend");
+
+    park_child_at_turn_end(&mut manager, &parked);
+
+    let record = manager.get_worker_record(&parked).expect("worker record");
+    assert_eq!(
+        record.status,
+        AgentWorkerStatus::WaitingForUser,
+        "the parked projection is unchanged; only coordination learns to read it"
+    );
+    assert!(
+        record.parked_at_turn_end,
+        "the record must carry the park/ask distinction rather than have it guessed"
+    );
+    assert!(
+        !manager.is_live_coordination_owner(&parked),
+        "a parked child must not gate peers as a live writer"
+    );
+    assert!(
+        !manager.admissible_coordination_owners().contains(&parked),
+        "admission and the liveness predicate share one answer"
+    );
+
+    // The exact refusal from the report: resuming the same work under a new
+    // agent id must be admitted.
+    claim_shared_root(&mut manager, "agent_resume", "src/shared")
+        .expect("a resume of parked work must not be refused by the parked claim");
+    assert!(
+        manager
+            .live_peer_shared_write_claim_owners("agent_resume")
+            .is_empty(),
+        "and the parked owner must not keep gating the resumed child's shell"
+    );
+
+    // Re-dispatch under the same id clears the flag, so a claim that becomes
+    // live again is honoured without a second authority deciding that.
+    manager.record_worker_event(&parked, AgentWorkerStatus::Running, None, None, None);
+    assert!(
+        !manager
+            .get_worker_record(&parked)
+            .expect("worker record")
+            .parked_at_turn_end
+    );
+}
+
+/// #5906: `cancel` is the release path the contention refusal names, and it was
+/// a no-op on exactly the records that leak — `cancel_agent` returned early
+/// because the child had already left `Running`, leaving a non-terminal worker
+/// record holding the claim.
+#[tokio::test]
+async fn cancelling_a_settled_waiting_child_terminalizes_it_and_releases_its_claim() {
+    let tmp = tempdir().expect("tempdir");
+    let workspace = tmp.path().canonicalize().expect("canonical workspace");
+    std::fs::create_dir_all(workspace.join("src/shared")).expect("claimed tree");
+    let mut manager = SubAgentManager::new(workspace.clone(), 8);
+
+    let waiting = manager.insert_test_running_agent("waiting", &workspace);
+    claim_shared_root(&mut manager, &waiting, "src/shared").expect("initial claim");
+    // A paired child that genuinely asked the user something: still live,
+    // because the user can answer and the child will write again.
+    manager.agents.get_mut(&waiting).expect("agent").status =
+        SubAgentStatus::Interrupted("awaiting user input".to_string());
+    manager.agents.get_mut(&waiting).expect("agent").needs_input = Some(SubAgentNeedsInput {
+        question: "which branch?".to_string(),
+    });
+    manager
+        .worker_records
+        .get_mut(&waiting)
+        .expect("worker record")
+        .status = AgentWorkerStatus::WaitingForUser;
+    assert!(
+        manager.is_live_coordination_owner(&waiting),
+        "an unanswered question is not a leak"
+    );
+    claim_shared_root(&mut manager, "agent_peer", "src/shared")
+        .expect_err("its claim legitimately blocks while the question stands");
+
+    manager.cancel_agent(&waiting).expect("cancel");
+
+    assert!(
+        manager
+            .get_worker_record(&waiting)
+            .expect("worker record")
+            .status
+            .is_terminal(),
+        "cancel must terminalize a settled child's worker record"
+    );
+    assert!(
+        manager
+            .agents
+            .get(&waiting)
+            .expect("agent")
+            .needs_input
+            .is_none(),
+        "the withdrawn question must not keep offering a resume"
+    );
+    assert!(
+        !manager.is_live_coordination_owner(&waiting),
+        "and the claim releases through the one liveness predicate"
+    );
+    claim_shared_root(&mut manager, "agent_peer", "src/shared")
+        .expect("the cancelled child's claim must stop refusing the peer");
+}
+
+/// #5906: the reported claim named a worktree that had since been deleted with
+/// `git worktree remove` and kept refusing every claimant anyway. "Gone" and
+/// "not created yet" must not be confused: a forward-looking claim on a tree
+/// its owner is about to create is the reservation the ledger exists to honor.
+#[test]
+fn a_claim_whose_paths_vanished_stops_blocking_but_a_future_tree_still_does() {
+    let tmp = tempdir().expect("tempdir");
+    let workspace = tmp.path().canonicalize().expect("canonical workspace");
+    let mut manager = SubAgentManager::new(workspace.clone(), 8);
+    let doomed = workspace.join("worktrees/cw-gone");
+    std::fs::create_dir_all(&doomed).expect("worktree checkout");
+
+    manager
+        .register_worker_with_coordination(make_write_worker_spec(
+            "worker-worktree",
+            workspace.clone(),
+            "worktrees/cw-gone",
+        ))
+        .expect("headless worker registration");
+    assert!(
+        manager.is_live_coordination_owner("worker-worktree"),
+        "the owner stays live throughout: only the path changes"
+    );
+    claim_shared_root(&mut manager, "agent_next", "worktrees/cw-gone")
+        .expect_err("an existing claimed checkout must still contend");
+
+    std::fs::remove_dir_all(&doomed).expect("git worktree remove");
+
+    assert!(
+        !manager
+            .admissible_coordination_owners()
+            .contains("worker-worktree"),
+        "a claim on a checkout that no longer exists cannot block admission"
+    );
+    assert!(
+        manager
+            .live_peer_shared_write_claim_owners("agent_next")
+            .is_empty(),
+        "nor gate a peer's command execution"
+    );
+    claim_shared_root(&mut manager, "agent_next", "worktrees/cw-gone")
+        .expect("the vanished claim must not refuse the next writer");
+
+    // The other half: a claim on a tree that never existed is a reservation,
+    // not a leak, and two writers must not both be admitted to it.
+    let mut fresh = SubAgentManager::new(workspace.clone(), 8);
+    let planner = fresh.insert_test_running_agent("planner", &workspace);
+    claim_shared_root(&mut fresh, &planner, "crates/not-created-yet").expect("forward claim");
+    claim_shared_root(&mut fresh, "agent_other", "crates/not-created-yet")
+        .expect_err("a not-yet-created tree is still exclusively claimed");
 }
 
 #[tokio::test]

--- a/crates/tui/src/tui/coordination_detail.rs
+++ b/crates/tui/src/tui/coordination_detail.rs
@@ -307,6 +307,7 @@ mod tests {
                 },
                 sequence: 2,
                 isolated_worktree: false,
+                present_at_claim: Vec::new(),
             }],
             reconciliations: vec![ReconciliationReceipt {
                 reconciliation_id: "reconcile-ui".to_string(),

--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -502,6 +502,7 @@ mod tests {
                 },
                 sequence: 1,
                 isolated_worktree: false,
+                present_at_claim: Vec::new(),
             }],
             reconciliations: Vec::new(),
             context_projections: Vec::new(),


### PR DESCRIPTION
Closes #5906

## The bug

A child parked because its parent's turn ended kept its coordination write claim indefinitely. Parking projects as `Interrupted` -> `WaitingForUser`, and a *paired* `WaitingForUser` worker is deliberately counted live so a user can still answer it. But a parked child asked nobody anything: its recovery path is `resume_from`, which starts a **new** agent that registers a claim of its own. So the parked claim stood forever, refusing

- the resume of the same work under a new agent id,
- every later write-capable spawn overlapping the scope,
- and, through the shared-checkout peer gate, *all* command execution for those peers ("blocking peers: agent_X").

Cancel could not clear it either: `cancel_agent` returned early because the child had already left `Running`, so the non-terminal worker record kept holding the claim. And the remediation both refusals named — `agents/coordinate action=release` — is not in any catalog since #5462, so the surface that raised the error could not reach the fix.

## What changed

**1. A parked child no longer holds a write claim.** The park/ask distinction is now *recorded*, not guessed from a reason string: `SubAgentCheckpoint` and `AgentWorkerRecord` carry `parked_at_turn_end`, set by the turn-end parking projection and cleared whenever the record is dispatched again. `is_live_coordination_owner` — the one liveness predicate admission, the peer gate, and stale-claim release all share — stops counting a parked record live. A paired child that genuinely asked a question is untouched and keeps its claim.

**2. Cancelling a parked/waiting child terminalizes its worker record.** `cancel_agent` on a child that already left `Running` now records a terminal `Cancelled` worker event and withdraws its `needs_input`, so the claim releases through the same liveness predicate rather than reaching into the ledger behind its back. A child that is still `Running` with its terminal delivery already claimed is left alone (that path would otherwise record two terminal outcomes for one child).

**3. A claim whose paths are gone no longer blocks admission or gates a peer's shell.** This deliberately distinguishes "gone" from "not created yet" — the two are indistinguishable from a bare `exists()` call and mean opposite things. `PersistedWriteClaim::present_at_claim` stamps which of a claim's paths existed at registration; only a claim whose stamped paths have all since disappeared is treated as stale. A forward-looking claim on a tree its owner is about to create keeps its exclusivity, so two writers still cannot both be admitted to a new module directory. Admission (`admissible_coordination_owners`) uses this; `coordinate release`, which *deletes* records, keeps using owner liveness alone.

**4. The refusals name a release path that exists.** Both the ledger's `write-scope contention with ...` error and the blocking-peers shell refusal now name `agent(action="release")`, and that action now exists: it dispatches to the same `release_stale_write_claims` (which never removes a live claimant's claim), is approval-gated and role-gated exactly like `action=claim`, and takes an optional `agent_id` to clear one claim instead of sweeping all stale ones.

## Verified

```
cargo fmt --all -- --check                      clean
cargo check -p codewhale-tui                    clean
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- tools::subagent
  test result: ok. 547 passed; 0 failed; 0 ignored   (544 before this change)
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib
  test result: ok. 11696 passed; 0 failed; 13 ignored
```

Three new regression tests, each shown failing on its exact assertion with the corresponding guard reverted:

- `a_parked_child_stops_holding_its_write_claim` — drives the real turn-end parking projection through `finish_terminal_result`, then asserts the resume of the same scope is admitted and the parked owner no longer gates the resumed child's shell. Also asserts re-dispatch clears the flag.
- `cancelling_a_settled_waiting_child_terminalizes_it_and_releases_its_claim` — asserts an unanswered question legitimately blocks *before* the cancel, and that the cancel terminalizes, withdraws the question, and unblocks the peer.
- `a_claim_whose_paths_vanished_stops_blocking_but_a_future_tree_still_does` — covers both halves: a deleted worktree stops blocking; a not-yet-created tree still does.

One existing test was updated with the code (`contended_shared_writer_refusal_names_blocking_peer_and_remediation`) — it pinned the old, unreachable remediation string. It now also asserts `release` is a real value in the advertised `agent` action enum, so the message and the surface cannot drift apart again.

## Not verified / not done

- **No provider call, no deploy, no manual reproduction of the original incident.** This is local-test evidence only.
- **Pre-existing flake, unrelated to this change:** `remote_control::tests::separate_predispatch_crashes_on_one_run_get_distinct_recovery_turn_ids` failed once in a full-suite run under parallel execution. I confirmed it fails the same way on unmodified `origin/main` and passes in isolation both with and without this change; it passed in the final full-suite run above.
- **Claims persisted before this change have an empty `present_at_claim`** and are therefore never treated as path-stale. That is the deliberate safe default (no evidence of disappearance), but it means the specific already-persisted claim from the incident report is cleared by changes 1/2 and `agent(action="release")`, not by change 3.
- **Change 3 accepts a known limit:** a claim that names both contracts and paths loses contract-level protection once all its paths vanish. Path-vanished is treated as claim-stale wholesale.
- I did not touch `release_stale_claims`' own semantics, the `resume_from` validation path, or any UI projection of `WaitingForUser` — a parked child still reports `waiting_for_user` to the roster, only coordination learned to read it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XYyJaw9Mh9uSrqQBoqhm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared coordination liveness, write-claim admission, and cancel semantics for sub-agents—high-impact for parallel writers but bounded by tests and explicit safe defaults for legacy persisted claims.
> 
> **Overview**
> Fixes **#5906**: stale sub-agent write claims could block resumes, overlapping spawns, and shared-checkout shell work indefinitely.
> 
> **Parked vs. waiting children** now carry `parked_at_turn_end` on checkpoints and worker records. Turn-end parking sets it; re-dispatch clears it. `is_live_coordination_owner` no longer treats parked workers as live, so their claims stop gating peers while children that genuinely asked a question still hold claims.
> 
> **Cancel on settled children** terminalizes non-terminal worker records when the agent is no longer `Running` (parked or waiting), withdraws `needs_input`, and releases claims through the same liveness path instead of being a no-op.
> 
> **Vanished-path staleness** adds `PersistedWriteClaim::present_at_claim` and routes registration through `register_claim_with_presence`. **Admission** uses `admissible_coordination_owners` (live owners whose stamped paths still exist); forward-looking claims on not-yet-created paths stay exclusive. The peer shell gate ignores claims whose paths have all disappeared.
> 
> **Operator surface**: `agent(action="release")` maps to stale claim release (optional `agent_id`), with schema/docs and contention/blocking-peer errors updated to name `agent(action="release")` / `agent(action="cancel", ...)` instead of retired `agents/coordinate`. Regression tests cover parking, cancel, and vanished vs. future paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd9517b7551a91e89fc3f5e5979395758fcadd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->