### PR TITLE
fix(web): retry JS-shell 200s past every cache and name the escalation

### DIFF
--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -195,7 +195,7 @@ impl ToolSpec for FetchUrlTool {
                     };
                     let fields = match body_text.as_deref() {
                         Some(body) => {
-                            project_json_fields(body, &fetched.content_type, &requested_fields)?
+                            project_json_fields(body, &fetched.content_type, requested_fields)?
                         }
                         None => None,
                     };

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -14,7 +14,8 @@ use super::spec::{
 };
 use super::web::extract::{DocumentKind, ExtractedDocument, decode_response_body};
 use super::web::fetch::{
-    DEFAULT_MAX_BYTES, DEFAULT_TIMEOUT, FetchOptions, HARD_MAX_BYTES, HARD_MAX_TIMEOUT, fetch,
+    DEFAULT_MAX_BYTES, DEFAULT_TIMEOUT, FetchAttempt, FetchOptions, HARD_MAX_BYTES,
+    HARD_MAX_TIMEOUT, fetch_readable,
 };
 use super::web::overflow::bound_text as bound_web_text;
 #[cfg(test)]
@@ -73,6 +74,10 @@ struct FetchReceipt {
     cache_hit: bool,
     retries: usize,
     redirects: usize,
+    /// Every request this fetch made, in order: session `cache_hit`, whether
+    /// the attempt bypassed caches, which one produced content, and the
+    /// response headers that explain the cache state (#5904).
+    attempts: Vec<FetchAttempt>,
 }
 
 #[derive(Debug)]
@@ -165,38 +170,56 @@ impl ToolSpec for FetchUrlTool {
         let timeout_ms = optional_u64(&input, "timeout_ms", DEFAULT_TIMEOUT.as_millis() as u64)?
             .clamp(1, HARD_MAX_TIMEOUT.as_millis() as u64);
         let requested_fields = parse_fields(&input)?;
-        let fetched = fetch(
+        // Bound as a reference so the `Fn` extractor can run twice without
+        // moving the field list into its first future.
+        let requested_fields = &requested_fields;
+        // A 2xx that extracts to nothing is re-fetched once past every cache
+        // before it becomes an error; the receipt keeps both attempts (#5904).
+        let readable = fetch_readable(
             &url,
             &FetchOptions::new(Duration::from_millis(timeout_ms), max_bytes, FETCH_ACCEPT),
             context,
             "fetch_url",
+            |fetched: super::web::fetch::FetchedPayload| {
+                Box::pin(async move {
+                    let is_success = (200..300).contains(&fetched.status);
+                    let body_text = if requested_fields.is_empty() {
+                        None
+                    } else {
+                        // JSON is never allowed to discover an encoding from body markup.
+                        Some(decode_response_body(
+                            &fetched.bytes,
+                            Some(&fetched.content_type),
+                            false,
+                        )?)
+                    };
+                    let fields = match body_text.as_deref() {
+                        Some(body) => {
+                            project_json_fields(body, &fetched.content_type, &requested_fields)?
+                        }
+                        None => None,
+                    };
+                    let extracted = extract_fetched_document(
+                        format,
+                        &fetched.url,
+                        &fetched.content_type,
+                        &fetched.bytes,
+                        is_success,
+                        body_text.as_deref(),
+                        PdfTextCommand::system(context.cancel_token.as_ref()),
+                    )
+                    .await?;
+                    Ok((extracted, fields))
+                })
+            },
         )
         .await?;
+        let super::web::fetch::ReadableFetch {
+            payload: fetched,
+            document: (extracted, fields),
+            attempts,
+        } = readable;
         let is_success = (200..300).contains(&fetched.status);
-        let body_text = if requested_fields.is_empty() {
-            None
-        } else {
-            // JSON is never allowed to discover an encoding from body markup.
-            Some(decode_response_body(
-                &fetched.bytes,
-                Some(&fetched.content_type),
-                false,
-            )?)
-        };
-        let fields = match body_text.as_deref() {
-            Some(body) => project_json_fields(body, &fetched.content_type, &requested_fields)?,
-            None => None,
-        };
-        let extracted = extract_fetched_document(
-            format,
-            &fetched.url,
-            &fetched.content_type,
-            &fetched.bytes,
-            is_success,
-            body_text.as_deref(),
-            PdfTextCommand::system(context.cancel_token.as_ref()),
-        )
-        .await?;
 
         let citation_title = extracted.title.clone();
         let (processed, artifact_write) = render_extracted(
@@ -229,6 +252,7 @@ impl ToolSpec for FetchUrlTool {
                 cache_hit: fetched.cache_hit,
                 retries: fetched.retries,
                 redirects: fetched.redirects,
+                attempts,
             },
             artifact,
             fields,

--- a/crates/tui/src/tools/web/extract.rs
+++ b/crates/tui/src/tools/web/extract.rs
@@ -363,9 +363,24 @@ fn markdown_title(body: &str) -> Option<String> {
     })
 }
 
+/// Stable prefix for "the response parsed, but carried no readable body".
+///
+/// The fetch pipeline matches on this to decide whether a cache-busting
+/// re-fetch is worth one more request, and to attach the role-aware recovery
+/// text. Extraction itself has no `ToolContext`, so it cannot know which
+/// escalation the calling role actually owns; it states the fact and leaves
+/// the remedy to [`super::fetch`].
+pub(crate) const JS_SHELL_MARKER: &str = "No readable page content was found at";
+
+/// Whether `error` is the JS-shell extraction failure (a parsed response whose
+/// body held no readable content), as opposed to a transport or type failure.
+pub(crate) fn is_js_shell_error(error: &ToolError) -> bool {
+    error.to_string().contains(JS_SHELL_MARKER)
+}
+
 fn js_required_error(url: &str) -> ToolError {
     ToolError::execution_failed(format!(
-        "No readable page content was found at {url}; the page may require JavaScript. Recovery: use browser automation for this URL."
+        "{JS_SHELL_MARKER} {url}; the response parsed but its body held no readable content, so the page may require JavaScript."
     ))
 }
 
@@ -898,8 +913,19 @@ mod tests {
         .expect_err("empty app shell must fail");
 
         let message = error.to_string();
-        assert!(message.contains("may require JavaScript"));
-        assert!(message.contains("browser automation"));
+        assert!(message.contains("may require JavaScript"), "{message}");
+        assert!(
+            message.contains("https://example.com/app"),
+            "the shell failure must name the URL: {message}"
+        );
+        assert!(
+            is_js_shell_error(&error),
+            "the fetch pipeline recognizes this failure by marker: {message}"
+        );
+        assert!(
+            !is_js_shell_error(&ToolError::execution_failed("connection reset")),
+            "transport failures must not look like a JS shell"
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/tools/web/fetch.rs
+++ b/crates/tui/src/tools/web/fetch.rs
@@ -7,12 +7,16 @@ use std::time::{Duration, Instant};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures_util::StreamExt;
+use serde::Serialize;
 
 use super::cache::{self, CachedFetch};
+use super::extract::is_js_shell_error;
 use super::guard::{
     DnsPin, guarded_reqwest_client_builder, validate_fetch_target, validate_network_policy,
 };
+use crate::features::Feature;
 use crate::tools::spec::{ToolContext, ToolError};
+use crate::worker_profile::ShellPolicy;
 
 pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 pub(crate) const HARD_MAX_TIMEOUT: Duration = Duration::from_secs(60);
@@ -55,13 +59,274 @@ pub(crate) struct FetchedPayload {
     pub(crate) redirects: usize,
 }
 
-pub(crate) async fn fetch(
+/// Whether one request may be answered from a cache, or must revalidate.
+///
+/// `Revalidate` bypasses the session fetch cache *and* asks every intermediary
+/// to revalidate. An edge cache can hold a prerendered variant while an origin
+/// MISS serves the client-side shell, so the same URL alternates between
+/// readable and unreadable depending on which variant answered (#5904).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CacheMode {
+    Default,
+    Revalidate,
+}
+
+impl CacheMode {
+    const fn is_revalidate(self) -> bool {
+        matches!(self, Self::Revalidate)
+    }
+}
+
+/// Response headers that explain the cache state behind a 200.
+///
+/// These are the four that distinguish "the edge served a prerendered page"
+/// from "the origin served the JavaScript shell", so both the success and the
+/// failure receipt carry whichever of them the response actually had.
+const CACHE_STATE_HEADERS: [&str; 4] = [
+    "age",
+    "cf-cache-status",
+    "x-nextjs-prerender",
+    "x-vercel-cache",
+];
+
+/// One request inside a readable-fetch sequence, as it appears on the receipt.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FetchAttempt {
+    /// 1-based position in the sequence.
+    pub(crate) attempt: usize,
+    pub(crate) status: u16,
+    /// Whether the session fetch cache answered this attempt.
+    pub(crate) cache_hit: bool,
+    /// Whether this attempt sent `Cache-Control: no-cache` / `Pragma: no-cache`
+    /// and skipped the session cache.
+    pub(crate) cache_busted: bool,
+    /// Whether this attempt is the one that yielded a readable document.
+    pub(crate) produced_content: bool,
+    /// `age`, `cf-cache-status`, `x-nextjs-prerender`, `x-vercel-cache` — only
+    /// those the response actually carried.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) cache_headers: BTreeMap<String, String>,
+}
+
+impl FetchAttempt {
+    fn record(payload: &FetchedPayload, attempt: usize, mode: CacheMode) -> Self {
+        Self {
+            attempt,
+            status: payload.status,
+            cache_hit: payload.cache_hit,
+            cache_busted: mode.is_revalidate(),
+            produced_content: false,
+            cache_headers: cache_state_headers(&payload.headers),
+        }
+    }
+
+    fn summarize(&self) -> String {
+        let mut facts = vec![format!("HTTP {}", self.status)];
+        if self.cache_hit {
+            facts.push("session cache hit".to_string());
+        }
+        for (name, value) in &self.cache_headers {
+            facts.push(format!("{name}={value}"));
+        }
+        let label = if self.cache_busted {
+            format!("attempt {} (Cache-Control: no-cache)", self.attempt)
+        } else {
+            format!("attempt {}", self.attempt)
+        };
+        format!("{label}: {}", facts.join(", "))
+    }
+}
+
+fn cache_state_headers(headers: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    CACHE_STATE_HEADERS
+        .iter()
+        .filter_map(|name| {
+            headers
+                .get(*name)
+                .map(|value| ((*name).to_string(), value.clone()))
+        })
+        .collect()
+}
+
+/// The extraction step [`fetch_readable`] may run against either attempt.
+///
+/// Spelled as an explicit boxed future over an *owned* payload rather than as
+/// an `AsyncFn` over a borrowed one: the callers live inside
+/// `async fn execute(&self, .., &ToolContext)` futures that must stay `Send`,
+/// and a higher-ranked borrow of the payload would force the returned future
+/// to outlive the tool context it reads.
+pub(crate) type ExtractFuture<'a, T> =
+    std::pin::Pin<Box<dyn Future<Output = Result<T, ToolError>> + Send + 'a>>;
+
+/// A fetch that produced a readable document, plus the attempts it took.
+#[derive(Debug)]
+pub(crate) struct ReadableFetch<T> {
+    pub(crate) payload: FetchedPayload,
+    pub(crate) document: T,
+    pub(crate) attempts: Vec<FetchAttempt>,
+}
+
+/// Fetch `url` and extract it, re-fetching once past every cache when a 2xx
+/// response yields no readable content.
+///
+/// This is the single place that turns the JS-shell case into either a second
+/// chance or an error the model can act on. `extract` runs against the fetched
+/// payload; only [`is_js_shell_error`] failures earn the second request, so
+/// transport failures keep the existing single-retry behavior of one request.
+pub(crate) async fn fetch_readable<'e, T, F>(
     url: &str,
     options: &FetchOptions,
     context: &ToolContext,
     tool_label: &str,
-) -> Result<FetchedPayload, ToolError> {
-    fetch_inner(url, options, context, tool_label, None).await
+    extract: F,
+) -> Result<ReadableFetch<T>, ToolError>
+where
+    F: Fn(FetchedPayload) -> ExtractFuture<'e, T>,
+{
+    fetch_readable_inner(url, options, context, tool_label, None, extract).await
+}
+
+#[cfg(test)]
+pub(crate) async fn fetch_readable_with_initial_pin<'e, T, F>(
+    url: &str,
+    options: &FetchOptions,
+    context: &ToolContext,
+    tool_label: &str,
+    initial_pin: DnsPin,
+    extract: F,
+) -> Result<ReadableFetch<T>, ToolError>
+where
+    F: Fn(FetchedPayload) -> ExtractFuture<'e, T>,
+{
+    fetch_readable_inner(
+        url,
+        options,
+        context,
+        tool_label,
+        Some(initial_pin),
+        extract,
+    )
+    .await
+}
+
+async fn fetch_readable_inner<'e, T, F>(
+    url: &str,
+    options: &FetchOptions,
+    context: &ToolContext,
+    tool_label: &str,
+    test_initial_pin: Option<DnsPin>,
+    extract: F,
+) -> Result<ReadableFetch<T>, ToolError>
+where
+    F: Fn(FetchedPayload) -> ExtractFuture<'e, T>,
+{
+    let mut attempts: Vec<FetchAttempt> = Vec::with_capacity(2);
+    for mode in [CacheMode::Default, CacheMode::Revalidate] {
+        let payload = fetch_inner(
+            url,
+            options,
+            context,
+            tool_label,
+            test_initial_pin.clone(),
+            mode,
+        )
+        .await?;
+        let mut record = FetchAttempt::record(&payload, attempts.len() + 1, mode);
+        let final_url = payload.url.clone();
+        match extract(payload.clone()).await {
+            Ok(document) => {
+                record.produced_content = true;
+                attempts.push(record);
+                return Ok(ReadableFetch {
+                    payload,
+                    document,
+                    attempts,
+                });
+            }
+            // A 2xx whose body held no readable content is the one failure a
+            // second request can fix: the first response may have been a
+            // cached client-side shell.
+            Err(error)
+                if is_js_shell_error(&error)
+                    && (200..300).contains(&payload.status)
+                    && mode == CacheMode::Default =>
+            {
+                attempts.push(record);
+            }
+            Err(error) => {
+                attempts.push(record);
+                return Err(if is_js_shell_error(&error) {
+                    js_shell_failure(&final_url, &attempts, context, tool_label)
+                } else {
+                    error
+                });
+            }
+        }
+    }
+    unreachable!("the revalidate pass either returns a document or an error");
+}
+
+/// The terminal JS-shell error, carrying the failure receipt and the recovery
+/// the *calling role* actually owns.
+fn js_shell_failure(
+    url: &str,
+    attempts: &[FetchAttempt],
+    context: &ToolContext,
+    tool_label: &str,
+) -> ToolError {
+    let receipt = attempts
+        .iter()
+        .map(FetchAttempt::summarize)
+        .collect::<Vec<_>>()
+        .join("; ");
+    ToolError::execution_failed(format!(
+        "{marker} {url} after {count} attempts, the second past every cache ({receipt}). The response parsed but held no readable body, which usually means the page renders its content with JavaScript. Recovery: {recovery}",
+        marker = super::extract::JS_SHELL_MARKER,
+        count = attempts.len(),
+        recovery = js_shell_recovery(context, tool_label),
+    ))
+}
+
+/// Whether the `web.run` browse surface is reachable from this context.
+///
+/// Both facts already exist: the web family is feature-gated, and a
+/// network-denied Fleet worker carries `network_access: Some(false)` on the
+/// authority envelope that also removes `web.run` from its registry
+/// (`fleet::role::NETWORK_TOOL_DENYLIST`). Nothing new is registered here.
+fn browser_surface_available(context: &ToolContext) -> bool {
+    context.features.enabled(Feature::WebSearch) && network_authorized(context)
+}
+
+/// Whether this role could shell out to `curl` as a last resort. Read-only and
+/// shell-less roles cannot: the read-only grammar rejects a network fetch.
+fn shell_fallback_available(context: &ToolContext) -> bool {
+    context.shell_policy == ShellPolicy::Full && network_authorized(context)
+}
+
+fn network_authorized(context: &ToolContext) -> bool {
+    context
+        .tool_authority
+        .as_deref()
+        .is_none_or(|authority| authority.network_access != Some(false))
+}
+
+fn js_shell_recovery(context: &ToolContext, tool_label: &str) -> String {
+    // `web.run` is itself the escalation, so it never names itself.
+    if tool_label != "web_run" && browser_surface_available(context) {
+        return "open this URL with the `web.run` browse surface (`web.run {\"open\": {\"url\": ...}}`), which requests it with a browser user-agent and a ten-megabyte budget and usually receives the prerendered variant.".to_string();
+    }
+    let unavailable = if tool_label == "web_run" {
+        "this is already the `web.run` browse surface, so there is no further web escalation."
+    } else {
+        "the `web.run` browse surface is not available to this role."
+    };
+    if shell_fallback_available(context) {
+        format!("{unavailable} Fall back to a shell fetch (`curl -sSL`) or a rendering tool.")
+    } else {
+        format!(
+            "{unavailable} This role is read-only and cannot fall back to a shell fetch, so report this URL as unreadable rather than substituting another source."
+        )
+    }
 }
 
 #[cfg(test)]
@@ -72,7 +337,15 @@ pub(crate) async fn fetch_with_initial_pin(
     tool_label: &str,
     initial_pin: DnsPin,
 ) -> Result<FetchedPayload, ToolError> {
-    fetch_inner(url, options, context, tool_label, Some(initial_pin)).await
+    fetch_inner(
+        url,
+        options,
+        context,
+        tool_label,
+        Some(initial_pin),
+        CacheMode::Default,
+    )
+    .await
 }
 
 async fn fetch_inner(
@@ -81,6 +354,7 @@ async fn fetch_inner(
     context: &ToolContext,
     tool_label: &str,
     test_initial_pin: Option<DnsPin>,
+    cache_mode: CacheMode,
 ) -> Result<FetchedPayload, ToolError> {
     let initial_url = reqwest::Url::parse(url)
         .map_err(|err| ToolError::invalid_input(format!("invalid URL: {err}")))?;
@@ -97,12 +371,17 @@ async fn fetch_inner(
         None => validate_fetch_target(&initial_url, context, tool_label).await?,
     };
 
-    if let Some(cached) = cache::get(
-        &context.state_namespace,
-        &initial_url,
-        options.accept,
-        options.max_bytes,
-    ) {
+    if let Some(cached) = (!cache_mode.is_revalidate())
+        .then(|| {
+            cache::get(
+                &context.state_namespace,
+                &initial_url,
+                options.accept,
+                options.max_bytes,
+            )
+        })
+        .flatten()
+    {
         let cached_url = reqwest::Url::parse(&cached.url).map_err(|err| {
             ToolError::execution_failed(format!("cached response URL was invalid: {err}"))
         })?;
@@ -130,6 +409,7 @@ async fn fetch_inner(
             tool_label,
             remaining,
             validated_initial_pin.clone(),
+            cache_mode,
         )
         .await
         {
@@ -187,6 +467,7 @@ async fn fetch_attempt(
     tool_label: &str,
     timeout: Duration,
     initial_pin: DnsPin,
+    cache_mode: CacheMode,
 ) -> Result<CachedFetch, AttemptError> {
     let mut current_url = initial_url;
     let mut redirects = 0usize;
@@ -225,10 +506,20 @@ async fn fetch_attempt(
                 "failed to build HTTP client: {err}"
             )))
         })?;
-        let response = client
+        let mut request = client
             .get(current_url.clone())
             .header("Accept", options.accept)
-            .header("Accept-Language", "en-US,en;q=0.5")
+            .header("Accept-Language", "en-US,en;q=0.5");
+        if cache_mode.is_revalidate() {
+            // `no-cache` (revalidate), not `no-store`: the shared caches still
+            // get to serve a validated copy, which is what recovers a page
+            // whose prerendered variant exists but was not the one served.
+            // `Pragma` is the HTTP/1.0 spelling some CDNs still honor.
+            request = request
+                .header("Cache-Control", "no-cache")
+                .header("Pragma", "no-cache");
+        }
+        let response = request
             .send()
             .await
             .map_err(|err| AttemptError::Transient(err.to_string()))?;
@@ -467,6 +758,229 @@ mod tests {
         assert!(!large.cache_hit);
     }
 
+    /// A Vercel-style edge that serves the client-side shell to an ordinary
+    /// request and the prerendered page to a revalidating one (#5904).
+    #[derive(Clone)]
+    struct ShellUntilRevalidated {
+        calls: Arc<AtomicUsize>,
+        always_shell: bool,
+    }
+
+    const JS_SHELL_BODY: &str = "<html><head><title>Pricing</title></head><body><div id='root'></div><script>boot()</script></body></html>";
+    const PRERENDERED_BODY: &str = "<html><head><title>Pricing</title></head><body><main><h1>Pricing</h1><p>The prerendered variant carries the full pricing table for every plan.</p></main></body></html>";
+
+    impl Respond for ShellUntilRevalidated {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let revalidating = request
+                .headers
+                .get("cache-control")
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.contains("no-cache"));
+            if revalidating && !self.always_shell {
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .insert_header("x-vercel-cache", "HIT")
+                    .insert_header("x-nextjs-prerender", "1")
+                    .insert_header("age", "12")
+                    .set_body_string(PRERENDERED_BODY)
+            } else {
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .insert_header("x-vercel-cache", "MISS")
+                    .set_body_string(JS_SHELL_BODY)
+            }
+        }
+    }
+
+    async fn js_shell_server(always_shell: bool) -> (MockServer, Arc<AtomicUsize>) {
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("GET"))
+            .and(path("/pricing"))
+            .respond_with(ShellUntilRevalidated {
+                calls: Arc::clone(&calls),
+                always_shell,
+            })
+            .mount(&server)
+            .await;
+        (server, calls)
+    }
+
+    fn extract_html_document(
+        payload: FetchedPayload,
+    ) -> ExtractFuture<'static, super::super::extract::ExtractedDocument> {
+        Box::pin(async move {
+            super::super::extract::extract_document(
+                &payload.url,
+                Some(&payload.content_type),
+                &payload.bytes,
+                None,
+            )
+            .await
+        })
+    }
+
+    #[tokio::test]
+    async fn js_shell_is_refetched_past_every_cache_before_it_becomes_an_error() {
+        let (server, calls) = js_shell_server(false).await;
+        let url = format!("http://public.example:{}/pricing", server.address().port());
+        let context = context("js-shell-recovers");
+
+        let readable = fetch_readable_with_initial_pin(
+            &url,
+            &FetchOptions::new(Duration::from_secs(5), 65_536, "text/html"),
+            &context,
+            "fetch_url",
+            pin(),
+            extract_html_document,
+        )
+        .await
+        .expect("the revalidated response carries the prerendered page");
+
+        assert!(
+            readable.document.markdown.contains("full pricing table"),
+            "the second attempt's content must be what the caller receives: {}",
+            readable.document.markdown
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "exactly one extra request");
+        assert_eq!(readable.attempts.len(), 2);
+        assert!(!readable.attempts[0].cache_busted);
+        assert!(!readable.attempts[0].produced_content);
+        assert_eq!(
+            readable.attempts[0].cache_headers.get("x-vercel-cache"),
+            Some(&"MISS".to_string()),
+            "the failing attempt keeps the header that explains its cache state"
+        );
+        assert!(readable.attempts[1].cache_busted);
+        assert!(readable.attempts[1].produced_content);
+        assert_eq!(
+            readable.attempts[1].cache_headers.get("x-vercel-cache"),
+            Some(&"HIT".to_string())
+        );
+        assert_eq!(
+            readable.attempts[1].cache_headers.get("x-nextjs-prerender"),
+            Some(&"1".to_string())
+        );
+        assert_eq!(
+            readable.attempts[1].cache_headers.get("age"),
+            Some(&"12".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn two_shells_fail_with_the_escalation_the_calling_role_owns() {
+        let (server, calls) = js_shell_server(true).await;
+        let url = format!("http://public.example:{}/pricing", server.address().port());
+        let options = FetchOptions::new(Duration::from_secs(5), 65_536, "text/html");
+
+        let error = fetch_readable_with_initial_pin(
+            &url,
+            &options,
+            &context("js-shell-browser-role"),
+            "fetch_url",
+            pin(),
+            extract_html_document,
+        )
+        .await
+        .expect_err("two shells must fail");
+        let message = error.to_string();
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "no third request");
+        assert!(
+            message.contains("web.run"),
+            "a role that has the browse surface must be told to use it: {message}"
+        );
+        assert!(
+            message.contains("attempt 1")
+                && message.contains("attempt 2 (Cache-Control: no-cache)"),
+            "the failure receipt names both attempts: {message}"
+        );
+        assert!(
+            message.contains("x-vercel-cache=MISS"),
+            "the failure receipt carries the cache-state headers: {message}"
+        );
+
+        // A read-only worker whose envelope denies network keeps `Web{fetch}`
+        // but loses `web.run` and any shell fallback, so the error must say so
+        // instead of naming a surface the role cannot call.
+        let mut denied = context("js-shell-read-only-role");
+        denied.shell_policy = ShellPolicy::ReadOnly;
+        denied.execution.tool_authority =
+            Some(Arc::new(crate::tools::spec::ToolAuthorityEnvelope {
+                schema_version: 1,
+                owner: "scout".to_string(),
+                authority: crate::tools::spec::ToolMutationAuthority::ReadOnly,
+                network_access: Some(false),
+                shell: crate::tools::spec::ToolShellAuthority::ReadOnly,
+                verification: crate::tools::spec::ToolVerificationAuthority::None,
+                writable_roots: Vec::new(),
+                writable_files: Vec::new(),
+                coordination_contracts: Vec::new(),
+            }));
+        let error = fetch_readable_with_initial_pin(
+            &url,
+            &options,
+            &denied,
+            "fetch_url",
+            pin(),
+            extract_html_document,
+        )
+        .await
+        .expect_err("two shells must fail");
+        let message = error.to_string();
+        assert!(
+            message.contains("not available to this role"),
+            "a role without the browse surface must be told plainly: {message}"
+        );
+        assert!(
+            message.contains("cannot fall back to a shell fetch"),
+            "read-only roles must not be sent to curl: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_failures_do_not_earn_a_cache_busting_refetch() {
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("GET"))
+            .and(path("/flaky"))
+            .respond_with(FailOnce {
+                calls: Arc::clone(&calls),
+            })
+            .mount(&server)
+            .await;
+        let url = format!("http://public.example:{}/flaky", server.address().port());
+        let context = context("js-shell-transport-retry");
+
+        let readable = fetch_readable_with_initial_pin(
+            &url,
+            &FetchOptions::new(Duration::from_secs(5), 1_024, "text/plain"),
+            &context,
+            "fetch_url",
+            pin(),
+            |payload: FetchedPayload| {
+                Box::pin(async move { Ok(String::from_utf8_lossy(&payload.bytes).into_owned()) })
+            },
+        )
+        .await
+        .expect("the existing transport retry still recovers");
+
+        assert_eq!(readable.document, "recovered response");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "the 503 costs the existing single transport retry and nothing more"
+        );
+        assert_eq!(
+            readable.attempts.len(),
+            1,
+            "a transport retry is not a readable-fetch attempt"
+        );
+        assert_eq!(readable.payload.retries, 1);
+        assert!(!readable.attempts[0].cache_busted);
+        assert!(readable.attempts[0].produced_content);
+    }
+
     #[test]
     fn fetch_user_agent_tracks_the_crate_version() {
         assert!(
@@ -522,11 +1036,13 @@ mod tests {
         let context =
             context("policy-cache").with_network_policy(NetworkPolicyDecider::new(policy, None));
 
-        let error = fetch(
+        let error = fetch_inner(
             url.as_str(),
             &FetchOptions::new(Duration::from_secs(1), 100, "text/plain"),
             &context,
             "fetch_url",
+            None,
+            CacheMode::Default,
         )
         .await
         .expect_err("policy must win over cache");
@@ -563,11 +1079,13 @@ mod tests {
         let context = context("redirect-policy-cache")
             .with_network_policy(NetworkPolicyDecider::new(policy, None));
 
-        let error = fetch(
+        let error = fetch_inner(
             initial_url.as_str(),
             &FetchOptions::new(Duration::from_secs(1), 100, "text/plain"),
             &context,
             "fetch_url",
+            None,
+            CacheMode::Default,
         )
         .await
         .expect_err("final redirect policy must win over cache");

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -7,10 +7,10 @@ use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
     optional_u64, required_str,
 };
-use super::web::extract::{DocumentKind, extract_document};
+use super::web::extract::{DocumentKind, ExtractedDocument, extract_document};
 #[cfg(test)]
-use super::web::fetch::fetch_with_initial_pin;
-use super::web::fetch::{FetchOptions, HARD_MAX_BYTES, fetch};
+use super::web::fetch::fetch_readable_with_initial_pin;
+use super::web::fetch::{FetchOptions, HARD_MAX_BYTES, fetch_readable};
 #[cfg(test)]
 use super::web::guard::DnsPin;
 use super::web::overflow::bound_text as bound_web_text;
@@ -1052,23 +1052,30 @@ fn page_from_search(query: &str, results: &[NormalizedSearchResult]) -> WebPage 
     }
 }
 
+fn open_fetch_options(timeout_ms: u64) -> FetchOptions {
+    FetchOptions::new(
+        Duration::from_millis(timeout_ms),
+        HARD_MAX_BYTES,
+        "text/html,text/markdown,text/plain,application/xhtml+xml,application/pdf,image/*,audio/*,video/*,*/*;q=0.5",
+    )
+}
+
 async fn fetch_page(
     url: &str,
     timeout_ms: u64,
     context: &ToolContext,
 ) -> Result<WebPage, ToolError> {
-    let payload = fetch(
+    let readable = fetch_readable(
         url,
-        &FetchOptions::new(
-            Duration::from_millis(timeout_ms),
-            HARD_MAX_BYTES,
-            "text/html,text/markdown,text/plain,application/xhtml+xml,application/pdf,image/*,audio/*,video/*,*/*;q=0.5",
-        ),
+        &open_fetch_options(timeout_ms),
         context,
         "web_run",
+        |payload: super::web::fetch::FetchedPayload| {
+            Box::pin(async move { document_from_fetched(&payload, context).await })
+        },
     )
     .await?;
-    page_from_fetched(payload, context).await
+    page_from_document(readable.payload, readable.document, context)
 }
 
 #[cfg(test)]
@@ -1078,38 +1085,48 @@ async fn fetch_page_with_initial_pin(
     context: &ToolContext,
     initial_pin: Option<DnsPin>,
 ) -> Result<WebPage, ToolError> {
-    let payload = fetch_with_initial_pin(
+    let readable = fetch_readable_with_initial_pin(
         url,
-        &FetchOptions::new(
-            Duration::from_millis(timeout_ms),
-            HARD_MAX_BYTES,
-            "text/html,text/markdown,text/plain,application/xhtml+xml,application/pdf,image/*,audio/*,video/*,*/*;q=0.5",
-        ),
+        &open_fetch_options(timeout_ms),
         context,
         "web_run",
         initial_pin.flatten(),
+        |payload: super::web::fetch::FetchedPayload| {
+            Box::pin(async move { document_from_fetched(&payload, context).await })
+        },
     )
     .await?;
-    page_from_fetched(payload, context).await
+    page_from_document(readable.payload, readable.document, context)
 }
 
-async fn page_from_fetched(
-    payload: super::web::fetch::FetchedPayload,
+/// Reject non-2xx responses, then extract one readable document.
+///
+/// Kept separate from rendering so `fetch_readable` can re-run exactly this
+/// step against a cache-busted second response (#5904).
+async fn document_from_fetched(
+    payload: &super::web::fetch::FetchedPayload,
     context: &ToolContext,
-) -> Result<WebPage, ToolError> {
+) -> Result<ExtractedDocument, ToolError> {
     if !(200..300).contains(&payload.status) {
         return Err(ToolError::execution_failed(format!(
             "Web request to {} failed: HTTP {}",
             payload.url, payload.status
         )));
     }
-    let document = extract_document(
+    extract_document(
         &payload.url,
         Some(&payload.content_type),
         &payload.bytes,
         context.cancel_token.as_ref(),
     )
-    .await?;
+    .await
+}
+
+fn page_from_document(
+    payload: super::web::fetch::FetchedPayload,
+    document: ExtractedDocument,
+    context: &ToolContext,
+) -> Result<WebPage, ToolError> {
     let content_type = Some(payload.content_type);
     match document.kind {
         DocumentKind::Html => {
@@ -1836,7 +1853,7 @@ mod tests {
         };
         let context = ToolContext::new(PathBuf::from("."));
 
-        let error = page_from_fetched(payload, &context)
+        let error = document_from_fetched(&payload, &context)
             .await
             .expect_err("non-2xx pages must not be rendered");
         let message = error.to_string();


### PR DESCRIPTION
Closes #5904

## What was broken

A 200 whose body extracted to nothing was terminal. `crates/tui/src/tools/web/extract.rs:197,206` raised `js_required_error` on the spot, and the `retries` counter in `crates/tui/src/tools/web/fetch.rs` only ever covered transport failures — a 200-with-JS-shell was never re-fetched. Because an edge cache can hold a prerendered variant while an origin MISS serves the client-side shell, the same URL failed on one fetch and succeeded minutes later, and research agents lost primary sources non-deterministically.

## What changed

- **One retry, past every cache.** `web/fetch.rs` gains `fetch_readable`: the single place that fetches *and* extracts. A 2xx that yields no readable content is re-fetched once with `Cache-Control: no-cache` and `Pragma: no-cache`, skipping the session fetch cache. `no-cache` rather than `no-store` deliberately — shared caches still get to serve a validated copy, which is what recovers a page whose prerendered variant exists but was not the one served. Transport failures keep exactly their existing single retry and earn no extra request.
- **The receipt records both attempts.** `fetch_url`'s receipt gains `attempts`: per attempt the session `cache_hit`, whether it bypassed caches (`cache_busted`), which one `produced_content`, and the response headers that explain the cache state (`age`, `cf-cache-status`, `x-nextjs-prerender`, `x-vercel-cache`, only when present). The terminal error carries the same receipt inline, so a failure explains itself as well as a success does.
- **The error names the escalation the calling role owns.** Read from capability facts already on `ToolContext` — no second registry: `Feature::WebSearch` plus the authority envelope's `network_access` decide whether `web.run` is reachable (that same envelope is what removes `web.run` via `fleet::role::NETWORK_TOOL_DENYLIST`), and `shell_policy` decides whether a shell fetch is even an option. A role that has the browse surface is told to use it; a read-only, network-denied worker is told plainly that it has neither `web.run` nor a `curl` fallback and should report the URL as unreadable rather than substitute a source.
- **Both consumers migrated.** `fetch_url` and `web_run` now go through `fetch_readable`; the raw `fetch` entry point had no remaining callers and was removed rather than left as a second path.

Naming `web.run` as the escalation is accurate for this codebase and matches the evidence in the issue: `web.run` open requests the same URL with a browser user-agent and a ten-megabyte budget where `fetch_url` uses the codewhale UA and one megabyte, which is exactly the difference that gets the prerendered variant from a Vercel/Next origin.

## Verified locally

No live network calls to third-party sites; every new test drives a `wiremock` mock server whose responder returns the JS shell to an ordinary request and the prerendered body to one carrying `Cache-Control: no-cache`.

```
cargo fmt --all -- --check                                          clean
cargo check -p codewhale-tui                                        clean
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- tools::web
    test result: ok. 194 passed; 0 failed; 1 ignored
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- tools::
    test result: ok. 1937 passed; 0 failed; 4 ignored
```

Both new regression tests were shown failing without the fix (retry guard disabled: `7 passed; 2 failed`):
- `js_shell_is_refetched_past_every_cache_before_it_becomes_an_error` — shell then content: succeeds, exactly one extra request, receipt shows two attempts with the second `cache_busted` and `produced_content`, and the cache-state headers on both.
- `two_shells_fail_with_the_escalation_the_calling_role_owns` — shell twice: fails, no third request, error names `web.run` for a normal role and says "not available to this role" / "cannot fall back to a shell fetch" for a read-only network-denied envelope, and carries both attempt lines plus `x-vercel-cache=MISS`.
- `transport_failures_do_not_earn_a_cache_busting_refetch` — a 503-then-200 costs the existing single transport retry and records one readable-fetch attempt, not two.

## What only a live fetch can prove

The mock proves the mechanism: we send the cache-busting headers, we re-fetch once, and a differing second response is what the caller receives. It cannot prove the *rate* at which real edges (Vercel, Cloudflare) actually hand back a prerendered variant on a revalidating request — that is a property of those CDNs, and the issue's own evidence (`x-vercel-cache: HIT` + `x-nextjs-prerender: 1` on the successful fetch of `deepgram.com/pricing`) is the only sample we have. The pages named in the issue were not fetched from this branch, and the `alibabacloud.com` docs app may well be a page that never has a prerendered variant, in which case the value delivered there is the second half of this change: an error that tells the model exactly which surface to escalate to, rather than one that reads as "this URL is unfetchable".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XYyJaw9Mh9uSrqQBoqhm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default HTTP fetch behavior for fetch_url and web.run (up to one additional network request per URL) and alters error text agents act on, but scope is bounded to JS-shell 2xx cases with new regression tests.
> 
> **Overview**
> Fixes non-deterministic failures when a **200 OK** returns a JavaScript app shell (empty readable body) while a prerendered variant might exist behind edge caches (#5904).
> 
> **`fetch_readable`** replaces the old fetch-then-extract split for **`fetch_url`** and **`web.run` open**. On a **2xx** whose extraction fails with the new **JS-shell marker**, the pipeline makes **one extra request** with **`Cache-Control: no-cache`** / **`Pragma: no-cache`**, skips the session fetch cache, and runs extraction again. Transport retries are unchanged and do **not** trigger this second pass.
> 
> Successful **`fetch_url`** responses now include a richer **`receipt.attempts`** list (cache hit, cache-busted, which attempt produced content, and selective cache-state headers). Terminal JS-shell errors embed the same attempt summary and **role-aware recovery** text (`web.run`, shell/`curl`, or “report unreadable”) derived from existing **`ToolContext`** capabilities.
> 
> **`extract.rs`** exposes **`JS_SHELL_MARKER`** / **`is_js_shell_error`** so the fetch layer can recognize shell failures without conflating transport errors. Wiremock tests cover shell-then-prerender recovery, double-shell failure messaging, and that flaky HTTP status retries stay a single readable-fetch attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77cf192081c44a46e2860a9d9d17eafd9f7a1284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->