### PR TITLE
test: isolate CODEWHALE_HOME in the provider onboarding tests

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1275,6 +1275,10 @@ mod provider_key_validation_tests {
 
     struct ConfigPathEnvGuard {
         _tmp: TempDir,
+        // Onboarding completion runs the setup transaction (setup_state.json,
+        // settings.toml) against `CODEWHALE_HOME`; without this guard the
+        // fixture provider landed in the developer's real ~/.codewhale (#5932).
+        _codewhale_home: crate::test_support::EnvVarGuard,
         _codewhale_config_path: crate::test_support::EnvVarGuard,
         _deepseek_config_path: crate::test_support::EnvVarGuard,
         _lock: crate::test_support::TestEnvLock,
@@ -1284,11 +1288,13 @@ mod provider_key_validation_tests {
         fn new() -> Self {
             let lock = crate::test_support::lock_test_env();
             let tmp = TempDir::new().expect("config tempdir");
-            let config_path = tmp.path().join(".codewhale").join("config.toml");
+            let home = tmp.path().join(".codewhale");
+            let config_path = home.join("config.toml");
             std::fs::create_dir_all(config_path.parent().expect("config parent"))
                 .expect("config dir");
             Self {
                 _tmp: tmp,
+                _codewhale_home: crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", &home),
                 _codewhale_config_path: crate::test_support::EnvVarGuard::set(
                     "CODEWHALE_CONFIG_PATH",
                     &config_path,


### PR DESCRIPTION
Refs #5932 (targeted guard; the process-wide guard and a hermetic CI home both stay open there — each broke tests that rely on an implicit home, receipts on the issue)

The onboarding tests in `tui::ui::provider_key_validation_tests` guarded `CODEWHALE_CONFIG_PATH` but not `CODEWHALE_HOME`, so completing onboarding wrote `setup_state.json` into the developer's real `~/.codewhale` (tonight's full-suite runs left the founder's provider step recorded as `fixture-local`). `ConfigPathEnvGuard` now sets both to one temp dir.

Verified: `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- tui::ui::provider_key_validation_tests` → 15 passed, 0 failed, with the real `~/.codewhale/setup_state.json` mtime unchanged across the run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only environment isolation; no production runtime or persistence behavior changes.
> 
> **Overview**
> Fixes **#5932** by extending `ConfigPathEnvGuard` in `provider_key_validation_tests` so onboarding runs against a temp home, not the developer's real `~/.codewhale`.
> 
> The guard already pointed `CODEWHALE_CONFIG_PATH` (and `DEEPSEEK_CONFIG_PATH`) at a temp `config.toml`, but **onboarding completion** still persisted `setup_state.json` and `settings.toml` via **`CODEWHALE_HOME`**. Full-suite runs could therefore record fixture provider progress in the user's actual setup state.
> 
> `ConfigPathEnvGuard::new()` now builds a single temp `.codewhale` directory, sets **`CODEWHALE_HOME`** to that path alongside the existing config env guards, and documents why both are required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7fc0007b378543e83f8ec235307b7b76c2768bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->