### PR TITLE
chore(deps): bump rmcp from 2.2.0 to 3.2.0 and port the OAuth transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4444,13 +4446,14 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "indexmap",
  "oauth2",
  "pin-project-lite",
  "reqwest 0.13.4",

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -62,7 +62,7 @@ ratatui = { version = "=0.30.2", features = ["unstable-rendered-line-info"] }
 regex = "1.11"
 reqwest = { workspace = true, features = ["blocking", "stream", "form", "http2"] }
 rusqlite.workspace = true
-rmcp = { version = "2.2.0", default-features = false, features = ["auth", "client"] }
+rmcp = { version = "3.2.0", default-features = false, features = ["auth", "client"] }
 rustls.workspace = true
 qrcode = { version = "0.14", default-features = false }
 similar = { version = "3", features = ["unicode"] }

--- a/crates/tui/src/mcp/oauth.rs
+++ b/crates/tui/src/mcp/oauth.rs
@@ -10,7 +10,9 @@ use reqwest::Url;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use rmcp::transport::AuthorizationManager;
 use rmcp::transport::AuthorizationSession;
-use rmcp::transport::auth::{AuthError, OAuthClientConfig, OAuthState, OAuthTokenResponse};
+use rmcp::transport::auth::{
+    AuthError, AuthorizationRequest, OAuthClientConfig, OAuthState, OAuthTokenResponse,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -76,6 +78,14 @@ pub fn error_text_looks_auth_required(text: &str) -> bool {
         || text.contains("unauthorized")
         || text.contains("authentication_required")
         || text.contains("invalid_grant")
+        // rmcp 3.2 collapsed several unrecoverable refresh outcomes onto
+        // `AuthError::AuthorizationRequired` (Display: "OAuth authorization
+        // required") — a stored credential with no usable refresh grant, and
+        // every refresh the server definitively rejected. In 2.2 those
+        // arrived as `TokenRefreshFailed("No refresh token available")`, which
+        // no surface recognised. The full phrase is matched so it stays
+        // anchored to rmcp's own wording.
+        || text.contains("oauth authorization required")
         || text.contains("◆ auth required")
         || text.contains("requires oauth login")
         || text.contains("requires oauth authentication")
@@ -611,9 +621,9 @@ async fn discover_streamable_http_oauth_with_headers(
         .context("building MCP OAuth discovery client")?;
     let mut manager = AuthorizationManager::new(url).await?;
     manager.with_client(client)?;
-    match manager.discover_metadata().await {
-        Ok(metadata) => Ok(Some(McpOAuthDiscovery {
-            scopes_supported: normalize_scopes(metadata.scopes_supported),
+    match manager.resolve_metadata().await {
+        Ok(resolution) => Ok(Some(McpOAuthDiscovery {
+            scopes_supported: normalize_scopes(resolution.metadata.scopes_supported),
         })),
         Err(AuthError::NoAuthorizationSupport) => Ok(None),
         Err(err) => Err(err.into()),
@@ -1344,14 +1354,18 @@ async fn start_authorization(
     let Some(client_id) = oauth_client_id.filter(|client_id| !client_id.trim().is_empty()) else {
         let mut oauth_state = OAuthState::new(server_url, Some(client)).await?;
         oauth_state
-            .start_authorization(scopes, redirect_uri, Some("Codewhale"))
+            .start_authorization(
+                AuthorizationRequest::new(redirect_uri)
+                    .with_scopes(scopes.iter().copied())
+                    .with_client_name("Codewhale"),
+            )
             .await?;
         return Ok(oauth_state);
     };
 
     let mut manager = AuthorizationManager::new(server_url).await?;
     manager.with_client(client)?;
-    let metadata = manager.discover_metadata().await?;
+    let metadata = manager.resolve_metadata().await?.metadata;
     manager.set_metadata(metadata);
     manager.configure_client(
         OAuthClientConfig::new(client_id, redirect_uri)
@@ -1676,6 +1690,15 @@ mod tests {
         assert!(error_text_looks_auth_required("wiki: ◆ auth required"));
         assert!(!error_text_looks_auth_required(
             "invalid_request: missing parameter"
+        ));
+        // rmcp's own `AuthError::AuthorizationRequired` wording: a stored
+        // credential that can no longer be refreshed is a login, not a
+        // transport failure.
+        assert!(error_text_looks_auth_required(
+            "refreshing MCP OAuth token for server wiki: OAuth authorization required"
+        ));
+        assert!(!error_text_looks_auth_required(
+            "authorization required for the requested file"
         ));
     }
 

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -5986,9 +5986,16 @@ impl OAuthMcpMock {
                             .to_ascii_lowercase()
                             .contains("authorization: bearer cw-test-access");
 
-                    if method == "GET"
-                        && path_only.starts_with("/.well-known/oauth-authorization-server")
-                    {
+                    // RFC 8414: the authorization server lives at the origin
+                    // root, so it publishes its metadata only at the canonical
+                    // `/.well-known/oauth-authorization-server` and its
+                    // `issuer` is the root origin. The path-insertion
+                    // candidates rmcp probes first (`.../oauth-authorization-server/mcp`)
+                    // belong to a *different* issuer and must 404 here: rmcp
+                    // 3.2 validates the discovered `issuer` against the
+                    // discovery URL and rejects metadata served at the wrong
+                    // one.
+                    if method == "GET" && path_only == "/.well-known/oauth-authorization-server" {
                         let metadata = serde_json::json!({
                             "issuer": format!("http://{addr}"),
                             "authorization_endpoint": format!("http://{addr}/authorize"),


### PR DESCRIPTION
No-Issue: dependency bump (rmcp 2.2.0 → 3.2.0), supersedes Dependabot PR #5877 which was red on every leg.

Supersedes #5877 (the Dependabot bump, red on every leg).

Bumps `rmcp` 2.2.0 -> 3.2.0 and ports `crates/tui/src/mcp/oauth.rs` to the
reshaped `rmcp::transport::auth` contract.

## What changed in rmcp 3.2

Compared against `rmcp-2.2.0/src/transport/auth.rs` in the local registry:

1. **`discover_metadata()` -> `resolve_metadata()`**, now returning
   `AuthorizationMetadataResolution { metadata, source }` where `source` says
   whether the endpoints came from RFC 9728 protected resource metadata, RFC
   8414 / OIDC metadata, or the legacy synthesized `/authorize` `/token`
   `/register` fallback. The discovery *order* and the legacy fallback are
   byte-for-byte the same as 2.2, so the semantics our two call sites depend on
   did not move.

2. **`OAuthState::start_authorization` takes an `AuthorizationRequest`
   builder** instead of `(scopes, redirect_uri, client_name)`. The builder also
   introduces a client-identity priority order: a pre-registered client ID,
   then a Client ID Metadata Document (SEP-991), then Dynamic Client
   Registration. We supply neither of the first two, so we still land on DCR
   exactly as before. Empty scopes now mean "let the SDK select from the
   `WWW-Authenticate` challenge / PRM / AS metadata" rather than "request
   none".

3. **Discovery now validates the `issuer`.** `fetch_authorization_metadata`
   derives the expected issuer from the discovery URL (RFC 8414 path-insertion,
   OIDC path-insertion and path-appended forms) and hard-fails with
   `AuthError::AuthorizationServerMismatch` / `AuthorizationServerMissingIssuer`
   when the document disagrees. 2.2 performed this check only at token
   exchange. There is a new `set_allow_missing_issuer` escape hatch we do not
   use.

4. **`AuthError` split the refresh outcomes.** `TokenRefreshFailed` is now the
   retryable case; the new `TokenRefreshRejected` carries a definitive
   `invalid_grant` from the authorization server. Separately, `refresh_token()`
   returns `AuthError::AuthorizationRequired` ("OAuth authorization required")
   where 2.2 returned `TokenRefreshFailed("No refresh token available")`.

5. Not load-bearing for us, listed for the record: `StoredCredentials` gained
   an `issuer` field and `initialize_from_store` discards tokens when the
   authorization server changes; `CredentialStore` gained an optional
   `acquire_refresh_guard` hook; the RFC 8707 `resource` parameter on refreshes
   now prefers a discovered PRM resource indicator and falls back to the base
   URL (what 2.2 always sent); `OAuthHttpClientError` became a type-erased
   boxed error; the resource-metadata POST probe was dropped in favour of a GET
   probe. We keep our own credential store, so rmcp's in-memory default is
   untouched by any of this.

## What we adapted

- `oauth.rs`: the three renamed call sites (`resolve_metadata().metadata` in
  `discover_streamable_http_oauth_with_headers` and `start_authorization`, and
  the `AuthorizationRequest` builder).
- `oauth.rs`: `error_text_looks_auth_required` now also matches rmcp's
  `"OAuth authorization required"`. Item 4 above moved a real product case —
  a stored credential with no usable refresh grant left — from an unmatched
  string onto a phrase no surface recognised, which would have shown that
  server as a plain transport failure instead of `auth required` with the
  self-serve login tool. The full phrase is matched so the predicate stays
  anchored to rmcp's own wording rather than the bare words "authorization
  required". Covered by a new case in
  `auth_required_classifier_treats_rejected_grants_as_auth_required`, including
  a negative case.
- `tests.rs`, the in-process `OAuthMcpMock`: it answered **every**
  `/.well-known/oauth-authorization-server*` path with one document whose
  `issuer` is the origin root — including rmcp's first discovery candidate
  `/.well-known/oauth-authorization-server/mcp`, whose issuer must be
  `<origin>/mcp` per RFC 8414. Under item 3 that now hard-fails discovery,
  which is what turned all eight OAuth tests red. The mock now answers only the
  canonical `/.well-known/oauth-authorization-server`, which is how a real
  authorization server sitting at the origin root behaves.

**No test assertion was changed.** The four product guarantees those eight
tests encode are intact and still asserted: a dead grant flips the server to
`auth required` and offers the login tool; a rotated on-disk token is adopted;
invalidation never deletes a credential rotated after the re-read; the browser
wait releases the pool lock. The only test edit is the mock's HTTP routing —
a conformance fix to a test double, not a behavior change.

## Verified locally

```
cargo fmt                                                       clean
cargo check -p codewhale-tui                                    clean
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- mcp::
    230 passed; 0 failed; 1 ignored      (before: 222 passed; 8 failed)
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib
    11717 passed; 0 failed; 13 ignored
```

Two earlier full-suite runs each tripped one different pre-existing
parallel-execution flake in a module this change does not touch
(`model_inventory::...ollama_default_prefers_live_local_tags...`, then
`remote_control::...distinct_recovery_turn_ids`); both pass in isolation and
the run above is clean.

## What CI has to prove

Local runs cover only `-p codewhale-tui --lib` on macOS/arm64 against
in-process mock servers. CI still owns the workspace-wide build and test
matrix, the other platform legs, `npm run check:web`, and anything that
exercises a real OAuth provider — no real authorization server was contacted
in any of the above, so item 3 (issuer validation) and item 2 (SDK scope
auto-selection) are verified against our mock only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP OAuth discovery, login, and token-refresh error classification; behavior is mostly API porting plus tighter issuer checks, with risk if real providers differ from the updated mock assumptions.
> 
> **Overview**
> Upgrades **`rmcp`** from 2.2.0 to 3.2.0 and updates the TUI MCP OAuth layer to match the reshaped transport/auth API.
> 
> **OAuth integration** now calls **`resolve_metadata()`** (instead of `discover_metadata()`) for scope discovery and pre-registered client flows, and starts login via the **`AuthorizationRequest`** builder rather than separate scope/redirect/client-name arguments. **`error_text_looks_auth_required`** also treats rmcp 3.2’s **`OAuth authorization required`** message as a login-needed signal so dead or unrefreshable stored credentials surface **`auth required`** and the login tool instead of a generic transport failure.
> 
> **Tests:** the in-process OAuth mock only serves the canonical **`/.well-known/oauth-authorization-server`** path (404 on path-insertion variants), aligning with rmcp 3.2’s **issuer validation** during discovery. New classifier tests cover the rmcp wording without matching unrelated “authorization required” errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3511d5a1d47ded035ae7b1fea6931c8997fb65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->