### PR TITLE
feat(agents): show a parked child as parked, not "waiting for input"

### DIFF
--- a/crates/protocol/src/event_msg.rs
+++ b/crates/protocol/src/event_msg.rs
@@ -196,7 +196,8 @@ pub struct AgentRosterRow {
     pub worker_id: String,
     pub display_name: String,
     pub model: String,
-    /// Coarse rail state: `running | waiting | done | failed | cancelled`.
+    /// Coarse rail state:
+    /// `running | waiting | parked | done | failed | cancelled`.
     pub state: String,
     /// `AgentWorkerStatus` in snake_case.
     pub status: String,

--- a/crates/tui/locales/ca.json
+++ b/crates/tui/locales/ca.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "Esperant-te",
   "WhaleStateBlocked": "Bloquejada",
   "WhaleStateOffline": "Fora de línia",
+  "AgentStatusParked": "en pausa",
+  "AgentStatusParkedRecovery": "ningú no l'està esperant; fes servir resume_from per continuar o cancel per descartar-lo",
   "WhaleAnimalScout": "zífid",
   "WhaleAnimalPatch": "marsopa comuna",
   "WhaleAnimalHarbor": "iubarta",

--- a/crates/tui/locales/de.json
+++ b/crates/tui/locales/de.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "Wartet auf dich",
   "WhaleStateBlocked": "Blockiert",
   "WhaleStateOffline": "Offline",
+  "AgentStatusParked": "geparkt",
+  "AgentStatusParkedRecovery": "niemand wartet darauf; mit resume_from fortsetzen oder mit cancel verwerfen",
   "WhaleAnimalScout": "Schnabelwal",
   "WhaleAnimalPatch": "Schweinswal",
   "WhaleAnimalHarbor": "Buckelwal",

--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "Waiting for you",
   "WhaleStateBlocked": "Blocked",
   "WhaleStateOffline": "Offline",
+  "AgentStatusParked": "parked",
+  "AgentStatusParkedRecovery": "nobody is waiting on it; resume_from to continue, or cancel to dismiss",
   "WhaleAnimalScout": "beaked whale",
   "WhaleAnimalPatch": "harbor porpoise",
   "WhaleAnimalHarbor": "humpback whale",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "Esperándote",
   "WhaleStateBlocked": "Bloqueada",
   "WhaleStateOffline": "Sin conexión",
+  "AgentStatusParked": "en pausa",
+  "AgentStatusParkedRecovery": "nadie lo está esperando; usa resume_from para continuar o cancel para descartarlo",
   "WhaleAnimalScout": "zifio",
   "WhaleAnimalPatch": "marsopa común",
   "WhaleAnimalHarbor": "ballena jorobada",

--- a/crates/tui/locales/fr.json
+++ b/crates/tui/locales/fr.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "Vous attend",
   "WhaleStateBlocked": "Bloquée",
   "WhaleStateOffline": "Hors ligne",
+  "AgentStatusParked": "en pause",
+  "AgentStatusParkedRecovery": "personne ne l'attend ; resume_from pour continuer, ou cancel pour l'écarter",
   "WhaleAnimalScout": "baleine à bec",
   "WhaleAnimalPatch": "marsouin commun",
   "WhaleAnimalHarbor": "baleine à bosse",

--- a/crates/tui/locales/hi.json
+++ b/crates/tui/locales/hi.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "आपकी प्रतीक्षा में",
   "WhaleStateBlocked": "अवरुद्ध",
   "WhaleStateOffline": "ऑफ़लाइन",
+  "AgentStatusParked": "रुका हुआ",
+  "AgentStatusParkedRecovery": "इसकी कोई प्रतीक्षा नहीं कर रहा; जारी रखने के लिए resume_from, हटाने के लिए cancel",
   "WhaleAnimalScout": "चोंचदार व्हेल",
   "WhaleAnimalPatch": "बंदरगाह पोरपॉइज़",
   "WhaleAnimalHarbor": "हंपबैक व्हेल",

--- a/crates/tui/locales/id.json
+++ b/crates/tui/locales/id.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "Menunggu Anda",
   "WhaleStateBlocked": "Terblokir",
   "WhaleStateOffline": "Luring",
+  "AgentStatusParked": "dijeda",
+  "AgentStatusParkedRecovery": "tidak ada yang menunggunya; gunakan resume_from untuk melanjutkan atau cancel untuk membuangnya",
   "WhaleAnimalScout": "paus berparuh",
   "WhaleAnimalPatch": "lumba-lumba pelabuhan",
   "WhaleAnimalHarbor": "paus bungkuk",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "あなたの操作待ち",
   "WhaleStateBlocked": "ブロック中",
   "WhaleStateOffline": "オフライン",
+  "AgentStatusParked": "保留中",
+  "AgentStatusParkedRecovery": "誰も応答を待っていません。続行するには resume_from、破棄するには cancel",
   "WhaleAnimalScout": "アカボウクジラ",
   "WhaleAnimalPatch": "ネズミイルカ",
   "WhaleAnimalHarbor": "ザトウクジラ",

--- a/crates/tui/locales/ko.json
+++ b/crates/tui/locales/ko.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "당신을 기다리는 중",
   "WhaleStateBlocked": "차단됨",
   "WhaleStateOffline": "오프라인",
+  "AgentStatusParked": "보류됨",
+  "AgentStatusParkedRecovery": "아무도 기다리고 있지 않습니다. 계속하려면 resume_from, 정리하려면 cancel",
   "WhaleAnimalScout": "부리고래",
   "WhaleAnimalPatch": "쇠돌고래",
   "WhaleAnimalHarbor": "혹등고래",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "Aguardando você",
   "WhaleStateBlocked": "Bloqueada",
   "WhaleStateOffline": "Offline",
+  "AgentStatusParked": "em pausa",
+  "AgentStatusParkedRecovery": "ninguém está esperando por ele; use resume_from para continuar ou cancel para descartar",
   "WhaleAnimalScout": "baleia-bicuda",
   "WhaleAnimalPatch": "boto-do-porto",
   "WhaleAnimalHarbor": "baleia-jubarte",

--- a/crates/tui/locales/ru.json
+++ b/crates/tui/locales/ru.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "Ждёт вас",
   "WhaleStateBlocked": "Заблокирован",
   "WhaleStateOffline": "Не в сети",
+  "AgentStatusParked": "приостановлен",
+  "AgentStatusParkedRecovery": "его никто не ждёт; resume_from чтобы продолжить, или cancel чтобы отбросить",
   "WhaleAnimalScout": "клюворыл",
   "WhaleAnimalPatch": "морская свинья",
   "WhaleAnimalHarbor": "горбатый кит",

--- a/crates/tui/locales/uk.json
+++ b/crates/tui/locales/uk.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "Чекає на вас",
   "WhaleStateBlocked": "Заблоковано",
   "WhaleStateOffline": "Поза мережею",
+  "AgentStatusParked": "призупинено",
+  "AgentStatusParkedRecovery": "на нього ніхто не чекає; resume_from щоб продовжити, або cancel щоб відхилити",
   "WhaleAnimalScout": "дзьоборил",
   "WhaleAnimalPatch": "морська свиня",
   "WhaleAnimalHarbor": "горбатий кит",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "Đang chờ bạn",
   "WhaleStateBlocked": "Bị chặn",
   "WhaleStateOffline": "Ngoại tuyến",
+  "AgentStatusParked": "tạm dừng",
+  "AgentStatusParkedRecovery": "không ai đang chờ nó; dùng resume_from để tiếp tục, hoặc cancel để bỏ",
   "WhaleAnimalScout": "cá voi mõm khoằm",
   "WhaleAnimalPatch": "cá heo chuột",
   "WhaleAnimalHarbor": "cá voi lưng gù",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "等待你",
   "WhaleStateBlocked": "已阻塞",
   "WhaleStateOffline": "离线",
+  "AgentStatusParked": "已停放",
+  "AgentStatusParkedRecovery": "没有人在等待它；用 resume_from 继续，或用 cancel 关闭",
   "WhaleAnimalScout": "喙鲸",
   "WhaleAnimalPatch": "港湾鼠海豚",
   "WhaleAnimalHarbor": "座头鲸",

--- a/crates/tui/locales/zh-Hant.json
+++ b/crates/tui/locales/zh-Hant.json
@@ -1724,6 +1724,8 @@
   "WhaleStateWaiting": "等待你",
   "WhaleStateBlocked": "已阻塞",
   "WhaleStateOffline": "離線",
+  "AgentStatusParked": "已停放",
+  "AgentStatusParkedRecovery": "沒有人在等待它；用 resume_from 繼續，或用 cancel 關閉",
   "WhaleAnimalScout": "喙鯨",
   "WhaleAnimalPatch": "港灣鼠海豚",
   "WhaleAnimalHarbor": "座頭鯨",

--- a/crates/tui/src/core/protocol_parity.rs
+++ b/crates/tui/src/core/protocol_parity.rs
@@ -104,6 +104,7 @@ fn roster_state_str(state: RosterState) -> &'static str {
     match state {
         RosterState::Running => "running",
         RosterState::Waiting => "waiting",
+        RosterState::Parked => "parked",
         RosterState::Done => "done",
         RosterState::Failed => "failed",
         RosterState::Cancelled => "cancelled",

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -2039,6 +2039,11 @@ pub enum MessageId {
     WhaleStateWaiting,
     WhaleStateBlocked,
     WhaleStateOffline,
+    /// Parked-child status word and its recovery line (#5906). A child parked
+    /// at the parent's turn end is not "waiting for input": nothing will
+    /// answer it, so the surfaces name the state and the two ways out.
+    AgentStatusParked,
+    AgentStatusParkedRecovery,
     WhaleAnimalScout,
     WhaleAnimalPatch,
     WhaleAnimalHarbor,
@@ -4131,6 +4136,8 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::WhaleStateWaiting,
     MessageId::WhaleStateBlocked,
     MessageId::WhaleStateOffline,
+    MessageId::AgentStatusParked,
+    MessageId::AgentStatusParkedRecovery,
     MessageId::WhaleAnimalScout,
     MessageId::WhaleAnimalPatch,
     MessageId::WhaleAnimalHarbor,
@@ -4824,6 +4831,48 @@ mod tests {
             .skip(1)
             .filter_map(|suffix| suffix.split_once('}').map(|(name, _)| name.to_string()))
             .collect()
+    }
+
+    /// #5906: the parked-agent vocabulary is new copy on the busiest rows in
+    /// the product, so it gets the same hard parity gate coordination copy
+    /// has — and the recovery line must keep the tool tokens it names, or it
+    /// tells an operator to type a verb that does not exist.
+    #[test]
+    fn parked_agent_copy_is_translated_and_keeps_its_tool_verbs() {
+        for locale in Locale::shipped_complete() {
+            let word = tr(*locale, MessageId::AgentStatusParked);
+            assert!(
+                !word.trim().is_empty(),
+                "{} has no parked status word",
+                locale.tag()
+            );
+            let recovery = tr(*locale, MessageId::AgentStatusParkedRecovery);
+            assert!(
+                recovery.contains("resume_from"),
+                "{} lost the resume verb the agent tool exposes: {recovery}",
+                locale.tag()
+            );
+            assert!(
+                recovery.contains("cancel"),
+                "{} lost the dismiss verb: {recovery}",
+                locale.tag()
+            );
+            if *locale == Locale::En {
+                continue;
+            }
+            assert_ne!(
+                word,
+                tr(Locale::En, MessageId::AgentStatusParked),
+                "{} fell back to the English parked status word",
+                locale.tag()
+            );
+            assert_ne!(
+                recovery,
+                tr(Locale::En, MessageId::AgentStatusParkedRecovery),
+                "{} fell back to the English parked recovery line",
+                locale.tag()
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/agent_details.rs
+++ b/crates/tui/src/tui/agent_details.rs
@@ -254,7 +254,7 @@ pub(crate) fn project_agent_details(app: &App, agent_id: &str) -> Option<AgentDe
                 | AgentCurrentActivityStatus::Waiting
         )
     {
-        let mut current = vec![activity_status_label(activity.status).to_string()];
+        let mut current = vec![activity_status_label(activity.status, app.ui_locale).into_owned()];
         if let Some(tool) = activity
             .current_tool
             .as_deref()
@@ -429,8 +429,14 @@ fn safe_parent_from_meta(app: &App, meta: Option<&AgentProgressMeta>) -> String 
     }
 }
 
-fn activity_status_label(status: AgentCurrentActivityStatus) -> &'static str {
-    match status {
+fn activity_status_label(
+    status: AgentCurrentActivityStatus,
+    locale: crate::localization::Locale,
+) -> std::borrow::Cow<'static, str> {
+    if status == AgentCurrentActivityStatus::Parked {
+        return crate::localization::tr(locale, crate::localization::MessageId::AgentStatusParked);
+    }
+    std::borrow::Cow::Borrowed(match status {
         AgentCurrentActivityStatus::Queued => "queued",
         AgentCurrentActivityStatus::Starting => "starting",
         AgentCurrentActivityStatus::Running => "running",
@@ -441,13 +447,21 @@ fn activity_status_label(status: AgentCurrentActivityStatus) -> &'static str {
         AgentCurrentActivityStatus::Failed => "failed",
         AgentCurrentActivityStatus::Canceled => "canceled",
         AgentCurrentActivityStatus::Interrupted => "interrupted",
-    }
+        AgentCurrentActivityStatus::Parked => unreachable!("handled above"),
+    })
 }
 
 fn pending_question<'a>(
     agent: Option<&'a SubAgentResult>,
     meta: Option<&'a AgentProgressMeta>,
 ) -> Option<&'a str> {
+    // A parked child carries a `needs_input` note that is phrased as a
+    // question but asks the *operator* nothing — it is the resume recipe.
+    // Reporting it as a pending question is the #5906 complaint verbatim, so
+    // this surface reports the parked state and its recovery instead.
+    if agent.is_some_and(crate::tui::subagent_routing::subagent_is_parked) {
+        return None;
+    }
     agent
         .and_then(|agent| agent.needs_input.as_ref())
         .map(|needs_input| needs_input.question.as_str())
@@ -954,5 +968,90 @@ mod tests {
                     if id == agent_id
             ));
         }
+    }
+    // === #5906: a parked husk is not a pending question ==================
+
+    /// The runtime hands a parked child a `needs_input` note that reads like a
+    /// question, so Agent Details used to print `Pending question: Resume this
+    /// parked child with ...` — a question no operator ever asked and none can
+    /// answer. Build one exactly as the runtime does and assert the view names
+    /// the state and both ways out instead.
+    fn parked_child(agent_id: &str) -> SubAgentResult {
+        let mut child = agent(
+            agent_id,
+            SubAgentStatus::Interrupted(
+                "Parent turn ended before this turn-owned child settled.".to_string(),
+            ),
+        );
+        child.worker_status = Some(AgentWorkerStatus::WaitingForUser);
+        child.needs_input = Some(SubAgentNeedsInput {
+            question: format!(
+                "Resume this parked child with agent(action=\"start\", resume_from=\"{agent_id}\")."
+            ),
+        });
+        child.checkpoint = Some(crate::tools::subagent::SubAgentCheckpoint {
+            checkpoint_id: format!("{agent_id}:step:2"),
+            agent_id: agent_id.to_string(),
+            continuation_handle: format!("agent:{agent_id}:checkpoint"),
+            reason: "Parent turn ended before this turn-owned child settled.".to_string(),
+            continuable: true,
+            steps_taken: 2,
+            message_count: 4,
+            created_at_ms: 1_000,
+            messages: Vec::new(),
+            omitted_messages: 0,
+            parked_at_turn_end: true,
+        });
+        child
+    }
+
+    #[test]
+    fn parked_details_name_the_state_and_the_recovery_not_a_pending_question() {
+        let tmp = tempdir().expect("tempdir");
+        let mut app = test_app(tmp.path().to_path_buf());
+        let agent_id = "agent_parked_details";
+        app.subagent_cache.push(parked_child(agent_id));
+        crate::tui::subagent_routing::reconcile_subagent_activity_state(&mut app);
+
+        let body = project_agent_details(&app, agent_id)
+            .expect("projection")
+            .body;
+
+        assert!(body.contains("State: parked"), "{body}");
+        assert!(
+            !body.contains("waiting for input") && !body.contains("State: waiting"),
+            "a parked husk must not wear the answerable label: {body}"
+        );
+        assert!(
+            !body.contains("Pending question"),
+            "nothing asked the operator anything: {body}"
+        );
+        // The recovery is quoted with the verbs the runtime actually exposes.
+        assert!(body.contains("resume_from"), "{body}");
+        assert!(body.contains("cancel"), "{body}");
+    }
+
+    #[test]
+    fn a_child_that_really_asked_still_reports_waiting_for_input() {
+        let tmp = tempdir().expect("tempdir");
+        let mut app = test_app(tmp.path().to_path_buf());
+        let agent_id = "agent_really_asked";
+        let mut child = agent(agent_id, SubAgentStatus::Running);
+        child.worker_status = Some(AgentWorkerStatus::WaitingForUser);
+        child.needs_input = Some(SubAgentNeedsInput {
+            question: "Which path should I use?".to_string(),
+        });
+        app.subagent_cache.push(child);
+        crate::tui::subagent_routing::reconcile_subagent_activity_state(&mut app);
+
+        let body = project_agent_details(&app, agent_id)
+            .expect("projection")
+            .body;
+        assert!(body.contains("State: waiting"), "{body}");
+        assert!(
+            body.contains("Pending question: Which path should I use?"),
+            "{body}"
+        );
+        assert!(!body.contains("parked"), "{body}");
     }
 }

--- a/crates/tui/src/tui/agent_roster.rs
+++ b/crates/tui/src/tui/agent_roster.rs
@@ -31,6 +31,12 @@ use crate::tools::subagent::{AgentWorkerRecord, AgentWorkerStatus};
 pub enum RosterState {
     Running,
     Waiting,
+    /// Settled because the parent's turn ended before this child did (#5906).
+    ///
+    /// Distinct from `Waiting`, which means a person can answer it. Nothing
+    /// will answer a parked husk; it is continued with `resume_from` or
+    /// dismissed with `cancel`.
+    Parked,
     Done,
     Failed,
     Cancelled,
@@ -43,6 +49,8 @@ impl RosterState {
         match self {
             Self::Running => "●",
             Self::Waiting => "◐",
+            // Hollow, dotted: at rest but not finished.
+            Self::Parked => "◌",
             Self::Done => "○",
             Self::Failed => "✗",
             Self::Cancelled => "⊘",
@@ -52,6 +60,19 @@ impl RosterState {
     #[must_use]
     pub const fn is_terminal(self) -> bool {
         matches!(self, Self::Done | Self::Failed | Self::Cancelled)
+    }
+
+    /// Row state for one retained record.
+    ///
+    /// `parked_at_turn_end` is checked first and outranks the worker status:
+    /// a parked child settles as `WaitingForUser` or `Interrupted` like any
+    /// other, and only this flag separates it from a child that really asked
+    /// (#5906).
+    const fn from_record(record: &AgentWorkerRecord) -> Self {
+        if record.parked_at_turn_end {
+            return Self::Parked;
+        }
+        Self::from_worker(record.status)
     }
 
     const fn from_worker(status: AgentWorkerStatus) -> Self {
@@ -126,6 +147,11 @@ pub fn build_agent_roster(records: &[AgentWorkerRecord], now_ms: u64) -> Vec<Age
     // reorders itself as agents finish is unreadable while you are watching it.
     rows.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
     rows.sort_by_key(|row| creation_key(records, &row.worker_id));
+    // ...except parked husks, which sink below everything still live or
+    // answerable (#5906). They are the one class of row the operator is not
+    // meant to scan past to find real work, and the sort is stable so the
+    // history order survives inside each group.
+    rows.sort_by_key(|row| row.state == RosterState::Parked);
     rows
 }
 
@@ -137,7 +163,7 @@ fn creation_key(records: &[AgentWorkerRecord], worker_id: &str) -> u64 {
 }
 
 fn row_from_record(record: &AgentWorkerRecord, now_ms: u64) -> AgentRosterRow {
-    let state = RosterState::from_worker(record.status);
+    let state = RosterState::from_record(record);
     AgentRosterRow {
         worker_id: record.spec.worker_id.clone(),
         display_name: display_name(record),

--- a/crates/tui/src/tui/agent_roster/tests.rs
+++ b/crates/tui/src/tui/agent_roster/tests.rs
@@ -416,3 +416,82 @@ fn rendered_roster_shape() {
     assert!(text.contains("step 7 · apply_patch"), "{text}");
     assert!(text.contains("↓ 306.7k"), "{text}");
 }
+
+// === #5906: a parked husk is not an agent waiting for input ===
+
+/// A child parked at the parent's turn end settles as `WaitingForUser` like a
+/// child that really asked a question. Only `parked_at_turn_end` separates
+/// them, and the rail has to read it or it prints the same row for both.
+#[test]
+fn a_parked_record_is_its_own_roster_state_not_waiting() {
+    let mut parked = record("parked_child", 1_000);
+    parked.status = AgentWorkerStatus::WaitingForUser;
+    parked.parked_at_turn_end = true;
+
+    let mut asked = record("asking_child", 2_000);
+    asked.status = AgentWorkerStatus::WaitingForUser;
+
+    let rows = build_agent_roster(&[parked, asked], 5_000);
+    let parked_row = rows
+        .iter()
+        .find(|row| row.worker_id == "parked_child")
+        .expect("parked row");
+    let asked_row = rows
+        .iter()
+        .find(|row| row.worker_id == "asking_child")
+        .expect("asking row");
+
+    assert_eq!(parked_row.state, RosterState::Parked);
+    assert_eq!(
+        asked_row.state,
+        RosterState::Waiting,
+        "a child that genuinely asked must keep the answerable state"
+    );
+    assert_ne!(parked_row.state.glyph(), asked_row.state.glyph());
+    assert!(
+        !parked_row.state.is_terminal(),
+        "parked work is unfinished, not settled-done"
+    );
+}
+
+/// The rail is otherwise oldest-first, but a parked husk is exactly the row an
+/// operator must not have to scan past to find live work.
+#[test]
+fn parked_husks_sort_below_live_and_waiting_agents() {
+    let mut parked = record("aaa_parked", 1_000);
+    parked.status = AgentWorkerStatus::WaitingForUser;
+    parked.parked_at_turn_end = true;
+
+    let running = record("bbb_running", 2_000);
+
+    let mut waiting = record("ccc_waiting", 3_000);
+    waiting.status = AgentWorkerStatus::WaitingForUser;
+
+    let rows = build_agent_roster(&[parked, running, waiting], 9_000);
+    let order: Vec<&str> = rows.iter().map(|row| row.worker_id.as_str()).collect();
+    assert_eq!(
+        order,
+        vec!["bbb_running", "ccc_waiting", "aaa_parked"],
+        "the parked husk sinks below live and answerable rows despite being oldest"
+    );
+}
+
+/// Re-dispatch clears the flag on the record (#5921); the rail must follow it
+/// back rather than latching a row as parked forever.
+#[test]
+fn a_re_dispatched_record_stops_reading_as_parked() {
+    let mut rec = record("resumed", 1_000);
+    rec.status = AgentWorkerStatus::WaitingForUser;
+    rec.parked_at_turn_end = true;
+    assert_eq!(
+        build_agent_roster(&[rec.clone()], 5_000)[0].state,
+        RosterState::Parked
+    );
+
+    rec.parked_at_turn_end = false;
+    rec.status = AgentWorkerStatus::RunningTool;
+    assert_eq!(
+        build_agent_roster(&[rec], 5_000)[0].state,
+        RosterState::Running
+    );
+}

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -383,6 +383,16 @@ pub enum AgentCurrentActivityStatus {
     ModelWait,
     RunningTool,
     Waiting,
+    /// Settled because the parent's turn ended before this child did, not
+    /// because it asked anyone anything (#5906).
+    ///
+    /// The runtime parks such a child with a `needs_input` note that reads
+    /// like a question, so every surface used to render it as
+    /// `waiting for input` — indistinguishable from a child a user can
+    /// actually answer. It is its own state here because the recovery is
+    /// different: nobody will answer it, and it is continued through
+    /// `resume_from` (a *new* agent) or dismissed with `cancel`.
+    Parked,
     Done,
     Failed,
     Canceled,
@@ -390,6 +400,11 @@ pub enum AgentCurrentActivityStatus {
 }
 
 impl From<AgentWorkerStatus> for AgentCurrentActivityStatus {
+    /// Never yields [`Self::Parked`]: the worker status vocabulary cannot
+    /// express it (a parked child reports `WaitingForUser` /`Interrupted`
+    /// like any other settled one). Parked is derived from the checkpoint
+    /// flag by `crate::tui::subagent_routing::subagent_is_parked` and layered
+    /// over this mapping there — the one place that distinction is made.
     fn from(status: AgentWorkerStatus) -> Self {
         match status {
             AgentWorkerStatus::Queued => Self::Queued,

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -82,10 +82,18 @@ pub(crate) fn sidebar_agent_rows(app: &App) -> Vec<SidebarAgentRow> {
                 name: display_name,
                 model: Some(agent.model.clone()).filter(|model| !model.trim().is_empty()),
                 status: current_activity
-                    .map(|activity| sidebar_current_activity_status_text(activity.status))
-                    .or_else(|| agent.worker_status.map(sidebar_worker_status_text))
-                    .unwrap_or_else(|| subagent_status_text(&agent.status))
-                    .to_string(),
+                    .map(|activity| {
+                        sidebar_current_activity_status_text(activity.status, app.ui_locale)
+                    })
+                    .or_else(|| {
+                        agent.worker_status.map(|status| {
+                            std::borrow::Cow::Borrowed(sidebar_worker_status_text(status))
+                        })
+                    })
+                    .unwrap_or_else(|| {
+                        std::borrow::Cow::Borrowed(subagent_status_text(&agent.status))
+                    })
+                    .into_owned(),
                 steps_taken: agent.steps_taken,
                 duration_ms: Some(agent.duration_ms),
                 // Filled in by `annotate_child_progress` once every row exists.
@@ -115,9 +123,13 @@ pub(crate) fn sidebar_agent_rows(app: &App) -> Vec<SidebarAgentRow> {
                     name: display_name,
                     model: meta.and_then(|meta| meta.resolved_model.clone()),
                     status: current_activity
-                        .map(|activity| sidebar_current_activity_status_text(activity.status))
-                        .unwrap_or(sidebar_worker_status_text(AgentWorkerStatus::Running))
-                        .to_string(),
+                        .map(|activity| {
+                            sidebar_current_activity_status_text(activity.status, app.ui_locale)
+                        })
+                        .unwrap_or(std::borrow::Cow::Borrowed(sidebar_worker_status_text(
+                            AgentWorkerStatus::Running,
+                        )))
+                        .into_owned(),
                     steps_taken: 0,
                     duration_ms: None,
                     children_settled: None,
@@ -233,8 +245,16 @@ fn sidebar_worker_status_text(status: AgentWorkerStatus) -> &'static str {
     }
 }
 
-fn sidebar_current_activity_status_text(status: AgentCurrentActivityStatus) -> &'static str {
-    match status {
+fn sidebar_current_activity_status_text(
+    status: AgentCurrentActivityStatus,
+    locale: crate::localization::Locale,
+) -> std::borrow::Cow<'static, str> {
+    // A parked husk gets its own word, translated (#5906) — "waiting" here
+    // would be the same lie the work surface used to tell.
+    if status == AgentCurrentActivityStatus::Parked {
+        return crate::localization::tr(locale, crate::localization::MessageId::AgentStatusParked);
+    }
+    std::borrow::Cow::Borrowed(match status {
         AgentCurrentActivityStatus::Queued => "queued",
         AgentCurrentActivityStatus::Starting => "starting",
         AgentCurrentActivityStatus::Running => "running",
@@ -245,7 +265,8 @@ fn sidebar_current_activity_status_text(status: AgentCurrentActivityStatus) -> &
         AgentCurrentActivityStatus::Failed => "failed",
         AgentCurrentActivityStatus::Canceled => "canceled",
         AgentCurrentActivityStatus::Interrupted => "interrupted",
-    }
+        AgentCurrentActivityStatus::Parked => unreachable!("handled above"),
+    })
 }
 
 fn sidebar_agent_status_is_terminal(status: &str) -> bool {
@@ -743,6 +764,91 @@ mod tests {
                 crate::tools::subagent::whale_name_for_id_in_locale(&row.id, "en")
             );
         }
+    }
+
+    // === #5906: parked husks vs. children that actually asked ============
+
+    /// A child parked at the parent's turn end is handed a `needs_input` note
+    /// phrased as a question ("Resume this parked child with ..."), which is
+    /// why every surface used to label it `waiting`. Build one exactly the way
+    /// the runtime does and assert the row names the state instead.
+    fn parked_agent(agent_id: &str) -> crate::tools::subagent::SubAgentResult {
+        let mut agent = cached_agent(agent_id, None);
+        agent.status = crate::tools::subagent::SubAgentStatus::Interrupted(
+            "Parent turn ended before this turn-owned child settled.".to_string(),
+        );
+        agent.worker_status = Some(crate::tools::subagent::AgentWorkerStatus::WaitingForUser);
+        agent.needs_input = Some(crate::tools::subagent::SubAgentNeedsInput {
+            question: format!(
+                "Resume this parked child with agent(action=\"start\", resume_from=\"{agent_id}\")."
+            ),
+        });
+        agent.checkpoint = Some(crate::tools::subagent::SubAgentCheckpoint {
+            checkpoint_id: format!("{agent_id}:step:2"),
+            agent_id: agent_id.to_string(),
+            continuation_handle: format!("agent:{agent_id}:checkpoint"),
+            reason: "Parent turn ended before this turn-owned child settled.".to_string(),
+            continuable: true,
+            steps_taken: 2,
+            message_count: 4,
+            created_at_ms: 1_000,
+            messages: Vec::new(),
+            omitted_messages: 0,
+            parked_at_turn_end: true,
+        });
+        agent
+    }
+
+    fn asking_agent(agent_id: &str) -> crate::tools::subagent::SubAgentResult {
+        let mut agent = cached_agent(agent_id, None);
+        agent.worker_status = Some(crate::tools::subagent::AgentWorkerStatus::WaitingForUser);
+        agent.needs_input = Some(crate::tools::subagent::SubAgentNeedsInput {
+            question: "Which path should I use?".to_string(),
+        });
+        agent
+    }
+
+    #[test]
+    fn a_parked_row_says_parked_and_a_real_question_still_says_waiting() {
+        let mut app = create_test_app();
+        app.subagent_cache.push(parked_agent("agent_parked"));
+        app.subagent_cache.push(asking_agent("agent_asking"));
+        crate::tui::subagent_routing::reconcile_subagent_activity_state(&mut app);
+
+        let rows = sidebar_agent_rows(&app);
+        let parked = rows
+            .iter()
+            .find(|row| row.id == "agent_parked")
+            .expect("parked row");
+        let asking = rows
+            .iter()
+            .find(|row| row.id == "agent_asking")
+            .expect("asking row");
+
+        assert_eq!(parked.status, "parked");
+        assert_ne!(
+            parked.status, "waiting",
+            "a parked husk must not wear the label a child a user can answer wears"
+        );
+        assert_eq!(asking.status, "waiting");
+    }
+
+    /// The status word is registry copy, not a hardcoded English literal.
+    #[test]
+    fn the_parked_status_word_follows_the_ui_locale() {
+        let mut app = create_test_app();
+        app.ui_locale = Locale::De;
+        app.subagent_cache.push(parked_agent("agent_parked_de"));
+        crate::tui::subagent_routing::reconcile_subagent_activity_state(&mut app);
+
+        let rows = sidebar_agent_rows(&app);
+        assert_eq!(
+            rows[0].status,
+            crate::localization::tr(
+                Locale::De,
+                crate::localization::MessageId::AgentStatusParked
+            )
+        );
     }
 
     // --- Unicode / CJK / terminal-width QA (issue #3488) -------------------

--- a/crates/tui/src/tui/subagent_routing.rs
+++ b/crates/tui/src/tui/subagent_routing.rs
@@ -91,6 +91,32 @@ pub(super) fn active_fanout_counts(app: &App) -> Option<(usize, usize)> {
     None
 }
 
+/// True when this child settled by being *parked* at the parent's turn end
+/// rather than by asking anyone anything (#5906).
+///
+/// The runtime parks a turn-owned child with a `needs_input` note that reads
+/// like a question ("Resume this parked child with ..."), so every surface
+/// that keys off `needs_input` used to render a parked husk with the same
+/// "waiting for input" label as a child a user can actually answer. The
+/// checkpoint records which of the two it is; this is the one place the UI
+/// asks, so no surface has to sniff the reason string.
+pub(crate) fn subagent_is_parked(agent: &SubAgentResult) -> bool {
+    agent
+        .checkpoint
+        .as_ref()
+        .is_some_and(|checkpoint| checkpoint.parked_at_turn_end)
+}
+
+/// The one-line recovery a parked row shows instead of a pending question:
+/// nobody will answer it, so it names the two ways out that actually exist.
+pub(crate) fn parked_recovery_detail(app: &App) -> String {
+    crate::localization::tr(
+        app.ui_locale,
+        crate::localization::MessageId::AgentStatusParkedRecovery,
+    )
+    .into_owned()
+}
+
 pub(super) fn reconcile_subagent_activity_state(app: &mut App) {
     reconcile_subagent_activity_state_at(app, Instant::now());
 }
@@ -109,15 +135,22 @@ pub(super) fn apply_subagent_terminal_projection(
         .agent_progress_meta
         .entry(agent_id.to_string())
         .or_default();
-    let activity_status = if worker_status == AgentWorkerStatus::Interrupted
-        && meta
-            .current_activity
-            .as_ref()
-            .is_some_and(|activity| activity.status == AgentCurrentActivityStatus::Waiting)
-    {
-        AgentCurrentActivityStatus::Waiting
-    } else {
-        worker_status.into()
+    // A parked child projects as `Interrupted` here. Interrupted-over-Waiting
+    // and interrupted-over-Parked are both "the settled state the surface
+    // already established, restated" — do not downgrade either (#5906).
+    let sticky = meta
+        .current_activity
+        .as_ref()
+        .map(|activity| activity.status)
+        .filter(|status| {
+            matches!(
+                status,
+                AgentCurrentActivityStatus::Waiting | AgentCurrentActivityStatus::Parked
+            )
+        });
+    let activity_status = match sticky {
+        Some(status) if worker_status == AgentWorkerStatus::Interrupted => status,
+        _ => worker_status.into(),
     };
     let step = meta
         .current_activity
@@ -199,6 +232,7 @@ pub(super) fn reconcile_subagent_activity_state_at(app: &mut App, now: Instant) 
             .or_insert_with(|| objective.clone());
     }
 
+    let recovery_detail = parked_recovery_detail(app);
     for agent in &cached_agents {
         let meta = app
             .agent_progress_meta
@@ -212,7 +246,12 @@ pub(super) fn reconcile_subagent_activity_state_at(app: &mut App, now: Instant) 
         meta.spawn_depth = agent.spawn_depth;
 
         let existing = meta.current_activity.clone();
-        let mut structured_status = if agent.needs_input.is_some() {
+        let parked = subagent_is_parked(agent);
+        // Parked outranks `needs_input`: the park note *is* phrased as a
+        // question, and reading it as one is exactly the bug (#5906).
+        let mut structured_status = if parked {
+            AgentCurrentActivityStatus::Parked
+        } else if agent.needs_input.is_some() {
             AgentCurrentActivityStatus::Waiting
         } else if let Some(worker_status) = agent.worker_status {
             worker_status.into()
@@ -232,10 +271,14 @@ pub(super) fn reconcile_subagent_activity_state_at(app: &mut App, now: Instant) 
             structured_status = AgentCurrentActivityStatus::Waiting;
         }
 
-        let detail = agent
-            .needs_input
-            .as_ref()
-            .map(|needs_input| needs_input.question.clone())
+        let detail = parked
+            .then(|| recovery_detail.clone())
+            .or_else(|| {
+                agent
+                    .needs_input
+                    .as_ref()
+                    .map(|needs_input| needs_input.question.clone())
+            })
             .or_else(|| {
                 existing
                     .as_ref()

--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -1761,6 +1761,172 @@ mod tests {
         assert!(row.detail.contains("step 5"), "{}", row.detail);
     }
 
+    // === #5906: a parked husk is not an agent waiting for input ==========
+
+    /// Build a child exactly the way the turn-end parking projection does:
+    /// `Interrupted` + `WaitingForUser` + a `needs_input` note phrased as a
+    /// question, distinguished from a real question only by the checkpoint's
+    /// `parked_at_turn_end` flag.
+    fn parked_worker(id: &str, objective: &str) -> SubAgentResult {
+        let mut agent = fleet_worker(
+            id,
+            "general-purpose",
+            objective,
+            753_000,
+            SubAgentStatus::Interrupted(
+                "Parent turn ended before this turn-owned child settled.".to_string(),
+            ),
+        );
+        agent.worker_status = Some(AgentWorkerStatus::WaitingForUser);
+        agent.needs_input = Some(crate::tools::subagent::SubAgentNeedsInput {
+            question: format!(
+                "Resume this parked child with agent(action=\"start\", resume_from=\"{id}\")."
+            ),
+        });
+        agent.checkpoint = Some(crate::tools::subagent::SubAgentCheckpoint {
+            checkpoint_id: format!("{id}:step:2"),
+            agent_id: id.to_string(),
+            continuation_handle: format!("agent:{id}:checkpoint"),
+            reason: "Parent turn ended before this turn-owned child settled.".to_string(),
+            continuable: true,
+            steps_taken: 2,
+            message_count: 4,
+            created_at_ms: 1_000,
+            messages: Vec::new(),
+            omitted_messages: 0,
+            parked_at_turn_end: true,
+        });
+        agent
+    }
+
+    fn asking_worker(id: &str, objective: &str) -> SubAgentResult {
+        let mut agent = fleet_worker(
+            id,
+            "general-purpose",
+            objective,
+            120_000,
+            SubAgentStatus::Running,
+        );
+        agent.worker_status = Some(AgentWorkerStatus::WaitingForUser);
+        agent.needs_input = Some(crate::tools::subagent::SubAgentNeedsInput {
+            question: "Which path should I use?".to_string(),
+        });
+        agent
+    }
+
+    fn parked_fixture() -> App {
+        let mut app = app();
+        app.current_session_id = Some(SESSION.to_string());
+        app.subagent_cache
+            .push(parked_worker("agent_parked", "Parked dead-code removal"));
+        app.subagent_cache
+            .push(asking_worker("agent_asking", "Asking about the path"));
+        app.subagent_cache.push(fleet_worker(
+            "agent_live",
+            "general-purpose",
+            "Streaming dead-code removal",
+            30_000,
+            SubAgentStatus::Running,
+        ));
+        crate::tui::subagent_routing::reconcile_subagent_activity_state(&mut app);
+        app
+    }
+
+    #[test]
+    fn a_parked_work_row_says_parked_and_names_its_recovery() {
+        let mut app = parked_fixture();
+        let rows = super::model::project(&mut app);
+
+        let parked = rows
+            .iter()
+            .find(|row| row.id.0 == "worker:agent_parked")
+            .expect("parked work row");
+        assert!(parked.detail.starts_with("parked"), "{}", parked.detail);
+        assert!(
+            !parked.detail.contains("waiting for input"),
+            "a parked husk must not wear the answerable label: {}",
+            parked.detail
+        );
+        // The recovery names verbs the runtime actually exposes.
+        assert!(parked.detail.contains("resume_from"), "{}", parked.detail);
+        assert!(parked.detail.contains("cancel"), "{}", parked.detail);
+        assert!(
+            !parked.detail.contains("Resume this parked child"),
+            "the parking note is not a question to replay at the operator: {}",
+            parked.detail
+        );
+
+        let asking = rows
+            .iter()
+            .find(|row| row.id.0 == "worker:agent_asking")
+            .expect("asking work row");
+        assert!(
+            asking.detail.contains("waiting for input"),
+            "a child that really asked keeps the answerable label: {}",
+            asking.detail
+        );
+        assert!(
+            asking.detail.contains("Which path should I use?"),
+            "{}",
+            asking.detail
+        );
+    }
+
+    #[test]
+    fn parked_rows_sort_below_live_work_and_leave_the_needs_input_count_alone() {
+        let mut app = parked_fixture();
+        let rows = super::model::project(&mut app);
+
+        let heading = rows
+            .iter()
+            .find(|row| row.id.0 == "section:work")
+            .expect("work heading");
+        // The attention chip counts children a person is actually blocking:
+        // one, the child that asked. Two would mean the parked husk had been
+        // counted as waiting for input all over again.
+        assert!(
+            heading.label.contains("1 blocked"),
+            "only the child that actually asked is blocked on a person: {}",
+            heading.label
+        );
+
+        let position = |id: &str| {
+            rows.iter()
+                .position(|row| row.id.0 == id)
+                .unwrap_or_else(|| panic!("{id} missing from {rows:?}"))
+        };
+        assert!(
+            position("worker:agent_parked") > position("worker:agent_live"),
+            "a parked husk must not sort above live work"
+        );
+        assert!(
+            position("worker:agent_parked") > position("worker:agent_asking"),
+            "a parked husk must not sort above a child a person can answer"
+        );
+    }
+
+    #[test]
+    fn the_parked_status_word_survives_the_narrow_row_ladder() {
+        // The status word outlives the whole receipt as the strip narrows
+        // (see the degradation test above); `parked` is the fact the row
+        // exists to carry, so it must survive the same ladder `running` does.
+        let mut app = app();
+        app.current_session_id = Some(SESSION.to_string());
+        app.subagent_cache
+            .push(parked_worker("agent_parked", "Parked dead-code removal"));
+        crate::tui::subagent_routing::reconcile_subagent_activity_state(&mut app);
+
+        for width in [96u16, 72, 56] {
+            let rows = render_rows(&mut app, width, 6);
+            let row = rows
+                .iter()
+                .find(|line| line.contains("Parked dead-code"))
+                .unwrap_or_else(|| panic!("no parked row at width {width} in {rows:?}"));
+            assert!(row.contains("parked"), "width {width}: {row}");
+            assert!(!row.contains("waiting for input"), "width {width}: {row}");
+        }
+    }
+
     #[test]
     fn agent_transcript_keyboard_mouse_and_return_selection_converge() {
         fn add_worker(app: &mut App) {

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -1531,9 +1531,15 @@ fn agent_rows(app: &App) -> Vec<RankedWorkRow> {
             let meta = app.agent_progress_meta.get(&agent.agent_id);
             let current_activity = meta.and_then(|meta| meta.current_activity.as_ref());
             let status = current_activity
-                .map(|activity| current_activity_status_label(activity.status))
-                .or_else(|| agent.worker_status.map(worker_status_label))
-                .unwrap_or_else(|| subagent_status_label(&agent.status));
+                .map(|activity| current_activity_status_label(activity.status, app.ui_locale))
+                .or_else(|| {
+                    agent
+                        .worker_status
+                        .map(|status| std::borrow::Cow::Borrowed(worker_status_label(status)))
+                })
+                .unwrap_or_else(|| {
+                    std::borrow::Cow::Borrowed(subagent_status_label(&agent.status))
+                });
             let bucket = current_activity
                 .map(|activity| current_activity_status_bucket(activity.status))
                 .or_else(|| agent.worker_status.map(worker_status_bucket))
@@ -1649,8 +1655,8 @@ fn agent_rows(app: &App) -> Vec<RankedWorkRow> {
                 let meta = app.agent_progress_meta.get(id);
                 let current_activity = meta.and_then(|meta| meta.current_activity.as_ref());
                 let status = current_activity
-                    .map(|activity| current_activity_status_label(activity.status))
-                    .unwrap_or("running");
+                    .map(|activity| current_activity_status_label(activity.status, app.ui_locale))
+                    .unwrap_or(std::borrow::Cow::Borrowed("running"));
                 let bucket = current_activity
                     .map(|activity| current_activity_status_bucket(activity.status))
                     .unwrap_or(WorkBucket::Active);
@@ -1820,7 +1826,13 @@ fn current_activity_status_bucket(status: AgentCurrentActivityStatus) -> WorkBuc
         AgentCurrentActivityStatus::Waiting
         | AgentCurrentActivityStatus::Interrupted
         | AgentCurrentActivityStatus::Failed => WorkBucket::Attention,
-        AgentCurrentActivityStatus::Queued => WorkBucket::Ready,
+        // Not Attention (#5906): a parked husk asked nobody anything, so it
+        // must not sort above live work nor be counted in the `needs input`
+        // chip. Ready ranks below Attention and Active and stays actionable,
+        // which is what it is — resumable, or dismissable.
+        AgentCurrentActivityStatus::Parked | AgentCurrentActivityStatus::Queued => {
+            WorkBucket::Ready
+        }
         AgentCurrentActivityStatus::Done | AgentCurrentActivityStatus::Canceled => {
             WorkBucket::Recent
         }
@@ -1831,8 +1843,17 @@ fn current_activity_status_bucket(status: AgentCurrentActivityStatus) -> WorkBuc
     }
 }
 
-fn current_activity_status_label(status: AgentCurrentActivityStatus) -> &'static str {
-    match status {
+fn current_activity_status_label(
+    status: AgentCurrentActivityStatus,
+    locale: crate::localization::Locale,
+) -> std::borrow::Cow<'static, str> {
+    // `parked` is the one word here that has to be translated: it is new
+    // vocabulary a reader has never seen on this row, and the whole point is
+    // that it does not read as "waiting for input" (#5906).
+    if status == AgentCurrentActivityStatus::Parked {
+        return crate::localization::tr(locale, crate::localization::MessageId::AgentStatusParked);
+    }
+    std::borrow::Cow::Borrowed(match status {
         AgentCurrentActivityStatus::Queued => "queued",
         AgentCurrentActivityStatus::Starting => "starting",
         AgentCurrentActivityStatus::Running => "running",
@@ -1843,7 +1864,8 @@ fn current_activity_status_label(status: AgentCurrentActivityStatus) -> &'static
         AgentCurrentActivityStatus::Failed => "failed",
         AgentCurrentActivityStatus::Canceled => "cancelled",
         AgentCurrentActivityStatus::Interrupted => "interrupted",
-    }
+        AgentCurrentActivityStatus::Parked => unreachable!("handled above"),
+    })
 }
 
 fn worker_status_bucket(status: AgentWorkerStatus) -> WorkBucket {


### PR DESCRIPTION
No-Issue: display half of #5906 (the claim half closed with #5921); the founder's "2 sub agents waiting for input" report.

Refs #5906

Builds on the recording work that landed in #5921 (now on `main`), which
added `parked_at_turn_end` to `SubAgentCheckpoint` and `AgentWorkerRecord`
but deliberately left every UI projection of `WaitingForUser` alone. This
is the display half.

## The complaint that remained

A child parked because its parent's turn ended shows up in the Agents
panel, the sidebar and Agent Details as **"waiting for input"** — the same
label as a child that actually asked the operator a question. There is no
way to tell them apart, and Agent Details prints a `Pending question:`
line quoting a resume recipe nobody asked for.

The runtime is why the surfaces got it wrong. Parking hands the child a
`needs_input` note *phrased as a question*:

> Resume this parked child with agent(action="start", resume_from="agent_X").

Every projection keys off `needs_input`, so the parked husk reads as
answerable. The flag has to outrank it.

## What changed

**One derivation, one status vocabulary.** `AgentCurrentActivityStatus`
gains `Parked`; it is derived in exactly one place —
`subagent_routing::subagent_is_parked`, reading the checkpoint flag —
*ahead of* `needs_input`, and made sticky across the `Interrupted`
terminal projection the same way `Waiting` already was. No surface sniffs
a reason string, and no second status enum was introduced.

**Three surfaces say `parked`.** The work-surface / Agents rows, the
sidebar and Agent Details render the state, with a one-line recovery
standing in for the fake question: `resume_from` to continue, `cancel` to
dismiss — the verbs the `agent` tool actually exposes, quoted exactly.
Agent Details also suppresses the parked child's `needs_input` note as a
pending question; it asks the operator nothing.

**Parked sorts below live work and stops inflating the chip.** Parked
lands in `WorkBucket::Ready`, not `Attention`, so it ranks under both
Active and Attention and the work heading's `blocked` count covers only
children a person is genuinely holding up. `RosterState::Parked` gives the
receipts roster its own state and glyph (`◌`, hollow-but-unfinished), and
parked husks sink below live and waiting rows there too despite the rail's
otherwise-chronological order. The wire `state` string gains `parked`.

**Translated, not fallen back.** `AgentStatusParked` and
`AgentStatusParkedRecovery` ship in all 15 complete packs. A new parity
test additionally pins `resume_from` and `cancel` as untranslatable
tokens in every pack, so no translation can tell an operator to type a
verb that does not exist.

## Verified

```
cargo fmt --all -- --check                       clean
cargo check -p codewhale-tui                     clean
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib \
  -- tui::work_surface tui::agent_details tui::sidebar \
     tui::agent_roster localization
  test result: ok. 227 passed; 0 failed; 0 ignored   (216 before this change)
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib
  test result: ok. 11733 passed; 0 failed; 13 ignored
```

Eleven new tests, each built from a child constructed exactly as the
turn-end parking projection builds one (`Interrupted` + `WaitingForUser`
+ the question-shaped `needs_input` note + a checkpoint with the flag),
paired against a child that genuinely asked:

- `sidebar`: parked row says `parked`, the asking row still says
  `waiting`; the parked word follows the UI locale (asserted against
  `tr(De, AgentStatusParked)`, not a literal).
- `work_surface`: the parked row's detail leads with `parked`, names
  `resume_from` and `cancel`, and never replays the parking note; the
  asking row keeps `waiting for input` and its real question; the
  `blocked` chip counts one, not two; the parked row sorts below both the
  live and the asking row; and the status word survives the narrow-row
  ladder at widths 96 / 72 / 56, where the existing degradation test
  already pins `running`.
- `agent_details`: parked body says `State: parked`, carries both recovery
  verbs, and has no `Pending question` line; a child that really asked
  still reports `State: waiting` with its question.
- `agent_roster`: a parked record is `RosterState::Parked` with a distinct
  glyph and is not terminal; parked husks sort below live and waiting rows
  despite being oldest; clearing the flag on re-dispatch returns the row
  to `Running`.
- `localization`: every complete pack translates both keys away from
  English and keeps `resume_from` / `cancel` intact.

The five UI guards were each shown failing on their exact assertion with
`subagent_is_parked` reverted to `false`.

## Not verified / not done

- **Local-test evidence only.** No provider call, no deploy, and no manual
  reproduction of the original incident in a running TUI.
- **`whales.rs` is untouched.** `WhaleState::for_subagent` still maps a
  parked child to `Waiting` via `needs_input`. That is the ambient whale
  glyph vocabulary, not the Agents/sidebar/details rows this issue is
  about; folding it in would have widened the change past the surfaces
  named in the complaint.
- **The `Ready` bucket is a reuse, not a new one.** A parked husk is not
  "queued", but `Ready` is the existing rank that sits below Active and
  Attention while staying actionable, and adding a fifth bucket would have
  rippled through the heading copy and every bucket match in the module
  for no behavioral gain.
- **`resume_from` is not offered as a keybinding.** The recovery line
  names the two tool actions that exist; wiring a row action to invoke
  them is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XYyJaw9Mh9uSrqQBoqhm
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI presentation and sorting only; no changes to auth, persistence, or agent execution semantics beyond how parked checkpoints are displayed.
> 
> **Overview**
> Fixes **#5906** by treating turn-end–parked child agents as their own state instead of **“waiting for input”**, which previously matched real operator questions because parking still sets a question-shaped `needs_input` note.
> 
> **Derivation and activity model.** `subagent_is_parked` reads `checkpoint.parked_at_turn_end` in `subagent_routing` and maps to `AgentCurrentActivityStatus::Parked` **before** `needs_input`; that status stays sticky across `Interrupted` terminal projection like `Waiting`. Parked rows show localized recovery copy (`resume_from` / `cancel`) instead of the fake question, and Agent Details no longer surfaces a **Pending question** for parked husks.
> 
> **Surfaces and sorting.** Work surface, sidebar, agent details, and the agent roster all label **parked** (with `RosterState::Parked`, glyph `◌`, wire `state: "parked"`). Parked work lands in `WorkBucket::Ready` so it does not inflate the **blocked** chip or sort above live/answerable agents; the roster sinks parked rows below live and waiting rows.
> 
> **i18n.** `AgentStatusParked` and `AgentStatusParkedRecovery` ship in all locale packs, with a parity test that keeps `resume_from` and `cancel` as literal tool tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab9d13b0b32d891611dd563be7c44837ff2add3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->