### PR TITLE
fix(computer-use): truthful macOS permission probe, working CGEvent input, and frontmost-guarded keystrokes

### DIFF
--- a/crates/tui/plugins/computer-use/src/backends/darwin.mjs
+++ b/crates/tui/plugins/computer-use/src/backends/darwin.mjs
@@ -47,8 +47,19 @@ export function create({ exec }) {
       fs.writeFileSync(file, script);
       // Payload travels as a plain argv string: osascript is spawned without a
       // shell, so JSON content can never become script syntax.
+      // Input and accessibility scripts need the Accessibility grant. When the
+      // last probe saw it denied, refuse here with the remedy instead of
+      // letting osascript hang on a TCC prompt nobody can answer (#5917).
+      if (state.tcc?.accessibility === false && /CGEventPost|System Events/.test(script)) {
+        throw new ExecError(`accessibility permission is not granted to ${await grantTarget()}: ${TCC_FIX.accessibility}`);
+      }
       const r = await runL("osascript", ["-l", "JavaScript", file, JSON.stringify(payload)], { timeoutMs });
-      if (r.timedOut) throw new ExecError("osascript timed out", r);
+      if (r.timedOut) {
+        const hint = state.tcc?.accessibility === true
+          ? ""
+          : ` (if macOS is showing a permission prompt, grant Accessibility to ${await grantTarget()}: ${TCC_FIX.accessibility})`;
+        throw new ExecError(`osascript timed out${hint}`, r);
+      }
       if (r.code !== 0) {
         const msg = (r.stderr || r.stdout).trim().split("\n")[0] || "osascript failed";
         throw new ExecError(/(not allowed assistive|assistive access|250)/i.test(r.stderr || "") || /(-25211|-1719|not allowed)/i.test(msg)
@@ -223,11 +234,16 @@ export function create({ exec }) {
   }
 
   // ---------- raw input via CGEvent ----------
-  async function cg(script, timeoutMs = 10_000) {
+  // Every caller hands its values as `payload`; the script reads them as `P`.
+  // The old `(script, timeoutMs)` shape silently swallowed the payload (so
+  // `P.code`, `P.x`, `P.text` were undefined) and coerced the object to a
+  // zero timeout, which is why every CGEvent input on macOS reported
+  // "osascript timed out" instantly (#5917).
+  async function cg(script, payload = {}, timeoutMs = 10_000) {
     return jxa(`ObjC.import('CoreGraphics');
       function run(argv){ var P = JSON.parse(argv[0]);
         ${script}
-      }`, {}, timeoutMs);
+      }`, payload, timeoutMs);
   }
 
   async function postMouseEvent(type, x, y, button, clickState) {
@@ -326,7 +342,16 @@ export function create({ exec }) {
     }
     args.push(file);
     const r = await runL("screencapture", args, { timeoutMs: 20_000 });
-    if (r.code !== 0) throw new ExecError(`screencapture exited ${r.code}: ${r.stderr.trim().slice(0, 300)}`, r);
+    if (r.code !== 0) {
+      const detail = r.stderr.trim().slice(0, 300);
+      // This is what screencapture says when the display is locked, asleep, or
+      // the session is not the console user — not a permission problem
+      // (without the Screen Recording grant it exits 0 and omits windows).
+      const remedy = /could not create image/i.test(detail)
+        ? " — the display is locked, asleep, or this session is not at the console; unlock or wake it and retry"
+        : "";
+      throw new ExecError(`screencapture exited ${r.code}: ${detail}${remedy}`, r);
+    }
     const stat = fs.statSync(file);
     const displays = await displayInfo();
     const d = displays.find((x) => x.index === (disp === "all" ? 1 : disp)) ?? displays[0];
@@ -493,20 +518,93 @@ print('{\"x\": %d, \"y\": %d}' % (l.x, l.y))`;
   }
 
   // ---------- probe ----------
-  async function probe() {
-    const caps = { screenshot: true, recording: true, accessibility_tree: true, clipboard: true, displays: true };
-    const perms = {};
-    try { await jxa(`function run(argv){ return JSON.stringify({n: Application('System Events').applicationProcesses.length}); }`, {}, 8_000); perms.accessibility = "granted"; }
-    catch (e) { perms.accessibility = "denied_or_unavailable"; caps.accessibility_tree = false; caps.raw_input = "unreliable"; }
-    try {
-      const t = os.tmpdir() + `/cu-probe-${crypto.randomBytes(3).toString("hex")}.png`;
-      const r = await runL("screencapture", ["-x", "-R0,0,2,2", "-t", "png", t], { timeoutMs: 8_000 });
-      perms.screen_capture = r.code === 0 ? "ok" : "failed";
-      try { fs.rmSync(t, { force: true }); } catch {}
-    } catch { perms.screen_capture = "failed"; }
-    const hasRecording = fs.existsSync("/usr/sbin/screencapture");
-    return { platform: "darwin", capabilities: caps, permissions: perms, note: "macOS does not expose Screen-Recording TCC state to CLI; a black/empty screenshot means Screen Recording permission is missing. Raw pointer/keyboard events go to whatever is frontmost at the target point — activate the app first for click-type actions." };
+  const TCC_FIX = {
+    accessibility: "System Settings → Privacy & Security → Accessibility → enable the host app, then relaunch it",
+    screen_recording: "System Settings → Privacy & Security → Screen & System Audio Recording → enable the host app, then relaunch it",
+  };
+  // TCC attributes grants to the .app that owns this process tree (the
+  // terminal or IDE hosting the engine), never to node or osascript. Name it so
+  // the remedy says which row to flip.
+  async function hostAppName() {
+    if (state.hostApp !== undefined) return state.hostApp;
+    // Keep the outermost bundle: framework binaries also live inside an .app
+    // (python3 runs from Python.app), but TCC holds the launching app
+    // responsible for everything under it.
+    let pid = process.ppid;
+    let found = null;
+    for (let depth = 0; depth < 12 && pid > 1; depth++) {
+      const r = await runL("ps", ["-o", "ppid=,comm=", "-p", String(pid)], { timeoutMs: 4_000 });
+      if (r.code !== 0) break;
+      const m = /^\s*(\d+)\s+(.*)$/.exec(r.stdout.trim());
+      if (!m) break;
+      const app = /([^/]+)\.app\//.exec(m[2]);
+      if (app) found = app[1];
+      pid = Number(m[1]);
+    }
+    state.hostApp = found;
+    return found;
   }
+  async function grantTarget() {
+    const host = await hostAppName().catch(() => null);
+    return host ? `"${host}"` : "the app hosting the Codewhale engine (your terminal)";
+  }
+  // Ask TCC instead of guessing from tool presence: screencapture exits 0
+  // without the grant (it just omits windows) and osascript hangs on the
+  // prompt, so probing by running them proves nothing.
+  // The JXA bridge does not expose CGPreflightScreenCaptureAccess, so the
+  // Screen Recording state is read the way TCC enforces it: without the grant,
+  // CGWindowListCopyWindowInfo strips kCGWindowName from every other
+  // process's window. No other windows on screen means the answer is unknown.
+  async function tccState() {
+    const r = await jxa(`ObjC.import('ApplicationServices'); ObjC.import('CoreGraphics'); ObjC.import('Foundation');
+function run(){
+  const out = { accessibility: !!$.AXIsProcessTrusted(), screen_recording: null };
+  const me = $.NSProcessInfo.processInfo.processIdentifier;
+  const list = $.CGWindowListCopyWindowInfo($.kCGWindowListOptionOnScreenOnly | $.kCGWindowListExcludeDesktopElements, $.kCGNullWindowID);
+  const n = Number($.CFArrayGetCount(list));
+  let others = 0, named = 0;
+  for (let i = 0; i < n; i++) {
+    const d = ObjC.deepUnwrap(ObjC.castRefToObject($.CFArrayGetValueAtIndex(list, i)));
+    if (!d || d.kCGWindowOwnerPID === me || d.kCGWindowLayer !== 0) continue;
+    others++;
+    if (typeof d.kCGWindowName === 'string' && d.kCGWindowName.length) named++;
+  }
+  if (others > 0) out.screen_recording = named > 0;
+  return JSON.stringify(out);
+}`, {}, 8_000);
+    return r && typeof r === "object" ? r : {};
+  }
+  async function probe() {
+    const caps = { screenshot: true, recording: true, accessibility_tree: true, raw_input: true, clipboard: true, displays: true };
+    const perms = {};
+    const missing = [];
+    let tcc = {};
+    try { tcc = await tccState(); } catch (e) { perms.probe_error = String(e?.message || e).slice(0, 200); }
+    state.tcc = tcc;
+    const target = await grantTarget();
+    if (tcc.accessibility === false) {
+      perms.accessibility = "denied";
+      caps.accessibility_tree = false;
+      caps.raw_input = false;
+      missing.push("accessibility");
+    } else {
+      perms.accessibility = tcc.accessibility === true ? "granted" : "unknown";
+    }
+    if (tcc.screen_recording === false) {
+      perms.screen_recording = "denied";
+      caps.screenshot = false;
+      caps.recording = false;
+      missing.push("screen_recording");
+    } else {
+      perms.screen_recording = tcc.screen_recording === true ? "granted" : "unknown";
+    }
+    const how_to_fix = Object.fromEntries(missing.map((m) => [m, `${TCC_FIX[m]} — grant it to ${target}`]));
+    const note = missing.length
+      ? `Missing: ${missing.join(", ")}. Grants belong to ${target}, not to node or osascript. ${Object.values(how_to_fix).join(" ")}`
+      : "Raw pointer/keyboard events go to whatever is frontmost at the target point — activate the app first for click-type actions.";
+    return { platform: "darwin", capabilities: caps, permissions: perms, missing, how_to_fix, host_app: state.hostApp ?? null, note };
+  }
+
 
   return {
     platform: "darwin",

--- a/crates/tui/plugins/computer-use/src/backends/darwin.mjs
+++ b/crates/tui/plugins/computer-use/src/backends/darwin.mjs
@@ -467,6 +467,33 @@ export function create({ exec }) {
     }`, {}, 25_000);
   }
 
+  // Which app owns the keyboard right now. Raw CGEvents go to it no matter
+  // what the caller meant (#5927), so every input receipt names it.
+  async function frontmostApp() {
+    const r = await jxa(`${JXA_PRELUDE}
+      var se = Application('System Events');
+      var list = se.applicationProcesses.whose({ frontmost: true })();
+      if (!list.length) return JSON.stringify({ found: false });
+      var p = list[0];
+      return JSON.stringify({ found: true, name: g(function(){ return String(p.name()); }), pid: num(function(){ return p.unixId(); }),
+        bundle_id: g(function(){ var b = p.bundleIdentifier(); return b ? String(b) : null; }) });
+    }`, { probe: "frontmost-app" }, 8_000);
+    return r && r.found ? { name: r.name, pid: r.pid, bundle_id: r.bundle_id } : null;
+  }
+
+  // Refuse to post keystrokes when the app the caller named is not the one
+  // that would receive them. Returns the frontmost app for the receipt.
+  async function guardInput(appRef) {
+    const front = await frontmostApp().catch(() => null);
+    if (!appRef) return front;
+    const target = await findProcess(appRef);
+    if (!target.found) throw new ExecError("application not found — call list_apps for exact names/pids");
+    if (!front || front.pid !== target.pid) {
+      throw new ExecError(`refusing to send input: "${target.name}" is not frontmost${front ? ` ("${front.name}" is)` : ""}; bring it forward first with open_application { activate: true } or click into it`);
+    }
+    return front;
+  }
+
   async function listWindows(appRef) {
     const p = await findProcess(appRef ?? {});
     if (!p.found) throw new ExecError("application not found — call list_apps for exact names/pids");
@@ -481,11 +508,25 @@ export function create({ exec }) {
     if (activate) args.unshift("-F");
     const r = await runL("open", args, { timeoutMs: 25_000 });
     if (r.code !== 0) throw new ExecError(`open failed: ${r.stderr.trim().slice(0, 200)}`, r);
-    await new Promise((res) => setTimeout(res, 600));
     const find = {};
     if (bid) find.bundle_id = bid; else if (pid) find.pid = pid; else find.name = String(name).replace(/\.app$/, "");
-    const p = await findProcess(find).catch(() => null);
-    return { launched: true, activate, url: urlArg ?? null, resolved: p?.found ? { name: p.name, pid: p.pid, bundle_id: p.bundle_id, frontmost: p.frontmost } : null };
+    // `open -F` returns before the app is in front. Wait for the process to
+    // exist and, when activation was asked for, to actually be frontmost;
+    // otherwise the next keystroke lands in whatever app is (#5927).
+    let p = null;
+    for (let attempt = 0; attempt < 10; attempt++) {
+      await new Promise((res) => setTimeout(res, 300));
+      p = await findProcess(find).catch(() => null);
+      if (p?.found && (!activate || p.frontmost)) break;
+    }
+    const resolved = p?.found ? { name: p.name, pid: p.pid, bundle_id: p.bundle_id, frontmost: !!p.frontmost } : null;
+    const frontmost = !!resolved?.frontmost;
+    const note = activate && !frontmost
+      ? (resolved
+        ? `"${resolved.name}" is running but did not come to the front within 3 s; keystrokes would go to another app — retry activation or click into its window before typing`
+        : `the app did not appear within 3 s of \`open\`; call list_apps to see what is running`)
+      : undefined;
+    return { launched: true, activate, frontmost, pid: resolved?.pid ?? null, url: urlArg ?? null, resolved, ...(note ? { note } : {}) };
   }
 
   // ---------- clipboard / cursor / waits ----------
@@ -663,8 +704,9 @@ function run(){
         $.CGEventPost($.kCGHIDEventTap, ev);
         return JSON.stringify({ ok: true });`, { dx, dy }).then(() => ({ action_sent: true, direction, amount }));
     },
-    type: async ({ text }) => {
+    type: async ({ text, app_ref }) => {
       if (!text) return { action_sent: false, note: "empty text" };
+      const frontmost_app = await guardInput(app_ref);
       const r = await cg(`var ev = $.CGEventCreateKeyboardEvent($(), 0, true);
         $.CGEventKeyboardSetUnicodeString(ev, P.text.length, P.text);
         $.CGEventPost($.kCGHIDEventTap, ev);
@@ -672,24 +714,26 @@ function run(){
         $.CGEventKeyboardSetUnicodeString(ev2, P.text.length, P.text);
         $.CGEventPost($.kCGHIDEventTap, ev2);
         return JSON.stringify({ ok: true, chars: P.text.length });`, { text }, 15_000);
-      return { action_sent: true, chars: text.length, strategy: "unicode-events" };
+      return { action_sent: true, chars: text.length, strategy: "unicode-events", frontmost_app };
     },
-    key: async ({ text, repeat = 1 }) => {
+    key: async ({ text, repeat = 1, app_ref }) => {
       const { flags, code, key } = parseChord(text);
+      const frontmost_app = await guardInput(app_ref);
       for (let i = 0; i < Math.max(1, Math.min(100, repeat)); i++) {
         await keyEvent(code, flags, true);
         await keyEvent(code, flags, false);
         if (i < repeat - 1) await new Promise((r) => setTimeout(r, 30));
       }
-      return { action_sent: true, key, code, repeat: Math.max(1, Math.min(100, repeat)) };
+      return { action_sent: true, key, code, repeat: Math.max(1, Math.min(100, repeat)), frontmost_app };
     },
-    hold_key: async ({ text, duration }) => {
+    hold_key: async ({ text, duration, app_ref }) => {
       const { flags, code, key } = parseChord(text);
+      const frontmost_app = await guardInput(app_ref);
       const d = Math.max(0.05, Math.min(30, Number(duration) || 1));
       await keyEvent(code, flags, true);
       await new Promise((r) => setTimeout(r, d * 1000));
       await keyEvent(code, flags, false);
-      return { action_sent: true, key, heldSec: d };
+      return { action_sent: true, key, heldSec: d, frontmost_app };
     },
     set_value: async ({ target, value }) => {
       const el = await elementAction(target.app_ref, target.windowIndex, target.path, { kind: "set_value", value });

--- a/crates/tui/plugins/computer-use/src/tools.mjs
+++ b/crates/tui/plugins/computer-use/src/tools.mjs
@@ -6,6 +6,14 @@ const computerParam = {
   description: "Computer id to act on. Defaults to the active computer. Providing a different registered id switches to it first (sticky).",
 };
 
+// Optional guard for keystroke tools: the app that must be frontmost.
+const inputAppRef = {
+  type: "object",
+  description: "Refuse to send the keystrokes unless this app is frontmost (name, bundle_id, or pid).",
+  properties: { pid: { type: "integer" }, name: { type: "string" }, bundle_id: { type: "string" } },
+  additionalProperties: false,
+};
+
 const targetSchema = {
   oneOf: [
     {
@@ -211,16 +219,16 @@ export const TOOLS = [
   },
   // ---- text & keyboard ----
   {
-    name: "type", description: "Type text into the focused control (unicode). Focus the field first (click/element action).",
-    inputSchema: { type: "object", required: ["text"], properties: { text: { type: "string" }, computer: computerParam }, additionalProperties: false },
+    name: "type", description: "Type text into the focused control (unicode). Focus the field first (click/element action). Pass app_ref to refuse unless that app is frontmost; the receipt names frontmost_app either way.",
+    inputSchema: { type: "object", required: ["text"], properties: { text: { type: "string" }, app_ref: inputAppRef, computer: computerParam }, additionalProperties: false },
   },
   {
-    name: "key", description: "Press a key or chord, e.g. 'return', 'cmd+c' (macOS), 'ctrl+c' (Linux/Windows). Repeat with `repeat`.",
-    inputSchema: { type: "object", required: ["text"], properties: { text: { type: "string" }, repeat: { type: "integer", minimum: 1, maximum: 100 }, computer: computerParam }, additionalProperties: false },
+    name: "key", description: "Press a key or chord, e.g. 'return', 'cmd+c' (macOS), 'ctrl+c' (Linux/Windows). Repeat with `repeat`. Pass app_ref to refuse unless that app is frontmost; the receipt names frontmost_app either way.",
+    inputSchema: { type: "object", required: ["text"], properties: { text: { type: "string" }, repeat: { type: "integer", minimum: 1, maximum: 100 }, app_ref: inputAppRef, computer: computerParam }, additionalProperties: false },
   },
   {
     name: "hold_key", description: "Hold a key for `duration` seconds (0.05..30).",
-    inputSchema: { type: "object", required: ["text", "duration"], properties: { text: { type: "string" }, duration: { type: "number", minimum: 0.05, maximum: 30 }, computer: computerParam }, additionalProperties: false },
+    inputSchema: { type: "object", required: ["text", "duration"], properties: { text: { type: "string" }, duration: { type: "number", minimum: 0.05, maximum: 30 }, app_ref: inputAppRef, computer: computerParam }, additionalProperties: false },
   },
   {
     name: "set_value", description: "Set an editable element's value through the accessibility layer (background-safe, no keystrokes). Element targets only.",

--- a/crates/tui/plugins/computer-use/tests/backends.test.mjs
+++ b/crates/tui/plugins/computer-use/tests/backends.test.mjs
@@ -221,7 +221,7 @@ test("darwin: CGEvent input scripts receive their payload and a real timeout (#5
   };
   const b = createDarwin({ exec: { run, runOk: run } });
   await b.key({ text: "cmd+q" });
-  const scripts = calls.filter((c) => c.cmd === "osascript");
+  const scripts = calls.filter((c) => c.cmd === "osascript" && JSON.parse(c.args.at(-1)).code !== undefined);
   assert.equal(scripts.length, 2, "one keydown and one keyup event");
   for (const c of scripts) {
     const payload = JSON.parse(c.args[c.args.length - 1]);
@@ -233,4 +233,58 @@ test("darwin: CGEvent input scripts receive their payload and a real timeout (#5
   const typed = JSON.parse(calls.at(-1).args.at(-1));
   assert.equal(typed.text, "hi");
   assert.equal(calls.at(-1).opts.timeoutMs, 15_000);
+});
+
+
+// ---------- darwin: keystrokes name and guard the app that receives them (#5927) ----------
+function darwinDesktopExec({ frontmost, calculatorFrontmost }) {
+  const calls = [];
+  const run = async (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    if (cmd === "open") return { code: 0, stdout: "", stderr: "" };
+    if (cmd !== "osascript") return { code: 1, stdout: "", stderr: "" };
+    const payload = JSON.parse(args.at(-1));
+    if (payload.probe === "frontmost-app") return { code: 0, stdout: JSON.stringify({ found: true, ...frontmost }), stderr: "" };
+    if (payload.name || payload.bundle_id || payload.pid != null) {
+      const isCalc = String(payload.name || "").toLowerCase() === "calculator";
+      return { code: 0, stdout: JSON.stringify(isCalc ? { found: true, name: "Calculator", pid: 2, bundle_id: "com.apple.calculator", frontmost: calculatorFrontmost } : { found: false }), stderr: "" };
+    }
+    return { code: 0, stdout: JSON.stringify({ ok: true }), stderr: "" };
+  };
+  return { run, runOk: run, calls };
+}
+const cgEventCalls = (calls) => calls.filter((c) => c.cmd === "osascript" && JSON.parse(c.args.at(-1)).code !== undefined);
+
+test("darwin: open_application with activate reports truthfully when the app never comes to the front", async () => {
+  const exec = darwinDesktopExec({ frontmost: { name: "Ghostty", pid: 1, bundle_id: "com.mitchellh.ghostty" }, calculatorFrontmost: false });
+  const b = createDarwin({ exec });
+  const r = await b.open_application({ name: "Calculator", activate: true });
+  assert.equal(r.launched, true);
+  assert.equal(r.frontmost, false);
+  assert.equal(r.pid, 2);
+  assert.match(r.note, /did not come to the front/);
+});
+
+test("darwin: a guarded key refuses when the named app is not frontmost and posts nothing", async () => {
+  const exec = darwinDesktopExec({ frontmost: { name: "Ghostty", pid: 1, bundle_id: "com.mitchellh.ghostty" }, calculatorFrontmost: false });
+  const b = createDarwin({ exec });
+  await assert.rejects(() => b.key({ text: "cmd+q", app_ref: { name: "Calculator" } }), /"Calculator" is not frontmost \("Ghostty" is\)/);
+  assert.equal(cgEventCalls(exec.calls).length, 0, "no CGEvent may be posted to the wrong app");
+});
+
+test("darwin: an unguarded key still names the app that received it", async () => {
+  const exec = darwinDesktopExec({ frontmost: { name: "Ghostty", pid: 1, bundle_id: "com.mitchellh.ghostty" }, calculatorFrontmost: false });
+  const b = createDarwin({ exec });
+  const r = await b.key({ text: "a" });
+  assert.equal(r.action_sent, true);
+  assert.deepEqual(r.frontmost_app, { name: "Ghostty", pid: 1, bundle_id: "com.mitchellh.ghostty" });
+  assert.equal(cgEventCalls(exec.calls).length, 2);
+});
+
+test("darwin: a guarded key goes through when the named app is frontmost", async () => {
+  const exec = darwinDesktopExec({ frontmost: { name: "Calculator", pid: 2, bundle_id: "com.apple.calculator" }, calculatorFrontmost: true });
+  const b = createDarwin({ exec });
+  const r = await b.type({ text: "7", app_ref: { name: "Calculator" } });
+  assert.equal(r.action_sent, true);
+  assert.equal(r.frontmost_app.name, "Calculator");
 });

--- a/crates/tui/plugins/computer-use/tests/backends.test.mjs
+++ b/crates/tui/plugins/computer-use/tests/backends.test.mjs
@@ -151,3 +151,86 @@ test("remote agent answers the platform probe", async () => {
   assert.equal(reply.ok, true);
   assert.equal(reply.platform, process.platform);
 });
+
+// ---------- darwin: permission probe names the missing grant and its owner (#5917) ----------
+import { create as createDarwin } from "../src/backends/darwin.mjs";
+
+function darwinExec({ accessibility, screen_recording }) {
+  const calls = [];
+  const shell = String(process.ppid + 1);
+  const chain = {
+    [String(process.ppid)]: `${shell} /bin/zsh`,
+    [shell]: "1 /Applications/iTerm.app/Contents/MacOS/iTerm2",
+  };
+  const run = async (cmd, args) => {
+    calls.push({ cmd, args });
+    if (cmd === "osascript") return { code: 0, stdout: JSON.stringify({ accessibility, screen_recording }), stderr: "" };
+    if (cmd === "ps") {
+      const row = chain[args[args.length - 1]];
+      return row ? { code: 0, stdout: row, stderr: "" } : { code: 1, stdout: "", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  return { run, runOk: run, calls };
+}
+
+test("darwin: probe reports denied TCC grants as missing capabilities and names the host app to fix", async () => {
+  const exec = darwinExec({ accessibility: false, screen_recording: false });
+  const b = createDarwin({ exec });
+  const p = await b.probe();
+  assert.deepEqual(p.missing, ["accessibility", "screen_recording"]);
+  assert.equal(p.capabilities.screenshot, false);
+  assert.equal(p.capabilities.recording, false);
+  assert.equal(p.capabilities.accessibility_tree, false);
+  assert.equal(p.capabilities.raw_input, false);
+  assert.equal(p.permissions.accessibility, "denied");
+  assert.equal(p.permissions.screen_recording, "denied");
+  assert.equal(p.host_app, "iTerm");
+  assert.match(p.how_to_fix.accessibility, /Privacy & Security → Accessibility.*"iTerm"/);
+  assert.match(p.how_to_fix.screen_recording, /Screen & System Audio Recording.*"iTerm"/);
+  assert.match(p.note, /Missing: accessibility, screen_recording/);
+});
+
+test("darwin: after a denied probe, input fails fast with the remedy instead of spawning osascript", async () => {
+  const exec = darwinExec({ accessibility: false, screen_recording: true });
+  const b = createDarwin({ exec });
+  await b.probe();
+  const before = exec.calls.filter((c) => c.cmd === "osascript").length;
+  await assert.rejects(() => b.key({ text: "a" }), /accessibility permission is not granted to "iTerm".*Privacy & Security → Accessibility/);
+  assert.equal(exec.calls.filter((c) => c.cmd === "osascript").length, before, "no osascript spawn for a known-denied grant");
+});
+
+test("darwin: granted TCC state reports every capability available and no remedy", async () => {
+  const exec = darwinExec({ accessibility: true, screen_recording: true });
+  const b = createDarwin({ exec });
+  const p = await b.probe();
+  assert.deepEqual(p.missing, []);
+  assert.deepEqual(p.how_to_fix, {});
+  assert.equal(p.permissions.accessibility, "granted");
+  assert.equal(p.permissions.screen_recording, "granted");
+  assert.equal(p.capabilities.screenshot, true);
+  assert.equal(p.capabilities.raw_input, true);
+});
+
+test("darwin: CGEvent input scripts receive their payload and a real timeout (#5917)", async () => {
+  const calls = [];
+  const run = async (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    if (cmd === "osascript") return { code: 0, stdout: JSON.stringify({ ok: true }), stderr: "" };
+    return { code: 1, stdout: "", stderr: "" };
+  };
+  const b = createDarwin({ exec: { run, runOk: run } });
+  await b.key({ text: "cmd+q" });
+  const scripts = calls.filter((c) => c.cmd === "osascript");
+  assert.equal(scripts.length, 2, "one keydown and one keyup event");
+  for (const c of scripts) {
+    const payload = JSON.parse(c.args[c.args.length - 1]);
+    assert.equal(payload.code, 12, "q keycode travels in the payload");
+    assert.ok(payload.flags > 0, "cmd modifier flag travels in the payload");
+    assert.equal(c.opts.timeoutMs, 10_000, "the timeout is the CGEvent default, not the payload object");
+  }
+  await b.type({ text: "hi" });
+  const typed = JSON.parse(calls.at(-1).args.at(-1));
+  assert.equal(typed.text, "hi");
+  assert.equal(calls.at(-1).opts.timeoutMs, 15_000);
+});


### PR DESCRIPTION
Closes #5917
Closes #5927

## What was wrong (all found by driving the bundled MCP server live on macOS for the #5856 receipt)

1. **`request_access` lied.** It checked that `screencapture`/`osascript` exist, not that the Screen Recording and Accessibility grants are held, and always answered `screenshot: true`.
2. **Every CGEvent input was broken.** `cg()` took `(script, timeoutMs)` but `keyEvent`, `type`, `scroll`, and `postMouseEvent` passed their payload as the second argument: the script saw no `P.code`/`P.x`/`P.text` and the payload object coerced to a zero timeout, so `key`, `type`, `hold_key`, `scroll`, and clicks reported `osascript timed out` instantly.
3. **`open_application { activate: true }` reported `launched: true` before the app was in front**, and `key`/`type` carried no target and no receipt of where the event went. A cleanup `cmd+q` from the test client went to the frontmost app and quit the terminal hosting the founder's session (#5927).
4. A `screencapture` failure of `could not create image from display` (locked or asleep display) was indistinguishable from a permission problem.

## Change

- Probe reads `AXIsProcessTrusted()` and the CGWindowList name-stripping TCC applies without the Screen Recording grant (the JXA bridge has no `CGPreflightScreenCaptureAccess`); reports each grant granted/denied/unknown, lists `missing`, and names the outermost `.app` in the process tree in `how_to_fix` — the app TCC holds responsible. Input scripts fail fast with that remedy after a denied probe instead of hanging on a prompt.
- `cg(script, payload, timeoutMs)`.
- `open_application` waits up to 3 s for the process and (when activating) for it to be frontmost; returns `frontmost`, `pid`, and a note when it could not bring the app forward.
- `key`/`type`/`hold_key` accept `app_ref`, refuse when that app is not frontmost, and receipt `frontmost_app`.
- Screenshot failure names the locked/asleep display.

## Verified

- `npm test` in `crates/tui/plugins/computer-use`: **55 passed, 0 failed** (9 new tests through the injected runner, host-agnostic).
- Live on this Mac: `request_access` → `host_app: Ghostty`, both grants granted; `screenshot` produces a 15 MB PNG; `key cmd+q` → `ok: true` (which is how #5927 was found).
- Not verified: the guarded flow against a real app end-to-end — I stopped live keystroke tests after the incident. The win32/linux backends ignore `app_ref` (they destructure named fields); their guard is a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS raw keyboard/mouse automation and permission gating; misconfiguration could still send events to the frontmost app when `app_ref` is omitted, but guarded paths reduce accidental quit/key delivery (#5927).
> 
> **Overview**
> Fixes macOS computer-use reliability around **TCC permissions**, **CGEvent input**, and **keystrokes hitting the wrong app**.
> 
> The **permission probe** (`request_access` → `probe`) now reads real Accessibility and Screen Recording state (via `AXIsProcessTrusted` and window-name stripping), identifies the **host `.app`** in the process tree, and returns `missing`, `how_to_fix`, and accurate capability flags. After a denied Accessibility probe, input/a11y scripts **fail fast** with remediation instead of hanging on TCC prompts.
> 
> **CGEvent input** is repaired by changing `cg()` to `(script, payload, timeoutMs)` so keycodes, coordinates, and text reach JXA with proper timeouts (fixing instant false `osascript timed out` failures).
> 
> **Keyboard safety**: `type`, `key`, and `hold_key` accept optional **`app_ref`** (tool schema updated), refuse when that app is not frontmost, and always receipt **`frontmost_app`**. **`open_application`** with `activate: true` polls up to ~3s for the app to be frontmost and returns `frontmost`, `pid`, and a warning note when activation fails. Screenshot errors distinguish **locked/asleep display** from permission issues.
> 
> Nine injected **darwin backend tests** cover probe, fail-fast input, CGEvent payloads, and frontmost guarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46552c6f5c2a1f41ce8ebfa0ef3368b1db6d8843. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->