### PR TITLE
fix(tui): keep startup type-ahead whole and never re-read a command as prose (#5925)

### DIFF
--- a/crates/tui/src/palette/osc11.rs
+++ b/crates/tui/src/palette/osc11.rs
@@ -115,8 +115,10 @@ fn scale_hex_channel(digits: &str) -> Option<u8> {
 ///
 /// This reads from stdin, so it must only be called while the terminal is in
 /// raw mode and before the event loop starts. Bytes that arrive during the
-/// window and are not part of the reply are discarded — at startup that window
-/// is sub-millisecond on any terminal that answers at all.
+/// window and are not part of the reply are *not* discarded: they are the
+/// user's type-ahead, and are handed to
+/// [`carry_typed_ahead`] for the event loop to
+/// replay in order (#5925).
 #[must_use]
 pub fn query_terminal_background(timeout: std::time::Duration) -> Option<(u8, u8, u8)> {
     let reply = query_terminal(OSC11_QUERY, timeout)?;
@@ -145,6 +147,221 @@ pub(crate) fn query_terminal_csi(query: &[u8], timeout: std::time::Duration) -> 
     query_terminal_inner(query, timeout, true)
 }
 
+/// Largest reply any of the three probes can produce. Past this the answer
+/// is not one of ours.
+const MAX_REPLY_BYTES: usize = 128;
+
+// ---------------------------------------------------------------------------
+// Type-ahead carried across the probe window (#5925).
+//
+// The probe readers below are the only readers of the tty between raw-mode
+// entry and the input pump, so anything the user typed at launch arrives in
+// the same stream as the replies. The reader keeps its reply and parks every
+// other byte here; `tui::startup_input` drains this and replays it into the
+// composer. The buffers live in this module rather than with the replay
+// logic because `src/palette/` is `#[path]`-included by test harnesses that
+// do not compile the `tui` module tree.
+// ---------------------------------------------------------------------------
+
+/// Upper bound on carried type-ahead. A terminal that answers a probe does
+/// so in well under a millisecond, so this only ever holds a line or two;
+/// the cap stops a wedged tty from growing the buffer without limit.
+pub const MAX_CARRIED_BYTES: usize = 4096;
+
+/// Bytes a probe consumed that were not part of its reply.
+static CARRIED_TYPE_AHEAD: std::sync::Mutex<Vec<u8>> = std::sync::Mutex::new(Vec::new());
+/// Bytes a probe consumed that cannot be replayed as keystrokes.
+static CONSUMED_UNREPLAYABLE: std::sync::Mutex<Vec<u8>> = std::sync::Mutex::new(Vec::new());
+
+/// Park non-reply bytes for the event loop to replay.
+#[cfg_attr(not(unix), allow(dead_code))]
+pub fn carry_typed_ahead(bytes: &[u8]) {
+    if bytes.is_empty() {
+        return;
+    }
+    let Ok(mut carried) = CARRIED_TYPE_AHEAD.lock() else {
+        note_consumed_unreplayable(bytes);
+        return;
+    };
+    let room = MAX_CARRIED_BYTES.saturating_sub(carried.len());
+    let (keep, overflow) = bytes.split_at(room.min(bytes.len()));
+    carried.extend_from_slice(keep);
+    drop(carried);
+    note_consumed_unreplayable(overflow);
+}
+
+/// Record bytes startup consumed and cannot hand back.
+pub fn note_consumed_unreplayable(bytes: &[u8]) {
+    if bytes.is_empty() {
+        return;
+    }
+    if let Ok(mut dropped) = CONSUMED_UNREPLAYABLE.lock() {
+        let room = MAX_CARRIED_BYTES.saturating_sub(dropped.len());
+        dropped.extend_from_slice(&bytes[..room.min(bytes.len())]);
+    }
+}
+
+/// Take everything parked by [`carry_typed_ahead`].
+pub fn take_carried_type_ahead() -> Vec<u8> {
+    CARRIED_TYPE_AHEAD
+        .lock()
+        .map(|mut carried| std::mem::take(&mut *carried))
+        .unwrap_or_default()
+}
+
+/// Take everything recorded by [`note_consumed_unreplayable`].
+pub fn take_consumed_unreplayable() -> Vec<u8> {
+    CONSUMED_UNREPLAYABLE
+        .lock()
+        .map(|mut dropped| std::mem::take(&mut *dropped))
+        .unwrap_or_default()
+}
+
+/// What the caller should do after feeding one byte to [`ProbeSplit`].
+#[cfg_attr(not(unix), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeStep {
+    /// Keep reading.
+    Continue,
+    /// The reply is complete.
+    Done,
+    /// The reply ended with the `ESC` of an `ESC \` string terminator: read
+    /// one more byte and give it to [`ProbeSplit::finish_string_terminator`].
+    AwaitStringTerminator,
+    /// Carried type-ahead hit its cap; stop reading.
+    Overflow,
+}
+
+/// Splits one probe stream into the terminal's reply and the user's
+/// type-ahead (#5925).
+///
+/// Pure and byte-driven so the split — the actual defect in #5925, where
+/// everything that was not the reply was thrown away — is testable without a
+/// terminal. The reply always opens with the same two bytes the query did
+/// (`ESC ]` for OSC 11, `ESC _` for the kitty graphics query, `ESC [` for the
+/// sixel primary-DA query); anything before that introducer is input the user
+/// typed, and an `ESC` that does not go on to match it is theirs too.
+#[cfg_attr(not(unix), allow(dead_code))]
+#[derive(Debug)]
+pub(crate) struct ProbeSplit<'a> {
+    introducer: &'a [u8],
+    stop_at_csi_final: bool,
+    carried: Vec<u8>,
+    /// A partial introducer match, still undecided between reply and input.
+    undecided: Vec<u8>,
+    reply: Vec<u8>,
+    in_reply: bool,
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+impl<'a> ProbeSplit<'a> {
+    /// `query` is the sequence just written; its first two bytes are the
+    /// introducer the reply will open with.
+    pub(crate) fn for_query(query: &'a [u8], stop_at_csi_final: bool) -> Self {
+        Self {
+            introducer: if query.len() >= 2 && query[0] == 0x1b {
+                &query[..2]
+            } else {
+                &[]
+            },
+            stop_at_csi_final,
+            carried: Vec::new(),
+            undecided: Vec::new(),
+            reply: Vec::new(),
+            in_reply: false,
+        }
+    }
+
+    pub(crate) fn feed(&mut self, byte: u8) -> ProbeStep {
+        if !self.in_reply {
+            self.feed_before_reply(byte);
+            if self.carried.len() >= MAX_CARRIED_BYTES {
+                return ProbeStep::Overflow;
+            }
+            return ProbeStep::Continue;
+        }
+        // BEL, or the ESC of an `ESC \` string terminator, ends the reply.
+        if byte == 0x07 {
+            return ProbeStep::Done;
+        }
+        if byte == 0x1b {
+            return ProbeStep::AwaitStringTerminator;
+        }
+        self.reply.push(byte);
+        // A CSI reply (`ESC [` …) ends at its first final byte (`@..=~`):
+        // keep the final and stop, so a DA answer never eats past itself.
+        if self.stop_at_csi_final
+            && self.reply.len() >= 3
+            && self.reply[0] == 0x1b
+            && self.reply[1] == b'['
+            && (0x40..=0x7e).contains(&byte)
+        {
+            return ProbeStep::Done;
+        }
+        if self.reply.len() >= MAX_REPLY_BYTES {
+            return ProbeStep::Overflow;
+        }
+        ProbeStep::Continue
+    }
+
+    fn feed_before_reply(&mut self, byte: u8) {
+        if self.undecided.is_empty() {
+            if byte == 0x1b && !self.introducer.is_empty() {
+                self.undecided.push(byte);
+            } else {
+                self.carried.push(byte);
+            }
+            return;
+        }
+        self.undecided.push(byte);
+        if self.introducer.starts_with(&self.undecided) {
+            if self.undecided.len() == self.introducer.len() {
+                self.in_reply = true;
+                self.reply = std::mem::take(&mut self.undecided);
+            }
+            return;
+        }
+        // Not our reply after all — an `Esc` keypress, or an escape sequence
+        // from some other source. Everything held is the user's, except a
+        // fresh `ESC` which may still open the reply we are waiting for.
+        let restarts = byte == 0x1b;
+        if restarts {
+            self.undecided.pop();
+        }
+        self.carried.append(&mut self.undecided);
+        if restarts {
+            self.undecided.push(byte);
+        }
+    }
+
+    /// The byte read after an [`ProbeStep::AwaitStringTerminator`]. The `\`
+    /// of `ESC \` belongs to the reply; anything else is the user's next
+    /// keystroke and must not vanish with the terminator.
+    pub(crate) fn finish_string_terminator(&mut self, byte: u8) {
+        if byte != b'\\' {
+            self.carried.push(byte);
+        }
+    }
+
+    /// Consume the split: `(reply, carried type-ahead)`. An undecided
+    /// introducer is input the terminal never claimed.
+    pub(crate) fn finish(mut self) -> (Vec<u8>, Vec<u8>) {
+        self.carried.append(&mut self.undecided);
+        (self.reply, self.carried)
+    }
+}
+
+/// Read a probe reply off stdin without eating the user's type-ahead.
+///
+/// The reply always opens with the same two bytes the query did (`ESC ]` for
+/// OSC 11, `ESC _` for the kitty graphics query, `ESC [` for the sixel
+/// primary-DA query), so every byte before that introducer — and the one
+/// lookahead byte after an `ESC` that turned out not to open `ESC \` — is
+/// input the user typed, not terminal chatter. Those bytes are carried to
+/// [`carry_typed_ahead`] for replay instead of being dropped on the
+/// floor (#5925). Bytes this reader consumed but cannot hand back (a reply
+/// the terminal never terminated) are recorded as dropped so the startup
+/// receipt names them.
 #[cfg(unix)]
 fn query_terminal_inner(
     query: &[u8],
@@ -174,48 +391,44 @@ fn query_terminal_inner(
     }
 
     let deadline = Instant::now() + timeout;
-    let mut reply = Vec::with_capacity(32);
+    let mut split = ProbeSplit::for_query(query, stop_at_csi_final);
     let mut stdin = stdin.lock();
     let mut byte = [0u8; 1];
-    loop {
+    let answered = loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            return None;
-        }
-        if !wait_readable(in_fd, remaining) {
-            return None;
+        if remaining.is_zero() || !wait_readable(in_fd, remaining) {
+            break false;
         }
         match stdin.read(&mut byte) {
             Ok(1) => {}
-            _ => return None,
+            _ => break false,
         }
-        // BEL, or the ESC of a `ESC \` string terminator, ends the reply.
-        if byte[0] == 0x07 || (byte[0] == 0x1b && !reply.is_empty()) {
-            // Consume the `\` of an `ESC \` terminator so it cannot surface
-            // later as a keypress once the event loop owns stdin.
-            if byte[0] == 0x1b
-                && wait_readable(in_fd, std::time::Duration::from_millis(5))
-                && stdin.read(&mut byte).is_ok_and(|n| n == 1)
-                && byte[0] != b'\\'
-            {
-                reply.push(byte[0]);
+        match split.feed(byte[0]) {
+            ProbeStep::Continue => {}
+            ProbeStep::Done => break true,
+            ProbeStep::Overflow => break false,
+            ProbeStep::AwaitStringTerminator => {
+                // Consume the `\` of an `ESC \` terminator so it cannot
+                // surface later as a keypress once the event loop owns
+                // stdin. Anything else is the user's next keystroke.
+                if wait_readable(in_fd, std::time::Duration::from_millis(5))
+                    && stdin.read(&mut byte).is_ok_and(|n| n == 1)
+                {
+                    split.finish_string_terminator(byte[0]);
+                }
+                break true;
             }
-            break;
         }
-        reply.push(byte[0]);
-        // A CSI reply (`ESC [` …) ends at its first final byte (`@..=~`):
-        // keep the final and stop, so a DA answer never eats past itself.
-        if stop_at_csi_final
-            && reply.len() >= 3
-            && reply[0] == 0x1b
-            && reply[1] == b'['
-            && (0x40..=0x7e).contains(&byte[0])
-        {
-            break;
-        }
-        if reply.len() >= 128 {
-            return None;
-        }
+    };
+
+    let (reply, carried) = split.finish();
+    carry_typed_ahead(&carried);
+    if !answered {
+        // A reply we started reading and never finished cannot be replayed
+        // as keystrokes — it is terminal chatter, not typing — but it was
+        // consumed, so it belongs in the startup receipt.
+        note_consumed_unreplayable(&reply);
+        return None;
     }
 
     Some(reply)

--- a/crates/tui/src/palette/tests.rs
+++ b/crates/tui/src/palette/tests.rs
@@ -669,7 +669,7 @@ use super::contrast::{
     theme_uses_terminal_owned_surfaces,
 };
 use super::detect::TerminalBackground;
-use super::osc11::parse_osc11_reply;
+use super::osc11::{ProbeSplit, ProbeStep, parse_osc11_reply};
 use super::tokens::{
     MODE_OPERATE, STATUS_SUCCESS, TEXT_MUTED, TEXT_SECONDARY, TEXT_SOFT, USER_BODY,
 };
@@ -994,6 +994,87 @@ fn osc11_replies_parse_across_the_shapes_terminals_emit() {
     assert_eq!(parse_osc11_reply("rgb:ff/ff/ff/ff"), None);
     assert_eq!(parse_osc11_reply("rgb:zz/zz/zz"), None);
     assert_eq!(parse_osc11_reply("#ff00"), None);
+}
+
+/// Drive a whole byte stream through the split the way the reader does,
+/// including the one-byte lookahead after an `ESC \` terminator.
+fn split_probe_stream(query: &[u8], stream: &[u8], csi: bool) -> (Vec<u8>, Vec<u8>) {
+    let mut split = ProbeSplit::for_query(query, csi);
+    let mut index = 0;
+    while index < stream.len() {
+        let byte = stream[index];
+        index += 1;
+        match split.feed(byte) {
+            ProbeStep::Continue => {}
+            ProbeStep::Done | ProbeStep::Overflow => break,
+            ProbeStep::AwaitStringTerminator => {
+                if let Some(next) = stream.get(index) {
+                    split.finish_string_terminator(*next);
+                }
+                break;
+            }
+        }
+    }
+    split.finish()
+}
+
+#[test]
+fn a_probe_reply_never_swallows_the_line_typed_before_it() {
+    // #5925: `/plugin install …` typed at launch arrived before the terminal
+    // answered the OSC 11 query. The reply is ours; every other byte is the
+    // user's and must come back out, in order.
+    let (reply, carried) = split_probe_stream(
+        b"\x1b]11;?\x1b\\",
+        b"/plugin install /tmp/bundle\r\x1b]11;rgb:ffff/ffff/ffff\x1b\\",
+        false,
+    );
+    assert_eq!(
+        parse_osc11_reply(&String::from_utf8_lossy(&reply)),
+        Some((255, 255, 255)),
+        "the reply still parses"
+    );
+    assert_eq!(
+        carried,
+        b"/plugin install /tmp/bundle\r".to_vec(),
+        "not one typed byte is consumed or reordered"
+    );
+}
+
+#[test]
+fn a_probe_that_is_never_answered_still_hands_back_what_was_typed() {
+    let (reply, carried) = split_probe_stream(b"\x1b]11;?\x1b\\", b"/plugin list\r", false);
+    assert!(reply.is_empty(), "no reply arrived");
+    assert_eq!(carried, b"/plugin list\r".to_vec());
+}
+
+#[test]
+fn an_escape_that_is_not_the_reply_is_the_users_keystroke() {
+    // A bare `Esc`, then typing, then the real reply.
+    let (reply, carried) = split_probe_stream(
+        b"\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\",
+        b"\x1bhi\x1b_Gi=31;OK\x1b\\",
+        false,
+    );
+    assert_eq!(reply, b"\x1b_Gi=31;OK".to_vec());
+    assert_eq!(carried, b"\x1bhi".to_vec());
+}
+
+#[test]
+fn a_keystroke_after_the_string_terminator_escape_is_kept() {
+    // The reply ends `ESC \`; if the byte after `ESC` is not `\` it belongs
+    // to the user and must not vanish with the terminator.
+    let (reply, carried) = split_probe_stream(b"\x1b]11;?\x1b\\", b"\x1b]11;rgb:0/0/0\x1bx", false);
+    assert_eq!(reply, b"\x1b]11;rgb:0/0/0".to_vec());
+    assert_eq!(carried, b"x".to_vec());
+}
+
+#[test]
+fn a_da_reply_stops_at_its_final_byte_and_keeps_the_rest_of_the_line() {
+    let (reply, carried) = split_probe_stream(b"\x1b[c", b"\x1b[?62;4c/plugin list\r", true);
+    assert_eq!(reply, b"\x1b[?62;4c".to_vec());
+    // Bytes after the DA reply were never read by the split; the reader
+    // leaves them in the tty for the input pump.
+    assert!(carried.is_empty(), "{carried:?}");
 }
 
 #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -819,6 +819,19 @@ pub struct ComposerState {
     /// `selection_anchor` is the fixed end.  Both are char-indexed.
     /// `None` means no selection is active.
     pub selection_anchor: Option<usize>,
+    /// The first character typed into this composer line was `/` (#5925).
+    ///
+    /// A line that began as a command stays a command until Enter: if the
+    /// leading `/` is gone at submit time and no edit removed it, bytes were
+    /// lost between the terminal and the composer, and the line must not be
+    /// re-interpreted as a prose prompt for the model. Composer edits
+    /// re-derive the claim through
+    /// [`ComposerState::resync_command_line_claim`]; `clear_input` drops it.
+    pub(crate) line_began_with_slash: bool,
+    /// Startup consumed bytes it could not replay, so the shell cannot prove
+    /// it saw the whole line (#5925). Set once from the startup input
+    /// receipt; cleared by the first submit it holds.
+    pub(crate) startup_input_unproven: bool,
 }
 
 impl Default for ComposerState {
@@ -848,6 +861,8 @@ impl Default for ComposerState {
             vim_mode: VimMode::Normal,
             vim_pending_d: false,
             selection_anchor: None,
+            line_began_with_slash: false,
+            startup_input_unproven: false,
         }
     }
 }

--- a/crates/tui/src/tui/app/composer.rs
+++ b/crates/tui/src/tui/app/composer.rs
@@ -478,11 +478,31 @@ const MAX_COMPOSER_DISPLAY_CHARS: usize = 4_000;
 const MAX_DRAFT_HISTORY: usize = 50;
 
 impl ComposerState {
+    /// Re-derive the "this line began as a command" claim from the current
+    /// composer text (#5925).
+    ///
+    /// Called after every composer mutation. A user edit that removes the
+    /// leading `/` releases the claim — removing it was intentional. Bytes
+    /// lost between the terminal and the composer never pass through here,
+    /// which is exactly the difference the submit guard needs: a claim that
+    /// survives to Enter means the line still starts with `/` and must be
+    /// dispatched as a command, never re-read as a prose prompt.
+    pub(crate) fn resync_command_line_claim(&mut self) {
+        self.line_began_with_slash &= self.input.trim_start().starts_with('/');
+    }
+
+    /// Whether this line is claimed as a command: it began with a typed `/`
+    /// and still starts with one.
+    pub(crate) fn command_line_claimed(&self) -> bool {
+        self.line_began_with_slash && looks_like_slash_command_input(&self.input)
+    }
+
     /// When the user starts editing a truncated oversized paste, restore the
     /// full text so they can see and edit the complete content (#3263).
     fn auto_expand_oversized_paste(&mut self) {
         if let Some(full) = self.oversized_paste_full_text.take() {
             self.input = full;
+            self.resync_command_line_claim();
             // Clamp cursor to the new length instead of resetting to 0,
             // so the user's position in the truncated preview is preserved.
             self.cursor_position = self.cursor_position.min(char_count(&self.input));
@@ -504,6 +524,7 @@ impl ComposerState {
             strip_raw_mouse_report_runs(&self.input, self.cursor_position)
         {
             self.input = input;
+            self.resync_command_line_claim();
             self.cursor_position = cursor_position;
         }
     }
@@ -668,6 +689,7 @@ impl ComposerState {
         };
         self.history_index = Some(new_index);
         self.input = self.input_history[new_index].clone();
+        self.resync_command_line_claim();
         self.cursor_position = char_count(&self.input);
         self.selection_anchor = None;
         self.selected_attachment_index = None;
@@ -692,6 +714,7 @@ impl App {
         let cursor = self.cursor_position.min(char_count(&self.input));
         let byte_index = byte_index_at_char(&self.input, cursor);
         self.input.insert_str(byte_index, text);
+        self.resync_command_line_claim();
         self.cursor_position = cursor + char_count(text);
         self.strip_raw_mouse_reports_from_input();
         self.slash_menu_hidden = false;
@@ -899,9 +922,18 @@ impl App {
         self.auto_expand_oversized_paste();
         self.delete_selection();
         self.selected_attachment_index = None;
+        // #5925: a line that starts with a typed `/` is a command from its
+        // first byte, and stays one until Enter. Recorded here — the only
+        // place a character reaches the composer by typing — so the submit
+        // guard can tell a lost `/` from a deleted one.
+        let starts_line = self.input.trim().is_empty();
         let cursor = self.cursor_position.min(char_count(&self.input));
         let byte_index = byte_index_at_char(&self.input, cursor);
         self.input.insert(byte_index, c);
+        if starts_line {
+            self.line_began_with_slash = c == '/';
+        }
+        self.resync_command_line_claim();
         self.cursor_position = cursor + 1;
         self.strip_raw_mouse_reports_from_input();
         self.slash_menu_hidden = false;
@@ -926,6 +958,7 @@ impl App {
         let cursor = self.cursor_position.min(char_count(&self.input));
         let target = prev_grapheme_boundary(&self.input, cursor);
         let removed = remove_char_range(&mut self.input, target, cursor);
+        self.resync_command_line_claim();
         if removed {
             self.cursor_position = target;
             self.slash_menu_hidden = false;
@@ -950,6 +983,7 @@ impl App {
         let target = self.cursor_position;
         let end = next_grapheme_boundary(&self.input, target);
         let removed = remove_char_range(&mut self.input, target, end);
+        self.resync_command_line_claim();
         if !removed {
             self.cursor_position = char_count(&self.input);
         }
@@ -995,6 +1029,7 @@ impl App {
 
         if word_start < cursor_byte {
             self.input.replace_range(word_start..cursor_byte, "");
+            self.resync_command_line_claim();
             self.cursor_position = char_count(&self.input[..word_start]);
             self.slash_menu_hidden = false;
             self.mention_menu_hidden = false;
@@ -1023,6 +1058,7 @@ impl App {
 
         if line_start < cursor_byte {
             self.input.replace_range(line_start..cursor_byte, "");
+            self.resync_command_line_claim();
             self.cursor_position = char_count(&self.input[..line_start]);
             self.slash_menu_hidden = false;
             self.mention_menu_hidden = false;
@@ -1066,6 +1102,7 @@ impl App {
 
         if cursor_byte < word_end {
             self.input.replace_range(cursor_byte..word_end, "");
+            self.resync_command_line_claim();
             self.slash_menu_hidden = false;
             self.mention_menu_hidden = false;
             self.mention_menu_selected = 0;
@@ -1117,6 +1154,7 @@ impl App {
 
         self.kill_buffer = removed;
         self.input.replace_range(start_byte..end_byte, "");
+        self.resync_command_line_claim();
         // Cursor stays at the same character index (start of removed range).
         self.cursor_position = cursor;
         self.slash_menu_hidden = false;
@@ -1139,6 +1177,7 @@ impl App {
         let cursor = self.cursor_position.min(char_count(&self.input));
         let byte_index = byte_index_at_char(&self.input, cursor);
         self.input.insert_str(byte_index, &text);
+        self.resync_command_line_claim();
         self.cursor_position = cursor + char_count(&text);
         self.slash_menu_hidden = false;
         self.mention_menu_hidden = false;
@@ -1295,6 +1334,7 @@ impl App {
         let sb = byte_index_at_char(&self.input, start);
         let eb = byte_index_at_char(&self.input, end);
         self.input.replace_range(sb..eb, "");
+        self.resync_command_line_claim();
         self.cursor_position = start;
         self.selection_anchor = None;
         self.clear_input_history_navigation();
@@ -1352,6 +1392,7 @@ impl App {
         // Grapheme-aware: `x` deletes the whole cluster under the cursor.
         let end = next_grapheme_boundary(&self.input, pos);
         remove_char_range(&mut self.input, pos, end);
+        self.resync_command_line_claim();
         // Keep cursor in bounds after deletion.
         let new_total = char_count(&self.input);
         if self.cursor_position > 0 && self.cursor_position >= new_total {
@@ -1383,6 +1424,7 @@ impl App {
         };
 
         self.input.replace_range(remove_start..remove_end, "");
+        self.resync_command_line_claim();
         self.cursor_position = char_count(&self.input[..remove_start]);
         self.needs_redraw = true;
     }
@@ -1475,6 +1517,7 @@ impl App {
     pub fn clear_input(&mut self) {
         self.clear_input_history_navigation();
         self.input.clear();
+        self.resync_command_line_claim();
         self.cursor_position = 0;
         // Prevent stale oversized-paste state from leaking when the user
         // clears the composer or navigates to a different input (#3263).
@@ -1573,6 +1616,7 @@ impl App {
             .cloned()
         {
             self.input = selected;
+            self.resync_command_line_claim();
             self.cursor_position = char_count(&self.input);
             self.history_index = None;
             self.status_message = Some("History match inserted into composer".to_string());
@@ -1591,8 +1635,21 @@ impl App {
             return;
         };
         self.input = search.pre_search_input;
+        self.resync_command_line_claim();
         self.cursor_position = search.pre_search_cursor.min(char_count(&self.input));
         self.status_message = Some("History search canceled".to_string());
+        self.needs_redraw = true;
+    }
+
+    /// Refuse a submit the shell cannot vouch for, leaving the text exactly
+    /// where the user can see it (#5925).
+    ///
+    /// Never destructive: the composer keeps its content and the next Enter
+    /// sends it. The hold exists so a line whose first bytes may be missing
+    /// is read by a human before it is read by a model.
+    fn hold_unproven_submit(&mut self, reason: &str) {
+        self.status_message = Some(reason.to_string());
+        self.push_status_toast(reason, StatusToastLevel::Warning, Some(8_000));
         self.needs_redraw = true;
     }
 
@@ -1601,6 +1658,25 @@ impl App {
             self.paste_burst.clear_after_explicit_paste();
             return None;
         }
+        // #5925: startup consumed bytes it could not replay, so this shell
+        // cannot prove it saw the whole line. Keep the text in the composer
+        // and let the user look at it rather than sending a line that may be
+        // missing its first characters — a truncated `/command` submitted as
+        // prose runs with the session's full authority. Cleared here, so the
+        // deliberate second Enter sends exactly what is on screen.
+        if self.startup_input_unproven {
+            self.startup_input_unproven = false;
+            self.hold_unproven_submit(
+                "Codewhale could not confirm it received everything you typed during startup. \
+                 Check the line above and press Enter again to send it as shown.",
+            );
+            return None;
+        }
+        // A line that began with `/` stays a command until Enter. If the
+        // outgoing text is no longer a command — a submit-time rewrite, or
+        // bytes lost after the composer accepted them — never fall through
+        // to the prose-prompt branch; hold it instead.
+        let claimed_command = self.command_line_claimed();
         // Safety net: if any earlier path filled the buffer above the
         // safety cap without going through `insert_paste_text`, fold it
         // into a workspace paste file now (#553). Bracketed pastes hit
@@ -1627,6 +1703,25 @@ impl App {
             };
         } else if let Some(full) = self.oversized_paste_full_text.take() {
             input = full;
+        }
+        if claimed_command && !looks_like_slash_command_input(&input) {
+            // The line was a command when the composer accepted it and is
+            // not one now. Something rewrote it between Enter and dispatch;
+            // the one thing that must never happen is sending it to the
+            // model as prose (#5925). Put the text back and say so.
+            tracing::warn!(
+                target: "startup_input",
+                submitted = %input,
+                "a command line stopped looking like a command before dispatch; holding it in the composer"
+            );
+            self.input = input;
+            self.cursor_position = char_count(&self.input);
+            self.line_began_with_slash = false;
+            self.hold_unproven_submit(
+                "That line started as a command but no longer reads as one. \
+                 Check it and press Enter again to send it as shown.",
+            );
+            return None;
         }
         if !looks_like_slash_command_input(&input) {
             self.input_history.push(input.clone());
@@ -1662,6 +1757,7 @@ impl App {
         };
 
         self.input = prompt.to_string();
+        self.resync_command_line_claim();
         self.cursor_position = char_count(&self.input);
         self.history_index = None;
         self.history_navigation_draft = None;
@@ -1681,6 +1777,7 @@ impl App {
         };
 
         self.input = saved;
+        self.resync_command_line_claim();
         self.cursor_position = char_count(&self.input);
         self.history_index = None;
         self.history_navigation_draft = None;
@@ -1783,6 +1880,7 @@ impl App {
             // Fallback: keep a truncated version so we don't lose the
             // user's input entirely when the filesystem is unhappy.
             self.input = full_input.chars().take(MAX_SUBMITTED_INPUT_CHARS).collect();
+            self.resync_command_line_claim();
             self.cursor_position = char_count(&self.input);
             self.push_status_toast(
                 format!("Failed to create paste directory: {e}"),
@@ -1795,6 +1893,7 @@ impl App {
         let file_path = self.workspace.join(&rel_path);
         if let Err(e) = std::fs::write(&file_path, &full_input) {
             self.input = full_input.chars().take(MAX_SUBMITTED_INPUT_CHARS).collect();
+            self.resync_command_line_claim();
             self.cursor_position = char_count(&self.input);
             self.push_status_toast(
                 format!("Failed to write paste file: {e}"),
@@ -1816,6 +1915,7 @@ impl App {
             truncated.push_str("\n\n---\n(content truncated for display — start typing to expand; full text sent to model)");
         }
         self.input = truncated;
+        self.resync_command_line_claim();
         self.cursor_position = 0;
         self.push_status_toast(
             "Large paste backed up to file — the model will receive the full content.",
@@ -1834,6 +1934,7 @@ impl App {
                 if i + 1 < self.input_history.len() {
                     self.history_index = Some(i + 1);
                     self.input = self.input_history[i + 1].clone();
+                    self.resync_command_line_claim();
                     self.cursor_position = char_count(&self.input);
                     self.selection_anchor = None;
                     self.selected_attachment_index = None;
@@ -1843,6 +1944,7 @@ impl App {
                     self.history_index = None;
                     if let Some(draft) = self.history_navigation_draft.take() {
                         self.input = draft.input;
+                        self.resync_command_line_claim();
                         self.cursor_position = draft.cursor.min(char_count(&self.input));
                         self.selection_anchor = None;
                         self.selected_attachment_index = None;

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -734,6 +734,10 @@ impl App {
                 vim_mode: VimMode::Normal,
                 vim_pending_d: false,
                 selection_anchor: None,
+                // Seeded text was not typed, so it makes no command claim;
+                // startup integrity is decided by the replay receipt (#5925).
+                line_began_with_slash: false,
+                startup_input_unproven: false,
             },
             viewport: ViewportState::default(),
             work_surface: {

--- a/crates/tui/src/tui/mod.rs
+++ b/crates/tui/src/tui/mod.rs
@@ -104,6 +104,7 @@ pub mod slash_menu;
 pub mod sound_policy;
 pub mod spinner;
 pub mod startup_defaults;
+pub mod startup_input;
 pub mod streaming;
 pub mod streaming_thinking;
 mod subagent_routing;

--- a/crates/tui/src/tui/startup_input.rs
+++ b/crates/tui/src/tui/startup_input.rs
@@ -1,0 +1,303 @@
+//! Type-ahead integrity across TUI startup (#5925).
+//!
+//! Startup asks the terminal three questions whose answers arrive on stdin —
+//! the OSC 11 background query, the kitty graphics probe, and the sixel
+//! primary-DA probe (see [`crate::palette::osc11`]). All three run after raw
+//! mode is on and before the [`crate::tui::ui::TerminalInputPump`] exists, so
+//! for that window Codewhale is the only reader of the tty. Anything the user
+//! has already typed sits in the same buffer as the replies.
+//!
+//! Before this module the probe readers consumed those bytes and threw them
+//! away: a `/plugin install …` typed at launch reached the composer as
+//! `gin install …`, no longer began with `/`, and was submitted to the model
+//! as a prose prompt (#5925).
+//!
+//! The contract now is: a probe reader keeps only its own reply and hands
+//! every other byte it consumed to [`osc11::carry_typed_ahead`]. The event
+//! loop replays that buffer, in order, into the same `pending` queue the input
+//! pump feeds, before the pump is spawned — so replayed keys are delivered
+//! ahead of anything still sitting in the tty. Bytes that cannot be turned
+//! back into a key event (a control byte, an escape sequence, invalid UTF-8)
+//! are never guessed at: they are named in an INFO receipt and recorded as
+//! evidence that the shell did not see the whole line.
+
+use std::collections::VecDeque;
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+use crate::palette::osc11;
+
+/// What [`decode`] could and could not turn back into key events.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct DecodedTypeAhead {
+    pub(crate) events: Vec<Event>,
+    /// Bytes deliberately not replayed. Never guessed at — an escape
+    /// sequence replayed as a bare `Esc` plus letters would type garbage
+    /// into the composer, and a synthesized Ctrl+C would cancel work the
+    /// user never asked to cancel.
+    pub(crate) undecodable: Vec<u8>,
+}
+
+fn plain_key(code: KeyCode) -> Event {
+    Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+}
+
+/// Byte length of the UTF-8 sequence a lead byte opens, or `None` when it is
+/// not a valid lead byte.
+fn utf8_sequence_len(lead: u8) -> Option<usize> {
+    match lead {
+        0x00..=0x7f => Some(1),
+        0xc2..=0xdf => Some(2),
+        0xe0..=0xef => Some(3),
+        0xf0..=0xf4 => Some(4),
+        _ => None,
+    }
+}
+
+/// Exclusive end of the escape sequence that starts at `start` (an `ESC`).
+///
+/// `ESC [` / `ESC O` run to their final byte (`@`..=`~`); a bare `ESC x` is
+/// two bytes; a trailing `ESC` is one. Used only to keep a sequence together
+/// so it is dropped as a unit.
+fn escape_sequence_end(bytes: &[u8], start: usize) -> usize {
+    match bytes.get(start + 1) {
+        Some(b'[' | b'O') => {
+            let mut end = start + 2;
+            while end < bytes.len() {
+                let byte = bytes[end];
+                end += 1;
+                if (0x40..=0x7e).contains(&byte) {
+                    break;
+                }
+            }
+            end
+        }
+        Some(_) => start + 2,
+        None => start + 1,
+    }
+}
+
+/// Turn carried bytes back into the key events the pump would have produced.
+///
+/// Only unambiguous keys are reconstructed: printable text (any UTF-8
+/// scalar), Enter, Tab, and Backspace. Everything else — `ESC`, other C0
+/// control bytes, invalid UTF-8 — is reported as undecodable rather than
+/// approximated.
+pub(crate) fn decode(bytes: &[u8]) -> DecodedTypeAhead {
+    let mut decoded = DecodedTypeAhead::default();
+    let mut index = 0;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        match byte {
+            b'\r' | b'\n' => {
+                decoded.events.push(plain_key(KeyCode::Enter));
+                index += 1;
+                // A CRLF pair is one Enter, not two.
+                if byte == b'\r' && bytes.get(index) == Some(&b'\n') {
+                    index += 1;
+                }
+            }
+            b'\t' => {
+                decoded.events.push(plain_key(KeyCode::Tab));
+                index += 1;
+            }
+            0x08 | 0x7f => {
+                decoded.events.push(plain_key(KeyCode::Backspace));
+                index += 1;
+            }
+            0x1b => {
+                // An escape sequence is taken whole, never in pieces: an
+                // arrow key replayed as its tail would type `[A` into the
+                // composer, which is worse than losing it with a receipt.
+                let end = escape_sequence_end(bytes, index);
+                decoded.undecodable.extend_from_slice(&bytes[index..end]);
+                index = end;
+            }
+            0x00..=0x1f => {
+                decoded.undecodable.push(byte);
+                index += 1;
+            }
+            _ => {
+                let width = utf8_sequence_len(byte).unwrap_or(0);
+                let end = index + width;
+                match bytes
+                    .get(index..end)
+                    .filter(|_| width > 0)
+                    .and_then(|slice| std::str::from_utf8(slice).ok())
+                {
+                    Some(text) => {
+                        decoded
+                            .events
+                            .extend(text.chars().map(|ch| plain_key(KeyCode::Char(ch))));
+                        index = end;
+                    }
+                    None => {
+                        decoded.undecodable.push(byte);
+                        index += 1;
+                    }
+                }
+            }
+        }
+    }
+    decoded
+}
+
+/// Printable rendering of raw bytes for a log receipt.
+pub(crate) fn escape_bytes(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|byte| match byte {
+            0x20..=0x7e => (*byte as char).to_string(),
+            _ => format!("\\x{byte:02x}"),
+        })
+        .collect()
+}
+
+/// What the replay did, for the caller's own bookkeeping.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct StartupInputReceipt {
+    /// Key events pushed onto the pending queue.
+    pub(crate) replayed: usize,
+    /// Bytes startup consumed that never became key events.
+    pub(crate) dropped: Vec<u8>,
+}
+
+impl StartupInputReceipt {
+    /// Whether the shell can prove it saw everything the user typed. When
+    /// this is false the composer holds the next submit instead of sending
+    /// a line it cannot vouch for.
+    pub(crate) fn whole_line_proven(&self) -> bool {
+        self.dropped.is_empty()
+    }
+}
+
+/// Replay everything startup consumed into `pending`, oldest byte first.
+///
+/// Call once, before the input pump is spawned, so replayed keys are ahead
+/// of anything the pump reads next. Emits an INFO receipt whenever startup
+/// touched the user's input at all — a future report of a mangled command
+/// then has a line naming the exact bytes.
+pub(crate) fn replay_into(pending: &mut VecDeque<Event>) -> StartupInputReceipt {
+    let carried = osc11::take_carried_type_ahead();
+    let mut dropped = osc11::take_consumed_unreplayable();
+    let decoded = decode(&carried);
+    dropped.extend_from_slice(&decoded.undecodable);
+
+    let receipt = StartupInputReceipt {
+        replayed: decoded.events.len(),
+        dropped,
+    };
+    if carried.is_empty() && receipt.dropped.is_empty() {
+        return receipt;
+    }
+    // The replay is prepended, not appended: these bytes were consumed
+    // before anything still sitting in the tty, so they must be delivered
+    // first or the line is reordered.
+    for event in decoded.events.into_iter().rev() {
+        pending.push_front(event);
+    }
+    tracing::info!(
+        target: "startup_input",
+        consumed_bytes = carried.len(),
+        replayed_keys = receipt.replayed,
+        replayed = %escape_bytes(&carried),
+        dropped_bytes = receipt.dropped.len(),
+        dropped = %escape_bytes(&receipt.dropped),
+        "startup terminal probes consumed typed-ahead input; replaying it into the composer"
+    );
+    receipt
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_a_typed_slash_command_line_in_order() {
+        let decoded = decode(b"/plugin list\r");
+        let typed: String = decoded
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char(ch),
+                    ..
+                }) => Some(*ch),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(typed, "/plugin list");
+        assert_eq!(
+            decoded.events.last(),
+            Some(&plain_key(KeyCode::Enter)),
+            "the trailing carriage return must replay as Enter"
+        );
+        assert!(decoded.undecodable.is_empty());
+    }
+
+    #[test]
+    fn crlf_replays_as_one_enter() {
+        let decoded = decode(b"hi\r\n");
+        assert_eq!(
+            decoded
+                .events
+                .iter()
+                .filter(|e| **e == plain_key(KeyCode::Enter))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn escape_sequences_and_invalid_utf8_are_reported_never_guessed() {
+        let decoded = decode(b"a\x1b[Ab\xff");
+        // The arrow key is dropped whole — replaying its tail would type
+        // `[A` into the composer. Only `a` and `b` come back as keys.
+        assert_eq!(decoded.undecodable, b"\x1b[A\xff".to_vec());
+        assert_eq!(decoded.events.len(), 2);
+    }
+
+    #[test]
+    fn a_lone_escape_at_the_end_is_one_dropped_byte() {
+        let decoded = decode(b"hi\x1b");
+        assert_eq!(decoded.undecodable, vec![0x1b]);
+        assert_eq!(decoded.events.len(), 2);
+    }
+
+    #[test]
+    fn multibyte_text_survives_the_round_trip() {
+        let decoded = decode("héllo→".as_bytes());
+        let typed: String = decoded
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char(ch),
+                    ..
+                }) => Some(*ch),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(typed, "héllo→");
+        assert!(decoded.undecodable.is_empty());
+    }
+
+    #[test]
+    fn a_receipt_with_dropped_bytes_does_not_prove_the_whole_line() {
+        let proven = StartupInputReceipt {
+            replayed: 3,
+            dropped: Vec::new(),
+        };
+        assert!(proven.whole_line_proven());
+        let lossy = StartupInputReceipt {
+            replayed: 3,
+            dropped: vec![0x1b],
+        };
+        assert!(!lossy.whole_line_proven());
+    }
+
+    #[test]
+    fn escape_bytes_names_unprintable_bytes() {
+        assert_eq!(escape_bytes(b"/pl\x1b"), "/pl\\x1b");
+    }
+}

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -1218,8 +1218,20 @@ pub(crate) async fn run_event_loop(
     let mut last_focus_recovery = Instant::now()
         .checked_sub(Duration::from_secs(60))
         .unwrap_or_else(Instant::now);
-    let mut terminal_input = TerminalInputPump::spawn()?;
+    // #5925: the startup terminal probes (OSC 11 background, kitty graphics,
+    // sixel primary-DA) were the only readers of the tty until now, and they
+    // consumed whatever the user had already typed. Replay it into the same
+    // queue the pump feeds — and do it *before* the pump is spawned, so those
+    // keys are delivered ahead of anything still sitting in the tty rather
+    // than behind it.
     let mut pending_terminal_events: VecDeque<Event> = VecDeque::new();
+    let startup_input_receipt =
+        crate::tui::startup_input::replay_into(&mut pending_terminal_events);
+    // When startup could not account for every byte it consumed, the shell
+    // cannot prove it saw the whole line. The composer holds the next submit
+    // instead of sending text it cannot vouch for.
+    app.startup_input_unproven = !startup_input_receipt.whole_line_proven();
+    let mut terminal_input = TerminalInputPump::spawn()?;
     let mut last_terminal_input_recovery = Instant::now()
         .checked_sub(TERMINAL_INPUT_RECOVERY_COOLDOWN)
         .unwrap_or_else(Instant::now);

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -24851,3 +24851,155 @@ fn a_scroll_burst_is_folded_into_one_frame() {
     assert_eq!(pending.len(), 1, "the non-scroll event was pushed back");
     assert!(matches!(pending.front(), Some(Event::Key(_))));
 }
+
+// ---------------------------------------------------------------------------
+// Startup type-ahead integrity (#5925).
+//
+// A line typed right after launch — while the OSC 11 / kitty / sixel probes
+// are the only readers of the tty — must reach the composer whole and
+// dispatch as what it was typed as. Before the fix the probes ate the first
+// bytes of `/plugin install …`, the survivor no longer began with `/`, and it
+// was submitted to the model as a prose prompt.
+// ---------------------------------------------------------------------------
+
+/// The carried-input buffer is process-global (one tty, one startup), so the
+/// tests that exercise it take turns.
+fn startup_input_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Replay a queue of pending terminal events through the composer exactly
+/// as the event loop's key arm does: plain characters insert, Enter submits.
+fn drive_composer_events(app: &mut App, pending: &mut VecDeque<Event>) -> Option<String> {
+    let mut submitted = None;
+    while let Some(event) = pending.pop_front() {
+        let Event::Key(key) = event else { continue };
+        match key.code {
+            KeyCode::Char(c) => app.insert_char(c),
+            KeyCode::Enter => submitted = app.handle_composer_enter(),
+            KeyCode::Backspace => app.delete_char(),
+            _ => {}
+        }
+    }
+    submitted
+}
+
+#[test]
+fn startup_typeahead_dispatches_as_a_command_not_a_prompt() {
+    let _lock = startup_input_test_lock();
+    let _home = SettingsHomeGuard::new();
+    // What a startup probe consumed off the tty before the input pump existed.
+    crate::palette::osc11::carry_typed_ahead(b"/plugin list\r");
+
+    let mut pending: VecDeque<Event> = VecDeque::new();
+    let receipt = crate::tui::startup_input::replay_into(&mut pending);
+    assert!(
+        receipt.whole_line_proven(),
+        "every byte was replayable: {receipt:?}"
+    );
+    assert_eq!(receipt.replayed, "/plugin list".len() + 1, "{receipt:?}");
+
+    let mut app = App::new(create_test_options(), &Config::default());
+    app.startup_input_unproven = !receipt.whole_line_proven();
+    let submitted = drive_composer_events(&mut app, &mut pending);
+
+    let submitted = submitted.expect("the replayed Enter submitted the line");
+    assert_eq!(
+        submitted, "/plugin list",
+        "no byte was consumed or reordered"
+    );
+    assert!(
+        looks_like_slash_command_input(&submitted),
+        "the line dispatches as a command, not as a prompt for the model"
+    );
+    assert!(app.input.is_empty(), "the composer consumed the line");
+}
+
+#[test]
+fn startup_that_cannot_account_for_its_bytes_keeps_the_line_in_the_composer() {
+    let _lock = startup_input_test_lock();
+    let _home = SettingsHomeGuard::new();
+    // The pre-fix shape: a probe swallowed `/plu` (here: consumed bytes it
+    // cannot replay) and only the tail reached the composer.
+    crate::palette::osc11::note_consumed_unreplayable(b"/plu");
+    crate::palette::osc11::carry_typed_ahead(b"gin install /tmp/bundle\r");
+
+    let mut pending: VecDeque<Event> = VecDeque::new();
+    let receipt = crate::tui::startup_input::replay_into(&mut pending);
+    assert!(
+        !receipt.whole_line_proven(),
+        "dropped bytes mean the whole line is not proven: {receipt:?}"
+    );
+
+    let mut app = App::new(create_test_options(), &Config::default());
+    app.startup_input_unproven = !receipt.whole_line_proven();
+    let submitted = drive_composer_events(&mut app, &mut pending);
+
+    assert!(
+        submitted.is_none(),
+        "a line the shell cannot vouch for is never submitted to the model"
+    );
+    assert_eq!(
+        app.input, "gin install /tmp/bundle",
+        "the text stays in the composer for the user to look at"
+    );
+    assert!(
+        app.status_message
+            .as_deref()
+            .is_some_and(|message| message.contains("startup")),
+        "the hold explains itself: {:?}",
+        app.status_message
+    );
+
+    // The user has now seen it; a deliberate second Enter sends what is shown.
+    let resent = app.handle_composer_enter();
+    assert_eq!(resent.as_deref(), Some("gin install /tmp/bundle"));
+}
+
+#[test]
+fn a_command_line_that_stops_looking_like_one_is_held_not_reinterpreted() {
+    let _home = SettingsHomeGuard::new();
+    let mut app = App::new(create_test_options(), &Config::default());
+    for ch in "/plugin install".chars() {
+        app.insert_char(ch);
+    }
+    assert!(app.command_line_claimed(), "typed `/` claims the line");
+
+    // The submit pipeline rewrites an oversized composer into a paste
+    // @-mention. That rewrite must never silently turn a command line into a
+    // prose turn for the model (#5925).
+    app.composer.pending_paste_reference = Some("@.codewhale/pastes/p.md".to_string());
+    let submitted = app.handle_composer_enter();
+    assert!(
+        submitted.is_none(),
+        "a claimed command is never re-read as a prose prompt"
+    );
+    assert_eq!(
+        app.input, "@.codewhale/pastes/p.md",
+        "the exact text that would have been sent is left on screen"
+    );
+}
+
+#[test]
+fn deleting_the_leading_slash_releases_the_command_claim() {
+    let _home = SettingsHomeGuard::new();
+    let mut app = App::new(create_test_options(), &Config::default());
+    for ch in "/plugin".chars() {
+        app.insert_char(ch);
+    }
+    assert!(app.command_line_claimed());
+
+    // A deliberate edit that removes the `/` is not lost input.
+    app.cursor_position = 1;
+    app.delete_char();
+    assert!(
+        !app.line_began_with_slash,
+        "the claim is released by an edit"
+    );
+    assert_eq!(
+        app.handle_composer_enter().as_deref(),
+        Some("plugin"),
+        "the edited line submits normally"
+    );
+}


### PR DESCRIPTION
Closes #5925

## The mechanism

Between raw-mode entry and `TerminalInputPump::spawn`, three startup probes are the only readers of the tty: the OSC 11 background query, the kitty graphics query, and the sixel primary-DA query — all through `palette::osc11::query_terminal_inner`. That reader read stdin one byte at a time, kept whatever it decided was the reply, and **discarded everything else**; on a timeout it discarded what it had collected too. Nothing replayed any of it.

So a `/plugin install /path` typed at launch had its first bytes eaten by a probe. The survivor no longer began with `/`, `looks_like_slash_command_input` said "not a command", and it was dispatched to the model as a prose prompt with the session's full authority.

## The fix

1. **Nothing is consumed.** `palette::osc11::ProbeSplit` is a pure, byte-driven split of the probe stream into `(reply, type-ahead)`. The reply is recognised by the two-byte introducer the query itself opened with (`ESC ]` / `ESC _` / `ESC [`), so bytes before it — and the byte after an `ESC` that turned out not to open `ESC \` — are the user's and are carried, not dropped. The reader is now a thin loop over that split.
2. **It is replayed in order.** `tui::startup_input::replay_into` decodes the carried bytes back into key events and seeds the event loop's existing `pending_terminal_events` queue *before* the pump is spawned, so replayed keys land ahead of anything still sitting in the tty. No second input path: the events go through the same queue and the same key arm.
3. **Nothing is guessed.** Only unambiguous keys are reconstructed (text, Enter, Tab, Backspace). Escape sequences are dropped **whole** — replaying an arrow key's tail would type `[A` into the composer — and reported, never approximated.
4. **A receipt at INFO.** `target: "startup_input"` names consumed byte count, replayed key count, and the exact replayed and dropped bytes (escaped). A future report of a mangled command now has evidence.
5. **A submit is never re-interpreted.** `submit_input` holds instead of sending when (a) startup could not account for bytes it consumed, or (b) a line that began with a typed `/` is no longer a command in the outgoing text (a submit-time rewrite, e.g. oversized-paste consolidation into an `@`-mention). Both holds are non-destructive: the text stays on screen, the status line says why, and the next Enter sends exactly what is shown. The claim is re-derived after every composer mutation, so deleting the `/` yourself releases it and never trips a hold.

## What is actually verified, and what is not

**Proven by tests (macOS, `cargo test -p codewhale-tui --lib`, `RUST_MIN_STACK=16777216`):**

| filter | result |
| --- | --- |
| `startup_input` | 7 passed; 0 failed |
| `palette` | 125 passed; 0 failed |
| `composer` | 135 passed; 0 failed |
| `tui::app` | 333 passed; 0 failed |
| `tui::ui` | 790 passed; 0 failed |

`cargo fmt --all -- --check` clean; `cargo check -p codewhale-tui` clean.

**The regression tests fail without the fix.** With `carry_typed_ahead` and the composer hold neutralised, `startup_typeahead_dispatches_as_a_command_not_a_prompt` replays 0 of 13 bytes, and `startup_that_cannot_account_for_its_bytes_keeps_the_line_in_the_composer` fails with the composer empty — i.e. it submitted `gin install /tmp/bundle` as prose, which is the reported bug verbatim.

**What only a real terminal can prove.** No live TUI was driven for this PR — no pty run, no real `CODEWHALE_HOME`, no provider call. The tests exercise the split as a pure function, the replay into the real `pending` queue, and the real composer submit path; they do **not** prove:

- that a given terminal's OSC 11 / kitty / sixel reply is still parsed correctly against the live reader (the reader itself needs a tty and is not unit-testable);
- the end-to-end timing on a real pty — whether the typed bytes actually land inside the probe window on any particular terminal;
- Windows behaviour: the probe reader is `#[cfg(unix)]`, so on Windows nothing is carried and nothing changes.

**Known limit, deliberately left.** If the sixel primary-DA probe is running and the user presses an arrow key at exactly that moment, `ESC [ A` matches the DA introducer and is consumed as a (bogus) reply with no receipt. This is pre-existing behaviour, only reachable when kitty graphics said no, and the alternative — validating reply shape inside the reader — belongs with the probe's own parser in `tui::mark`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XYyJaw9Mh9uSrqQBoqhm

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes raw-mode stdin handling at TUI startup and submit dispatch for slash commands; logic is heavily tested but timing and terminal-specific probe behavior are not exercised in live PTY runs (Unix-only probe path).
> 
> **Overview**
> Fixes **#5925**, where startup terminal probes (OSC 11, kitty graphics, sixel DA) read stdin before the input pump and **dropped** bytes that were not part of the reply—often the start of a `/command` line—so the composer lost the leading `/` and the line went to the model as prose.
> 
> **Probe path:** `ProbeSplit` separates each probe stream into terminal reply vs user type-ahead; `query_terminal_inner` parks non-reply bytes via `carry_typed_ahead` instead of discarding them. Partial or untrusted replies are tracked as unreplayable for the startup receipt.
> 
> **Replay:** New `startup_input` decodes carried bytes into conservative key events (text, Enter, Tab, Backspace only—no guessed escape sequences), prepends them to `pending_terminal_events` **before** `TerminalInputPump::spawn`, and logs an INFO receipt when anything was consumed or dropped.
> 
> **Submit safety:** The composer records when a line **began with a typed `/`** and blocks the first Enter if startup could not prove the whole line, or if a claimed command no longer looks like one after submit-time rewrites (e.g. paste consolidation)—non-destructive holds with a warning; a second Enter sends what is on screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bbc35e6e30e1d28a5fc8a8a583a9a75067f7ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->