### PR TITLE
tools: replace a same-named tool in the registry builder instead of registering it twice

### DIFF
--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -723,7 +723,20 @@ impl ToolRegistryBuilder {
     /// Add a custom tool.
     #[must_use]
     pub fn with_tool(mut self, tool: Arc<dyn ToolSpec>) -> Self {
-        self.tools.push(tool);
+        // A later builder step that supplies an existing name is an intended
+        // upgrade (`with_patch_tools` swaps the default `File` for the
+        // patch-capable one), so replace in place. `ToolRegistry::register`
+        // keeps warning about the collisions that are not planned (#5934).
+        let name = tool.name().to_string();
+        if let Some(slot) = self
+            .tools
+            .iter_mut()
+            .find(|existing| existing.name() == name)
+        {
+            *slot = tool;
+        } else {
+            self.tools.push(tool);
+        }
         self
     }
 

--- a/crates/tui/src/tools/registry/tests.rs
+++ b/crates/tui/src/tools/registry/tests.rs
@@ -1690,3 +1690,26 @@ fn rlm_family_removes_legacy_aliases() {
         );
     }
 }
+
+#[test]
+fn a_builder_upgrade_replaces_the_tool_instead_of_registering_it_twice() {
+    // `with_patch_tools` swaps the default `File` for the patch-capable one;
+    // that used to reach `register` as a second `File` and warn on every
+    // registry rebuild (#5934).
+    let builder = ToolRegistryBuilder::new()
+        .with_file_tools()
+        .with_patch_tools();
+    let file_tools = builder
+        .tools
+        .iter()
+        .filter(|tool| tool.name() == "File")
+        .count();
+    assert_eq!(file_tools, 1, "one File tool after the upgrade");
+    assert!(
+        builder
+            .tools
+            .iter()
+            .any(|tool| tool.name() == "apply_patch"),
+        "the upgrade still adds apply_patch"
+    );
+}


### PR DESCRIPTION
Closes #5934

`ToolRegistryBuilder::with_patch_tools` upgrades the default `File` tool to the patch-capable one by pushing a second `Arc` with the same name; `ToolRegistry::register` then overwrote the first and logged `Overwriting existing tool: File` on every rebuild (42 times across the founder's recent sessions). The builder now replaces a same-named tool in place, so the warning is left for collisions that were not planned.

Verified: `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- tools::registry::` → 48 passed, 0 failed (one new test pins the single `File` plus `apply_patch`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized builder deduplication for intentional tool upgrades; runtime registration behavior is unchanged except fewer duplicate entries reaching `register`.
> 
> **Overview**
> Fixes noisy **`Overwriting existing tool: File`** warnings on every registry rebuild (#5934).
> 
> **`ToolRegistryBuilder::with_tool`** now **replaces** an already-registered tool when the new one has the same name, instead of appending a duplicate. That matches the intended **upgrade** path where **`with_patch_tools`** swaps the default **`File`** implementation for the patch-capable one after **`with_file_tools`**. **`ToolRegistry::register`** still logs overwrite warnings for unplanned name collisions at build time.
> 
> A regression test asserts **`with_file_tools().with_patch_tools()`** leaves exactly one **`File`** entry and still registers **`apply_patch`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d83d07d6e69b81613d9a794c6f43482d57ef63b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->