### PR TITLE
test(tui): name the command a dispatch smoke stalls on, and skip /pin on Windows

### DIFF
--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -1587,8 +1587,78 @@ mod tests {
     /// `scoped_home` (snapshot repo init shells out to git, which races
     /// against parallel-running tests). Skip it here so this smoke test
     /// stays parallel-safe.
+    ///
+    /// `/pin` is skipped on Windows only. Its handler is not a state toggle:
+    /// it drives the *host terminal window* through Win32 (see
+    /// `tui::window_control`), and the resolved `HWND` belongs to another
+    /// process. `SetWindowPos`/`ShowWindow` against a foreign window are
+    /// delivered to that window's thread and block until it pumps them, so on
+    /// a headless CI window station the call never returns — this is the
+    /// 600 s nextest timeout in #5919 (the CI breadcrumb stalled on `/pin`
+    /// and on its `/mini` alias, the same handler). On macOS and Linux
+    /// `toggle_pin()` is a compiled-out no-op, so dispatch coverage for
+    /// `/pin` is kept there.
     fn skip_in_dispatch_smoke(name: &str) -> bool {
-        name == "restore"
+        name == "restore" || (cfg!(windows) && name == "pin")
+    }
+
+    /// Upper bound on a single command dispatch in the smoke tests.
+    ///
+    /// Generous next to the millisecond each handler actually takes, and far
+    /// below nextest's 600 s test timeout, so a handler that blocks fails the
+    /// test *by name* instead of burning a ten-minute CI slot with no
+    /// attribution (#5919).
+    const DISPATCH_WATCHDOG: std::time::Duration = std::time::Duration::from_secs(30);
+
+    /// Dispatch one command under a per-command watchdog and return the
+    /// handler's message.
+    ///
+    /// The app is built and the command executed on a dedicated thread; the
+    /// test thread waits on the result with a timeout. A handler that never
+    /// returns leaves its thread parked, but the test itself fails
+    /// immediately, naming the invocation. A handler that panics still
+    /// surfaces as that panic — the smoke tests are the repo's only
+    /// panic-in-a-handler net, so the payload is resumed rather than
+    /// swallowed.
+    fn dispatch_under_watchdog(command_name: &str, alias_or_name: &str) -> Option<String> {
+        let label = format!("/{alias_or_name}");
+        let (tx, rx) = std::sync::mpsc::channel();
+        let name = command_name.to_string();
+        let alias = alias_or_name.to_string();
+        let handle = std::thread::Builder::new()
+            .name(format!("dispatch-smoke-{alias_or_name}"))
+            // Command handlers are deeply recursive in debug builds; match the
+            // 16 MiB the CI runner sets via RUST_MIN_STACK for the main thread.
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || {
+                let (mut app, tmpdir, _guard) = create_isolated_test_app();
+                let invocation = invocation_for(&name, &alias, tmpdir.path());
+                let result = execute(&invocation, &mut app);
+                let _ = tx.send(result.message);
+            })
+            .expect("spawn dispatch smoke thread");
+
+        let started = std::time::Instant::now();
+        match rx.recv_timeout(DISPATCH_WATCHDOG) {
+            Ok(message) => {
+                let _ = handle.join();
+                // Quiet on the common path; a handler heading for the
+                // watchdog still leaves a named breadcrumb in the log.
+                let elapsed = started.elapsed();
+                if elapsed > std::time::Duration::from_secs(1) {
+                    eprintln!("dispatch smoke: {label} took {elapsed:?}");
+                }
+                message
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => panic!(
+                "{label} did not return within {DISPATCH_WATCHDOG:?}: its handler blocks. \
+                 Fix the handler or add it to skip_in_dispatch_smoke with a reason."
+            ),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => match handle.join() {
+                Ok(()) => panic!("{label} dispatch thread ended without producing a result"),
+                Err(payload) => std::panic::resume_unwind(payload),
+            },
+        }
     }
 
     #[test]
@@ -1690,18 +1760,7 @@ mod tests {
             if skip_in_dispatch_smoke(command.name) {
                 continue;
             }
-            let (mut app, tmpdir, _guard) = create_isolated_test_app();
-            let invocation = invocation_for(command.name, command.name, tmpdir.path());
-            // Breadcrumb for a terminated run: the last line names the handler
-            // that never returned.
-            eprintln!("dispatch smoke: {invocation}");
-            let started = std::time::Instant::now();
-            let result = execute(&invocation, &mut app);
-            eprintln!(
-                "dispatch smoke: {invocation} returned in {:?}",
-                started.elapsed()
-            );
-            if let Some(msg) = &result.message {
+            if let Some(msg) = dispatch_under_watchdog(command.name, command.name) {
                 assert!(
                     !msg.contains("Unknown command"),
                     "/{} fell through to the unknown-command branch: {msg}",
@@ -1720,16 +1779,7 @@ mod tests {
                 continue;
             }
             for alias in command.aliases {
-                let (mut app, tmpdir, _guard) = create_isolated_test_app();
-                let invocation = invocation_for(command.name, alias, tmpdir.path());
-                eprintln!("dispatch smoke: {invocation}");
-                let started = std::time::Instant::now();
-                let result = execute(&invocation, &mut app);
-                eprintln!(
-                    "dispatch smoke: {invocation} returned in {:?}",
-                    started.elapsed()
-                );
-                if let Some(msg) = &result.message {
+                if let Some(msg) = dispatch_under_watchdog(command.name, alias) {
                     assert!(
                         !msg.contains("Unknown command"),
                         "/{alias} (alias of /{}) fell through to unknown: {msg}",


### PR DESCRIPTION
Closes #5919

## The offender: `/pin`

The stderr breadcrumbs in run 34013201624 / job 101432543520 name it. In
`every_registered_command_dispatches_to_a_handler` the last line is:

```
dispatch smoke: /pin
```

with no matching `/pin returned in …`. In `every_command_alias_dispatches_to_a_handler`
the last line is `dispatch smoke: /mini` — and `mini` is the first alias of
`pin` (`crates/tui/src/commands/groups/core/pin.rs`). Two independent tests,
same handler, neither returned.

`/pin` is not a state toggle. It calls `tui::window_control::toggle_pin()`,
which resolves the **host terminal window** (`GetConsoleWindow`, else the
foreground window, else an `EnumWindows` walk of the parent process chain)
and then drives it with Win32 `SetWindowPos` / `ShowWindow`. That `HWND`
belongs to a *different process*: those calls are delivered to that window's
thread and block until it pumps them. On a headless CI window station there
is nothing pumping, so the call never returns and the test runs out the
600 s nextest timeout.

## What this PR does

1. **Per-command watchdog** — each dispatch now builds its app and runs
   `execute` on its own thread; the test waits 30 s for the result. A
   blocking handler now fails the test in milliseconds, naming the
   invocation, instead of costing a ten-minute CI slot with no attribution.
   Handler panics still surface as that panic (the payload is resumed), which
   is a property the smoke tests exist for.
2. **Skip `/pin` on Windows only**, with the reason in the doc comment next
   to the existing `/restore` skip. On macOS and Linux `toggle_pin()` is a
   compiled-out no-op, so dispatch coverage for `/pin` is kept there.
3. Drops the unconditional per-command `eprintln` pair (≈15k log lines per
   run) whose only job the watchdog now does; a single line remains for any
   dispatch slower than a second.

No production code changed — the diff is entirely inside `#[cfg(test)] mod tests`.

## Verified locally (macOS, aarch64)

```
cargo fmt --all -- --check                                    clean (exit 0)
cargo test -p codewhale-tui --lib -- commands::tests::every_
  test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 11704 filtered out
cargo test -p codewhale-tui --lib -- commands::
  test result: ok. 977 passed; 0 failed; 0 ignored; 0 measured; 10730 filtered out
```

`cargo check -p codewhale-tui` does not compile `cfg(test)` code, so the
`cargo test` runs above are the compile evidence for this diff.

The watchdog mechanism itself was proved, not assumed:

- `DISPATCH_WATCHDOG` temporarily set to `Duration::ZERO` → the test failed
  in **0.05 s** with `/anchor did not return within 0ns: its handler blocks.`
- a panic temporarily injected into the worker thread → propagated to the
  test, with the handler's name on the thread (`thread 'dispatch-smoke-anchor'`).

Both temporary edits were reverted before the runs quoted above.

## What only Windows CI can prove

I am on macOS, so I could not reproduce the hang. The `/pin` attribution is
read off the CI breadcrumbs plus the Win32 code, not from a Windows run;
`toggle_pin()` compiles to `false` on this host, so the skip is a no-op
locally and the two tests would pass here either way. **The acceptance
criterion "Windows matrix green on three consecutive runs" can only be
checked on windows-latest.**

Also deliberately not attempted: hardening `window_control::toggle_pin()`
itself (e.g. `SWP_ASYNCWINDOWPOS` / `ShowWindowAsync` so the TUI thread never
blocks on the terminal host's message pump). That is a real improvement for
Windows users, but it changes the semantics of the existing
apply-then-verify-then-retry logic and I cannot run it on this host. It
belongs in its own issue with a Windows author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XYyJaw9Mh9uSrqQBoqhm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in the TUI command module; no runtime or dispatch logic in production builds.
> 
> **Overview**
> Fixes **Windows CI hangs** (#5919) where the “every command dispatches” smoke tests could stall for the full nextest timeout when **`/pin`** (and alias **`/mini`**) blocked on Win32 window calls in headless CI.
> 
> **`/pin` is excluded from the smoke loop on Windows only**, with the same style of rationale as the existing **`/restore`** skip; macOS/Linux still exercise **`/pin`** because **`toggle_pin()`** is a no-op there.
> 
> The smoke tests now run each dispatch on a **dedicated thread with a 30s watchdog**, so a blocking handler **fails fast and names the invocation** instead of burning CI time. Handler **panics still propagate** via **`resume_unwind`**. Verbose per-command **`eprintln`** breadcrumbs were removed; only dispatches **slower than one second** log a line.
> 
> All changes are under **`#[cfg(test)]`** in **`commands/mod.rs`** — no production behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09fc7db1790958bb57b39d7c1c38637eadc0bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->