### PR TITLE
refactor(tui): adopt command shapes in session control slice (FEAT-024)

### DIFF
--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -1186,12 +1186,20 @@ pub struct PlanSections {
     pub items: Vec<PlanStep>,
 }
 
-/// One plan checklist item. The status is already rendered to its label
-/// (`pending`/`in_progress`/`completed`) host-side so no TUI step-status type
-/// crosses the boundary.
-#[derive(Clone, Debug, PartialEq)]
+/// Portable plan-step status. The adapter maps the TUI plan status onto this
+/// semantic enum; the command handler remains the sole owner of the exact
+/// `pending`/`in_progress`/`completed` labels.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlanStepStatus {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+/// One semantic plan checklist item.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PlanStep {
-    pub status_label: String,
+    pub status: PlanStepStatus,
     pub text: String,
 }
 
@@ -1326,9 +1334,10 @@ pub trait CommandSessionControlContext {
     /// read/parse/import text.
     fn import_session_file(&mut self, path: PathBuf) -> Result<ResumeImportReceipt, String>;
 
-    /// `/rename <title>`: sanitize, recover first-snapshot state, sync live
-    /// state, persist, and publish with baseline order. The handler already
-    /// applied blank/usage and 100-character validation.
+    /// `/rename <title>`: sanitize, validate the sanitized 100-character
+    /// limit, recover first-snapshot state, sync live state, persist, and
+    /// publish with baseline order. The handler already applied blank/usage
+    /// validation.
     fn rename_session(&mut self, raw_title: &str) -> Result<SessionTitleReceipt, String>;
 
     /// Bare `/title`: effective prefix and its source.

--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -1155,9 +1155,14 @@ pub enum TodoProjection {
 
 /// Plan-state distinction for the relay snapshot. `Busy` reproduces the
 /// baseline `try_lock` failure branch; `Absent` reproduces an empty snapshot.
+///
+/// `PlanSections` is intentionally not boxed: the command-crate boundary gate
+/// forbids boxed storage in the contract, and the section payload is only ever
+/// built once per `/relay` dispatch.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum PlanProjection {
-    Sections(Box<PlanSections>),
+    Sections(PlanSections),
     Busy,
     Absent,
 }

--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -1157,7 +1157,7 @@ pub enum TodoProjection {
 /// baseline `try_lock` failure branch; `Absent` reproduces an empty snapshot.
 #[derive(Clone, Debug, PartialEq)]
 pub enum PlanProjection {
-    Sections(PlanSections),
+    Sections(Box<PlanSections>),
     Busy,
     Absent,
 }

--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -1135,7 +1135,7 @@ pub struct RelayProjection {
     pub mode: String,
     pub model: String,
     pub goal_objective: Option<String>,
-    pub goal_token_budget: Option<u64>,
+    pub goal_token_budget: Option<u32>,
     pub todos: TodoProjection,
     pub plan: PlanProjection,
 }

--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -1261,14 +1261,6 @@ pub enum TitleSource {
     None,
 }
 
-/// `/title` set/clear outcome. `Set` carries the sanitized persisted title;
-/// `Cleared` is the `off|clear|none` result.
-#[derive(Clone, Debug, PartialEq)]
-pub enum TitleSetOutcome {
-    Set(String),
-    Cleared,
-}
-
 /// `/rc link` structured link data.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RemoteLink {
@@ -1334,19 +1326,25 @@ pub trait CommandSessionControlContext {
     /// read/parse/import text.
     fn import_session_file(&mut self, path: PathBuf) -> Result<ResumeImportReceipt, String>;
 
-    /// `/rename <title>`: sanitize, validate the sanitized 100-character
-    /// limit, recover first-snapshot state, sync live state, persist, and
-    /// publish with baseline order. The handler already applied blank/usage
-    /// validation.
-    fn rename_session(&mut self, raw_title: &str) -> Result<SessionTitleReceipt, String>;
+    /// Apply the authoritative session-title character policy before the
+    /// portable `/rename` and `/title` handlers validate and compose output.
+    fn sanitize_session_title(&self, raw_title: &str) -> String;
+
+    /// `/rename <title>`: recover first-snapshot state, sync live state,
+    /// persist, and publish with baseline order. The handler already applied
+    /// sanitization plus blank and 100-character validation.
+    fn rename_session(&mut self, title: &str) -> Result<SessionTitleReceipt, String>;
 
     /// Bare `/title`: effective prefix and its source.
     fn title_report(&self) -> TitleReport;
 
-    /// `/title [title|off]`: set or clear the session window title with
-    /// baseline persistence/redraw semantics. The handler already applied the
-    /// 100-character validation.
-    fn set_window_title(&mut self, title: Option<String>) -> Result<TitleSetOutcome, String>;
+    /// `/title <title>`: persist an already sanitized and validated window
+    /// title with baseline save/publication/redraw semantics.
+    fn set_window_title(&mut self, title: String) -> Result<(), String>;
+
+    /// `/title off|clear|none`: clear the session window title with the same
+    /// baseline persistence/redraw semantics.
+    fn clear_window_title(&mut self) -> Result<(), String>;
 
     /// `/rc status`: current remote-control status line.
     fn remote_status(&self) -> String;

--- a/crates/command-contract/src/facets.rs
+++ b/crates/command-contract/src/facets.rs
@@ -1108,3 +1108,251 @@ pub trait CommandSessionLifecycleContext {
     /// days while protecting the active session; returns the number pruned.
     fn prune_sessions(&mut self, days: u64) -> Result<usize, String>;
 }
+
+// ---------------------------------------------------------------------------
+// FEAT-024: session control slice (D2-D7).
+//
+// One independently optional session-control authority covering exactly the
+// host work the six control commands (`/relay`, `/rename`, `/resume`, `/rc`,
+// `/remote-env`, `/title`) consume. `CommandSessionContext` and
+// `CommandSessionLifecycleContext` are deliberately not widened: control
+// authority exists only on this facet, and every delegate is an atomic host
+// operation or a semantic projection so handlers keep byte-identical
+// composition. Portable values never expose TUI state beyond what the
+// baseline branches on.
+// ---------------------------------------------------------------------------
+
+/// `/relay` semantic snapshot (D4). The handler composes the byte-identical
+/// instruction from these deterministic fields; `crate::prompts`,
+/// `crate::todo_snapshot`, goal/todo/plan machinery, Work-state objects, and
+/// locks stay host-side.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RelayProjection {
+    /// Authoritative compact-template text (`COMPACT_TEMPLATE`), echoed with
+    /// a trailing trim by the handler exactly as today.
+    pub compact_template: String,
+    pub workspace: String,
+    pub mode: String,
+    pub model: String,
+    pub goal_objective: Option<String>,
+    pub goal_token_budget: Option<u64>,
+    pub todos: TodoProjection,
+    pub plan: PlanProjection,
+}
+
+/// To-do state distinction for the relay snapshot. The rendered body (if any)
+/// is produced host-side from the authoritative graph-backed snapshot seam.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TodoProjection {
+    /// Rendered to-do body lines.
+    Body(String),
+    /// Work state could not be read (`To-do: unavailable because the list is
+    /// busy.`).
+    Unavailable,
+    /// No Work state or no to-do body.
+    Absent,
+}
+
+/// Plan-state distinction for the relay snapshot. `Busy` reproduces the
+/// baseline `try_lock` failure branch; `Absent` reproduces an empty snapshot.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PlanProjection {
+    Sections(PlanSections),
+    Busy,
+    Absent,
+}
+
+/// Semantic plan snapshot fields consumed by `/relay`. Values are the raw
+/// snapshot values; the handler applies the baseline trim/empty filtering and
+/// label composition so ordering and spacing stay byte-identical.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PlanSections {
+    pub title: Option<String>,
+    pub objective: Option<String>,
+    pub context_summary: Option<String>,
+    pub explanation: Option<String>,
+    pub sources_used: Vec<String>,
+    pub critical_files: Vec<String>,
+    pub constraints: Vec<String>,
+    pub recommended_approach: Option<String>,
+    pub verification_plan: Option<String>,
+    pub risks_and_unknowns: Option<String>,
+    pub handoff_packet: Option<String>,
+    pub items: Vec<PlanStep>,
+}
+
+/// One plan checklist item. The status is already rendered to its label
+/// (`pending`/`in_progress`/`completed`) host-side so no TUI step-status type
+/// crosses the boundary.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PlanStep {
+    pub status_label: String,
+    pub text: String,
+}
+
+/// `/resume` route resolution (D6). The host resolves argument shape and
+/// performs container imports atomically; the handler selects the exact
+/// baseline message/action per variant.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ResumeSource {
+    /// Argument resolves to a readable file (`raw` direct path or
+    /// workspace-relative path); the handler calls `import_session_file`.
+    File(PathBuf),
+    /// Argument resolved through the session manager (id or prefix).
+    Session {
+        /// Durable session file when present; `None` reproduces the baseline
+        /// non-file fallback message arm.
+        load_path: Option<PathBuf>,
+        truncated_id: String,
+        title: String,
+    },
+    /// Argument parsed as a foreign session container, which was imported
+    /// atomically by the resolver.
+    Imported(ResumeImportReceipt),
+    /// Argument matched neither a file, a session, nor a container.
+    NotFound { raw: String, error: String },
+}
+
+/// Portable `/resume` import receipt. The handler renders
+/// `Imported foreign session as {truncated_id} ({entry_count} entries, leaf
+/// {leaf_display})`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResumeImportReceipt {
+    pub truncated_id: String,
+    pub entry_count: usize,
+    pub leaf_display: String,
+}
+
+/// `/rename` success receipt; the title is the sanitized persisted value so
+/// the handler echoes exactly what was written.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SessionTitleReceipt {
+    pub title: String,
+}
+
+/// Bare `/title` status projection (`Window title: [{effective}]{source}`).
+#[derive(Clone, Debug, PartialEq)]
+pub struct TitleReport {
+    /// Effective window-title prefix, or `unset`.
+    pub effective: String,
+    pub source: TitleSource,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TitleSource {
+    /// Session-level window title set.
+    Session,
+    /// Config-default title applies.
+    ConfigDefault,
+    /// Neither a session title nor a config default.
+    None,
+}
+
+/// `/title` set/clear outcome. `Set` carries the sanitized persisted title;
+/// `Cleared` is the `off|clear|none` result.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TitleSetOutcome {
+    Set(String),
+    Cleared,
+}
+
+/// `/rc link` structured link data.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RemoteLink {
+    pub url: String,
+    pub computer_url: Option<String>,
+}
+
+/// `/rc open` outcome. Browser launch stays synchronous and single-attempt;
+/// no deferred external-URL action is produced (D6).
+#[derive(Clone, Debug, PartialEq)]
+pub enum RemoteOpenOutcome {
+    NoLink,
+    Opened { url: String },
+    LaunchFailed { url: String },
+}
+
+/// `/rc start` wording input: the active-turn copy is used while a turn is
+/// loading or a dispatch is in flight.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RemoteStartInfo {
+    pub connecting: bool,
+}
+
+/// `/remote-env open` hosted-work target. The URL is fully encoded host-side
+/// (the portable handler must not depend on `urlencoding`); repo/branch echo
+/// the raw values used by the baseline message replacements.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HostedWorkTarget {
+    pub url: String,
+    pub repo: String,
+    pub branch: String,
+}
+
+/// Control authority for the session command slice (FEAT-024 D2/D5).
+///
+/// Operation-granular synchronous delegates over the exact minimum host work
+/// the six control commands consume. Delegates reproduce the baseline
+/// check/mutation order (transition gate before resume I/O, save before
+/// publication, single-attempt browser launch) and return portable receipts/
+/// projections or the exact host-error text the baseline surfaces. No
+/// `SessionManager`, saved-session/container type, `SessionPickerView`,
+/// remote-control service, Git wrapper, configuration, model/history type,
+/// lock, or host callback crosses the facet.
+pub trait CommandSessionControlContext {
+    /// Live transition gate consulted by `/resume` before any picker or I/O.
+    fn transition_blocked(&self) -> bool;
+
+    /// `/relay`: authoritative semantic snapshot (workspace/mode/model/goal/
+    /// to-do/plan/compact-template). Unavailable sources are represented as
+    /// explicit states, never panics.
+    fn relay_projection(&self) -> RelayProjection;
+
+    /// Bare `/resume`: push the existing picker without preselection.
+    fn open_resume_picker(&mut self);
+
+    /// `/resume <raw>`: resolve direct-path, workspace-relative, session
+    /// id/prefix, and inline-container routes in the established order; a
+    /// recognized inline container is imported atomically here.
+    fn resolve_resume_source(&mut self, raw: &str) -> Result<ResumeSource, String>;
+
+    /// `/resume <file>`: read, parse, persist, and apply a foreign session
+    /// file (container or plain saved session). Errors are the exact baseline
+    /// read/parse/import text.
+    fn import_session_file(&mut self, path: PathBuf) -> Result<ResumeImportReceipt, String>;
+
+    /// `/rename <title>`: sanitize, recover first-snapshot state, sync live
+    /// state, persist, and publish with baseline order. The handler already
+    /// applied blank/usage and 100-character validation.
+    fn rename_session(&mut self, raw_title: &str) -> Result<SessionTitleReceipt, String>;
+
+    /// Bare `/title`: effective prefix and its source.
+    fn title_report(&self) -> TitleReport;
+
+    /// `/title [title|off]`: set or clear the session window title with
+    /// baseline persistence/redraw semantics. The handler already applied the
+    /// 100-character validation.
+    fn set_window_title(&mut self, title: Option<String>) -> Result<TitleSetOutcome, String>;
+
+    /// `/rc status`: current remote-control status line.
+    fn remote_status(&self) -> String;
+
+    /// `/rc link`: live session link plus optional computer-management URL.
+    fn remote_link(&self) -> Option<RemoteLink>;
+
+    /// `/rc open`: synchronous single browser attempt over the authoritative
+    /// URL-opening helper; outcome carries the URL for exact message text.
+    fn remote_browser_open(&self) -> RemoteOpenOutcome;
+
+    /// `/rc start`: whether the active-turn copy applies.
+    fn remote_start_info(&self) -> RemoteStartInfo;
+
+    /// `/rc stop`: refusal reason while a remote turn/envelope is active.
+    fn remote_stop_refusal(&self) -> Option<String>;
+
+    /// `/remote-env open`: validate the hosted-work Git target host-side and
+    /// return the encoded URL plus raw repo/branch echoes; `None` reproduces
+    /// the unavailable-target error. Credentials never appear in values or
+    /// errors.
+    fn resolve_hosted_work_target(&self) -> Option<HostedWorkTarget>;
+}

--- a/crates/command-contract/src/handler.rs
+++ b/crates/command-contract/src/handler.rs
@@ -7,8 +7,9 @@
 use crate::facets::{
     CommandCostContext, CommandMediaContext, CommandMemoryContext, CommandModePolicyContext,
     CommandModelContext, CommandPluginContext, CommandPresentationContext, CommandProjectContext,
-    CommandSessionContext, CommandSessionLifecycleContext, CommandSkillGroupContext,
-    CommandSkillsContext, CommandSystemPromptContext, CommandWorkspaceContext,
+    CommandSessionContext, CommandSessionControlContext, CommandSessionLifecycleContext,
+    CommandSkillGroupContext, CommandSkillsContext, CommandSystemPromptContext,
+    CommandWorkspaceContext,
 };
 
 /// Exact host capabilities exposed to one contextual command handler.
@@ -43,6 +44,13 @@ impl CommandCapabilities {
     /// commands; `/compact` and `/purge` remain pure. Never widened by the
     /// basic session capability.
     pub const SESSION_LIFECYCLE: Self = Self(1 << 13);
+    /// Session-control host data (FEAT-024 D3), the next non-conflicting bit
+    /// after `SESSION_LIFECYCLE`. Required only by the six host-dependent
+    /// control commands (`/relay`, `/rename`, `/resume`, `/rc`, `/remote-env`,
+    /// `/title`); `/remote-env` also declares `PRESENTATION`. The backing
+    /// storage remains `u16` per the resolved maintainer review on FEAT-023 PR
+    /// #5902 — bit 14 is available, so no speculative widening is performed.
+    pub const SESSION_CONTROL: Self = Self(1 << 14);
 
     pub const fn union(self, other: Self) -> Self {
         Self(self.0 | other.0)
@@ -91,6 +99,7 @@ pub struct CommandContexts<'a> {
     skill_group: Option<&'a mut dyn CommandSkillGroupContext>,
     plugin: Option<&'a mut dyn CommandPluginContext>,
     lifecycle: Option<&'a mut dyn CommandSessionLifecycleContext>,
+    control: Option<&'a mut dyn CommandSessionControlContext>,
 }
 
 /// Consumed envelope used when one handler needs several independent facets.
@@ -109,6 +118,7 @@ pub struct ContextParts<'a> {
     pub skill_group: Option<&'a mut dyn CommandSkillGroupContext>,
     pub plugin: Option<&'a mut dyn CommandPluginContext>,
     pub lifecycle: Option<&'a mut dyn CommandSessionLifecycleContext>,
+    pub control: Option<&'a mut dyn CommandSessionControlContext>,
 }
 
 impl<'a> CommandContexts<'a> {
@@ -128,6 +138,7 @@ impl<'a> CommandContexts<'a> {
             skill_group: None,
             plugin: None,
             lifecycle: None,
+            control: None,
         }
     }
 
@@ -147,6 +158,7 @@ impl<'a> CommandContexts<'a> {
             skill_group: self.skill_group,
             plugin: self.plugin,
             lifecycle: self.lifecycle,
+            control: self.control,
         }
     }
 
@@ -255,6 +267,14 @@ impl<'a> CommandContexts<'a> {
         assert!(
             self.lifecycle.replace(value).is_none(),
             "lifecycle facet already set"
+        );
+        self
+    }
+
+    pub fn with_control(mut self, value: &'a mut dyn CommandSessionControlContext) -> Self {
+        assert!(
+            self.control.replace(value).is_none(),
+            "control facet already set"
         );
         self
     }

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -2102,3 +2102,398 @@ fn envelope_lifecycle_slot_is_independent_and_rejects_duplicates() {
     let lifecycle = inserted.into_parts().lifecycle.expect("inserted lifecycle");
     assert!(lifecycle.transition_blocked());
 }
+
+// ---------------------------------------------------------------------------
+// FEAT-024: session control contract (D2/D3/D6/D7).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn control_capability_is_stable_distinct_and_non_conflicting() {
+    let control = CommandCapabilities::SESSION_CONTROL;
+    for existing in [
+        CommandCapabilities::NONE,
+        CommandCapabilities::SESSION,
+        CommandCapabilities::MODEL,
+        CommandCapabilities::COST,
+        CommandCapabilities::MODE_POLICY,
+        CommandCapabilities::SYSTEM_PROMPT,
+        CommandCapabilities::SKILLS,
+        CommandCapabilities::WORKSPACE,
+        CommandCapabilities::PRESENTATION,
+        CommandCapabilities::MEDIA,
+        CommandCapabilities::MEMORY,
+        CommandCapabilities::PROJECT,
+        CommandCapabilities::SKILL_GROUP,
+        CommandCapabilities::PLUGIN,
+        CommandCapabilities::SESSION_LIFECYCLE,
+    ] {
+        assert_ne!(control, existing, "SESSION_CONTROL must not collide");
+    }
+    assert!(!CommandCapabilities::NONE.contains(control));
+    assert!(control.contains(control));
+    assert!(
+        control
+            .union(CommandCapabilities::PRESENTATION)
+            .contains(control)
+    );
+    assert!(
+        control
+            .union(CommandCapabilities::PRESENTATION)
+            .contains(CommandCapabilities::PRESENTATION)
+    );
+    assert!(!CommandCapabilities::SESSION_LIFECYCLE.contains(control));
+    assert!(!control.contains(CommandCapabilities::SESSION_LIFECYCLE));
+    // Storage remains u16-backed by construction: bit 14 (1 << 14 = 16384)
+    // fits the backing `u16` without the speculative widening FEAT-023's
+    // maintainer review ruled out.
+}
+
+/// Deterministic fake control facet: every delegate returns canned portable
+/// values or error text so the contract transport is exercised exactly.
+#[derive(Default)]
+struct FakeControl {
+    blocked: bool,
+    relay: Option<RelayProjection>,
+    resume: Option<Result<ResumeSource, String>>,
+    import: Option<Result<ResumeImportReceipt, String>>,
+    rename: Option<Result<SessionTitleReceipt, String>>,
+    title_report: Option<TitleReport>,
+    set_title: Option<Result<TitleSetOutcome, String>>,
+    remote_status: Option<String>,
+    remote_link: Option<Option<RemoteLink>>,
+    browser_open: Option<RemoteOpenOutcome>,
+    start_info: Option<RemoteStartInfo>,
+    stop_refusal: Option<Option<String>>,
+    hosted: Option<Option<HostedWorkTarget>>,
+}
+
+impl CommandSessionControlContext for FakeControl {
+    fn transition_blocked(&self) -> bool {
+        self.blocked
+    }
+    fn relay_projection(&self) -> RelayProjection {
+        self.relay
+            .clone()
+            .expect("unexpected relay_projection() on empty fake")
+    }
+    fn open_resume_picker(&mut self) {}
+    fn resolve_resume_source(&mut self, raw: &str) -> Result<ResumeSource, String> {
+        self.resume.clone().unwrap_or_else(|| {
+            Err(format!(
+                "unexpected resolve_resume_source({raw}) on empty fake"
+            ))
+        })
+    }
+    fn import_session_file(&mut self, path: PathBuf) -> Result<ResumeImportReceipt, String> {
+        self.import.clone().unwrap_or_else(|| {
+            Err(format!(
+                "unexpected import_session_file({path:?}) on empty fake"
+            ))
+        })
+    }
+    fn rename_session(&mut self, raw: &str) -> Result<SessionTitleReceipt, String> {
+        self.rename
+            .clone()
+            .unwrap_or_else(|| Err(format!("unexpected rename_session({raw}) on empty fake")))
+    }
+    fn title_report(&self) -> TitleReport {
+        self.title_report
+            .clone()
+            .expect("unexpected title_report() on empty fake")
+    }
+    fn set_window_title(&mut self, title: Option<String>) -> Result<TitleSetOutcome, String> {
+        self.set_title.clone().unwrap_or_else(|| {
+            Err(format!(
+                "unexpected set_window_title({title:?}) on empty fake"
+            ))
+        })
+    }
+    fn remote_status(&self) -> String {
+        self.remote_status
+            .clone()
+            .expect("unexpected remote_status() on empty fake")
+    }
+    fn remote_link(&self) -> Option<RemoteLink> {
+        self.remote_link
+            .clone()
+            .expect("unexpected remote_link() on empty fake")
+    }
+    fn remote_browser_open(&self) -> RemoteOpenOutcome {
+        self.browser_open
+            .clone()
+            .expect("unexpected remote_browser_open() on empty fake")
+    }
+    fn remote_start_info(&self) -> RemoteStartInfo {
+        self.start_info
+            .clone()
+            .expect("unexpected remote_start_info() on empty fake")
+    }
+    fn remote_stop_refusal(&self) -> Option<String> {
+        self.stop_refusal
+            .clone()
+            .expect("unexpected remote_stop_refusal() on empty fake")
+    }
+    fn resolve_hosted_work_target(&self) -> Option<HostedWorkTarget> {
+        self.hosted
+            .clone()
+            .expect("unexpected resolve_hosted_work_target() on empty fake")
+    }
+}
+
+fn control_relay_projection() -> RelayProjection {
+    RelayProjection {
+        compact_template: "# Session relay".to_string(),
+        workspace: "/workspace/control".to_string(),
+        mode: "operate".to_string(),
+        model: "control-model".to_string(),
+        goal_objective: Some("ship the slice".to_string()),
+        goal_token_budget: Some(42_000),
+        todos: TodoProjection::Body("- [ ] port relay".to_string()),
+        plan: PlanProjection::Sections(PlanSections {
+            title: Some("Plan title".to_string()),
+            items: vec![PlanStep {
+                status_label: "in_progress".to_string(),
+                text: "port the control slice".to_string(),
+            }],
+            ..PlanSections::default()
+        }),
+    }
+}
+
+#[test]
+fn control_facet_is_object_safe_and_transports_every_outcome() {
+    // Object safety: usable behind a single `dyn` reference.
+    fn accepts_dyn(_: &dyn CommandSessionControlContext) {}
+    fn accepts_dyn_mut(_: &mut dyn CommandSessionControlContext) {}
+
+    let mut fake = FakeControl {
+        blocked: true,
+        relay: Some(control_relay_projection()),
+        resume: Some(Ok(ResumeSource::Session {
+            load_path: Some(PathBuf::from("/tmp/sessions/abc123.json")),
+            truncated_id: "abc123".to_string(),
+            title: "Control Session".to_string(),
+        })),
+        import: Some(Ok(ResumeImportReceipt {
+            truncated_id: "imp-9".to_string(),
+            entry_count: 12,
+            leaf_display: "leaf-3".to_string(),
+        })),
+        rename: Some(Ok(SessionTitleReceipt {
+            title: "Renamed".to_string(),
+        })),
+        title_report: Some(TitleReport {
+            effective: "task-7".to_string(),
+            source: TitleSource::Session,
+        }),
+        set_title: Some(Ok(TitleSetOutcome::Set("task-7".to_string()))),
+        remote_status: Some("live".to_string()),
+        remote_link: Some(Some(RemoteLink {
+            url: "https://remote.example/s".to_string(),
+            computer_url: Some("https://remote.example/c".to_string()),
+        })),
+        browser_open: Some(RemoteOpenOutcome::Opened {
+            url: "https://remote.example/s".to_string(),
+        }),
+        start_info: Some(RemoteStartInfo { connecting: true }),
+        stop_refusal: Some(None),
+        hosted: Some(Some(HostedWorkTarget {
+            url: "https://app.codewhale.net/work?repo=A%2FB".to_string(),
+            repo: "A/B".to_string(),
+            branch: "main".to_string(),
+        })),
+    };
+    accepts_dyn(&fake);
+    accepts_dyn_mut(&mut fake);
+
+    assert!(fake.transition_blocked());
+    let relay = fake.relay_projection();
+    assert_eq!(relay.model, "control-model");
+    assert_eq!(relay.goal_token_budget, Some(42_000));
+    assert!(matches!(relay.todos, TodoProjection::Body(_)));
+    match relay.plan {
+        PlanProjection::Sections(sections) => {
+            assert_eq!(sections.title.as_deref(), Some("Plan title"));
+            assert_eq!(sections.items.len(), 1);
+            assert_eq!(sections.items[0].status_label, "in_progress");
+        }
+        other => panic!("expected Sections plan, got {other:?}"),
+    }
+    let resolved = fake
+        .resolve_resume_source("abc123")
+        .expect("resume resolution ok");
+    match resolved {
+        ResumeSource::Session {
+            load_path, title, ..
+        } => {
+            assert_eq!(load_path, Some(PathBuf::from("/tmp/sessions/abc123.json")));
+            assert_eq!(title, "Control Session");
+        }
+        other => panic!("expected Session resolution, got {other:?}"),
+    }
+    let imported = fake
+        .import_session_file(PathBuf::from("/tmp/import.json"))
+        .expect("import ok");
+    assert_eq!(imported.truncated_id, "imp-9");
+    assert_eq!(imported.entry_count, 12);
+    assert_eq!(imported.leaf_display, "leaf-3");
+    let renamed = fake.rename_session("Renamed").expect("rename ok");
+    assert_eq!(renamed.title, "Renamed");
+    let report = fake.title_report();
+    assert_eq!(report.effective, "task-7");
+    assert!(matches!(report.source, TitleSource::Session));
+    assert!(matches!(
+        fake.set_window_title(Some("task-7".to_string()))
+            .expect("set ok"),
+        TitleSetOutcome::Set(_)
+    ));
+    assert_eq!(fake.remote_status(), "live");
+    let link = fake.remote_link().expect("link present");
+    assert_eq!(link.url, "https://remote.example/s");
+    assert!(matches!(
+        fake.remote_browser_open(),
+        RemoteOpenOutcome::Opened { .. }
+    ));
+    assert!(fake.remote_start_info().connecting);
+    assert_eq!(fake.remote_stop_refusal(), None);
+    let hosted = fake.resolve_hosted_work_target().expect("target present");
+    assert_eq!(hosted.repo, "A/B");
+    assert_eq!(hosted.branch, "main");
+}
+
+#[test]
+fn control_error_and_empty_states_transport_exactly() {
+    let mut fake = FakeControl {
+        blocked: false,
+        resume: Some(Err("could not open sessions directory: boom".to_string())),
+        import: Some(Err(
+            "File x.json is not a recognized session export".to_string()
+        )),
+        rename: Some(Err("Could not save session: boom".to_string())),
+        set_title: Some(Err(
+            "Title cannot be empty; use /title off to clear a session title".to_string(),
+        )),
+        remote_link: Some(None),
+        browser_open: Some(RemoteOpenOutcome::NoLink),
+        stop_refusal: Some(Some(
+            "stop refused while a remote turn is active".to_string(),
+        )),
+        hosted: Some(None),
+        ..FakeControl::default()
+    };
+    assert!(!fake.transition_blocked());
+    assert_eq!(
+        fake.resolve_resume_source("x").unwrap_err(),
+        "could not open sessions directory: boom"
+    );
+    assert_eq!(
+        fake.import_session_file(PathBuf::from("x.json"))
+            .unwrap_err(),
+        "File x.json is not a recognized session export"
+    );
+    assert_eq!(
+        fake.rename_session("t").unwrap_err(),
+        "Could not save session: boom"
+    );
+    assert_eq!(
+        fake.set_window_title(None).unwrap_err(),
+        "Title cannot be empty; use /title off to clear a session title"
+    );
+    assert_eq!(fake.remote_link(), None);
+    assert!(matches!(
+        fake.remote_browser_open(),
+        RemoteOpenOutcome::NoLink
+    ));
+    assert_eq!(
+        fake.remote_stop_refusal().as_deref(),
+        Some("stop refused while a remote turn is active")
+    );
+    assert_eq!(fake.resolve_hosted_work_target(), None);
+
+    // Empty-state variants: absent to-do/plan and cleared title transport.
+    fake.relay = Some(RelayProjection {
+        todos: TodoProjection::Absent,
+        plan: PlanProjection::Absent,
+        ..control_relay_projection()
+    });
+    let relay = fake.relay_projection();
+    assert!(matches!(relay.todos, TodoProjection::Absent));
+    assert!(matches!(relay.plan, PlanProjection::Absent));
+    fake.title_report = Some(TitleReport {
+        effective: "unset".to_string(),
+        source: TitleSource::None,
+    });
+    assert!(matches!(fake.title_report().source, TitleSource::None));
+    fake.set_title = Some(Ok(TitleSetOutcome::Cleared));
+    assert!(matches!(
+        fake.set_window_title(None).expect("cleared"),
+        TitleSetOutcome::Cleared
+    ));
+}
+
+#[test]
+fn envelope_control_slot_is_independent_and_rejects_duplicates() {
+    let mut first = FakeControl::default();
+    let mut second = FakeControl::default();
+    let mut lifecycle = FakeLifecycle::default();
+
+    let parts = CommandContexts::empty()
+        .with_control(&mut first)
+        .with_lifecycle(&mut lifecycle)
+        .into_parts();
+    assert!(
+        parts.control.is_some(),
+        "control slot must be present when declared"
+    );
+    assert!(
+        parts.lifecycle.is_some(),
+        "lifecycle slot may coexist with control"
+    );
+    assert!(
+        parts.session.is_none() && parts.plugin.is_none() && parts.skill_group.is_none(),
+        "unrelated slots must stay absent (exact exposure)"
+    );
+
+    let bare = CommandContexts::empty().into_parts();
+    assert!(bare.control.is_none(), "undeclared control stays absent");
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        CommandContexts::empty()
+            .with_control(&mut first)
+            .with_control(&mut second);
+    }));
+    assert!(
+        result.is_err(),
+        "duplicate control slot must assert deterministically"
+    );
+
+    // Reading through the dyn facet works after insertion.
+    first.blocked = true;
+    let inserted = CommandContexts::empty().with_control(&mut first);
+    let control = inserted.into_parts().control.expect("inserted control");
+    assert!(control.transition_blocked());
+}
+
+#[test]
+fn control_surface_does_not_widen_session_or_lifecycle_facets() {
+    // The basic session and lifecycle facets still expose exactly their own
+    // method surface alongside the new control slot: all three may populate an
+    // envelope at once without colliding, and control does not add behavior to
+    // the existing facets.
+    let mut session = Session;
+    let mut lifecycle = FakeLifecycle::default();
+    let mut control = FakeControl::default();
+    control.blocked = true;
+
+    let mut parts = CommandContexts::empty()
+        .with_session(&mut session)
+        .with_lifecycle(&mut lifecycle)
+        .with_control(&mut control)
+        .into_parts();
+    assert_eq!(
+        parts.session.as_deref().unwrap().session_id().as_deref(),
+        Some("session")
+    );
+    assert!(!parts.lifecycle.as_deref_mut().unwrap().transition_blocked());
+    assert!(parts.control.as_deref_mut().unwrap().transition_blocked());
+}

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -2249,14 +2249,14 @@ fn control_relay_projection() -> RelayProjection {
         goal_objective: Some("ship the slice".to_string()),
         goal_token_budget: Some(42_000),
         todos: TodoProjection::Body("- [ ] port relay".to_string()),
-        plan: PlanProjection::Sections(Box::new(PlanSections {
+        plan: PlanProjection::Sections(PlanSections {
             title: Some("Plan title".to_string()),
             items: vec![PlanStep {
                 status_label: "in_progress".to_string(),
                 text: "port the control slice".to_string(),
             }],
             ..PlanSections::default()
-        })),
+        }),
     }
 }
 

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -2156,9 +2156,11 @@ struct FakeControl {
     relay: Option<RelayProjection>,
     resume: Option<Result<ResumeSource, String>>,
     import: Option<Result<ResumeImportReceipt, String>>,
+    sanitized_title: Option<String>,
     rename: Option<Result<SessionTitleReceipt, String>>,
     title_report: Option<TitleReport>,
-    set_title: Option<Result<TitleSetOutcome, String>>,
+    set_title: Option<Result<(), String>>,
+    clear_title: Option<Result<(), String>>,
     remote_status: Option<String>,
     remote_link: Option<Option<RemoteLink>>,
     browser_open: Option<RemoteOpenOutcome>,
@@ -2191,22 +2193,32 @@ impl CommandSessionControlContext for FakeControl {
             ))
         })
     }
-    fn rename_session(&mut self, raw: &str) -> Result<SessionTitleReceipt, String> {
+    fn sanitize_session_title(&self, raw: &str) -> String {
+        self.sanitized_title
+            .clone()
+            .unwrap_or_else(|| raw.to_string())
+    }
+    fn rename_session(&mut self, title: &str) -> Result<SessionTitleReceipt, String> {
         self.rename
             .clone()
-            .unwrap_or_else(|| Err(format!("unexpected rename_session({raw}) on empty fake")))
+            .unwrap_or_else(|| Err(format!("unexpected rename_session({title}) on empty fake")))
     }
     fn title_report(&self) -> TitleReport {
         self.title_report
             .clone()
             .expect("unexpected title_report() on empty fake")
     }
-    fn set_window_title(&mut self, title: Option<String>) -> Result<TitleSetOutcome, String> {
+    fn set_window_title(&mut self, title: String) -> Result<(), String> {
         self.set_title.clone().unwrap_or_else(|| {
             Err(format!(
-                "unexpected set_window_title({title:?}) on empty fake"
+                "unexpected set_window_title({title}) on empty fake"
             ))
         })
+    }
+    fn clear_window_title(&mut self) -> Result<(), String> {
+        self.clear_title
+            .clone()
+            .unwrap_or_else(|| Err("unexpected clear_window_title() on empty fake".to_string()))
     }
     fn remote_status(&self) -> String {
         self.remote_status
@@ -2279,6 +2291,7 @@ fn control_facet_is_object_safe_and_transports_every_outcome() {
             entry_count: 12,
             leaf_display: "leaf-3".to_string(),
         })),
+        sanitized_title: Some("Renamed".to_string()),
         rename: Some(Ok(SessionTitleReceipt {
             title: "Renamed".to_string(),
         })),
@@ -2286,7 +2299,8 @@ fn control_facet_is_object_safe_and_transports_every_outcome() {
             effective: "task-7".to_string(),
             source: TitleSource::Session,
         }),
-        set_title: Some(Ok(TitleSetOutcome::Set("task-7".to_string()))),
+        set_title: Some(Ok(())),
+        clear_title: Some(Ok(())),
         remote_status: Some("live".to_string()),
         remote_link: Some(Some(RemoteLink {
             url: "https://remote.example/s".to_string(),
@@ -2337,16 +2351,14 @@ fn control_facet_is_object_safe_and_transports_every_outcome() {
     assert_eq!(imported.truncated_id, "imp-9");
     assert_eq!(imported.entry_count, 12);
     assert_eq!(imported.leaf_display, "leaf-3");
+    assert_eq!(fake.sanitize_session_title("raw"), "Renamed");
     let renamed = fake.rename_session("Renamed").expect("rename ok");
     assert_eq!(renamed.title, "Renamed");
     let report = fake.title_report();
     assert_eq!(report.effective, "task-7");
     assert!(matches!(report.source, TitleSource::Session));
-    assert!(matches!(
-        fake.set_window_title(Some("task-7".to_string()))
-            .expect("set ok"),
-        TitleSetOutcome::Set(_)
-    ));
+    fake.set_window_title("task-7".to_string()).expect("set ok");
+    fake.clear_window_title().expect("clear ok");
     assert_eq!(fake.remote_status(), "live");
     let link = fake.remote_link().expect("link present");
     assert_eq!(link.url, "https://remote.example/s");
@@ -2370,9 +2382,8 @@ fn control_error_and_empty_states_transport_exactly() {
             "File x.json is not a recognized session export".to_string()
         )),
         rename: Some(Err("Could not save session: boom".to_string())),
-        set_title: Some(Err(
-            "Title cannot be empty; use /title off to clear a session title".to_string(),
-        )),
+        set_title: Some(Err("Could not save session: boom".to_string())),
+        clear_title: Some(Err("Could not save session: boom".to_string())),
         remote_link: Some(None),
         browser_open: Some(RemoteOpenOutcome::NoLink),
         stop_refusal: Some(Some(
@@ -2396,8 +2407,12 @@ fn control_error_and_empty_states_transport_exactly() {
         "Could not save session: boom"
     );
     assert_eq!(
-        fake.set_window_title(None).unwrap_err(),
-        "Title cannot be empty; use /title off to clear a session title"
+        fake.set_window_title("task".to_string()).unwrap_err(),
+        "Could not save session: boom"
+    );
+    assert_eq!(
+        fake.clear_window_title().unwrap_err(),
+        "Could not save session: boom"
     );
     assert_eq!(fake.remote_link(), None);
     assert!(matches!(
@@ -2410,7 +2425,7 @@ fn control_error_and_empty_states_transport_exactly() {
     );
     assert_eq!(fake.resolve_hosted_work_target(), None);
 
-    // Empty-state variants: absent to-do/plan and cleared title transport.
+    // Empty-state variants: absent to-do/plan and no effective title transport.
     fake.relay = Some(RelayProjection {
         todos: TodoProjection::Absent,
         plan: PlanProjection::Absent,
@@ -2424,11 +2439,8 @@ fn control_error_and_empty_states_transport_exactly() {
         source: TitleSource::None,
     });
     assert!(matches!(fake.title_report().source, TitleSource::None));
-    fake.set_title = Some(Ok(TitleSetOutcome::Cleared));
-    assert!(matches!(
-        fake.set_window_title(None).expect("cleared"),
-        TitleSetOutcome::Cleared
-    ));
+    fake.clear_title = Some(Ok(()));
+    fake.clear_window_title().expect("cleared");
 }
 
 #[test]

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -2450,7 +2450,10 @@ fn envelope_control_slot_is_independent_and_rejects_duplicates() {
         "lifecycle slot may coexist with control"
     );
     assert!(
-        parts.session.is_none() && parts.plugin.is_none() && parts.skill_group.is_none(),
+        parts.session.is_none()
+            && parts.plugin.is_none()
+            && parts.skill_group.is_none()
+            && parts.presentation.is_none(),
         "unrelated slots must stay absent (exact exposure)"
     );
 

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -2249,14 +2249,14 @@ fn control_relay_projection() -> RelayProjection {
         goal_objective: Some("ship the slice".to_string()),
         goal_token_budget: Some(42_000),
         todos: TodoProjection::Body("- [ ] port relay".to_string()),
-        plan: PlanProjection::Sections(PlanSections {
+        plan: PlanProjection::Sections(Box::new(PlanSections {
             title: Some("Plan title".to_string()),
             items: vec![PlanStep {
                 status_label: "in_progress".to_string(),
                 text: "port the control slice".to_string(),
             }],
             ..PlanSections::default()
-        }),
+        })),
     }
 }
 
@@ -2485,8 +2485,10 @@ fn control_surface_does_not_widen_session_or_lifecycle_facets() {
     // the existing facets.
     let mut session = Session;
     let mut lifecycle = FakeLifecycle::default();
-    let mut control = FakeControl::default();
-    control.blocked = true;
+    let mut control = FakeControl {
+        blocked: true,
+        ..FakeControl::default()
+    };
 
     let mut parts = CommandContexts::empty()
         .with_session(&mut session)

--- a/crates/command-contract/src/tests.rs
+++ b/crates/command-contract/src/tests.rs
@@ -2252,7 +2252,7 @@ fn control_relay_projection() -> RelayProjection {
         plan: PlanProjection::Sections(PlanSections {
             title: Some("Plan title".to_string()),
             items: vec![PlanStep {
-                status_label: "in_progress".to_string(),
+                status: PlanStepStatus::InProgress,
                 text: "port the control slice".to_string(),
             }],
             ..PlanSections::default()
@@ -2315,7 +2315,7 @@ fn control_facet_is_object_safe_and_transports_every_outcome() {
         PlanProjection::Sections(sections) => {
             assert_eq!(sections.title.as_deref(), Some("Plan title"));
             assert_eq!(sections.items.len(), 1);
-            assert_eq!(sections.items[0].status_label, "in_progress");
+            assert_eq!(sections.items[0].status, PlanStepStatus::InProgress);
         }
         other => panic!("expected Sections plan, got {other:?}"),
     }

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -1108,7 +1108,7 @@ impl CommandSessionControlContext for SessionControlAdapter<'_> {
                 if snapshot.is_empty() {
                     PlanProjection::Absent
                 } else {
-                    PlanProjection::Sections(Box::new(plan_snapshot_to_sections(&snapshot)))
+                    PlanProjection::Sections(plan_snapshot_to_sections(&snapshot))
                 }
             }
             Err(_) => PlanProjection::Busy,

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -52,7 +52,7 @@ use codewhale_command_contract::facets::{
     SkillActivationError, SkillActivationOutcome, SkillBundledTier, SkillEntry,
     SkillMutationOutcome, SkillMutationReceipt, SkillRecommendation, SkillRegistryProjection,
     SkillSourceKind, SkillSyncEntry, SkillSyncOutcome, SkillTargetScope, SnapshotEntry,
-    TitleReport, TitleSetOutcome, TitleSource, TodoProjection, TreeBodyProjection,
+    TitleReport, TitleSource, TodoProjection, TreeBodyProjection,
 };
 #[cfg(test)]
 use codewhale_command_contract::handler::ContextParts;
@@ -1120,16 +1120,12 @@ impl CommandSessionControlContext for SessionControlAdapter<'_> {
         import_foreign_file(&mut app, &path)
     }
 
-    fn rename_session(&mut self, raw_title: &str) -> Result<SessionTitleReceipt, String> {
+    fn sanitize_session_title(&self, raw_title: &str) -> String {
+        crate::session_manager::sanitize_session_title(raw_title)
+    }
+
+    fn rename_session(&mut self, new_title: &str) -> Result<SessionTitleReceipt, String> {
         let mut app = self.host.app.borrow_mut();
-        let sanitized = crate::session_manager::sanitize_session_title(raw_title);
-        let new_title = sanitized.trim();
-        if new_title.is_empty() {
-            return Err("Usage: /rename <new title>".to_string());
-        }
-        if new_title.chars().count() > MAX_TITLE_LEN {
-            return Err(format!("Title too long (max {MAX_TITLE_LEN} characters)"));
-        }
         let session_id = match &app.current_session_id {
             Some(id) => id.clone(),
             None => {
@@ -1216,88 +1212,14 @@ impl CommandSessionControlContext for SessionControlAdapter<'_> {
         }
     }
 
-    fn set_window_title(&mut self, title: Option<String>) -> Result<TitleSetOutcome, String> {
+    fn set_window_title(&mut self, title: String) -> Result<(), String> {
         let mut app = self.host.app.borrow_mut();
-        let sanitized = match title {
-            Some(raw) => {
-                let cleaned = crate::session_manager::sanitize_session_title(&raw);
-                let cleaned = cleaned.trim().to_string();
-                if cleaned.is_empty() {
-                    return Err(
-                        "Title cannot be empty; use /title off to clear a session title"
-                            .to_string(),
-                    );
-                }
-                Some(cleaned)
-            }
-            None => None,
-        };
-        let session_id = match &app.current_session_id {
-            Some(id) => id.clone(),
-            None => {
-                return Err(
-                    "No active session. Send a message first to start a session.".to_string(),
-                );
-            }
-        };
-        let manager = match crate::session_manager::SessionManager::default_location() {
-            Ok(m) => m,
-            Err(e) => return Err(format!("Could not open sessions directory: {e}")),
-        };
-        let mut session = match manager.load_session(&session_id) {
-            Ok(s) => s,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                match live_session_before_first_snapshot(&manager, &session_id, &app) {
-                    Some(s) => s,
-                    None => return Err(format!("Could not load session: {err}")),
-                }
-            }
-            Err(e) => return Err(format!("Could not load session: {e}")),
-        };
-        session = crate::session_manager::update_session(
-            session,
-            &app.api_messages,
-            u64::from(app.session.total_tokens),
-            app.system_prompt.as_ref(),
-        );
-        session.work_state = match app.work_state_snapshot() {
-            Ok(state) => state,
-            Err(err) => {
-                return Err(format!(
-                    "Could not snapshot Work state before setting title: {err}"
-                ));
-            }
-        };
-        session.context_references = app.session_context_references.clone();
-        session.artifacts = app.session_artifacts.clone();
-        session.last_auto_route = app.auto_route_for_persistence();
-        session.metadata.model = app.model_selection_for_persistence();
-        session
-            .metadata
-            .set_model_provider_route(app.api_provider.as_str(), app.provider_id_for_persistence());
-        session.metadata.workspace.clone_from(&app.workspace);
-        session.metadata.mode = Some(app.mode.as_setting().to_string());
-        app.sync_cost_to_metadata(&mut session.metadata);
-        session.window_title = sanitized.clone();
+        persist_window_title(&mut app, Some(title))
+    }
 
-        match manager.save_session(&session) {
-            Ok(_) => {
-                app.window_title = sanitized.clone();
-                // The render loop syncs the resolved prefix into the terminal
-                // title; force a frame so the change lands immediately.
-                app.needs_redraw = true;
-                if let Err(err) = app.publish_pending_work_state() {
-                    return Err(format!(
-                        "Window title saved, but Work views were not published: {err}"
-                    ));
-                }
-                Ok(match sanitized {
-                    Some(title) => TitleSetOutcome::Set(title),
-                    None => TitleSetOutcome::Cleared,
-                })
-            }
-            Err(e) => Err(format!("Could not save session: {e}")),
-        }
+    fn clear_window_title(&mut self) -> Result<(), String> {
+        let mut app = self.host.app.borrow_mut();
+        persist_window_title(&mut app, None)
     }
 
     fn remote_status(&self) -> String {
@@ -1347,6 +1269,73 @@ impl CommandSessionControlContext for SessionControlAdapter<'_> {
     }
 }
 
+/// Persist an already sanitized window title through the baseline host path.
+/// Manager resolution intentionally precedes active-session lookup, matching
+/// the original `/title` error precedence for both set and clear operations.
+fn persist_window_title(app: &mut App, title: Option<String>) -> Result<(), String> {
+    let manager = match crate::session_manager::SessionManager::default_location() {
+        Ok(manager) => manager,
+        Err(error) => return Err(format!("Could not open sessions directory: {error}")),
+    };
+    let session_id = match &app.current_session_id {
+        Some(id) => id.clone(),
+        None => {
+            return Err("No active session. Send a message first to start a session.".to_string());
+        }
+    };
+    let mut session = match manager.load_session(&session_id) {
+        Ok(session) => session,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            match live_session_before_first_snapshot(&manager, &session_id, app) {
+                Some(session) => session,
+                None => return Err(format!("Could not load session: {error}")),
+            }
+        }
+        Err(error) => return Err(format!("Could not load session: {error}")),
+    };
+    session = crate::session_manager::update_session(
+        session,
+        &app.api_messages,
+        u64::from(app.session.total_tokens),
+        app.system_prompt.as_ref(),
+    );
+    session.work_state = match app.work_state_snapshot() {
+        Ok(state) => state,
+        Err(error) => {
+            return Err(format!(
+                "Could not snapshot Work state before setting title: {error}"
+            ));
+        }
+    };
+    session.context_references = app.session_context_references.clone();
+    session.artifacts = app.session_artifacts.clone();
+    session.last_auto_route = app.auto_route_for_persistence();
+    session.metadata.model = app.model_selection_for_persistence();
+    session
+        .metadata
+        .set_model_provider_route(app.api_provider.as_str(), app.provider_id_for_persistence());
+    session.metadata.workspace.clone_from(&app.workspace);
+    session.metadata.mode = Some(app.mode.as_setting().to_string());
+    app.sync_cost_to_metadata(&mut session.metadata);
+    session.window_title.clone_from(&title);
+
+    match manager.save_session(&session) {
+        Ok(_) => {
+            app.window_title = title;
+            // The render loop syncs the resolved prefix into the terminal
+            // title; force a frame so the change lands immediately.
+            app.needs_redraw = true;
+            if let Err(error) = app.publish_pending_work_state() {
+                return Err(format!(
+                    "Window title saved, but Work views were not published: {error}"
+                ));
+            }
+            Ok(())
+        }
+        Err(error) => Err(format!("Could not save session: {error}")),
+    }
+}
+
 /// Map one synchronous browser-launch attempt to its portable outcome.
 /// Split out so the delegate's success/failure branches are unit-provable
 /// without spawning a real browser (utils tests cover the launcher itself).
@@ -1357,9 +1346,6 @@ fn map_browser_open_result(url: String, launched: bool) -> RemoteOpenOutcome {
         RemoteOpenOutcome::LaunchFailed { url }
     }
 }
-
-/// Session-name/window-title length policy shared by `/rename` and `/title`.
-const MAX_TITLE_LEN: usize = 100;
 
 fn plan_snapshot_to_sections(snapshot: &crate::tools::plan::PlanSnapshot) -> PlanSections {
     PlanSections {
@@ -6148,23 +6134,16 @@ mod tests {
         let reloaded = manager.load_session("rename-1").unwrap();
         assert_eq!(reloaded.metadata.title, "Brand New Title");
 
-        // Sanitized-empty input keeps the usage error; window title untouched.
-        let empty_err = {
+        // The facet exposes the authoritative sanitizer while the portable
+        // handler owns empty and length policy.
+        let sanitized = {
             let mut bundle = app.command_contexts();
             let mut parts = bundle.parts();
             let facet = parts.control.as_deref_mut().expect("control slot");
-            facet.rename_session("\u{1b}\u{7}\u{200b}").unwrap_err()
+            facet.sanitize_session_title("\u{1b}\u{7}\u{200b}")
         };
-        assert!(empty_err.contains("Usage: /rename"));
+        assert!(sanitized.is_empty());
         assert_eq!(app.window_title, None);
-
-        let too_long = {
-            let mut bundle = app.command_contexts();
-            let mut parts = bundle.parts();
-            let facet = parts.control.as_deref_mut().expect("control slot");
-            facet.rename_session(&"a".repeat(101)).unwrap_err()
-        };
-        assert!(too_long.contains("Title too long (max 100 characters)"));
     }
 
     #[test]
@@ -6237,15 +6216,14 @@ mod tests {
         assert!(matches!(report.source, TitleSource::None));
 
         // Set a window title: session name untouched, redraw requested.
-        let outcome = {
+        {
             let mut bundle = app.command_contexts();
             let mut parts = bundle.parts();
             let facet = parts.control.as_deref_mut().expect("control slot");
             facet
-                .set_window_title(Some("parallel-task".to_string()))
-                .expect("set ok")
-        };
-        assert!(matches!(outcome, TitleSetOutcome::Set(_)));
+                .set_window_title("parallel-task".to_string())
+                .expect("set ok");
+        }
         assert_eq!(app.window_title.as_deref(), Some("parallel-task"));
         assert!(app.needs_redraw);
         assert_eq!(
@@ -6257,25 +6235,23 @@ mod tests {
         assert_eq!(reloaded.window_title.as_deref(), Some("parallel-task"));
         assert_eq!(reloaded.metadata.title, "Control Session");
 
-        // Control-char-only input keeps the empty-title error.
-        let err = {
+        // Control-char-only input is normalized to empty before the portable
+        // handler applies its exact user-facing validation message.
+        let sanitized = {
             let mut bundle = app.command_contexts();
             let mut parts = bundle.parts();
             let facet = parts.control.as_deref_mut().expect("control slot");
-            facet
-                .set_window_title(Some("\u{1b}\u{7}\u{200b}".to_string()))
-                .unwrap_err()
+            facet.sanitize_session_title("\u{1b}\u{7}\u{200b}")
         };
-        assert!(err.contains("Title cannot be empty; use /title off to clear a session title"));
+        assert!(sanitized.is_empty());
 
         // Clear removes the session-level title.
-        let cleared = {
+        {
             let mut bundle = app.command_contexts();
             let mut parts = bundle.parts();
             let facet = parts.control.as_deref_mut().expect("control slot");
-            facet.set_window_title(None).expect("clear ok")
-        };
-        assert!(matches!(cleared, TitleSetOutcome::Cleared));
+            facet.clear_window_title().expect("clear ok");
+        }
         assert_eq!(app.window_title, None);
     }
 

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -66,6 +66,7 @@ use codewhale_execpolicy::ApprovalMode;
 
 use crate::commands::groups::plugins::plugin_network_policy;
 
+use crate::dependencies::ExternalTool as _;
 use crate::localization::{MessageId, tr};
 use crate::network_policy::NetworkPolicy;
 use crate::pricing::CostCurrency;
@@ -828,6 +829,253 @@ impl CommandSessionLifecycleContext for SessionLifecycleAdapter<'_> {
 }
 
 // ---------------------------------------------------------------------------
+// FEAT-024 Phase 4: relocated host machinery for the control slice.
+//
+// These helpers were extracted from the legacy `/rename` and `/remote-env`
+// command bodies when those files became portable; they are host-owned and
+// stay in TUI (the future movable group never names them).
+// ---------------------------------------------------------------------------
+
+/// `/rename`-style atomic persistence used by the picker/UI test seam and any
+/// host caller that holds an explicit `SessionManager`. Mirrors the baseline
+/// write path: sanitize, load (with first-snapshot recovery), sync live state,
+/// snapshot Work state, carry metadata, save, then publish. Returns the exact
+/// baseline messages.
+#[cfg(test)]
+pub(crate) fn rename_with_manager(
+    new_title: &str,
+    session_id: &str,
+    manager: &crate::session_manager::SessionManager,
+    app: &mut App,
+) -> crate::commands::CommandResult {
+    let sanitized = crate::session_manager::sanitize_session_title(new_title);
+    let new_title = sanitized.trim();
+    if new_title.is_empty() {
+        return crate::commands::CommandResult::error("Usage: /rename <new title>");
+    }
+    let mut session = match manager.load_session(session_id) {
+        Ok(s) => s,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            match live_session_before_first_snapshot(manager, session_id, app) {
+                Some(s) => s,
+                None => {
+                    return crate::commands::CommandResult::error(format!(
+                        "Could not load session: {err}"
+                    ));
+                }
+            }
+        }
+        Err(e) => {
+            return crate::commands::CommandResult::error(format!("Could not load session: {e}"));
+        }
+    };
+    session = crate::session_manager::update_session(
+        session,
+        &app.api_messages,
+        u64::from(app.session.total_tokens),
+        app.system_prompt.as_ref(),
+    );
+    session.work_state = match app.work_state_snapshot() {
+        Ok(state) => state,
+        Err(err) => {
+            return crate::commands::CommandResult::error(format!(
+                "Could not snapshot Work state before rename: {err}"
+            ));
+        }
+    };
+    session.context_references = app.session_context_references.clone();
+    session.artifacts = app.session_artifacts.clone();
+    session.last_auto_route = app.auto_route_for_persistence();
+    session.metadata.model = app.model_selection_for_persistence();
+    session
+        .metadata
+        .set_model_provider_route(app.api_provider.as_str(), app.provider_id_for_persistence());
+    session.metadata.workspace.clone_from(&app.workspace);
+    session.metadata.mode = Some(app.mode.as_setting().to_string());
+    app.sync_cost_to_metadata(&mut session.metadata);
+    session.metadata.title = new_title.to_string();
+
+    match manager.save_session(&session) {
+        Ok(_) => {
+            app.current_session_metadata = Some(session.metadata.clone());
+            app.session_title = Some(new_title.to_string());
+            if let Err(err) = app.publish_pending_work_state() {
+                return crate::commands::CommandResult::error(format!(
+                    "Session renamed, but Work views were not published: {err}"
+                ));
+            }
+            crate::commands::CommandResult::message(format!("Session renamed to \"{new_title}\""))
+        }
+        Err(e) => crate::commands::CommandResult::error(format!("Could not save session: {e}")),
+    }
+}
+
+const HOSTED_WORK_URL: &str = "https://app.codewhale.net/work";
+const MAX_GIT_VALUE_BYTES: usize = 4 * 1024;
+
+/// Validated hosted-work Git target (repo slug + checked-out branch).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RemoteEnvTarget {
+    repo: String,
+    branch: String,
+}
+
+/// Resolve the hosted-work launcher target for a workspace: read the origin
+/// URL and symbolic branch, normalize the repository slug against the
+/// allowlist, and encode the launcher URL. Credentials never appear in the
+/// returned values.
+fn resolve_target(workspace: &Path) -> Option<RemoteEnvTarget> {
+    let origin = read_git_value(
+        workspace,
+        &["config", "--local", "--get", "remote.origin.url"],
+    )?;
+    let repo = normalize_repo_slug(&origin)?;
+    let branch = read_git_value(workspace, &["symbolic-ref", "--quiet", "--short", "HEAD"])?;
+    if !valid_branch_name(&branch) {
+        return None;
+    }
+    Some(RemoteEnvTarget { repo, branch })
+}
+
+fn hosted_work_url(repo: &str, branch: &str) -> String {
+    format!(
+        "{HOSTED_WORK_URL}?repo={}&branch={}",
+        urlencoding::encode(repo),
+        urlencoding::encode(branch),
+    )
+}
+
+fn read_git_value(workspace: &Path, args: &[&str]) -> Option<String> {
+    let mut command = crate::dependencies::Git::command()?;
+    let output = command.arg("-C").arg(workspace).args(args).output().ok()?;
+    if !output.status.success()
+        || output.stdout.is_empty()
+        || output.stdout.len() > MAX_GIT_VALUE_BYTES
+    {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?;
+    let value = value.trim_end_matches(&['\r', '\n'][..]);
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn valid_branch_name(branch: &str) -> bool {
+    if branch.is_empty() || branch.len() > MAX_GIT_VALUE_BYTES {
+        return false;
+    }
+    let Some(mut command) = crate::dependencies::Git::command() else {
+        return false;
+    };
+    command
+        .args(["check-ref-format", "--branch"])
+        .arg(branch)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn normalize_repo_slug(origin: &str) -> Option<String> {
+    let origin = origin.trim();
+    if origin.is_empty()
+        || origin.len() > MAX_GIT_VALUE_BYTES
+        || origin.chars().any(char::is_control)
+    {
+        return None;
+    }
+
+    let (host, path) = if starts_with_ascii_case(origin, "https://") {
+        split_url_origin(&origin["https://".len()..], UrlScheme::Https)?
+    } else if starts_with_ascii_case(origin, "ssh://") {
+        split_url_origin(&origin["ssh://".len()..], UrlScheme::Ssh)?
+    } else {
+        split_scp_origin(origin)?
+    };
+    if !matches!(
+        host.to_ascii_lowercase().as_str(),
+        "github.com" | "cnb.cool"
+    ) {
+        return None;
+    }
+    normalize_repo_path(path)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum UrlScheme {
+    Https,
+    Ssh,
+}
+
+fn starts_with_ascii_case(value: &str, prefix: &str) -> bool {
+    value
+        .get(..prefix.len())
+        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
+}
+
+fn split_url_origin(origin: &str, scheme: UrlScheme) -> Option<(&str, &str)> {
+    let (authority, path) = origin.split_once('/')?;
+    if authority.is_empty() || path.is_empty() {
+        return None;
+    }
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    let host = match host_port.rsplit_once(':') {
+        Some((host, port))
+            if !host.is_empty()
+                && !port.is_empty()
+                && port.bytes().all(|byte| byte.is_ascii_digit())
+                && (matches!(scheme, UrlScheme::Ssh) || port == "443") =>
+        {
+            host
+        }
+        Some(_) => return None,
+        None => host_port,
+    };
+    (!host.is_empty()).then_some((host, path))
+}
+
+fn split_scp_origin(origin: &str) -> Option<(&str, &str)> {
+    let (authority, path) = origin.split_once(':')?;
+    let (_, host) = authority.rsplit_once('@')?;
+    if host.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some((host, path))
+}
+
+fn normalize_repo_path(path: &str) -> Option<String> {
+    if path.chars().any(|ch| matches!(ch, '?' | '#' | '\\')) {
+        return None;
+    }
+    let path = path.trim_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let mut parts = path.split('/');
+    let namespace = parts.next()?;
+    let repository = parts.next()?;
+    if parts.next().is_some()
+        || !valid_repo_component(namespace)
+        || !valid_repo_component(repository)
+    {
+        return None;
+    }
+    Some(format!("{namespace}/{repository}"))
+}
+
+fn valid_repo_component(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 255
+        && !matches!(value, "." | "..")
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+// ---------------------------------------------------------------------------
 // Session control adapter (FEAT-024 D4/D5)
 //
 // Sole host owner of concrete control machinery for the six control commands:
@@ -1163,11 +1411,8 @@ impl CommandSessionControlContext for SessionControlAdapter<'_> {
 
     fn resolve_hosted_work_target(&self) -> Option<HostedWorkTarget> {
         let app = self.host.app.borrow();
-        let target = crate::commands::groups::session::remote_env::resolve_target(&app.workspace)?;
-        let url = crate::commands::groups::session::remote_env::hosted_work_url(
-            &target.repo,
-            &target.branch,
-        );
+        let target = resolve_target(&app.workspace)?;
+        let url = hosted_work_url(&target.repo, &target.branch);
         Some(HostedWorkTarget {
             url,
             repo: target.repo,
@@ -1566,6 +1811,7 @@ impl CommandPresentationContext for PresentationAdapter<'_> {
         let Some(message_id) = key_to_utility_message_id(key)
             .or_else(|| key_to_project_message_id(key))
             .or_else(|| key_to_plugin_message_id(key))
+            .or_else(|| key_to_session_message_id(key))
         else {
             return Err("unknown translation key".to_string());
         };
@@ -1574,6 +1820,20 @@ impl CommandPresentationContext for PresentationAdapter<'_> {
         apply_named_replacements(&template, replacements)
             .ok_or_else(|| "invalid translation replacement contract".to_string())
     }
+}
+
+/// Resolve a stable session-control message key to the current catalog id
+/// (FEAT-024 D6). Only `/remote-env` makes runtime catalog calls; the other
+/// five control commands keep their metadata-only `description_key` usage.
+pub(crate) fn key_to_session_message_id(key: &str) -> Option<MessageId> {
+    Some(match key {
+        "cmd_remote_env_overview" => MessageId::CmdRemoteEnvOverview,
+        "cmd_remote_env_opening" => MessageId::CmdRemoteEnvOpening,
+        "cmd_remote_env_unavailable" => MessageId::CmdRemoteEnvUnavailable,
+        "cmd_remote_env_source_custody_policy" => MessageId::CmdRemoteEnvSourceCustodyPolicy,
+        "cmd_remote_env_browser_label" => MessageId::CmdRemoteEnvBrowserLabel,
+        _ => return None,
+    })
 }
 
 /// Resolve a stable plugin message key to the current catalog id (FEAT-020 D5).

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -39,9 +39,9 @@ use codewhale_command_contract::facets::{
     CommandSkillsContext, CommandSystemPromptContext, CommandWorkspaceContext, HostedWorkTarget,
     MediaAttachmentReceipt, MemoryDelete, MemoryDeleteScope, MemoryExport, MemoryGetOutcome,
     MemoryHit, MemoryImportOutcome, MemoryReindex, MemoryRememberTarget, MemoryRemembered,
-    MemoryStatus, PlanProjection, PlanSections, PlanStep, PluginDetail, PluginDiagnostic,
-    PluginDiagnosticLevel, PluginExportReceipt, PluginLegacyScan, PluginLegacyTool,
-    PluginManagedCandidate, PluginManagedScan, PluginMarketplaceAddReceipt,
+    MemoryStatus, PlanProjection, PlanSections, PlanStep, PlanStepStatus, PluginDetail,
+    PluginDiagnostic, PluginDiagnosticLevel, PluginExportReceipt, PluginLegacyScan,
+    PluginLegacyTool, PluginManagedCandidate, PluginManagedScan, PluginMarketplaceAddReceipt,
     PluginMarketplaceCandidate, PluginMarketplaceCatalog, PluginMarketplaceInstallPlan,
     PluginMarketplaceState, PluginMcpServerDetail, PluginMcpTransport, PluginMutationOutcome,
     PluginMutationReceipt, PluginSuggestion, PluginSummary, ProjectGoalState, ProjectGoalStatus,
@@ -831,84 +831,10 @@ impl CommandSessionLifecycleContext for SessionLifecycleAdapter<'_> {
 // ---------------------------------------------------------------------------
 // FEAT-024 Phase 4: relocated host machinery for the control slice.
 //
-// These helpers were extracted from the legacy `/rename` and `/remote-env`
-// command bodies when those files became portable; they are host-owned and
-// stay in TUI (the future movable group never names them).
+// These helpers were extracted from the legacy `/remote-env` command body
+// when that file became portable; they are host-owned and stay in TUI (the
+// future movable group never names them).
 // ---------------------------------------------------------------------------
-
-/// `/rename`-style atomic persistence used by the picker/UI test seam and any
-/// host caller that holds an explicit `SessionManager`. Mirrors the baseline
-/// write path: sanitize, load (with first-snapshot recovery), sync live state,
-/// snapshot Work state, carry metadata, save, then publish. Returns the exact
-/// baseline messages.
-#[cfg(test)]
-pub(crate) fn rename_with_manager(
-    new_title: &str,
-    session_id: &str,
-    manager: &crate::session_manager::SessionManager,
-    app: &mut App,
-) -> crate::commands::CommandResult {
-    let sanitized = crate::session_manager::sanitize_session_title(new_title);
-    let new_title = sanitized.trim();
-    if new_title.is_empty() {
-        return crate::commands::CommandResult::error("Usage: /rename <new title>");
-    }
-    let mut session = match manager.load_session(session_id) {
-        Ok(s) => s,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            match live_session_before_first_snapshot(manager, session_id, app) {
-                Some(s) => s,
-                None => {
-                    return crate::commands::CommandResult::error(format!(
-                        "Could not load session: {err}"
-                    ));
-                }
-            }
-        }
-        Err(e) => {
-            return crate::commands::CommandResult::error(format!("Could not load session: {e}"));
-        }
-    };
-    session = crate::session_manager::update_session(
-        session,
-        &app.api_messages,
-        u64::from(app.session.total_tokens),
-        app.system_prompt.as_ref(),
-    );
-    session.work_state = match app.work_state_snapshot() {
-        Ok(state) => state,
-        Err(err) => {
-            return crate::commands::CommandResult::error(format!(
-                "Could not snapshot Work state before rename: {err}"
-            ));
-        }
-    };
-    session.context_references = app.session_context_references.clone();
-    session.artifacts = app.session_artifacts.clone();
-    session.last_auto_route = app.auto_route_for_persistence();
-    session.metadata.model = app.model_selection_for_persistence();
-    session
-        .metadata
-        .set_model_provider_route(app.api_provider.as_str(), app.provider_id_for_persistence());
-    session.metadata.workspace.clone_from(&app.workspace);
-    session.metadata.mode = Some(app.mode.as_setting().to_string());
-    app.sync_cost_to_metadata(&mut session.metadata);
-    session.metadata.title = new_title.to_string();
-
-    match manager.save_session(&session) {
-        Ok(_) => {
-            app.current_session_metadata = Some(session.metadata.clone());
-            app.session_title = Some(new_title.to_string());
-            if let Err(err) = app.publish_pending_work_state() {
-                return crate::commands::CommandResult::error(format!(
-                    "Session renamed, but Work views were not published: {err}"
-                ));
-            }
-            crate::commands::CommandResult::message(format!("Session renamed to \"{new_title}\""))
-        }
-        Err(e) => crate::commands::CommandResult::error(format!("Could not save session: {e}")),
-    }
-}
 
 const HOSTED_WORK_URL: &str = "https://app.codewhale.net/work";
 const MAX_GIT_VALUE_BYTES: usize = 4 * 1024;
@@ -1452,18 +1378,14 @@ fn plan_snapshot_to_sections(snapshot: &crate::tools::plan::PlanSnapshot) -> Pla
             .items
             .iter()
             .map(|item| PlanStep {
-                status_label: plan_status_label(&item.status).to_string(),
+                status: match &item.status {
+                    crate::tools::plan::StepStatus::Pending => PlanStepStatus::Pending,
+                    crate::tools::plan::StepStatus::InProgress => PlanStepStatus::InProgress,
+                    crate::tools::plan::StepStatus::Completed => PlanStepStatus::Completed,
+                },
                 text: item.step.clone(),
             })
             .collect(),
-    }
-}
-
-fn plan_status_label(status: &crate::tools::plan::StepStatus) -> &'static str {
-    match status {
-        crate::tools::plan::StepStatus::Pending => "pending",
-        crate::tools::plan::StepStatus::InProgress => "in_progress",
-        crate::tools::plan::StepStatus::Completed => "completed",
     }
 }
 
@@ -5083,11 +5005,43 @@ mod tests {
         assert!(parts.skill_group.is_none());
         assert!(parts.plugin.is_none());
 
-        // Unrelated capability: memory and lifecycle both absent.
+        // Control-only: control present and every unrelated slot absent.
+        let parts = bundle
+            .contexts(CommandCapabilities::SESSION_CONTROL)
+            .into_parts();
+        assert!(parts.control.is_some());
+        assert!(parts.session.is_none());
+        assert!(parts.model.is_none());
+        assert!(parts.cost.is_none());
+        assert!(parts.mode_policy.is_none());
+        assert!(parts.system_prompt.is_none());
+        assert!(parts.skills.is_none());
+        assert!(parts.workspace.is_none());
+        assert!(parts.presentation.is_none());
+        assert!(parts.media.is_none());
+        assert!(parts.memory.is_none());
+        assert!(parts.project.is_none());
+        assert!(parts.skill_group.is_none());
+        assert!(parts.plugin.is_none());
+        assert!(parts.lifecycle.is_none());
+
+        // `/remote-env`: exactly control plus presentation.
+        let parts = bundle
+            .contexts(CommandCapabilities::SESSION_CONTROL.union(CommandCapabilities::PRESENTATION))
+            .into_parts();
+        assert!(parts.control.is_some());
+        assert!(parts.presentation.is_some());
+        assert!(parts.session.is_none());
+        assert!(parts.workspace.is_none());
+        assert!(parts.lifecycle.is_none());
+        assert!(parts.plugin.is_none());
+
+        // Unrelated capability: memory, lifecycle, and control all absent.
         let parts = bundle.contexts(CommandCapabilities::SESSION).into_parts();
         assert!(parts.session.is_some());
         assert!(parts.memory.is_none());
         assert!(parts.lifecycle.is_none());
+        assert!(parts.control.is_none());
     }
 
     // ─── FEAT-022 skill-group adapter tests ───────────────────────────────────
@@ -6104,7 +6058,7 @@ mod tests {
                 PlanProjection::Sections(sections) => {
                     assert_eq!(sections.title.as_deref(), Some("Relay Plan"));
                     assert_eq!(sections.items.len(), 1);
-                    assert_eq!(sections.items[0].status_label, "in_progress");
+                    assert_eq!(sections.items[0].status, PlanStepStatus::InProgress);
                     assert_eq!(sections.items[0].text, "port the control slice");
                 }
                 other => panic!("expected Sections plan after update, got {other:?}"),

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -35,21 +35,24 @@ use codewhale_command_contract::facets::{
     CommandApprovalState, CommandCostContext, CommandMediaContext, CommandMemoryContext,
     CommandModePolicyContext, CommandModelContext, CommandPluginContext,
     CommandPresentationContext, CommandProjectContext, CommandSessionContext,
-    CommandSessionLifecycleContext, CommandSkillGroupContext, CommandSkillsContext,
-    CommandSystemPromptContext, CommandWorkspaceContext, MediaAttachmentReceipt, MemoryDelete,
-    MemoryDeleteScope, MemoryExport, MemoryGetOutcome, MemoryHit, MemoryImportOutcome,
-    MemoryReindex, MemoryRememberTarget, MemoryRemembered, MemoryStatus, PluginDetail,
-    PluginDiagnostic, PluginDiagnosticLevel, PluginExportReceipt, PluginLegacyScan,
-    PluginLegacyTool, PluginManagedCandidate, PluginManagedScan, PluginMarketplaceAddReceipt,
+    CommandSessionControlContext, CommandSessionLifecycleContext, CommandSkillGroupContext,
+    CommandSkillsContext, CommandSystemPromptContext, CommandWorkspaceContext, HostedWorkTarget,
+    MediaAttachmentReceipt, MemoryDelete, MemoryDeleteScope, MemoryExport, MemoryGetOutcome,
+    MemoryHit, MemoryImportOutcome, MemoryReindex, MemoryRememberTarget, MemoryRemembered,
+    MemoryStatus, PlanProjection, PlanSections, PlanStep, PluginDetail, PluginDiagnostic,
+    PluginDiagnosticLevel, PluginExportReceipt, PluginLegacyScan, PluginLegacyTool,
+    PluginManagedCandidate, PluginManagedScan, PluginMarketplaceAddReceipt,
     PluginMarketplaceCandidate, PluginMarketplaceCatalog, PluginMarketplaceInstallPlan,
     PluginMarketplaceState, PluginMcpServerDetail, PluginMcpTransport, PluginMutationOutcome,
     PluginMutationReceipt, PluginSuggestion, PluginSummary, ProjectGoalState, ProjectGoalStatus,
-    ProjectShareProjection, RemoteRegistryOutcome, RemoteSkillEntry, ReviewOutcome,
+    ProjectShareProjection, RelayProjection, RemoteLink, RemoteOpenOutcome, RemoteRegistryOutcome,
+    RemoteSkillEntry, RemoteStartInfo, ResumeImportReceipt, ResumeSource, ReviewOutcome,
     SessionArchiveReceipt, SessionBranchOutcome, SessionForkFromReceipt, SessionForkReceipt,
-    SessionNewReceipt, SessionSaveReceipt, SessionSyncPayload, SkillActivationError,
-    SkillActivationOutcome, SkillBundledTier, SkillEntry, SkillMutationOutcome,
-    SkillMutationReceipt, SkillRecommendation, SkillRegistryProjection, SkillSourceKind,
-    SkillSyncEntry, SkillSyncOutcome, SkillTargetScope, SnapshotEntry, TreeBodyProjection,
+    SessionNewReceipt, SessionSaveReceipt, SessionSyncPayload, SessionTitleReceipt,
+    SkillActivationError, SkillActivationOutcome, SkillBundledTier, SkillEntry,
+    SkillMutationOutcome, SkillMutationReceipt, SkillRecommendation, SkillRegistryProjection,
+    SkillSourceKind, SkillSyncEntry, SkillSyncOutcome, SkillTargetScope, SnapshotEntry,
+    TitleReport, TitleSetOutcome, TitleSource, TodoProjection, TreeBodyProjection,
 };
 #[cfg(test)]
 use codewhale_command_contract::handler::ContextParts;
@@ -822,6 +825,491 @@ impl CommandSessionLifecycleContext for SessionLifecycleAdapter<'_> {
             .prune_sessions_older_than_keeping(max_age, keep)
             .map_err(|err| format!("prune failed: {err}"))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Session control adapter (FEAT-024 D4/D5)
+//
+// Sole host owner of concrete control machinery for the six control commands:
+// relay snapshot reads (goal/plan/work/todo/compact-template), rename/title
+// persistence (sanitization, checkpoint recovery, live synchronization, save,
+// publication, redraw), resume routing/imports, remote-control state and the
+// synchronous single-attempt browser launch, and hosted-work Git target
+// resolution. Every delegate reproduces the baseline check/mutation order
+// exactly (transition gate before resume I/O, save before publication,
+// browser launch without retry/deferral) and returns portable
+// projections/receipts or the exact host-error text the baseline surfaces.
+// No `SessionManager`, saved-session/container type, `SessionPickerView`,
+// remote-control service, Git wrapper, configuration, model/history type,
+// lock, or host callback crosses the facet.
+// ---------------------------------------------------------------------------
+pub(crate) struct SessionControlAdapter<'a> {
+    host: SharedCommandHost<'a>,
+}
+
+impl CommandSessionControlContext for SessionControlAdapter<'_> {
+    fn transition_blocked(&self) -> bool {
+        self.host.app.borrow().session_transition_blocked()
+    }
+
+    fn relay_projection(&self) -> RelayProjection {
+        let app = self.host.app.borrow();
+        let plan = match app.plan_state.try_lock() {
+            Ok(plan) => {
+                let snapshot = plan.snapshot();
+                if snapshot.is_empty() {
+                    PlanProjection::Absent
+                } else {
+                    PlanProjection::Sections(plan_snapshot_to_sections(&snapshot))
+                }
+            }
+            Err(_) => PlanProjection::Busy,
+        };
+        let todos = match app.work_state_snapshot() {
+            Ok(Some(state)) => match crate::todo_snapshot::todo_snapshot_body(&state.todos) {
+                Some(body) => TodoProjection::Body(body),
+                None => TodoProjection::Absent,
+            },
+            Ok(None) => TodoProjection::Absent,
+            Err(_) => TodoProjection::Unavailable,
+        };
+        RelayProjection {
+            compact_template: crate::prompts::COMPACT_TEMPLATE.to_string(),
+            workspace: app.workspace.display().to_string(),
+            mode: app.mode.label().to_string(),
+            model: app.model_display_label(),
+            goal_objective: app.goal.objective.clone(),
+            goal_token_budget: app.goal.token_budget,
+            todos,
+            plan,
+        }
+    }
+
+    fn open_resume_picker(&mut self) {
+        let mut app = self.host.app.borrow_mut();
+        let picker =
+            crate::tui::session_picker::SessionPickerView::new(&app.workspace, app.ui_locale);
+        app.view_stack.push(picker);
+    }
+
+    fn resolve_resume_source(&mut self, raw: &str) -> Result<ResumeSource, String> {
+        // Baseline order: direct path (or `.json` existing path) first, then
+        // workspace-relative, then session id/prefix, then inline container.
+        let raw_path = PathBuf::from(raw);
+        if raw_path.is_file() || (raw.ends_with(".json") && Path::new(raw).exists()) {
+            return Ok(ResumeSource::File(raw_path));
+        }
+        let workspace_relative = {
+            let app = self.host.app.borrow();
+            let ws_path = app.workspace.join(raw);
+            ws_path.is_file().then_some(ws_path)
+        };
+        if let Some(ws_path) = workspace_relative {
+            return Ok(ResumeSource::File(ws_path));
+        }
+        let manager = match crate::session_manager::SessionManager::default_location() {
+            Ok(m) => m,
+            Err(e) => return Err(format!("could not open sessions directory: {e}")),
+        };
+        match manager
+            .load_session(raw)
+            .or_else(|_| manager.load_session_by_prefix(raw))
+        {
+            Ok(sess) => {
+                let path = manager
+                    .sessions_dir()
+                    .join(format!("{}.json", sess.metadata.id));
+                Ok(ResumeSource::Session {
+                    load_path: path.exists().then_some(path),
+                    truncated_id: crate::session_manager::truncate_id(&sess.metadata.id)
+                        .to_string(),
+                    title: sess.metadata.title,
+                })
+            }
+            Err(e) => {
+                if let Ok(container) = crate::session_tree::SessionImportContainer::from_json(raw) {
+                    let mut app = self.host.app.borrow_mut();
+                    let receipt = import_session_container(&mut app, container)?;
+                    Ok(ResumeSource::Imported(receipt))
+                } else {
+                    Ok(ResumeSource::NotFound {
+                        raw: raw.to_string(),
+                        error: e.to_string(),
+                    })
+                }
+            }
+        }
+    }
+
+    fn import_session_file(&mut self, path: PathBuf) -> Result<ResumeImportReceipt, String> {
+        let mut app = self.host.app.borrow_mut();
+        import_foreign_file(&mut app, &path)
+    }
+
+    fn rename_session(&mut self, raw_title: &str) -> Result<SessionTitleReceipt, String> {
+        let mut app = self.host.app.borrow_mut();
+        let sanitized = crate::session_manager::sanitize_session_title(raw_title);
+        let new_title = sanitized.trim();
+        if new_title.is_empty() {
+            return Err("Usage: /rename <new title>".to_string());
+        }
+        if new_title.chars().count() > MAX_TITLE_LEN {
+            return Err(format!("Title too long (max {MAX_TITLE_LEN} characters)"));
+        }
+        let session_id = match &app.current_session_id {
+            Some(id) => id.clone(),
+            None => {
+                return Err(
+                    "No active session. Send a message first to start a session.".to_string(),
+                );
+            }
+        };
+        let manager = match crate::session_manager::SessionManager::default_location() {
+            Ok(m) => m,
+            Err(e) => return Err(format!("Could not open sessions directory: {e}")),
+        };
+
+        // Mirrors the baseline `/rename` write path exactly: load (with
+        // first-snapshot recovery), sync live state, snapshot Work state,
+        // carry context/artifacts/route/cost/model/workspace/mode metadata,
+        // persist, then publish. Publication failures keep their post-save
+        // partial-success semantics.
+        let mut session = match manager.load_session(&session_id) {
+            Ok(s) => s,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                match live_session_before_first_snapshot(&manager, &session_id, &app) {
+                    Some(s) => s,
+                    None => return Err(format!("Could not load session: {err}")),
+                }
+            }
+            Err(e) => return Err(format!("Could not load session: {e}")),
+        };
+        session = crate::session_manager::update_session(
+            session,
+            &app.api_messages,
+            u64::from(app.session.total_tokens),
+            app.system_prompt.as_ref(),
+        );
+        session.work_state = match app.work_state_snapshot() {
+            Ok(state) => state,
+            Err(err) => {
+                return Err(format!(
+                    "Could not snapshot Work state before rename: {err}"
+                ));
+            }
+        };
+        session.context_references = app.session_context_references.clone();
+        session.artifacts = app.session_artifacts.clone();
+        session.last_auto_route = app.auto_route_for_persistence();
+        session.metadata.model = app.model_selection_for_persistence();
+        session
+            .metadata
+            .set_model_provider_route(app.api_provider.as_str(), app.provider_id_for_persistence());
+        session.metadata.workspace.clone_from(&app.workspace);
+        session.metadata.mode = Some(app.mode.as_setting().to_string());
+        app.sync_cost_to_metadata(&mut session.metadata);
+        session.metadata.title = new_title.to_string();
+
+        match manager.save_session(&session) {
+            Ok(_) => {
+                app.current_session_metadata = Some(session.metadata.clone());
+                app.session_title = Some(new_title.to_string());
+                if let Err(err) = app.publish_pending_work_state() {
+                    return Err(format!(
+                        "Session renamed, but Work views were not published: {err}"
+                    ));
+                }
+                Ok(SessionTitleReceipt {
+                    title: new_title.to_string(),
+                })
+            }
+            Err(e) => Err(format!("Could not save session: {e}")),
+        }
+    }
+
+    fn title_report(&self) -> TitleReport {
+        let app = self.host.app.borrow();
+        let source = if app.window_title.is_some() {
+            TitleSource::Session
+        } else if app.title_default.is_some() {
+            TitleSource::ConfigDefault
+        } else {
+            TitleSource::None
+        };
+        TitleReport {
+            effective: app.window_title_prefix().unwrap_or("unset").to_string(),
+            source,
+        }
+    }
+
+    fn set_window_title(&mut self, title: Option<String>) -> Result<TitleSetOutcome, String> {
+        let mut app = self.host.app.borrow_mut();
+        let sanitized = match title {
+            Some(raw) => {
+                let cleaned = crate::session_manager::sanitize_session_title(&raw);
+                let cleaned = cleaned.trim().to_string();
+                if cleaned.is_empty() {
+                    return Err(
+                        "Title cannot be empty; use /title off to clear a session title"
+                            .to_string(),
+                    );
+                }
+                Some(cleaned)
+            }
+            None => None,
+        };
+        let session_id = match &app.current_session_id {
+            Some(id) => id.clone(),
+            None => {
+                return Err(
+                    "No active session. Send a message first to start a session.".to_string(),
+                );
+            }
+        };
+        let manager = match crate::session_manager::SessionManager::default_location() {
+            Ok(m) => m,
+            Err(e) => return Err(format!("Could not open sessions directory: {e}")),
+        };
+        let mut session = match manager.load_session(&session_id) {
+            Ok(s) => s,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                match live_session_before_first_snapshot(&manager, &session_id, &app) {
+                    Some(s) => s,
+                    None => return Err(format!("Could not load session: {err}")),
+                }
+            }
+            Err(e) => return Err(format!("Could not load session: {e}")),
+        };
+        session = crate::session_manager::update_session(
+            session,
+            &app.api_messages,
+            u64::from(app.session.total_tokens),
+            app.system_prompt.as_ref(),
+        );
+        session.work_state = match app.work_state_snapshot() {
+            Ok(state) => state,
+            Err(err) => {
+                return Err(format!(
+                    "Could not snapshot Work state before setting title: {err}"
+                ));
+            }
+        };
+        session.context_references = app.session_context_references.clone();
+        session.artifacts = app.session_artifacts.clone();
+        session.last_auto_route = app.auto_route_for_persistence();
+        session.metadata.model = app.model_selection_for_persistence();
+        session
+            .metadata
+            .set_model_provider_route(app.api_provider.as_str(), app.provider_id_for_persistence());
+        session.metadata.workspace.clone_from(&app.workspace);
+        session.metadata.mode = Some(app.mode.as_setting().to_string());
+        app.sync_cost_to_metadata(&mut session.metadata);
+        session.window_title = sanitized.clone();
+
+        match manager.save_session(&session) {
+            Ok(_) => {
+                app.window_title = sanitized.clone();
+                // The render loop syncs the resolved prefix into the terminal
+                // title; force a frame so the change lands immediately.
+                app.needs_redraw = true;
+                if let Err(err) = app.publish_pending_work_state() {
+                    return Err(format!(
+                        "Window title saved, but Work views were not published: {err}"
+                    ));
+                }
+                Ok(match sanitized {
+                    Some(title) => TitleSetOutcome::Set(title),
+                    None => TitleSetOutcome::Cleared,
+                })
+            }
+            Err(e) => Err(format!("Could not save session: {e}")),
+        }
+    }
+
+    fn remote_status(&self) -> String {
+        self.host.app.borrow().remote_control.status_line()
+    }
+
+    fn remote_link(&self) -> Option<RemoteLink> {
+        let app = self.host.app.borrow();
+        let url = app.remote_control.run_url()?.to_string();
+        Some(RemoteLink {
+            computer_url: app.remote_control.computer_url().map(str::to_string),
+            url,
+        })
+    }
+
+    fn remote_browser_open(&self) -> RemoteOpenOutcome {
+        let app = self.host.app.borrow();
+        let Some(url) = app.remote_control.run_url().map(str::to_string) else {
+            return RemoteOpenOutcome::NoLink;
+        };
+        // Synchronous single attempt through the authoritative URL-opening
+        // helper; never retried and never deferred to an external-URL action.
+        let launched = crate::utils::open_url(&url).is_ok();
+        map_browser_open_result(url, launched)
+    }
+
+    fn remote_start_info(&self) -> RemoteStartInfo {
+        let app = self.host.app.borrow();
+        RemoteStartInfo {
+            connecting: app.is_loading || app.dispatch_in_flight,
+        }
+    }
+
+    fn remote_stop_refusal(&self) -> Option<String> {
+        self.host.app.borrow().remote_control.stop_refusal().clone()
+    }
+
+    fn resolve_hosted_work_target(&self) -> Option<HostedWorkTarget> {
+        let app = self.host.app.borrow();
+        let target = crate::commands::groups::session::remote_env::resolve_target(&app.workspace)?;
+        let url = crate::commands::groups::session::remote_env::hosted_work_url(
+            &target.repo,
+            &target.branch,
+        );
+        Some(HostedWorkTarget {
+            url,
+            repo: target.repo,
+            branch: target.branch,
+        })
+    }
+}
+
+/// Map one synchronous browser-launch attempt to its portable outcome.
+/// Split out so the delegate's success/failure branches are unit-provable
+/// without spawning a real browser (utils tests cover the launcher itself).
+fn map_browser_open_result(url: String, launched: bool) -> RemoteOpenOutcome {
+    if launched {
+        RemoteOpenOutcome::Opened { url }
+    } else {
+        RemoteOpenOutcome::LaunchFailed { url }
+    }
+}
+
+/// Session-name/window-title length policy shared by `/rename` and `/title`.
+const MAX_TITLE_LEN: usize = 100;
+
+fn plan_snapshot_to_sections(snapshot: &crate::tools::plan::PlanSnapshot) -> PlanSections {
+    PlanSections {
+        title: snapshot.title.clone(),
+        objective: snapshot.objective.clone(),
+        context_summary: snapshot.context_summary.clone(),
+        explanation: snapshot.explanation.clone(),
+        sources_used: snapshot.sources_used.clone(),
+        critical_files: snapshot.critical_files.clone(),
+        constraints: snapshot.constraints.clone(),
+        recommended_approach: snapshot.recommended_approach.clone(),
+        verification_plan: snapshot.verification_plan.clone(),
+        risks_and_unknowns: snapshot.risks_and_unknowns.clone(),
+        handoff_packet: snapshot.handoff_packet.clone(),
+        items: snapshot
+            .items
+            .iter()
+            .map(|item| PlanStep {
+                status_label: plan_status_label(&item.status).to_string(),
+                text: item.step.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn plan_status_label(status: &crate::tools::plan::StepStatus) -> &'static str {
+    match status {
+        crate::tools::plan::StepStatus::Pending => "pending",
+        crate::tools::plan::StepStatus::InProgress => "in_progress",
+        crate::tools::plan::StepStatus::Completed => "completed",
+    }
+}
+
+/// Recover the session document for a live turn that has not completed (and
+/// therefore persisted) its first snapshot yet (#5430). Mirrors the legacy
+/// `/rename`/`/title` recovery exactly.
+fn live_session_before_first_snapshot(
+    manager: &crate::session_manager::SessionManager,
+    session_id: &str,
+    app: &App,
+) -> Option<crate::session_manager::SavedSession> {
+    if let Ok(Some(checkpoint)) = manager.load_session_checkpoint(session_id) {
+        return Some(checkpoint);
+    }
+    Some(
+        crate::session_manager::create_saved_session_with_id_and_mode(
+            session_id.to_string(),
+            &app.api_messages,
+            &app.model_selection_for_persistence(),
+            &app.workspace,
+            u64::from(app.session.total_tokens),
+            app.system_prompt.as_ref(),
+            Some(app.mode.as_setting()),
+        ),
+    )
+}
+
+/// `/resume <file>` import: read, parse a container or plain saved session,
+/// and apply it atomically. Errors are the exact baseline text.
+fn import_foreign_file(app: &mut App, path: &Path) -> Result<ResumeImportReceipt, String> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            return Err(format!(
+                "failed to read import file {}: {e}",
+                path.display()
+            ));
+        }
+    };
+    if let Ok(container) = crate::session_tree::SessionImportContainer::from_json(&content) {
+        return import_session_container(app, container);
+    }
+    if let Ok(foreign) = serde_json::from_str::<crate::session_manager::SavedSession>(&content) {
+        let container = foreign.export_container("foreign");
+        return import_session_container(app, container);
+    }
+    Err(format!(
+        "File {} is not a recognized session export",
+        path.display()
+    ))
+}
+
+/// Apply a parsed foreign container: persist, mutate the active session,
+/// select it in a fresh picker, and return the portable receipt.
+fn import_session_container(
+    app: &mut App,
+    container: crate::session_tree::SessionImportContainer,
+) -> Result<ResumeImportReceipt, String> {
+    let manager = match crate::session_manager::SessionManager::default_location() {
+        Ok(m) => m,
+        Err(e) => return Err(format!("could not open sessions directory: {e}")),
+    };
+    let model = app.model.clone();
+    let workspace = app.workspace.clone();
+    let imported =
+        match crate::session_manager::SavedSession::import_foreign(container, workspace, model) {
+            Ok(s) => s,
+            Err(e) => return Err(format!("foreign import failed: {e}")),
+        };
+    let new_id = imported.metadata.id.clone();
+    if let Err(e) = manager.save_session(&imported) {
+        return Err(format!("imported session could not be saved: {e}"));
+    }
+    app.current_session_id = Some(new_id.clone());
+    app.current_session_metadata = Some(imported.metadata.clone());
+    app.api_messages = imported.messages.clone();
+    let picker = crate::tui::session_picker::SessionPickerView::new_selecting(
+        &app.workspace,
+        app.ui_locale,
+        &new_id,
+    );
+    app.view_stack.push(picker);
+    Ok(ResumeImportReceipt {
+        truncated_id: crate::session_manager::truncate_id(&new_id).to_string(),
+        entry_count: imported
+            .journal
+            .as_ref()
+            .map(|journal| journal.entries.len())
+            .unwrap_or(0),
+        leaf_display: imported.leaf_id.as_deref().unwrap_or("(none)").to_string(),
+    })
 }
 
 /// Session identity, messages, queue operations, and token totals.
@@ -3274,6 +3762,7 @@ pub(crate) struct CommandContextBundle<'a> {
     skill_group: SkillGroupAdapter<'a>,
     plugin: PluginAdapter<'a>,
     lifecycle: SessionLifecycleAdapter<'a>,
+    control: SessionControlAdapter<'a>,
 }
 
 impl<'a> CommandContextBundle<'a> {
@@ -3322,6 +3811,9 @@ impl<'a> CommandContextBundle<'a> {
         if capabilities.contains(CommandCapabilities::SESSION_LIFECYCLE) {
             contexts = contexts.with_lifecycle(&mut self.lifecycle);
         }
+        if capabilities.contains(CommandCapabilities::SESSION_CONTROL) {
+            contexts = contexts.with_control(&mut self.control);
+        }
         contexts
     }
 
@@ -3341,7 +3833,8 @@ impl<'a> CommandContextBundle<'a> {
             .union(CommandCapabilities::PROJECT)
             .union(CommandCapabilities::SKILL_GROUP)
             .union(CommandCapabilities::PLUGIN)
-            .union(CommandCapabilities::SESSION_LIFECYCLE);
+            .union(CommandCapabilities::SESSION_LIFECYCLE)
+            .union(CommandCapabilities::SESSION_CONTROL);
         self.contexts(all_test_capabilities).into_parts()
     }
 }
@@ -3367,7 +3860,8 @@ impl App {
             memory: MemoryAdapter { host: host.clone() },
             skill_group: SkillGroupAdapter { host: host.clone() },
             plugin: PluginAdapter { host: host.clone() },
-            lifecycle: SessionLifecycleAdapter { host },
+            lifecycle: SessionLifecycleAdapter { host: host.clone() },
+            control: SessionControlAdapter { host },
         }
     }
 }
@@ -5248,5 +5742,561 @@ mod tests {
                 other => panic!("expected Journal projection, got {other:?}"),
             }
         }
+    }
+
+    // -------------------------------------------------------------------
+    // FEAT-024 Phase 3: SessionControlAdapter tests (Tasks 3.2/3.4/3.6).
+    // The bundle borrows `App` for its whole life, so each test scopes the
+    // facet (via a bound `parts` value) and re-reads `App` only after
+    // dropping it.
+    // -------------------------------------------------------------------
+
+    fn control_test_app(tmpdir: &TempDir) -> App {
+        lifecycle_test_app(tmpdir)
+    }
+
+    fn control_home_guard(tmpdir: &TempDir) -> crate::test_support::EnvVarGuard {
+        lifecycle_home_guard(tmpdir)
+    }
+
+    fn save_control_session(tmpdir: &TempDir, id: &str) {
+        let manager = crate::session_manager::SessionManager::default_location().unwrap();
+        let mut session = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmpdir.path(),
+            0,
+            None,
+            None,
+        );
+        session.metadata.id = id.to_string();
+        session.metadata.title = "Control Session".to_string();
+        manager.save_session(&session).unwrap();
+    }
+
+    #[test]
+    fn control_relay_projection_maps_authoritative_snapshot() {
+        let tmpdir = TempDir::new().unwrap();
+        let _lock = crate::test_support::lock_test_env();
+        let mut app = control_test_app(&tmpdir);
+        app.goal.objective = Some("ship the control slice".to_string());
+        app.goal.token_budget = Some(42_000);
+        let expected_workspace = app.workspace.display().to_string();
+        let expected_mode = app.mode.label().to_string();
+        let expected_model = app.model_display_label();
+
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            let projection = facet.relay_projection();
+            assert_eq!(projection.workspace, expected_workspace);
+            assert_eq!(projection.mode, expected_mode);
+            assert_eq!(projection.model, expected_model);
+            assert_eq!(
+                projection.goal_objective.as_deref(),
+                Some("ship the control slice")
+            );
+            assert_eq!(projection.goal_token_budget, Some(42_000));
+            assert_eq!(
+                projection.compact_template.trim(),
+                crate::prompts::COMPACT_TEMPLATE.trim()
+            );
+            assert!(matches!(projection.todos, TodoProjection::Absent));
+            assert!(matches!(projection.plan, PlanProjection::Absent));
+        }
+
+        // Plan state held by another owner -> busy state is represented,
+        // never a panic or lock wait.
+        {
+            let plan_state = app.plan_state.clone();
+            let guard = plan_state.try_lock().unwrap();
+            {
+                let mut bundle = app.command_contexts();
+                let mut parts = bundle.parts();
+                let facet = parts.control.as_deref_mut().expect("control slot");
+                assert!(matches!(
+                    facet.relay_projection().plan,
+                    PlanProjection::Busy
+                ));
+            }
+            drop(guard);
+        }
+
+        // Seeded plan sections transport the status label mapping.
+        {
+            let plan_state = app.plan_state.clone();
+            let mut plan = plan_state.try_lock().unwrap();
+            plan.update(crate::tools::plan::UpdatePlanArgs {
+                title: Some("Relay Plan".to_string()),
+                plan: vec![crate::tools::plan::PlanItemArg {
+                    step: "port the control slice".to_string(),
+                    status: crate::tools::plan::StepStatus::InProgress,
+                }],
+                ..crate::tools::plan::UpdatePlanArgs::default()
+            });
+        }
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            match facet.relay_projection().plan {
+                PlanProjection::Sections(sections) => {
+                    assert_eq!(sections.title.as_deref(), Some("Relay Plan"));
+                    assert_eq!(sections.items.len(), 1);
+                    assert_eq!(sections.items[0].status_label, "in_progress");
+                    assert_eq!(sections.items[0].text, "port the control slice");
+                }
+                other => panic!("expected Sections plan after update, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn control_hosted_work_target_resolves_and_never_echoes_credentials() {
+        let tmpdir = TempDir::new().unwrap();
+        let _lock = crate::test_support::lock_test_env();
+        let secret = "top-secret-token";
+        let mut app = control_test_app(&tmpdir);
+        init_control_git_repo(
+            tmpdir.path(),
+            &format!("https://hunter:{secret}@github.com/Hmbown/CodeWhale.git"),
+            "main",
+        );
+
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            let target = facet.resolve_hosted_work_target().expect("target");
+            assert_eq!(target.repo, "Hmbown/CodeWhale");
+            assert_eq!(target.branch, "main");
+            assert_eq!(
+                target.url,
+                "https://app.codewhale.net/work?repo=Hmbown%2FCodeWhale&branch=main"
+            );
+            assert!(!target.url.contains(secret));
+            assert!(!target.repo.contains(secret));
+        }
+
+        // Unsupported host resolves to None.
+        init_control_git_repo(tmpdir.path(), "git@gitlab.com:acme/widgets.git", "main");
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            assert_eq!(facet.resolve_hosted_work_target(), None);
+        }
+    }
+
+    fn init_control_git_repo(dir: &Path, origin: &str, branch: &str) {
+        let init = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .arg(dir)
+            .status()
+            .expect("run git init");
+        assert!(init.success());
+        let set_origin = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["config", "--local", "remote.origin.url", origin])
+            .status()
+            .expect("set origin");
+        assert!(set_origin.success());
+        let set_branch = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["symbolic-ref", "HEAD"])
+            .arg(format!("refs/heads/{branch}"))
+            .status()
+            .expect("set branch");
+        assert!(set_branch.success());
+    }
+
+    #[test]
+    fn control_rename_session_persists_title_and_preserves_order() {
+        let tmpdir = TempDir::new().unwrap();
+        let _lock = crate::test_support::lock_test_env();
+        let _home = control_home_guard(&tmpdir);
+        save_control_session(&tmpdir, "rename-1");
+        let mut app = control_test_app(&tmpdir);
+        app.current_session_id = Some("rename-1".to_string());
+
+        let receipt = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.rename_session("Brand New Title").expect("rename ok")
+        };
+        assert_eq!(receipt.title, "Brand New Title");
+        assert_eq!(app.session_title.as_deref(), Some("Brand New Title"));
+        let manager = crate::session_manager::SessionManager::default_location().unwrap();
+        let reloaded = manager.load_session("rename-1").unwrap();
+        assert_eq!(reloaded.metadata.title, "Brand New Title");
+
+        // Sanitized-empty input keeps the usage error; window title untouched.
+        let empty_err = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.rename_session("\u{1b}\u{7}\u{200b}").unwrap_err()
+        };
+        assert!(empty_err.contains("Usage: /rename"));
+        assert_eq!(app.window_title, None);
+
+        let too_long = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.rename_session(&"a".repeat(101)).unwrap_err()
+        };
+        assert!(too_long.contains("Title too long (max 100 characters)"));
+    }
+
+    #[test]
+    fn control_rename_recovers_first_snapshot_from_checkpoint() {
+        let tmpdir = TempDir::new().unwrap();
+        let _lock = crate::test_support::lock_test_env();
+        let _home = control_home_guard(&tmpdir);
+        let manager = crate::session_manager::SessionManager::default_location().unwrap();
+        let mut checkpoint = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmpdir.path(),
+            0,
+            None,
+            None,
+        );
+        checkpoint.metadata.id = "midturn-1".to_string();
+        manager.save_checkpoint(&checkpoint).unwrap();
+
+        let mut app = control_test_app(&tmpdir);
+        app.current_session_id = Some("midturn-1".to_string());
+        app.api_messages = vec![user_message("first turn still streaming")];
+
+        let receipt = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.rename_session("Midturn Rename").expect("rename ok")
+        };
+        assert_eq!(receipt.title, "Midturn Rename");
+        assert_eq!(app.session_title.as_deref(), Some("Midturn Rename"));
+        let persisted = manager.load_session("midturn-1").unwrap();
+        assert_eq!(persisted.metadata.title, "Midturn Rename");
+        assert_eq!(persisted.messages.len(), 1);
+    }
+
+    #[test]
+    fn control_rename_errors_match_the_baseline() {
+        let tmpdir = TempDir::new().unwrap();
+        let _lock = crate::test_support::lock_test_env();
+        let _home = control_home_guard(&tmpdir);
+        let mut app = control_test_app(&tmpdir);
+        app.current_session_id = None;
+        let err = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.rename_session("Anything").unwrap_err()
+        };
+        assert!(err.contains("No active session"));
+    }
+
+    #[test]
+    fn control_title_report_set_and_clear_preserve_semantics() {
+        let tmpdir = TempDir::new().unwrap();
+        let _lock = crate::test_support::lock_test_env();
+        let _home = control_home_guard(&tmpdir);
+        save_control_session(&tmpdir, "title-1");
+        let mut app = control_test_app(&tmpdir);
+        app.current_session_id = Some("title-1".to_string());
+
+        // No session window title and no config default -> unset, no source.
+        let report = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.title_report()
+        };
+        assert_eq!(report.effective, "unset");
+        assert!(matches!(report.source, TitleSource::None));
+
+        // Set a window title: session name untouched, redraw requested.
+        let outcome = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet
+                .set_window_title(Some("parallel-task".to_string()))
+                .expect("set ok")
+        };
+        assert!(matches!(outcome, TitleSetOutcome::Set(_)));
+        assert_eq!(app.window_title.as_deref(), Some("parallel-task"));
+        assert!(app.needs_redraw);
+        assert_eq!(
+            app.session_title, None,
+            "/title never changes the session name"
+        );
+        let manager = crate::session_manager::SessionManager::default_location().unwrap();
+        let reloaded = manager.load_session("title-1").unwrap();
+        assert_eq!(reloaded.window_title.as_deref(), Some("parallel-task"));
+        assert_eq!(reloaded.metadata.title, "Control Session");
+
+        // Control-char-only input keeps the empty-title error.
+        let err = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet
+                .set_window_title(Some("\u{1b}\u{7}\u{200b}".to_string()))
+                .unwrap_err()
+        };
+        assert!(err.contains("Title cannot be empty; use /title off to clear a session title"));
+
+        // Clear removes the session-level title.
+        let cleared = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.set_window_title(None).expect("clear ok")
+        };
+        assert!(matches!(cleared, TitleSetOutcome::Cleared));
+        assert_eq!(app.window_title, None);
+    }
+
+    #[test]
+    fn control_resume_gate_picker_and_resolution_routes() {
+        let tmpdir = TempDir::new().unwrap();
+        let _lock = crate::test_support::lock_test_env();
+        let _home = control_home_guard(&tmpdir);
+        save_control_session(&tmpdir, "resume-target-1");
+        let mut app = control_test_app(&tmpdir);
+
+        // Transition gate mirrors the host state.
+        app.is_loading = true;
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            assert!(facet.transition_blocked());
+        }
+        app.is_loading = false;
+
+        // Bare resume pushes the picker.
+        assert!(app.view_stack.is_empty());
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.open_resume_picker();
+        }
+        assert!(!app.view_stack.is_empty());
+
+        // Full id and prefix resolve to the durable session file.
+        let by_id = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet
+                .resolve_resume_source("resume-target-1")
+                .expect("resolve ok")
+        };
+        match by_id {
+            ResumeSource::Session {
+                load_path,
+                truncated_id,
+                title,
+            } => {
+                assert!(load_path.as_ref().is_some_and(|p| p.exists()));
+                assert!(!truncated_id.is_empty());
+                assert_eq!(title, "Control Session");
+            }
+            other => panic!("expected Session resolution, got {other:?}"),
+        }
+        let by_prefix = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet
+                .resolve_resume_source("resume-target")
+                .expect("prefix ok")
+        };
+        assert!(matches!(by_prefix, ResumeSource::Session { .. }));
+
+        // A readable file resolves as the direct-file route.
+        let export_file = tmpdir.path().join("session-export.json");
+        std::fs::write(&export_file, "{}").unwrap();
+        let as_file = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet
+                .resolve_resume_source(&export_file.display().to_string())
+                .expect("file ok")
+        };
+        assert!(matches!(as_file, ResumeSource::File(_)));
+
+        // Unknown input resolves to NotFound with the raw value for the
+        // handler's exact fallback message.
+        let missing = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet
+                .resolve_resume_source("not-a-real-session-xyz")
+                .expect("notfound ok")
+        };
+        match missing {
+            ResumeSource::NotFound { raw, error } => {
+                assert_eq!(raw, "not-a-real-session-xyz");
+                assert!(!error.is_empty());
+            }
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn control_resume_import_rejects_unrecognized_and_applies_foreign() {
+        let tmpdir = TempDir::new().unwrap();
+        let _lock = crate::test_support::lock_test_env();
+        let _home = control_home_guard(&tmpdir);
+        let mut app = control_test_app(&tmpdir);
+
+        let bad_file = tmpdir.path().join("not-an-export.json");
+        std::fs::write(&bad_file, "not session json at all").unwrap();
+        let err = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.import_session_file(bad_file).unwrap_err()
+        };
+        assert!(err.contains("is not a recognized session export"), "{err}");
+
+        // A real export container round-trips through import and mutates the
+        // active session atomically.
+        let manager = crate::session_manager::SessionManager::default_location().unwrap();
+        let mut source = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmpdir.path(),
+            0,
+            None,
+            None,
+        );
+        source.metadata.id = "foreign-source".to_string();
+        source.metadata.title = "Foreign Name".to_string();
+        let container = source.export_container("foreign");
+        let json = serde_json::to_string(&container).expect("serialize container");
+        let import_file = tmpdir.path().join("foreign-export.json");
+        std::fs::write(&import_file, &json).unwrap();
+
+        let receipt = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.import_session_file(import_file).expect("import ok")
+        };
+        assert!(!receipt.truncated_id.is_empty());
+        assert_eq!(receipt.entry_count, 0);
+        assert_eq!(receipt.leaf_display, "(none)");
+        let imported_id = app.current_session_id.clone().expect("active session");
+        let saved = manager
+            .load_session(&imported_id)
+            .expect("import persisted");
+        // Host import_foreign rebuilds the document with default metadata
+        // (fresh id/title), matching the baseline import path exactly.
+        assert_eq!(saved.metadata.title, "New Session");
+        assert_ne!(saved.metadata.id, "foreign-source");
+        assert!(
+            manager
+                .sessions_dir()
+                .join(format!("{imported_id}.json"))
+                .exists()
+        );
+    }
+
+    #[test]
+    fn control_remote_state_and_routing_are_deterministic() {
+        let tmpdir = TempDir::new().unwrap();
+        let _lock = crate::test_support::lock_test_env();
+        let mut app = control_test_app(&tmpdir);
+
+        // Off state: status line, no link, no browser open.
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            assert_eq!(facet.remote_status(), "Remote control: off");
+            assert_eq!(facet.remote_link(), None);
+            assert!(matches!(
+                facet.remote_browser_open(),
+                RemoteOpenOutcome::NoLink
+            ));
+            assert_eq!(facet.remote_stop_refusal(), None);
+        }
+
+        // Start wording distinguishes the active-turn copy.
+        app.is_loading = true;
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            assert!(facet.remote_start_info().connecting);
+        }
+        app.is_loading = false;
+        {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            assert!(!facet.remote_start_info().connecting);
+        }
+
+        // A live advertised link composes without spawning a browser.
+        app.remote_control.install_live_link_for_test(
+            "https://app.codewhale.net/session?run=run-1",
+            Some("https://app.codewhale.net/settings"),
+        );
+        let link = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.remote_link().expect("live link")
+        };
+        assert_eq!(link.url, "https://app.codewhale.net/session?run=run-1");
+        assert_eq!(
+            link.computer_url.as_deref(),
+            Some("https://app.codewhale.net/settings")
+        );
+    }
+
+    #[test]
+    fn control_remote_stop_refusal_guards_active_turns() {
+        let tmpdir = TempDir::new().unwrap();
+        let _lock = crate::test_support::lock_test_env();
+        let mut app = control_test_app(&tmpdir);
+        app.remote_control
+            .activate_prompt("run-1", "turn-1")
+            .unwrap();
+        let refusal = {
+            let mut bundle = app.command_contexts();
+            let mut parts = bundle.parts();
+            let facet = parts.control.as_deref_mut().expect("control slot");
+            facet.remote_stop_refusal().expect("refusal present")
+        };
+        assert!(refusal.contains("active remote turn"), "{refusal}");
+    }
+
+    #[test]
+    fn control_browser_open_outcome_mapping_is_exact() {
+        let url = "https://app.codewhale.net/session?run=run-9".to_string();
+        assert!(matches!(
+            map_browser_open_result(url.clone(), true),
+            RemoteOpenOutcome::Opened { url: u } if u == url
+        ));
+        assert!(matches!(
+            map_browser_open_result(url.clone(), false),
+            RemoteOpenOutcome::LaunchFailed { url: u } if u == url
+        ));
     }
 }

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -1,7 +1,7 @@
 //! FEAT-015 TUI command-boundary surface.
 //!
 //! This module holds the TUI-owned pieces of the staged command migration:
-//! the pending-frontier projection (D4), the seven capability facet adapters
+//! the pending-frontier projection (D4), the capability facet adapters
 //! (D1), boundary-value and localization-key mappings (D3/D8), the envelope
 //! construction helper (D1), and the seam helpers (D7-D9). It is deliberately
 //! the only new TUI module for the migration surface; the production
@@ -14,7 +14,7 @@
 //!
 //! ## Authoritative host-proxy design (D1)
 //!
-//! `CommandContexts` holds twelve independently borrowed facet objects, while
+//! `CommandContexts` holds fifteen independently borrowed facet objects, while
 //! important behavior (mode transitions, model invalidation, cost accounting,
 //! skill refresh) is authoritative on `App`. The adapters therefore share a
 //! synchronous TUI-owned host proxy. Each trait call borrows `App` only for the
@@ -272,7 +272,7 @@ pub(crate) fn key_to_message_id(key: &'static str) -> Option<MessageId> {
 
 /// Shared TUI host hidden behind the portable command facets.
 ///
-/// The envelope needs ten independently borrowed facet objects, while the
+/// The envelope needs fifteen independently borrowed facet objects, while the
 /// authoritative mutation methods live on `App`. Each adapter therefore owns
 /// an `Rc` clone of this synchronous host proxy. Trait calls borrow `App` only
 /// for the duration of one method, delegate to the real TUI authority, and
@@ -3742,7 +3742,7 @@ fn default_codewhale_tools_dir() -> Option<PathBuf> {
 // Envelope construction (D1)
 // ---------------------------------------------------------------------------
 
-/// Owns thirteen facet objects sharing one synchronous TUI host proxy.
+/// Owns fifteen facet objects sharing one synchronous TUI host proxy.
 ///
 /// Handlers borrow only these adapters. Every method delegates to the real App
 /// authority and releases its `RefCell` borrow before returning, so facets can

--- a/crates/tui/src/commands/contract.rs
+++ b/crates/tui/src/commands/contract.rs
@@ -1108,7 +1108,7 @@ impl CommandSessionControlContext for SessionControlAdapter<'_> {
                 if snapshot.is_empty() {
                     PlanProjection::Absent
                 } else {
-                    PlanProjection::Sections(plan_snapshot_to_sections(&snapshot))
+                    PlanProjection::Sections(Box::new(plan_snapshot_to_sections(&snapshot)))
                 }
             }
             Err(_) => PlanProjection::Busy,

--- a/crates/tui/src/commands/groups/session/control_test_support.rs
+++ b/crates/tui/src/commands/groups/session/control_test_support.rs
@@ -7,7 +7,7 @@
 use codewhale_command_contract::facets::{
     CommandSessionControlContext, HostedWorkTarget, PlanProjection, RelayProjection, RemoteLink,
     RemoteOpenOutcome, RemoteStartInfo, ResumeImportReceipt, ResumeSource, SessionTitleReceipt,
-    TitleReport, TitleSetOutcome, TodoProjection,
+    TitleReport, TodoProjection,
 };
 use std::cell::RefCell;
 use std::path::PathBuf;
@@ -18,9 +18,11 @@ pub(crate) struct FakeControl {
     pub(crate) relay: Option<RelayProjection>,
     pub(crate) resume: Option<Result<ResumeSource, String>>,
     pub(crate) import: Option<Result<ResumeImportReceipt, String>>,
+    pub(crate) sanitized_title: Option<String>,
     pub(crate) rename: Option<Result<SessionTitleReceipt, String>>,
     pub(crate) title_report: Option<TitleReport>,
-    pub(crate) set_title: Option<Result<TitleSetOutcome, String>>,
+    pub(crate) set_title: Option<Result<(), String>>,
+    pub(crate) clear_title: Option<Result<(), String>>,
     pub(crate) remote_status: Option<String>,
     pub(crate) remote_link: Option<Option<RemoteLink>>,
     pub(crate) browser_open: Option<RemoteOpenOutcome>,
@@ -28,6 +30,14 @@ pub(crate) struct FakeControl {
     pub(crate) stop_refusal: Option<Option<String>>,
     pub(crate) hosted: Option<Option<HostedWorkTarget>>,
     pub(crate) calls: RefCell<Vec<String>>,
+}
+
+pub(crate) fn message(result: &super::CommandResult) -> &str {
+    result
+        .message
+        .as_deref()
+        .map(|message| message.strip_prefix("Error: ").unwrap_or(message))
+        .unwrap_or("")
 }
 
 impl FakeControl {
@@ -72,11 +82,17 @@ impl CommandSessionControlContext for FakeControl {
             )),
         }
     }
-    fn rename_session(&mut self, raw: &str) -> Result<SessionTitleReceipt, String> {
-        self.call("rename_session", Some(raw));
+    fn sanitize_session_title(&self, raw: &str) -> String {
+        self.call("sanitize_session_title", Some(raw));
+        self.sanitized_title
+            .clone()
+            .unwrap_or_else(|| raw.to_string())
+    }
+    fn rename_session(&mut self, title: &str) -> Result<SessionTitleReceipt, String> {
+        self.call("rename_session", Some(title));
         match self.rename.clone() {
             Some(result) => result,
-            None => Err(format!("unexpected rename_session({raw}) on empty fake")),
+            None => Err(format!("unexpected rename_session({title}) on empty fake")),
         }
     }
     fn title_report(&self) -> TitleReport {
@@ -85,14 +101,18 @@ impl CommandSessionControlContext for FakeControl {
             .clone()
             .expect("unexpected title_report()")
     }
-    fn set_window_title(&mut self, title: Option<String>) -> Result<TitleSetOutcome, String> {
-        match &title {
-            Some(value) => self.call("set_window_title", Some(value)),
-            None => self.call("set_window_title", Some("clear")),
-        }
+    fn set_window_title(&mut self, title: String) -> Result<(), String> {
+        self.call("set_window_title", Some(&title));
         match self.set_title.clone() {
             Some(result) => result,
             None => Err("unexpected set_window_title on empty fake".to_string()),
+        }
+    }
+    fn clear_window_title(&mut self) -> Result<(), String> {
+        self.call("clear_window_title", None);
+        match self.clear_title.clone() {
+            Some(result) => result,
+            None => Err("unexpected clear_window_title on empty fake".to_string()),
         }
     }
     fn remote_status(&self) -> String {

--- a/crates/tui/src/commands/groups/session/control_test_support.rs
+++ b/crates/tui/src/commands/groups/session/control_test_support.rs
@@ -9,6 +9,7 @@ use codewhale_command_contract::facets::{
     RemoteOpenOutcome, RemoteStartInfo, ResumeImportReceipt, ResumeSource, SessionTitleReceipt,
     TitleReport, TitleSetOutcome, TodoProjection,
 };
+use std::cell::RefCell;
 use std::path::PathBuf;
 
 #[derive(Default)]
@@ -26,27 +27,30 @@ pub(crate) struct FakeControl {
     pub(crate) start_info: Option<RemoteStartInfo>,
     pub(crate) stop_refusal: Option<Option<String>>,
     pub(crate) hosted: Option<Option<HostedWorkTarget>>,
-    pub(crate) calls: Vec<String>,
+    pub(crate) calls: RefCell<Vec<String>>,
 }
 
 impl FakeControl {
-    fn call(&mut self, name: &str, arg: Option<&str>) {
+    fn call(&self, name: &str, arg: Option<&str>) {
+        let mut calls = self.calls.borrow_mut();
         match arg {
-            Some(arg) => self.calls.push(format!("{name}({arg})")),
-            None => self.calls.push(name.to_string()),
+            Some(arg) => calls.push(format!("{name}({arg})")),
+            None => calls.push(name.to_string()),
         }
     }
 }
 
 impl CommandSessionControlContext for FakeControl {
     fn transition_blocked(&self) -> bool {
+        self.call("transition_blocked", None);
         self.blocked
     }
     fn relay_projection(&self) -> RelayProjection {
+        self.call("relay_projection", None);
         self.relay.clone().expect("unexpected relay_projection()")
     }
     fn open_resume_picker(&mut self) {
-        self.calls.push("open_resume_picker".to_string());
+        self.call("open_resume_picker", None);
     }
     fn resolve_resume_source(&mut self, raw: &str) -> Result<ResumeSource, String> {
         self.call("resolve_resume_source", Some(raw));
@@ -76,6 +80,7 @@ impl CommandSessionControlContext for FakeControl {
         }
     }
     fn title_report(&self) -> TitleReport {
+        self.call("title_report", None);
         self.title_report
             .clone()
             .expect("unexpected title_report()")
@@ -83,7 +88,7 @@ impl CommandSessionControlContext for FakeControl {
     fn set_window_title(&mut self, title: Option<String>) -> Result<TitleSetOutcome, String> {
         match &title {
             Some(value) => self.call("set_window_title", Some(value)),
-            None => self.calls.push("set_window_title(clear)".to_string()),
+            None => self.call("set_window_title", Some("clear")),
         }
         match self.set_title.clone() {
             Some(result) => result,
@@ -91,27 +96,33 @@ impl CommandSessionControlContext for FakeControl {
         }
     }
     fn remote_status(&self) -> String {
+        self.call("remote_status", None);
         self.remote_status
             .clone()
             .expect("unexpected remote_status()")
     }
     fn remote_link(&self) -> Option<RemoteLink> {
+        self.call("remote_link", None);
         self.remote_link.clone().expect("unexpected remote_link()")
     }
     fn remote_browser_open(&self) -> RemoteOpenOutcome {
+        self.call("remote_browser_open", None);
         self.browser_open
             .clone()
             .expect("unexpected browser_open()")
     }
     fn remote_start_info(&self) -> RemoteStartInfo {
+        self.call("remote_start_info", None);
         self.start_info.clone().expect("unexpected start_info()")
     }
     fn remote_stop_refusal(&self) -> Option<String> {
+        self.call("remote_stop_refusal", None);
         self.stop_refusal
             .clone()
             .expect("unexpected stop_refusal()")
     }
     fn resolve_hosted_work_target(&self) -> Option<HostedWorkTarget> {
+        self.call("resolve_hosted_work_target", None);
         self.hosted.clone().expect("unexpected hosted()")
     }
 }

--- a/crates/tui/src/commands/groups/session/control_test_support.rs
+++ b/crates/tui/src/commands/groups/session/control_test_support.rs
@@ -1,0 +1,130 @@
+//! FEAT-024 Phase 4: deterministic fake session-control facet for portable
+//! handler tests. Canned returns plus a call log prove exact strings, actions,
+//! call arguments, operation counts, and check order without touching the host.
+
+#![cfg(test)]
+
+use codewhale_command_contract::facets::{
+    CommandSessionControlContext, HostedWorkTarget, PlanProjection, RelayProjection, RemoteLink,
+    RemoteOpenOutcome, RemoteStartInfo, ResumeImportReceipt, ResumeSource, SessionTitleReceipt,
+    TitleReport, TitleSetOutcome, TodoProjection,
+};
+use std::path::PathBuf;
+
+#[derive(Default)]
+pub(crate) struct FakeControl {
+    pub(crate) blocked: bool,
+    pub(crate) relay: Option<RelayProjection>,
+    pub(crate) resume: Option<Result<ResumeSource, String>>,
+    pub(crate) import: Option<Result<ResumeImportReceipt, String>>,
+    pub(crate) rename: Option<Result<SessionTitleReceipt, String>>,
+    pub(crate) title_report: Option<TitleReport>,
+    pub(crate) set_title: Option<Result<TitleSetOutcome, String>>,
+    pub(crate) remote_status: Option<String>,
+    pub(crate) remote_link: Option<Option<RemoteLink>>,
+    pub(crate) browser_open: Option<RemoteOpenOutcome>,
+    pub(crate) start_info: Option<RemoteStartInfo>,
+    pub(crate) stop_refusal: Option<Option<String>>,
+    pub(crate) hosted: Option<Option<HostedWorkTarget>>,
+    pub(crate) calls: Vec<String>,
+}
+
+impl FakeControl {
+    fn call(&mut self, name: &str, arg: Option<&str>) {
+        match arg {
+            Some(arg) => self.calls.push(format!("{name}({arg})")),
+            None => self.calls.push(name.to_string()),
+        }
+    }
+}
+
+impl CommandSessionControlContext for FakeControl {
+    fn transition_blocked(&self) -> bool {
+        self.blocked
+    }
+    fn relay_projection(&self) -> RelayProjection {
+        self.relay.clone().expect("unexpected relay_projection()")
+    }
+    fn open_resume_picker(&mut self) {
+        self.calls.push("open_resume_picker".to_string());
+    }
+    fn resolve_resume_source(&mut self, raw: &str) -> Result<ResumeSource, String> {
+        self.call("resolve_resume_source", Some(raw));
+        match self.resume.clone() {
+            Some(result) => result,
+            None => Ok(ResumeSource::NotFound {
+                raw: raw.to_string(),
+                error: "missing".to_string(),
+            }),
+        }
+    }
+    fn import_session_file(&mut self, path: PathBuf) -> Result<ResumeImportReceipt, String> {
+        self.call("import_session_file", Some(&path.display().to_string()));
+        match self.import.clone() {
+            Some(result) => result,
+            None => Err(format!(
+                "unexpected import_session_file({}) on empty fake",
+                path.display()
+            )),
+        }
+    }
+    fn rename_session(&mut self, raw: &str) -> Result<SessionTitleReceipt, String> {
+        self.call("rename_session", Some(raw));
+        match self.rename.clone() {
+            Some(result) => result,
+            None => Err(format!("unexpected rename_session({raw}) on empty fake")),
+        }
+    }
+    fn title_report(&self) -> TitleReport {
+        self.title_report
+            .clone()
+            .expect("unexpected title_report()")
+    }
+    fn set_window_title(&mut self, title: Option<String>) -> Result<TitleSetOutcome, String> {
+        match &title {
+            Some(value) => self.call("set_window_title", Some(value)),
+            None => self.calls.push("set_window_title(clear)".to_string()),
+        }
+        match self.set_title.clone() {
+            Some(result) => result,
+            None => Err("unexpected set_window_title on empty fake".to_string()),
+        }
+    }
+    fn remote_status(&self) -> String {
+        self.remote_status
+            .clone()
+            .expect("unexpected remote_status()")
+    }
+    fn remote_link(&self) -> Option<RemoteLink> {
+        self.remote_link.clone().expect("unexpected remote_link()")
+    }
+    fn remote_browser_open(&self) -> RemoteOpenOutcome {
+        self.browser_open
+            .clone()
+            .expect("unexpected browser_open()")
+    }
+    fn remote_start_info(&self) -> RemoteStartInfo {
+        self.start_info.clone().expect("unexpected start_info()")
+    }
+    fn remote_stop_refusal(&self) -> Option<String> {
+        self.stop_refusal
+            .clone()
+            .expect("unexpected stop_refusal()")
+    }
+    fn resolve_hosted_work_target(&self) -> Option<HostedWorkTarget> {
+        self.hosted.clone().expect("unexpected hosted()")
+    }
+}
+
+pub(crate) fn relay_projection_fixture() -> RelayProjection {
+    RelayProjection {
+        compact_template: "# Session relay".to_string(),
+        workspace: "/work".to_string(),
+        mode: "operate".to_string(),
+        model: "model-x".to_string(),
+        goal_objective: Some("objective-y".to_string()),
+        goal_token_budget: Some(900),
+        todos: TodoProjection::Absent,
+        plan: PlanProjection::Absent,
+    }
+}

--- a/crates/tui/src/commands/groups/session/mod.rs
+++ b/crates/tui/src/commands/groups/session/mod.rs
@@ -13,8 +13,6 @@ mod relay;
 mod remote_control;
 pub(crate) mod remote_env;
 mod rename;
-#[cfg(test)]
-pub(crate) use rename::rename_with_manager;
 mod resume;
 mod save;
 mod sessions;
@@ -37,14 +35,13 @@ pub struct SessionCommands;
 impl CommandGroup for SessionCommands {
     fn commands(&self) -> &'static [Box<dyn Command>] {
         cached_command_list!(vec![
-            Box::new(FunctionCommand::new(
-                rename::RenameCmd::info(),
-                rename::RenameCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                title::TitleCmd::info(),
-                title::TitleCmd::execute,
-            )),
+            Box::new(
+                ContextualCommand::from_contract::<rename::RenameCmd>()
+                    .expect("rename registration")
+            ),
+            Box::new(
+                ContextualCommand::from_contract::<title::TitleCmd>().expect("title registration")
+            ),
             Box::new(
                 ContextualCommand::from_contract::<save::SaveCmd>().expect("save registration")
             ),
@@ -59,10 +56,10 @@ impl CommandGroup for SessionCommands {
             Box::new(
                 ContextualCommand::from_contract::<load::LoadCmd>().expect("load registration")
             ),
-            Box::new(FunctionCommand::new(
-                resume::ResumeCmd::info(),
-                resume::ResumeCmd::execute,
-            )),
+            Box::new(
+                ContextualCommand::from_contract::<resume::ResumeCmd>()
+                    .expect("resume registration")
+            ),
             Box::new(
                 ContextualCommand::from_contract::<tree::TreeCmd>().expect("tree registration")
             ),
@@ -77,18 +74,17 @@ impl CommandGroup for SessionCommands {
             Box::new(
                 ContextualCommand::from_contract::<purge::PurgeCmd>().expect("purge registration")
             ),
-            Box::new(FunctionCommand::new(
-                relay::RelayCmd::info(),
-                relay::RelayCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                remote_control::RemoteControlCmd::info(),
-                remote_control::RemoteControlCmd::execute,
-            )),
-            Box::new(FunctionCommand::new(
-                remote_env::RemoteEnvCmd::info(),
-                remote_env::RemoteEnvCmd::execute,
-            )),
+            Box::new(
+                ContextualCommand::from_contract::<relay::RelayCmd>().expect("relay registration")
+            ),
+            Box::new(
+                ContextualCommand::from_contract::<remote_control::RemoteControlCmd>()
+                    .expect("remote_control registration")
+            ),
+            Box::new(
+                ContextualCommand::from_contract::<remote_env::RemoteEnvCmd>()
+                    .expect("remote_env registration")
+            ),
             Box::new(FunctionCommand::new(
                 export::ExportCmd::info(),
                 export::ExportCmd::execute,
@@ -120,6 +116,8 @@ pub(in crate::commands) fn sync_session_action(
     }
 }
 
+#[cfg(test)]
+mod control_test_support;
 #[cfg(test)]
 mod lifecycle_portable_tests;
 #[cfg(test)]

--- a/crates/tui/src/commands/groups/session/mod.rs
+++ b/crates/tui/src/commands/groups/session/mod.rs
@@ -11,7 +11,7 @@ mod new;
 mod purge;
 mod relay;
 mod remote_control;
-mod remote_env;
+pub(crate) mod remote_env;
 mod rename;
 #[cfg(test)]
 pub(crate) use rename::rename_with_manager;

--- a/crates/tui/src/commands/groups/session/mod.rs
+++ b/crates/tui/src/commands/groups/session/mod.rs
@@ -11,7 +11,7 @@ mod new;
 mod purge;
 mod relay;
 mod remote_control;
-pub(crate) mod remote_env;
+mod remote_env;
 mod rename;
 mod resume;
 mod save;
@@ -26,6 +26,9 @@ mod tree;
 mod session;
 
 use crate::commands::CommandResult;
+
+/// Shared user-facing length policy for `/rename` and `/title`.
+pub(in crate::commands) const MAX_TITLE_LEN: usize = 100;
 use crate::commands::traits::{
     Command, CommandGroup, ContextualCommand, FunctionCommand, RegisterCommand,
 };

--- a/crates/tui/src/commands/groups/session/relay.rs
+++ b/crates/tui/src/commands/groups/session/relay.rs
@@ -194,16 +194,7 @@ fn write_plan_list(out: &mut String, label: &str, values: &[String]) {
 
 #[cfg(test)]
 mod tests {
-    /// Message with the canonical "Error: " prefix removed so exact strings
-    /// compare against the baseline text.
-    fn message(result: &super::CommandResult) -> &str {
-        result
-            .message
-            .as_deref()
-            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
-            .unwrap_or("")
-    }
-
+    use super::super::control_test_support::message;
     use super::*;
     use codewhale_command_contract::facets::{
         PlanSections, PlanStep, RelayProjection, TodoProjection,

--- a/crates/tui/src/commands/groups/session/relay.rs
+++ b/crates/tui/src/commands/groups/session/relay.rs
@@ -3,7 +3,9 @@
 use std::fmt::Write as _;
 
 use super::CommandResult;
-use codewhale_command_contract::facets::{CommandSessionControlContext, PlanProjection};
+use codewhale_command_contract::facets::{
+    CommandSessionControlContext, PlanProjection, PlanStepStatus,
+};
 use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
 use codewhale_command_contract::metadata::{
     CommandInfo as ContractInfo, RegisterCommand as ContractRegisterCommand,
@@ -140,7 +142,12 @@ fn build_relay_instruction(
                 sections.handoff_packet.as_deref(),
             );
             for item in sections.items {
-                let _ = writeln!(out, "- [{}] {}", item.status_label, item.text);
+                let _ = writeln!(
+                    out,
+                    "- [{}] {}",
+                    plan_step_status_label(item.status),
+                    item.text
+                );
             }
         }
         PlanProjection::Absent => {}
@@ -160,6 +167,14 @@ fn build_relay_instruction(
         "\nKeep it under about 900 words unless the session genuinely needs more. After writing, report the path and the single next action."
     );
     out
+}
+
+fn plan_step_status_label(status: PlanStepStatus) -> &'static str {
+    match status {
+        PlanStepStatus::Pending => "pending",
+        PlanStepStatus::InProgress => "in_progress",
+        PlanStepStatus::Completed => "completed",
+    }
 }
 
 fn write_plan_field(out: &mut String, label: &str, value: Option<&str>) {
@@ -227,6 +242,7 @@ mod tests {
                 .as_deref()
                 .is_some_and(|m| m == "Preparing session relay at .deepseek/handoff.md...")
         );
+        assert_eq!(fake.calls.borrow().as_slice(), ["relay_projection"]);
     }
 
     #[test]
@@ -272,7 +288,7 @@ mod tests {
                     explanation: Some("  because  ".to_string()),
                     sources_used: vec!["repo-a".to_string(), "  ".to_string()],
                     items: vec![PlanStep {
-                        status_label: "in_progress".to_string(),
+                        status: PlanStepStatus::InProgress,
                         text: "port relay".to_string(),
                     }],
                     ..PlanSections::default()
@@ -289,6 +305,19 @@ mod tests {
         assert!(message.contains("- Explanation: because"));
         assert!(message.contains("- Source: repo-a"));
         assert!(message.contains("- [in_progress] port relay"));
+    }
+
+    #[test]
+    fn relay_owns_every_portable_plan_status_label() {
+        assert_eq!(plan_step_status_label(PlanStepStatus::Pending), "pending");
+        assert_eq!(
+            plan_step_status_label(PlanStepStatus::InProgress),
+            "in_progress"
+        );
+        assert_eq!(
+            plan_step_status_label(PlanStepStatus::Completed),
+            "completed"
+        );
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/session/relay.rs
+++ b/crates/tui/src/commands/groups/session/relay.rs
@@ -267,18 +267,16 @@ mod tests {
                 goal_objective: None,
                 goal_token_budget: None,
                 todos: TodoProjection::Absent,
-                plan: codewhale_command_contract::facets::PlanProjection::Sections(Box::new(
-                    PlanSections {
-                        title: Some("Relay Plan".to_string()),
-                        explanation: Some("  because  ".to_string()),
-                        sources_used: vec!["repo-a".to_string(), "  ".to_string()],
-                        items: vec![PlanStep {
-                            status_label: "in_progress".to_string(),
-                            text: "port relay".to_string(),
-                        }],
-                        ..PlanSections::default()
-                    },
-                )),
+                plan: codewhale_command_contract::facets::PlanProjection::Sections(PlanSections {
+                    title: Some("Relay Plan".to_string()),
+                    explanation: Some("  because  ".to_string()),
+                    sources_used: vec!["repo-a".to_string(), "  ".to_string()],
+                    items: vec![PlanStep {
+                        status_label: "in_progress".to_string(),
+                        text: "port relay".to_string(),
+                    }],
+                    ..PlanSections::default()
+                }),
             }),
             ..super::super::control_test_support::FakeControl::default()
         };

--- a/crates/tui/src/commands/groups/session/relay.rs
+++ b/crates/tui/src/commands/groups/session/relay.rs
@@ -267,16 +267,18 @@ mod tests {
                 goal_objective: None,
                 goal_token_budget: None,
                 todos: TodoProjection::Absent,
-                plan: codewhale_command_contract::facets::PlanProjection::Sections(PlanSections {
-                    title: Some("Relay Plan".to_string()),
-                    explanation: Some("  because  ".to_string()),
-                    sources_used: vec!["repo-a".to_string(), "  ".to_string()],
-                    items: vec![PlanStep {
-                        status_label: "in_progress".to_string(),
-                        text: "port relay".to_string(),
-                    }],
-                    ..PlanSections::default()
-                }),
+                plan: codewhale_command_contract::facets::PlanProjection::Sections(Box::new(
+                    PlanSections {
+                        title: Some("Relay Plan".to_string()),
+                        explanation: Some("  because  ".to_string()),
+                        sources_used: vec!["repo-a".to_string(), "  ".to_string()],
+                        items: vec![PlanStep {
+                            status_label: "in_progress".to_string(),
+                            text: "port relay".to_string(),
+                        }],
+                        ..PlanSections::default()
+                    },
+                )),
             }),
             ..super::super::control_test_support::FakeControl::default()
         };

--- a/crates/tui/src/commands/groups/session/relay.rs
+++ b/crates/tui/src/commands/groups/session/relay.rs
@@ -1,47 +1,72 @@
-//! `/relay` command.
+//! `/relay` command — portable handler over the session-control facet.
 
 use std::fmt::Write as _;
 
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
-use crate::tui::app::{App, AppAction};
-
 use super::CommandResult;
-
-pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
-    name: "relay",
-    aliases: &["batonpass", "接力"],
-    usage: "/relay [focus]",
-    description_id: MessageId::CmdRelayDescription,
+use codewhale_command_contract::facets::{CommandSessionControlContext, PlanProjection};
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{
+    CommandInfo as ContractInfo, RegisterCommand as ContractRegisterCommand,
 };
 
 pub(in crate::commands) struct RelayCmd;
 
-impl RegisterCommand for RelayCmd {
-    fn info() -> &'static CommandInfo {
-        &COMMAND_INFO
-    }
+// ---------------------------------------------------------------------------
+// FEAT-024 Phase 4 (D4/D6/D7): portable contextual registration and handler.
+// The handler owns complete relay-instruction composition (sections, labels,
+// list formatting, focus normalization, byte-identical text); the facet
+// supplies the semantic projection. Missing control authority fails safely
+// with the exact capability error (never a panic).
+// ---------------------------------------------------------------------------
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        relay(app, arg)
+pub(in crate::commands) const CONTRACT_INFO: ContractInfo = ContractInfo {
+    name: "relay",
+    aliases: &["batonpass", "接力"],
+    usage: "/relay [focus]",
+    description_key: "cmd_relay_description",
+};
+
+impl ContractRegisterCommand<CommandResult> for RelayCmd {
+    fn info() -> &'static ContractInfo {
+        &CONTRACT_INFO
+    }
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual {
+            capabilities: codewhale_command_contract::handler::CommandCapabilities::SESSION_CONTROL,
+            handler: relay_contextual,
+        }
     }
 }
 
-/// Ask the active model to write a compact relay artifact for the next thread.
-///
-/// The visible command is `/relay` (with `/接力` for Chinese users), but the
-/// durable file path remains `.deepseek/handoff.md` for compatibility with
-/// existing sessions and startup prompt loading.
-pub fn relay(app: &mut App, arg: Option<&str>) -> CommandResult {
+pub(in crate::commands) fn relay_contextual(
+    contexts: CommandContexts<'_>,
+    arg: Option<&str>,
+) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let Some(control) = parts.control.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: session_control".to_string());
+    };
+    relay_portable(control, arg)
+}
+
+pub(in crate::commands) fn relay_portable(
+    control: &mut dyn CommandSessionControlContext,
+    arg: Option<&str>,
+) -> CommandResult {
     let focus = arg.map(str::trim).filter(|value| !value.is_empty());
-    let message = build_relay_instruction(app, focus);
+    let message = build_relay_instruction(control, focus);
     CommandResult::with_message_and_action(
         "Preparing session relay at .deepseek/handoff.md...",
-        AppAction::SendMessage(message),
+        crate::tui::app::AppAction::SendMessage(message),
     )
 }
 
-fn build_relay_instruction(app: &App, focus: Option<&str>) -> String {
+/// Compose the byte-identical relay instruction from the portable snapshot.
+fn build_relay_instruction(
+    control: &dyn CommandSessionControlContext,
+    focus: Option<&str>,
+) -> String {
+    let projection = control.relay_projection();
     let mut out = String::new();
     let _ = writeln!(
         out,
@@ -56,83 +81,76 @@ fn build_relay_instruction(app: &App, focus: Option<&str>) -> String {
     let _ = writeln!(out);
     let _ = writeln!(out, "Use this relay structure:");
     let _ = writeln!(out);
-    let _ = writeln!(out, "{}", crate::prompts::COMPACT_TEMPLATE.trim());
+    let _ = writeln!(out, "{}", projection.compact_template.trim());
     let _ = writeln!(out);
     let _ = writeln!(out, "Current session snapshot:");
-    let _ = writeln!(out, "- Workspace: {}", app.workspace.display());
-    let _ = writeln!(out, "- Mode: {}", app.mode.label());
-    let _ = writeln!(out, "- Model: {}", app.model_display_label());
+    let _ = writeln!(out, "- Workspace: {}", projection.workspace);
+    let _ = writeln!(out, "- Mode: {}", projection.mode);
+    let _ = writeln!(out, "- Model: {}", projection.model);
     if let Some(focus) = focus {
         let _ = writeln!(out, "- Requested relay focus: {focus}");
     }
-    if let Some(objective) = app.goal.objective.as_deref() {
+    if let Some(objective) = projection.goal_objective.as_deref() {
         let _ = writeln!(out, "- Goal objective: {objective}");
     }
-    if let Some(budget) = app.goal.token_budget {
+    if let Some(budget) = projection.goal_token_budget {
         let _ = writeln!(out, "- Goal token budget: {budget}");
     }
-    // Read through the same authoritative graph-backed snapshot seam used by
-    // persistence. A model can call `work_update` immediately before `/relay`;
-    // the UI projection may not have published yet, but the handoff must still
-    // describe the staged To-do rather than a stale compatibility list.
-    match app.work_state_snapshot() {
-        Ok(Some(state)) => {
-            if let Some(body) = crate::todo_snapshot::todo_snapshot_body(&state.todos) {
-                let _ = writeln!(out, "\nCurrent To-do:");
-                let _ = writeln!(out, "{body}");
-            }
+    match projection.todos {
+        codewhale_command_contract::facets::TodoProjection::Body(body) => {
+            let _ = writeln!(out, "\nCurrent To-do:");
+            let _ = writeln!(out, "{body}");
         }
-        Ok(None) => {}
-        Err(_) => {
+        codewhale_command_contract::facets::TodoProjection::Absent => {}
+        codewhale_command_contract::facets::TodoProjection::Unavailable => {
             let _ = writeln!(out, "\nTo-do: unavailable because the list is busy.");
         }
     }
-
-    if let Ok(plan) = app.plan_state.try_lock() {
-        let snapshot = plan.snapshot();
-        if !snapshot.is_empty() {
+    match projection.plan {
+        PlanProjection::Sections(sections) => {
             let _ = writeln!(
                 out,
                 "\nConversational strategy notes from update_plan (reasoning context, not a Work surface):"
             );
-            write_plan_field(&mut out, "Title", snapshot.title.as_deref());
-            write_plan_field(&mut out, "Objective", snapshot.objective.as_deref());
-            write_plan_field(&mut out, "Context", snapshot.context_summary.as_deref());
-            write_plan_field(&mut out, "Explanation", snapshot.explanation.as_deref());
-            write_plan_list(&mut out, "Source", &snapshot.sources_used);
-            write_plan_list(&mut out, "Critical file", &snapshot.critical_files);
-            write_plan_list(&mut out, "Constraint", &snapshot.constraints);
+            write_plan_field(&mut out, "Title", sections.title.as_deref());
+            write_plan_field(&mut out, "Objective", sections.objective.as_deref());
+            write_plan_field(&mut out, "Context", sections.context_summary.as_deref());
+            write_plan_field(&mut out, "Explanation", sections.explanation.as_deref());
+            write_plan_list(&mut out, "Source", &sections.sources_used);
+            write_plan_list(&mut out, "Critical file", &sections.critical_files);
+            write_plan_list(&mut out, "Constraint", &sections.constraints);
             write_plan_field(
                 &mut out,
                 "Recommended approach",
-                snapshot.recommended_approach.as_deref(),
+                sections.recommended_approach.as_deref(),
             );
             write_plan_field(
                 &mut out,
                 "Verification plan",
-                snapshot.verification_plan.as_deref(),
+                sections.verification_plan.as_deref(),
             );
             write_plan_field(
                 &mut out,
                 "Risks and unknowns",
-                snapshot.risks_and_unknowns.as_deref(),
+                sections.risks_and_unknowns.as_deref(),
             );
             write_plan_field(
                 &mut out,
                 "Handoff packet",
-                snapshot.handoff_packet.as_deref(),
+                sections.handoff_packet.as_deref(),
             );
-            for item in snapshot.items {
-                let _ = writeln!(out, "- [{}] {}", plan_status_label(&item.status), item.step);
+            for item in sections.items {
+                let _ = writeln!(out, "- [{}] {}", item.status_label, item.text);
             }
         }
-    } else {
-        let _ = writeln!(
-            out,
-            "\nStrategy metadata: unavailable because plan state is busy."
-        );
+        PlanProjection::Absent => {}
+        PlanProjection::Busy => {
+            let _ = writeln!(
+                out,
+                "\nStrategy metadata: unavailable because plan state is busy."
+            );
+        }
     }
-
     let _ = writeln!(
         out,
         "\nBefore writing, inspect the current transcript context and any live tool evidence you need. Do not invent test results, file changes, blockers, or decisions."
@@ -159,10 +177,128 @@ fn write_plan_list(out: &mut String, label: &str, values: &[String]) {
     }
 }
 
-fn plan_status_label(status: &crate::tools::plan::StepStatus) -> &'static str {
-    match status {
-        crate::tools::plan::StepStatus::Pending => "pending",
-        crate::tools::plan::StepStatus::InProgress => "in_progress",
-        crate::tools::plan::StepStatus::Completed => "completed",
+#[cfg(test)]
+mod tests {
+    /// Message with the canonical "Error: " prefix removed so exact strings
+    /// compare against the baseline text.
+    fn message(result: &super::CommandResult) -> &str {
+        result
+            .message
+            .as_deref()
+            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
+            .unwrap_or("")
+    }
+
+    use super::*;
+    use codewhale_command_contract::facets::{
+        PlanSections, PlanStep, RelayProjection, TodoProjection,
+    };
+
+    #[test]
+    fn relay_composes_exact_instruction_and_action() {
+        let mut fake = super::super::control_test_support::FakeControl {
+            relay: Some(super::super::control_test_support::relay_projection_fixture()),
+            ..super::super::control_test_support::FakeControl::default()
+        };
+        let result = relay_portable(&mut fake, Some("focus on the handoff"));
+        assert!(!result.is_error);
+        let message = match result.action {
+            Some(crate::tui::app::AppAction::SendMessage(message)) => message,
+            other => panic!("expected SendMessage action, got {other:?}"),
+        };
+        assert!(
+            message
+                .contains("Create a compact session relay (接力) for a future Codewhale thread.")
+        );
+        assert!(message.contains("- Workspace: /work"));
+        assert!(message.contains("- Mode: operate"));
+        assert!(message.contains("- Model: model-x"));
+        assert!(message.contains("- Requested relay focus: focus on the handoff"));
+        assert!(message.contains("- Goal objective: objective-y"));
+        assert!(message.contains("- Goal token budget: 900"));
+        assert!(message.contains("Keep the existing file path for compatibility, but title the artifact `# Session relay`."));
+        assert!(message.contains("Before writing, inspect the current transcript context"));
+        assert!(message.contains("Keep it under about 900 words"));
+        assert!(!message.contains("Current To-do:"));
+        assert!(!message.contains("strategy notes"));
+        assert!(
+            result
+                .message
+                .as_deref()
+                .is_some_and(|m| m == "Preparing session relay at .deepseek/handoff.md...")
+        );
+    }
+
+    #[test]
+    fn relay_render_optional_sections_and_busy_states_exactly() {
+        let mut fake = super::super::control_test_support::FakeControl {
+            relay: Some(RelayProjection {
+                compact_template: "# Session relay".to_string(),
+                workspace: "/work".to_string(),
+                mode: "operate".to_string(),
+                model: "model-x".to_string(),
+                goal_objective: None,
+                goal_token_budget: None,
+                todos: TodoProjection::Unavailable,
+                plan: codewhale_command_contract::facets::PlanProjection::Busy,
+            }),
+            ..super::super::control_test_support::FakeControl::default()
+        };
+        let result = relay_portable(&mut fake, None);
+        let message = match result.action {
+            Some(crate::tui::app::AppAction::SendMessage(message)) => message,
+            other => panic!("expected SendMessage, got {other:?}"),
+        };
+        assert!(message.contains("\nTo-do: unavailable because the list is busy."));
+        assert!(message.contains("\nStrategy metadata: unavailable because plan state is busy."));
+        assert!(!message.contains("Requested relay focus"));
+        assert!(!message.contains("Goal objective"));
+        assert!(!message.contains("Goal token budget"));
+    }
+
+    #[test]
+    fn relay_renders_plan_sections_with_exact_labels() {
+        let mut fake = super::super::control_test_support::FakeControl {
+            relay: Some(RelayProjection {
+                compact_template: "template".to_string(),
+                workspace: "/w".to_string(),
+                mode: "m".to_string(),
+                model: "mo".to_string(),
+                goal_objective: None,
+                goal_token_budget: None,
+                todos: TodoProjection::Absent,
+                plan: codewhale_command_contract::facets::PlanProjection::Sections(PlanSections {
+                    title: Some("Relay Plan".to_string()),
+                    explanation: Some("  because  ".to_string()),
+                    sources_used: vec!["repo-a".to_string(), "  ".to_string()],
+                    items: vec![PlanStep {
+                        status_label: "in_progress".to_string(),
+                        text: "port relay".to_string(),
+                    }],
+                    ..PlanSections::default()
+                }),
+            }),
+            ..super::super::control_test_support::FakeControl::default()
+        };
+        let result = relay_portable(&mut fake, None);
+        let message = match result.action {
+            Some(crate::tui::app::AppAction::SendMessage(message)) => message,
+            other => panic!("expected SendMessage, got {other:?}"),
+        };
+        assert!(message.contains("- Title: Relay Plan"));
+        assert!(message.contains("- Explanation: because"));
+        assert!(message.contains("- Source: repo-a"));
+        assert!(message.contains("- [in_progress] port relay"));
+    }
+
+    #[test]
+    fn relay_missing_control_authority_fails_safely() {
+        let contexts = codewhale_command_contract::handler::CommandContexts::empty();
+        let result = relay_contextual(contexts, None);
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "Command capability unavailable: session_control"
+        );
     }
 }

--- a/crates/tui/src/commands/groups/session/remote_control.rs
+++ b/crates/tui/src/commands/groups/session/remote_control.rs
@@ -111,16 +111,7 @@ pub(in crate::commands) fn remote_control_portable(
 
 #[cfg(test)]
 mod tests {
-    /// Message with the canonical "Error: " prefix removed so exact strings
-    /// compare against the baseline text.
-    fn message(result: &super::CommandResult) -> &str {
-        result
-            .message
-            .as_deref()
-            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
-            .unwrap_or("")
-    }
-
+    use super::super::control_test_support::message;
     use super::*;
     use codewhale_command_contract::facets::{RemoteLink, RemoteOpenOutcome, RemoteStartInfo};
 

--- a/crates/tui/src/commands/groups/session/remote_control.rs
+++ b/crates/tui/src/commands/groups/session/remote_control.rs
@@ -1,17 +1,10 @@
-//! `/rc` account-owned web remote control.
-
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
-use crate::remote_control::RemoteControlAction;
-use crate::tui::app::{App, AppAction};
+//! `/rc` command — account-owned web remote control (portable handler).
 
 use super::CommandResult;
-
-pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
-    name: "rc",
-    aliases: &["remote-control"],
-    usage: "/rc [status|link|open|stop]",
-    description_id: MessageId::CmdRemoteControlDescription,
+use codewhale_command_contract::facets::{CommandSessionControlContext, RemoteOpenOutcome};
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{
+    CommandInfo as ContractInfo, RegisterCommand as ContractRegisterCommand,
 };
 
 /// Shown by `/rc link` and `/rc open` before the control plane has advertised
@@ -21,127 +14,259 @@ const NO_LINK_MESSAGE: &str =
 
 pub(in crate::commands) struct RemoteControlCmd;
 
-impl RegisterCommand for RemoteControlCmd {
-    fn info() -> &'static CommandInfo {
-        &COMMAND_INFO
-    }
+// ---------------------------------------------------------------------------
+// FEAT-024 Phase 4 (D6/D7): portable contextual registration and handler.
+// Start/status/link/open/stop routing, active-turn wording, no-link guidance,
+// stop-refusal safety, and the bounded RemoteControl action payload stay
+// handler-owned; all remote-service state stays behind the control facet.
+// `/rc open` remains synchronous with no deferred external-URL action.
+// ---------------------------------------------------------------------------
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        match arg.map(str::trim).filter(|value| !value.is_empty()) {
-            None | Some("start") => CommandResult::with_message_and_action(
-                if app.is_loading || app.dispatch_in_flight {
+pub(in crate::commands) const CONTRACT_INFO: ContractInfo = ContractInfo {
+    name: "rc",
+    aliases: &["remote-control"],
+    usage: "/rc [status|link|open|stop]",
+    description_key: "cmd_remote_control_description",
+};
+
+impl ContractRegisterCommand<CommandResult> for RemoteControlCmd {
+    fn info() -> &'static ContractInfo {
+        &CONTRACT_INFO
+    }
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual {
+            capabilities: codewhale_command_contract::handler::CommandCapabilities::SESSION_CONTROL,
+            handler: remote_control_contextual,
+        }
+    }
+}
+
+pub(in crate::commands) fn remote_control_contextual(
+    contexts: CommandContexts<'_>,
+    arg: Option<&str>,
+) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let Some(control) = parts.control.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: session_control".to_string());
+    };
+    remote_control_portable(control, arg)
+}
+
+pub(in crate::commands) fn remote_control_portable(
+    control: &mut dyn CommandSessionControlContext,
+    arg: Option<&str>,
+) -> CommandResult {
+    match arg.map(str::trim).filter(|value| !value.is_empty()) {
+        None | Some("start") => {
+            let connecting = control.remote_start_info().connecting;
+            CommandResult::with_message_and_action(
+                if connecting {
                     "Connecting web remote control to the active turn…"
                 } else {
                     "Starting account-owned web remote control…"
                 },
-                AppAction::RemoteControl(RemoteControlAction::Start),
-            ),
-            Some("status") => CommandResult::message(app.remote_control.status_line()),
-            Some("link") => match app.remote_control.run_url() {
-                Some(url) => {
-                    let mut message = format!("Remote control session: {url}");
-                    if let Some(computer_url) = app.remote_control.computer_url() {
-                        message.push_str(&format!("\nManage this computer: {computer_url}"));
-                    }
-                    CommandResult::message(message)
-                }
-                None => CommandResult::error(NO_LINK_MESSAGE),
-            },
-            Some("open") => match app.remote_control.run_url() {
-                Some(url) => {
-                    let url = url.to_string();
-                    match crate::utils::open_url(&url) {
-                        Ok(()) => CommandResult::message(format!("Opening {url} in your browser…")),
-                        Err(_) => CommandResult::error(format!(
-                            "Could not launch a browser; open {url} manually."
-                        )),
-                    }
-                }
-                None => CommandResult::error(NO_LINK_MESSAGE),
-            },
-            Some("stop") => {
-                // Stop is refused while a remote turn is active or while any
-                // terminal/approval/integrity envelope is still awaiting the
-                // server-confirmed cursor; releasing the session earlier could
-                // strand account-side truth or create a second owner.
-                if let Some(reason) = app.remote_control.stop_refusal() {
-                    return CommandResult::error(reason);
-                }
-                CommandResult::with_message_and_action(
-                    "Stopping web remote control…",
-                    AppAction::RemoteControl(RemoteControlAction::Stop),
-                )
-            }
-            Some(_) => CommandResult::error("Usage: /rc [status|link|open|stop]"),
+                crate::tui::app::AppAction::RemoteControl(
+                    crate::remote_control::RemoteControlAction::Start,
+                ),
+            )
         }
+        Some("status") => CommandResult::message(control.remote_status()),
+        Some("link") => match control.remote_link() {
+            Some(link) => {
+                let mut message = format!("Remote control session: {}", link.url);
+                if let Some(computer_url) = link.computer_url {
+                    message.push_str(&format!("\nManage this computer: {computer_url}"));
+                }
+                CommandResult::message(message)
+            }
+            None => CommandResult::error(NO_LINK_MESSAGE),
+        },
+        Some("open") => match control.remote_browser_open() {
+            RemoteOpenOutcome::Opened { url } => {
+                CommandResult::message(format!("Opening {url} in your browser…"))
+            }
+            RemoteOpenOutcome::LaunchFailed { url } => {
+                CommandResult::error(format!("Could not launch a browser; open {url} manually."))
+            }
+            RemoteOpenOutcome::NoLink => CommandResult::error(NO_LINK_MESSAGE),
+        },
+        Some("stop") => {
+            // Stop is refused while a remote turn is active or while any
+            // terminal/approval/integrity envelope is still awaiting the
+            // server-confirmed cursor; releasing the session earlier could
+            // strand account-side truth or create a second owner.
+            if let Some(reason) = control.remote_stop_refusal() {
+                return CommandResult::error(reason);
+            }
+            CommandResult::with_message_and_action(
+                "Stopping web remote control…",
+                crate::tui::app::AppAction::RemoteControl(
+                    crate::remote_control::RemoteControlAction::Stop,
+                ),
+            )
+        }
+        Some(_) => CommandResult::error("Usage: /rc [status|link|open|stop]"),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::tui::app::TuiOptions;
-    use std::path::PathBuf;
-
-    #[test]
-    fn start_during_an_active_turn_dispatches_the_typed_handoff() {
-        let options = TuiOptions {
-            ..crate::test_support::test_tui_options(PathBuf::from("."))
-        };
-        let mut app = crate::test_support::test_app_with_options(options);
-        app.is_loading = true;
-        let result = RemoteControlCmd::execute(&mut app, None);
-        assert!(!result.is_error);
-        assert!(matches!(
-            result.action,
-            Some(AppAction::RemoteControl(RemoteControlAction::Start))
-        ));
-        assert!(
-            result
-                .message
-                .as_deref()
-                .is_some_and(|message| message.contains("active turn"))
-        );
+    /// Message with the canonical "Error: " prefix removed so exact strings
+    /// compare against the baseline text.
+    fn message(result: &super::CommandResult) -> &str {
+        result
+            .message
+            .as_deref()
+            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
+            .unwrap_or("")
     }
 
-    #[test]
-    fn link_and_open_report_no_link_before_the_session_is_live() {
-        let options = TuiOptions {
-            ..crate::test_support::test_tui_options(PathBuf::from("."))
-        };
-        let mut app = crate::test_support::test_app_with_options(options);
-        for arg in ["link", "open"] {
-            let result = RemoteControlCmd::execute(&mut app, Some(arg));
-            assert!(result.is_error, "{arg} must not pretend a link exists");
-            assert!(result.action.is_none());
-            assert!(
-                result
-                    .message
-                    .as_deref()
-                    .is_some_and(|message| message.contains("no live session link"))
-            );
+    use super::*;
+    use codewhale_command_contract::facets::{RemoteLink, RemoteOpenOutcome, RemoteStartInfo};
+
+    fn fake_with_defaults() -> super::super::control_test_support::FakeControl {
+        super::super::control_test_support::FakeControl {
+            remote_status: Some("Remote control: off".to_string()),
+            remote_link: Some(None),
+            browser_open: Some(RemoteOpenOutcome::NoLink),
+            start_info: Some(RemoteStartInfo { connecting: false }),
+            stop_refusal: Some(None),
+            ..super::super::control_test_support::FakeControl::default()
         }
     }
 
     #[test]
-    fn stop_is_blocked_while_a_remote_turn_is_active() {
-        let options = TuiOptions {
-            ..crate::test_support::test_tui_options(PathBuf::from("."))
-        };
-        let mut app = crate::test_support::test_app_with_options(options);
-        app.remote_control
-            .activate_prompt("run-1", "turn-1")
-            .unwrap();
-
-        let result = RemoteControlCmd::execute(&mut app, Some("stop"));
-
-        assert!(result.is_error);
-        assert!(result.action.is_none());
+    fn rc_start_uses_active_turn_copy_when_connecting() {
+        let mut fake = fake_with_defaults();
+        fake.start_info = Some(RemoteStartInfo { connecting: true });
+        for arg in [None, Some("start")] {
+            let result = remote_control_portable(&mut fake, arg);
+            assert!(!result.is_error);
+            assert!(
+                result
+                    .message
+                    .as_deref()
+                    .is_some_and(|m| m == "Connecting web remote control to the active turn…")
+            );
+            assert!(matches!(
+                result.action,
+                Some(crate::tui::app::AppAction::RemoteControl(
+                    crate::remote_control::RemoteControlAction::Start
+                ))
+            ));
+        }
+        fake.start_info = Some(RemoteStartInfo { connecting: false });
+        let result = remote_control_portable(&mut fake, None);
         assert!(
             result
                 .message
                 .as_deref()
-                .is_some_and(|message| message.contains("active remote turn"))
+                .is_some_and(|m| m == "Starting account-owned web remote control…")
+        );
+    }
+
+    #[test]
+    fn rc_status_link_and_no_link_messages_are_exact() {
+        let mut fake = fake_with_defaults();
+        let status = remote_control_portable(&mut fake, Some("status"));
+        assert_eq!(message(&status), "Remote control: off");
+
+        let no_link = remote_control_portable(&mut fake, Some("link"));
+        assert!(no_link.is_error);
+        assert!(
+            no_link
+                .message
+                .as_deref()
+                .unwrap()
+                .contains("no live session link")
+        );
+
+        fake.remote_link = Some(Some(RemoteLink {
+            url: "https://remote.example/s".to_string(),
+            computer_url: Some("https://remote.example/c".to_string()),
+        }));
+        let link = remote_control_portable(&mut fake, Some("link"));
+        assert!(!link.is_error);
+        assert_eq!(
+            message(&link),
+            "Remote control session: https://remote.example/s\nManage this computer: https://remote.example/c"
+        );
+    }
+
+    #[test]
+    fn rc_open_is_synchronous_and_never_emits_external_url_action() {
+        let mut fake = fake_with_defaults();
+        let no_link = remote_control_portable(&mut fake, Some("open"));
+        assert!(no_link.is_error);
+        assert!(no_link.action.is_none());
+        assert!(
+            no_link
+                .message
+                .as_deref()
+                .unwrap()
+                .contains("no live session link")
+        );
+
+        fake.browser_open = Some(RemoteOpenOutcome::Opened {
+            url: "https://remote.example/s".to_string(),
+        });
+        let opened = remote_control_portable(&mut fake, Some("open"));
+        assert!(!opened.is_error);
+        assert_eq!(
+            message(&opened),
+            "Opening https://remote.example/s in your browser…"
+        );
+        assert!(opened.action.is_none());
+
+        fake.browser_open = Some(RemoteOpenOutcome::LaunchFailed {
+            url: "https://remote.example/s".to_string(),
+        });
+        let failed = remote_control_portable(&mut fake, Some("open"));
+        assert!(failed.is_error);
+        assert_eq!(
+            message(&failed),
+            "Could not launch a browser; open https://remote.example/s manually."
+        );
+        assert!(failed.action.is_none());
+    }
+
+    #[test]
+    fn rc_stop_refuses_active_turns_and_unknown_ops_show_usage() {
+        let mut fake = fake_with_defaults();
+        fake.stop_refusal = Some(Some(
+            "stop refused while a remote turn is active".to_string(),
+        ));
+        let refused = remote_control_portable(&mut fake, Some("stop"));
+        assert!(refused.is_error);
+        assert_eq!(
+            message(&refused),
+            "stop refused while a remote turn is active"
+        );
+        assert!(refused.action.is_none());
+
+        fake.stop_refusal = Some(None);
+        let stopped = remote_control_portable(&mut fake, Some("stop"));
+        assert!(!stopped.is_error);
+        assert!(matches!(
+            stopped.action,
+            Some(crate::tui::app::AppAction::RemoteControl(
+                crate::remote_control::RemoteControlAction::Stop
+            ))
+        ));
+
+        let unknown = remote_control_portable(&mut fake, Some("frobnicate"));
+        assert!(unknown.is_error);
+        assert_eq!(message(&unknown), "Usage: /rc [status|link|open|stop]");
+    }
+
+    #[test]
+    fn rc_missing_control_authority_fails_safely() {
+        let contexts = codewhale_command_contract::handler::CommandContexts::empty();
+        let result = remote_control_contextual(contexts, None);
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "Command capability unavailable: session_control"
         );
     }
 }

--- a/crates/tui/src/commands/groups/session/remote_control.rs
+++ b/crates/tui/src/commands/groups/session/remote_control.rs
@@ -163,6 +163,14 @@ mod tests {
                 .as_deref()
                 .is_some_and(|m| m == "Starting account-owned web remote control…")
         );
+        assert_eq!(
+            fake.calls.borrow().as_slice(),
+            [
+                "remote_start_info",
+                "remote_start_info",
+                "remote_start_info"
+            ]
+        );
     }
 
     #[test]
@@ -190,6 +198,10 @@ mod tests {
         assert_eq!(
             message(&link),
             "Remote control session: https://remote.example/s\nManage this computer: https://remote.example/c"
+        );
+        assert_eq!(
+            fake.calls.borrow().as_slice(),
+            ["remote_status", "remote_link", "remote_link"]
         );
     }
 
@@ -228,6 +240,14 @@ mod tests {
             "Could not launch a browser; open https://remote.example/s manually."
         );
         assert!(failed.action.is_none());
+        assert_eq!(
+            fake.calls.borrow().as_slice(),
+            [
+                "remote_browser_open",
+                "remote_browser_open",
+                "remote_browser_open"
+            ]
+        );
     }
 
     #[test]
@@ -257,6 +277,10 @@ mod tests {
         let unknown = remote_control_portable(&mut fake, Some("frobnicate"));
         assert!(unknown.is_error);
         assert_eq!(message(&unknown), "Usage: /rc [status|link|open|stop]");
+        assert_eq!(
+            fake.calls.borrow().as_slice(),
+            ["remote_stop_refusal", "remote_stop_refusal"]
+        );
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/session/remote_env.rs
+++ b/crates/tui/src/commands/groups/session/remote_env.rs
@@ -1,461 +1,229 @@
-//! `/remote-env` opens the hosted Work launcher without taking source custody.
-
-use std::path::Path;
-use std::process::Stdio;
-
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::dependencies::{ExternalTool, Git};
-use crate::localization::{Locale, MessageId, tr};
-use crate::tui::app::{App, AppAction};
+//! `/remote-env` — portable handler over the session-control + presentation
+//! facets. Opens the hosted Work launcher without taking source custody.
 
 use super::CommandResult;
-
-const HOSTED_WORK_URL: &str = "https://app.codewhale.net/work";
-const MAX_GIT_VALUE_BYTES: usize = 4 * 1024;
-
-pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
-    name: "remote-env",
-    aliases: &[],
-    usage: "/remote-env [open]",
-    description_id: MessageId::CmdRemoteEnvDescription,
+use codewhale_command_contract::facets::{
+    CommandPresentationContext, CommandSessionControlContext,
+};
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{
+    CommandInfo as ContractInfo, RegisterCommand as ContractRegisterCommand,
 };
 
 pub(in crate::commands) struct RemoteEnvCmd;
 
-impl RegisterCommand for RemoteEnvCmd {
-    fn info() -> &'static CommandInfo {
-        &COMMAND_INFO
-    }
+// ---------------------------------------------------------------------------
+// FEAT-024 Phase 4 (D3/D6/D7): portable contextual registration and handler.
+// `/remote-env` is the only control command with runtime localization and
+// therefore the only one receiving PRESENTATION. The handler translates the
+// exact stable keys with the baseline placeholder sets; Git/URL machinery and
+// credential-safe target resolution stay behind `resolve_hosted_work_target`.
+// ---------------------------------------------------------------------------
 
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        match arg.map(str::trim).filter(|value| !value.is_empty()) {
-            None => CommandResult::message(remote_env_copy(
-                app.ui_locale,
-                MessageId::CmdRemoteEnvOverview,
-            )),
-            Some("open") => open_hosted_work(app),
-            Some(_) => CommandResult::error(remote_env_copy(
-                app.ui_locale,
-                MessageId::CmdRemoteEnvSourceCustodyPolicy,
-            )),
+pub(in crate::commands) const CONTRACT_INFO: ContractInfo = ContractInfo {
+    name: "remote-env",
+    aliases: &[],
+    usage: "/remote-env [open]",
+    description_key: "cmd_remote_env_description",
+};
+
+impl ContractRegisterCommand<CommandResult> for RemoteEnvCmd {
+    fn info() -> &'static ContractInfo {
+        &CONTRACT_INFO
+    }
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual {
+            capabilities: codewhale_command_contract::handler::CommandCapabilities::SESSION_CONTROL
+                .union(codewhale_command_contract::handler::CommandCapabilities::PRESENTATION),
+            handler: remote_env_contextual,
         }
     }
 }
 
-fn open_hosted_work(app: &App) -> CommandResult {
-    let Some(target) = resolve_target(&app.workspace) else {
-        return CommandResult::error(remote_env_copy(
-            app.ui_locale,
-            MessageId::CmdRemoteEnvUnavailable,
-        ));
+pub(in crate::commands) fn remote_env_contextual(
+    contexts: CommandContexts<'_>,
+    arg: Option<&str>,
+) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let Some(control) = parts.control.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: session_control".to_string());
     };
-    let url = hosted_work_url(&target.repo, &target.branch);
-    let message = remote_env_copy(app.ui_locale, MessageId::CmdRemoteEnvOpening)
-        .replace("{url}", &url)
-        .replace("{repo}", &target.repo)
-        .replace("{branch}", &target.branch);
-    let label = tr(app.ui_locale, MessageId::CmdRemoteEnvBrowserLabel).into_owned();
-
-    CommandResult::with_message_and_action(message, AppAction::OpenExternalUrl { url, label })
-}
-
-fn remote_env_copy(locale: Locale, id: MessageId) -> String {
-    tr(locale, id)
-        .replace("{command}", "/remote-env open")
-        .replace("{origin}", "origin")
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct RemoteEnvTarget {
-    pub(crate) repo: String,
-    pub(crate) branch: String,
-}
-
-pub(crate) fn resolve_target(workspace: &Path) -> Option<RemoteEnvTarget> {
-    let origin = read_git_value(
-        workspace,
-        &["config", "--local", "--get", "remote.origin.url"],
-    )?;
-    let repo = normalize_repo_slug(&origin)?;
-    let branch = read_git_value(workspace, &["symbolic-ref", "--quiet", "--short", "HEAD"])?;
-    if !valid_branch_name(&branch) {
-        return None;
-    }
-    Some(RemoteEnvTarget { repo, branch })
-}
-
-fn read_git_value(workspace: &Path, args: &[&str]) -> Option<String> {
-    let mut command = Git::command()?;
-    let output = command.arg("-C").arg(workspace).args(args).output().ok()?;
-    if !output.status.success()
-        || output.stdout.is_empty()
-        || output.stdout.len() > MAX_GIT_VALUE_BYTES
-    {
-        return None;
-    }
-    let value = String::from_utf8(output.stdout).ok()?;
-    let value = value.trim_end_matches(&['\r', '\n'][..]);
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_string())
-    }
-}
-
-fn valid_branch_name(branch: &str) -> bool {
-    if branch.is_empty() || branch.len() > MAX_GIT_VALUE_BYTES {
-        return false;
-    }
-    let Some(mut command) = Git::command() else {
-        return false;
+    let Some(presentation) = parts.presentation.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: presentation".to_string());
     };
-    command
-        .args(["check-ref-format", "--branch"])
-        .arg(branch)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
+    remote_env_portable(control, presentation, arg)
 }
 
-pub(crate) fn hosted_work_url(repo: &str, branch: &str) -> String {
-    format!(
-        "{HOSTED_WORK_URL}?repo={}&branch={}",
-        urlencoding::encode(repo),
-        urlencoding::encode(branch),
-    )
-}
-
-fn normalize_repo_slug(origin: &str) -> Option<String> {
-    let origin = origin.trim();
-    if origin.is_empty()
-        || origin.len() > MAX_GIT_VALUE_BYTES
-        || origin.chars().any(char::is_control)
-    {
-        return None;
+pub(in crate::commands) fn remote_env_portable(
+    control: &mut dyn CommandSessionControlContext,
+    presentation: &mut dyn CommandPresentationContext,
+    arg: Option<&str>,
+) -> CommandResult {
+    match arg.map(str::trim).filter(|value| !value.is_empty()) {
+        None => match presentation.translate(
+            "cmd_remote_env_overview",
+            &[("command", "/remote-env open")],
+        ) {
+            Ok(copy) => CommandResult::message(copy),
+            Err(error) => CommandResult::error(error),
+        },
+        Some("open") => open_hosted_work(control, presentation),
+        Some(_) => match presentation.translate(
+            "cmd_remote_env_source_custody_policy",
+            &[("command", "/remote-env open")],
+        ) {
+            Ok(copy) => CommandResult::error(copy),
+            Err(error) => CommandResult::error(error),
+        },
     }
+}
 
-    let (host, path) = if starts_with_ascii_case(origin, "https://") {
-        split_url_origin(&origin["https://".len()..], UrlScheme::Https)?
-    } else if starts_with_ascii_case(origin, "ssh://") {
-        split_url_origin(&origin["ssh://".len()..], UrlScheme::Ssh)?
-    } else {
-        split_scp_origin(origin)?
+fn open_hosted_work(
+    control: &dyn CommandSessionControlContext,
+    presentation: &mut dyn CommandPresentationContext,
+) -> CommandResult {
+    let Some(target) = control.resolve_hosted_work_target() else {
+        return match presentation.translate(
+            "cmd_remote_env_unavailable",
+            &[("command", "/remote-env open"), ("origin", "origin")],
+        ) {
+            Ok(copy) => CommandResult::error(copy),
+            Err(error) => CommandResult::error(error),
+        };
     };
-    if !matches!(
-        host.to_ascii_lowercase().as_str(),
-        "github.com" | "cnb.cool"
+    let message = match presentation.translate(
+        "cmd_remote_env_opening",
+        &[
+            ("origin", "origin"),
+            ("url", &target.url),
+            ("repo", &target.repo),
+            ("branch", &target.branch),
+        ],
     ) {
-        return None;
-    }
-    normalize_repo_path(path)
-}
-
-#[derive(Debug, Clone, Copy)]
-enum UrlScheme {
-    Https,
-    Ssh,
-}
-
-fn starts_with_ascii_case(value: &str, prefix: &str) -> bool {
-    value
-        .get(..prefix.len())
-        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
-}
-
-fn split_url_origin(origin: &str, scheme: UrlScheme) -> Option<(&str, &str)> {
-    let (authority, path) = origin.split_once('/')?;
-    if authority.is_empty() || path.is_empty() {
-        return None;
-    }
-    let host_port = authority
-        .rsplit_once('@')
-        .map_or(authority, |(_, host)| host);
-    let host = match host_port.rsplit_once(':') {
-        Some((host, port))
-            if !host.is_empty()
-                && !port.is_empty()
-                && port.bytes().all(|byte| byte.is_ascii_digit())
-                && (matches!(scheme, UrlScheme::Ssh) || port == "443") =>
-        {
-            host
-        }
-        Some(_) => return None,
-        None => host_port,
+        Ok(copy) => copy,
+        Err(error) => return CommandResult::error(error),
     };
-    (!host.is_empty()).then_some((host, path))
-}
-
-fn split_scp_origin(origin: &str) -> Option<(&str, &str)> {
-    let (authority, path) = origin.split_once(':')?;
-    let (_, host) = authority.rsplit_once('@')?;
-    if host.is_empty() || path.is_empty() {
-        return None;
-    }
-    Some((host, path))
-}
-
-fn normalize_repo_path(path: &str) -> Option<String> {
-    if path.chars().any(|ch| matches!(ch, '?' | '#' | '\\')) {
-        return None;
-    }
-    let path = path.trim_matches('/');
-    let path = path.strip_suffix(".git").unwrap_or(path);
-    let mut parts = path.split('/');
-    let namespace = parts.next()?;
-    let repository = parts.next()?;
-    if parts.next().is_some()
-        || !valid_repo_component(namespace)
-        || !valid_repo_component(repository)
-    {
-        return None;
-    }
-    Some(format!("{namespace}/{repository}"))
-}
-
-fn valid_repo_component(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= 255
-        && !matches!(value, "." | "..")
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    let label = match presentation.translate("cmd_remote_env_browser_label", &[]) {
+        Ok(label) => label,
+        Err(error) => return CommandResult::error(error),
+    };
+    CommandResult::with_message_and_action(
+        message,
+        crate::tui::app::AppAction::OpenExternalUrl {
+            url: target.url,
+            label,
+        },
+    )
 }
 
 #[cfg(test)]
 mod tests {
+    /// Message with the canonical "Error: " prefix removed so exact strings
+    /// compare against the baseline text.
+    fn message(result: &super::CommandResult) -> &str {
+        result
+            .message
+            .as_deref()
+            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
+            .unwrap_or("")
+    }
+
     use super::*;
-    use crate::localization::{Locale, MessageId, tr};
-    use crate::tui::app::TuiOptions;
-    use std::process::Command;
-    use tempfile::TempDir;
+    use codewhale_command_contract::facets::HostedWorkTarget;
+    use std::cell::RefCell;
 
-    fn init_repo(origin: &str, branch: &str) -> TempDir {
-        let temp = TempDir::new().expect("temp repository");
-        let init = Command::new("git")
-            .args(["init", "--quiet"])
-            .arg(temp.path())
-            .status()
-            .expect("run git init");
-        assert!(init.success());
-        let set_origin = Command::new("git")
-            .arg("-C")
-            .arg(temp.path())
-            .args(["config", "--local", "remote.origin.url", origin])
-            .status()
-            .expect("set origin");
-        assert!(set_origin.success());
-        let set_branch = Command::new("git")
-            .arg("-C")
-            .arg(temp.path())
-            .args(["symbolic-ref", "HEAD"])
-            .arg(format!("refs/heads/{branch}"))
-            .status()
-            .expect("set branch");
-        assert!(set_branch.success());
-        temp
+    /// Deterministic fake presentation facet resolving the five remote-env
+    /// keys with exact placeholder-set enforcement like the real adapter.
+    #[derive(Default)]
+    struct FakePresentation {
+        calls: RefCell<Vec<(String, String)>>,
     }
 
-    fn app_for(workspace: &Path) -> App {
-        let options = TuiOptions {
-            ..crate::test_support::test_tui_options(workspace)
-        };
-        let mut app = crate::test_support::test_app_with_options(options);
-        app.ui_locale = Locale::En;
-        app
-    }
-
-    fn external_url(result: &CommandResult) -> &str {
-        match result.action.as_ref() {
-            Some(AppAction::OpenExternalUrl { url, .. }) => url,
-            other => panic!("expected external URL action, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn bare_command_only_explains_the_source_boundary() {
-        let temp = TempDir::new().expect("workspace");
-        let mut app = app_for(temp.path());
-        let result = RemoteEnvCmd::execute(&mut app, None);
-        let message = result.message.expect("overview");
-        assert!(!result.is_error);
-        assert!(result.action.is_none());
-        for boundary in ["unpushed", "dirty", "ignored", "secrets", "session state"] {
-            assert!(message.contains(boundary), "missing boundary: {boundary}");
-        }
-    }
-
-    #[test]
-    fn open_builds_encoded_launcher_url_without_embedded_credentials() {
-        let secret = "top-secret-token";
-        let temp = init_repo(
-            &format!("https://hunter:{secret}@github.com/Hmbown/CodeWhale.git"),
-            "feature/mobile&cloud-{url}",
-        );
-        let mut app = app_for(temp.path());
-        let result = RemoteEnvCmd::execute(&mut app, Some("open"));
-        assert!(!result.is_error);
-        let url = external_url(&result);
-        assert_eq!(
-            url,
-            "https://app.codewhale.net/work?repo=Hmbown%2FCodeWhale&branch=feature%2Fmobile%26cloud-%7Burl%7D"
-        );
-        assert!(
-            result
-                .message
-                .as_deref()
-                .unwrap_or_default()
-                .contains("feature/mobile&cloud-{url}")
-        );
-        assert!(!url.contains(secret));
-        assert!(
-            !result
-                .message
-                .as_deref()
-                .unwrap_or_default()
-                .contains(secret)
-        );
-    }
-
-    #[test]
-    fn supported_https_and_ssh_origins_normalize_to_namespace_and_repo() {
-        for (origin, expected) in [
-            (
-                "https://github.com/Hmbown/CodeWhale.git",
-                "Hmbown/CodeWhale",
-            ),
-            (
-                "https://user:token@github.com/Hmbown/CodeWhale",
-                "Hmbown/CodeWhale",
-            ),
-            (
-                "ssh://git@github.com/Hmbown/CodeWhale.git",
-                "Hmbown/CodeWhale",
-            ),
-            ("git@github.com:Hmbown/CodeWhale.git", "Hmbown/CodeWhale"),
-            ("https://cnb.cool/whale/codewhale.git", "whale/codewhale"),
-            (
-                "ssh://git@cnb.cool:2222/whale/codewhale.git",
-                "whale/codewhale",
-            ),
-            ("git@cnb.cool:whale/codewhale.git", "whale/codewhale"),
-        ] {
-            assert_eq!(
-                normalize_repo_slug(origin).as_deref(),
-                Some(expected),
-                "{origin}"
-            );
-        }
-    }
-
-    #[test]
-    fn unsupported_or_ambiguous_origins_are_rejected_without_echoing_them() {
-        let secret = "do-not-echo-this-token";
-        let temp = init_repo(
-            &format!("https://user:{secret}@gitlab.com/acme/widgets.git"),
-            "main",
-        );
-        let mut app = app_for(temp.path());
-        let result = RemoteEnvCmd::execute(&mut app, Some("open"));
-        assert!(result.is_error);
-        assert!(result.action.is_none());
-        assert!(
-            !result
-                .message
-                .as_deref()
-                .unwrap_or_default()
-                .contains(secret)
-        );
-
-        for origin in [
-            "http://github.com/acme/widgets.git",
-            "git://github.com/acme/widgets.git",
-            "https://github.com/acme/widgets/extra.git",
-            "https://github.com/acme/widgets.git?token=secret",
-            "file:///tmp/widgets.git",
-            "/tmp/widgets.git",
-        ] {
-            assert_eq!(normalize_repo_slug(origin), None, "{origin}");
-        }
-    }
-
-    #[test]
-    fn upload_migrate_sync_and_unknown_operations_are_read_only_rejections() {
-        let temp = TempDir::new().expect("workspace");
-        let mut app = app_for(temp.path());
-        for operation in ["upload", "migrate", "sync", "surprise"] {
-            let result = RemoteEnvCmd::execute(&mut app, Some(operation));
-            assert!(result.is_error, "{operation}");
-            assert!(result.action.is_none(), "{operation}");
-            let message = result.message.expect("policy message");
-            assert!(message.contains("does not upload, migrate, or sync"));
-            assert!(message.contains("/remote-env open"));
-        }
-    }
-
-    #[test]
-    fn opening_requires_a_symbolic_branch() {
-        let temp = init_repo("git@github.com:acme/widgets.git", "main");
-        let identity = Command::new("git")
-            .arg("-C")
-            .arg(temp.path())
-            .args(["config", "user.name", "Codewhale Test"])
-            .status()
-            .expect("set test name");
-        assert!(identity.success());
-        let identity = Command::new("git")
-            .arg("-C")
-            .arg(temp.path())
-            .args(["config", "user.email", "test@codewhale.invalid"])
-            .status()
-            .expect("set test email");
-        assert!(identity.success());
-        let commit = Command::new("git")
-            .arg("-C")
-            .arg(temp.path())
-            .args(["commit", "--allow-empty", "--quiet", "-m", "fixture"])
-            .status()
-            .expect("create fixture commit");
-        assert!(commit.success());
-        let detach = Command::new("git")
-            .arg("-C")
-            .arg(temp.path())
-            .args(["checkout", "--detach", "--quiet", "HEAD"])
-            .status()
-            .expect("detach HEAD");
-        assert!(detach.success());
-
-        let mut app = app_for(temp.path());
-        let result = RemoteEnvCmd::execute(&mut app, Some("open"));
-        assert!(result.is_error);
-        assert!(result.action.is_none());
-    }
-
-    #[test]
-    fn localized_copy_preserves_composed_placeholders() {
-        let cases: &[(MessageId, &[&str])] = &[
-            (MessageId::CmdRemoteEnvOverview, &["{command}"]),
-            (
-                MessageId::CmdRemoteEnvOpening,
-                &["{repo}", "{branch}", "{origin}", "{url}"],
-            ),
-            (
-                MessageId::CmdRemoteEnvUnavailable,
-                &["{origin}", "{command}"],
-            ),
-            (MessageId::CmdRemoteEnvSourceCustodyPolicy, &["{command}"]),
-        ];
-        for locale in Locale::shipped_complete() {
-            for (id, placeholders) in cases {
-                let message = tr(*locale, *id);
-                for placeholder in *placeholders {
-                    assert!(
-                        message.contains(placeholder),
-                        "{} {id:?} lost {placeholder}",
-                        locale.tag()
-                    );
+    impl CommandPresentationContext for FakePresentation {
+        fn translate(&self, key: &str, replacements: &[(&str, &str)]) -> Result<String, String> {
+            self.calls
+                .borrow_mut()
+                .push((key.to_string(), format!("{replacements:?}")));
+            let base = match key {
+                "cmd_remote_env_overview" => "Overview {command}".to_string(),
+                "cmd_remote_env_opening" => {
+                    "Opening {repo}/{branch} from {origin} at {url}".to_string()
                 }
+                "cmd_remote_env_unavailable" => "Unavailable {command} {origin}".to_string(),
+                "cmd_remote_env_source_custody_policy" => "Policy {command}".to_string(),
+                "cmd_remote_env_browser_label" => "Label".to_string(),
+                other => return Err(format!("unknown key {other}")),
+            };
+            let mut out = base;
+            for (name, value) in replacements {
+                out = out.replace(&format!("{{{name}}}"), value);
             }
+            Ok(out)
         }
+    }
+
+    fn fake_control(
+        target: Option<HostedWorkTarget>,
+    ) -> super::super::control_test_support::FakeControl {
+        super::super::control_test_support::FakeControl {
+            hosted: Some(target),
+            ..super::super::control_test_support::FakeControl::default()
+        }
+    }
+
+    #[test]
+    fn remote_env_overview_and_policy_branches_are_exact() {
+        let mut control = fake_control(None);
+        let mut presentation = FakePresentation::default();
+        let overview = remote_env_portable(&mut control, &mut presentation, None);
+        assert!(!overview.is_error);
+        assert_eq!(message(&overview), "Overview /remote-env open");
+        assert!(overview.action.is_none());
+
+        let mut control = fake_control(None);
+        let invalid =
+            remote_env_portable(&mut control, &mut FakePresentation::default(), Some("sync"));
+        assert!(invalid.is_error);
+        assert_eq!(message(&invalid), "Policy /remote-env open");
+        assert!(invalid.action.is_none());
+    }
+
+    #[test]
+    fn remote_env_open_composes_exact_url_message_and_action() {
+        let mut control = fake_control(Some(HostedWorkTarget {
+            url: "https://app.codewhale.net/work?repo=A%2FB&branch=main".to_string(),
+            repo: "A/B".to_string(),
+            branch: "main".to_string(),
+        }));
+        let result =
+            remote_env_portable(&mut control, &mut FakePresentation::default(), Some("open"));
+        assert!(!result.is_error);
+        assert_eq!(
+            message(&result),
+            "Opening A/B/main from origin at https://app.codewhale.net/work?repo=A%2FB&branch=main"
+        );
+        assert!(matches!(
+            result.action,
+            Some(crate::tui::app::AppAction::OpenExternalUrl { ref url, ref label })
+                if url == "https://app.codewhale.net/work?repo=A%2FB&branch=main" && label == "Label"
+        ));
+
+        let mut control = fake_control(None);
+        let result =
+            remote_env_portable(&mut control, &mut FakePresentation::default(), Some("open"));
+        assert!(result.is_error);
+        assert_eq!(message(&result), "Unavailable /remote-env open origin");
+        assert!(result.action.is_none());
+    }
+
+    #[test]
+    fn remote_env_missing_authority_fails_safely() {
+        let contexts = codewhale_command_contract::handler::CommandContexts::empty();
+        let result = remote_env_contextual(contexts, None);
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "Command capability unavailable: session_control"
+        );
     }
 }

--- a/crates/tui/src/commands/groups/session/remote_env.rs
+++ b/crates/tui/src/commands/groups/session/remote_env.rs
@@ -118,16 +118,7 @@ fn open_hosted_work(
 
 #[cfg(test)]
 mod tests {
-    /// Message with the canonical "Error: " prefix removed so exact strings
-    /// compare against the baseline text.
-    fn message(result: &super::CommandResult) -> &str {
-        result
-            .message
-            .as_deref()
-            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
-            .unwrap_or("")
-    }
-
+    use super::super::control_test_support::message;
     use super::*;
     use codewhale_command_contract::facets::HostedWorkTarget;
     use std::cell::RefCell;

--- a/crates/tui/src/commands/groups/session/remote_env.rs
+++ b/crates/tui/src/commands/groups/session/remote_env.rs
@@ -207,6 +207,10 @@ mod tests {
             Some(crate::tui::app::AppAction::OpenExternalUrl { ref url, ref label })
                 if url == "https://app.codewhale.net/work?repo=A%2FB&branch=main" && label == "Label"
         ));
+        assert_eq!(
+            control.calls.borrow().as_slice(),
+            ["resolve_hosted_work_target"]
+        );
 
         let mut control = fake_control(None);
         let result =
@@ -224,6 +228,20 @@ mod tests {
         assert_eq!(
             message(&result),
             "Command capability unavailable: session_control"
+        );
+
+        let mut control = fake_control(None);
+        let contexts = codewhale_command_contract::handler::CommandContexts::empty()
+            .with_control(&mut control);
+        let result = remote_env_contextual(contexts, None);
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "Command capability unavailable: presentation"
+        );
+        assert!(
+            control.calls.borrow().is_empty(),
+            "translation authority is checked before command work"
         );
     }
 }

--- a/crates/tui/src/commands/groups/session/remote_env.rs
+++ b/crates/tui/src/commands/groups/session/remote_env.rs
@@ -66,12 +66,12 @@ fn remote_env_copy(locale: Locale, id: MessageId) -> String {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct RemoteEnvTarget {
-    repo: String,
-    branch: String,
+pub(crate) struct RemoteEnvTarget {
+    pub(crate) repo: String,
+    pub(crate) branch: String,
 }
 
-fn resolve_target(workspace: &Path) -> Option<RemoteEnvTarget> {
+pub(crate) fn resolve_target(workspace: &Path) -> Option<RemoteEnvTarget> {
     let origin = read_git_value(
         workspace,
         &["config", "--local", "--get", "remote.origin.url"],
@@ -118,7 +118,7 @@ fn valid_branch_name(branch: &str) -> bool {
         .is_ok_and(|status| status.success())
 }
 
-fn hosted_work_url(repo: &str, branch: &str) -> String {
+pub(crate) fn hosted_work_url(repo: &str, branch: &str) -> String {
     format!(
         "{HOSTED_WORK_URL}?repo={}&branch={}",
         urlencoding::encode(repo),

--- a/crates/tui/src/commands/groups/session/rename.rs
+++ b/crates/tui/src/commands/groups/session/rename.rs
@@ -1,9 +1,9 @@
 //! `/rename` command — portable handler over the session-control facet.
 //!
-//! The handler owns argument trimming and the usage boundary; sanitization,
-//! the 100-character limit (applied to the sanitized title as in the
-//! baseline), first-snapshot recovery, persistence, and publication stay in
-//! the atomic `rename_session` delegate so ordering cannot drift.
+//! The handler owns sanitization, blank and 100-character validation, and
+//! exact message composition. The atomic `rename_session` delegate owns only
+//! first-snapshot recovery, persistence, and publication so the policy moves
+//! with the handler while host mutation ordering cannot drift.
 
 use super::CommandResult;
 use codewhale_command_contract::facets::CommandSessionControlContext;
@@ -48,10 +48,21 @@ pub(in crate::commands) fn rename_portable(
     control: &mut dyn CommandSessionControlContext,
     arg: Option<&str>,
 ) -> CommandResult {
-    let Some(raw) = arg.map(str::trim).filter(|s| !s.is_empty()) else {
+    let Some(raw) = arg else {
         return CommandResult::error("Usage: /rename <new title>");
     };
-    match control.rename_session(raw) {
+    let sanitized = control.sanitize_session_title(raw);
+    let title = sanitized.trim();
+    if title.is_empty() {
+        return CommandResult::error("Usage: /rename <new title>");
+    }
+    if title.chars().count() > super::MAX_TITLE_LEN {
+        return CommandResult::error(format!(
+            "Title too long (max {} characters)",
+            super::MAX_TITLE_LEN
+        ));
+    }
+    match control.rename_session(title) {
         Ok(receipt) => CommandResult::message(format!("Session renamed to \"{}\"", receipt.title)),
         Err(error) => CommandResult::error(error),
     }
@@ -59,16 +70,7 @@ pub(in crate::commands) fn rename_portable(
 
 #[cfg(test)]
 mod tests {
-    /// Message with the canonical "Error: " prefix removed so exact strings
-    /// compare against the baseline text.
-    fn message(result: &super::CommandResult) -> &str {
-        result
-            .message
-            .as_deref()
-            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
-            .unwrap_or("")
-    }
-
+    use super::super::control_test_support::message;
     use super::*;
     use codewhale_command_contract::facets::SessionTitleReceipt;
 
@@ -91,6 +93,22 @@ mod tests {
         let result = rename_portable(&mut blank, Some("   "));
         assert!(result.is_error);
         assert_eq!(message(&result), "Usage: /rename <new title>");
+        assert_eq!(
+            blank.calls.borrow().as_slice(),
+            ["sanitize_session_title(   )"],
+            "sanitized blank input never reaches host mutation"
+        );
+
+        let mut oversized = control_fake();
+        oversized.sanitized_title = Some("x".repeat(super::super::MAX_TITLE_LEN + 1));
+        let result = rename_portable(&mut oversized, Some("raw"));
+        assert!(result.is_error);
+        assert_eq!(message(&result), "Title too long (max 100 characters)");
+        assert_eq!(
+            oversized.calls.borrow().as_slice(),
+            ["sanitize_session_title(raw)"],
+            "length policy runs before host mutation"
+        );
 
         let mut ok = control_fake();
         ok.rename = Some(Ok(SessionTitleReceipt {
@@ -99,7 +117,13 @@ mod tests {
         let result = rename_portable(&mut ok, Some("New Name"));
         assert!(!result.is_error);
         assert_eq!(message(&result), "Session renamed to \"New Name\"");
-        assert_eq!(ok.calls.borrow().as_slice(), ["rename_session(New Name)"]);
+        assert_eq!(
+            ok.calls.borrow().as_slice(),
+            [
+                "sanitize_session_title(New Name)",
+                "rename_session(New Name)"
+            ]
+        );
         assert!(result.action.is_none(), "/rename emits no action");
     }
 

--- a/crates/tui/src/commands/groups/session/rename.rs
+++ b/crates/tui/src/commands/groups/session/rename.rs
@@ -82,7 +82,10 @@ mod tests {
         let result = rename_portable(&mut no_arg, None);
         assert!(result.is_error);
         assert_eq!(message(&result), "Usage: /rename <new title>");
-        assert!(no_arg.calls.is_empty(), "no delegate call for blank input");
+        assert!(
+            no_arg.calls.borrow().is_empty(),
+            "no delegate call for blank input"
+        );
 
         let mut blank = control_fake();
         let result = rename_portable(&mut blank, Some("   "));
@@ -96,7 +99,7 @@ mod tests {
         let result = rename_portable(&mut ok, Some("New Name"));
         assert!(!result.is_error);
         assert_eq!(message(&result), "Session renamed to \"New Name\"");
-        assert_eq!(ok.calls, vec!["rename_session(New Name)".to_string()]);
+        assert_eq!(ok.calls.borrow().as_slice(), ["rename_session(New Name)"]);
         assert!(result.action.is_none(), "/rename emits no action");
     }
 

--- a/crates/tui/src/commands/groups/session/rename.rs
+++ b/crates/tui/src/commands/groups/session/rename.rs
@@ -1,394 +1,122 @@
-//! `/rename` command — set a custom title for the current session.
-
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
-use crate::session_manager::{SessionManager, update_session};
-use crate::tui::app::App;
+//! `/rename` command — portable handler over the session-control facet.
+//!
+//! The handler owns argument trimming and the usage boundary; sanitization,
+//! the 100-character limit (applied to the sanitized title as in the
+//! baseline), first-snapshot recovery, persistence, and publication stay in
+//! the atomic `rename_session` delegate so ordering cannot drift.
 
 use super::CommandResult;
-
-const MAX_TITLE_LEN: usize = 100;
-
-pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
-    name: "rename",
-    aliases: &["gaiming", "chongmingming"],
-    usage: "/rename <new title>",
-    description_id: MessageId::CmdRenameDescription,
+use codewhale_command_contract::facets::CommandSessionControlContext;
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{
+    CommandInfo as ContractInfo, RegisterCommand as ContractRegisterCommand,
 };
 
 pub(in crate::commands) struct RenameCmd;
 
-impl RegisterCommand for RenameCmd {
-    fn info() -> &'static CommandInfo {
-        &COMMAND_INFO
+pub(in crate::commands) const CONTRACT_INFO: ContractInfo = ContractInfo {
+    name: "rename",
+    aliases: &["gaiming", "chongmingming"],
+    usage: "/rename <new title>",
+    description_key: "cmd_rename_description",
+};
+
+impl ContractRegisterCommand<CommandResult> for RenameCmd {
+    fn info() -> &'static ContractInfo {
+        &CONTRACT_INFO
     }
-
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        rename(app, arg)
-    }
-}
-
-/// Rename the current session to the given title.
-///
-/// Usage: `/rename <new title>`
-///
-/// The new title is persisted immediately to `~/.deepseek/sessions/<id>.json`
-/// so the updated name is visible the next time the session picker is opened.
-pub fn rename(app: &mut App, arg: Option<&str>) -> CommandResult {
-    // Same character policy as the picker and Runtime API rename: controls
-    // and bidi/zero-width format characters never reach the persisted title.
-    let sanitized = arg
-        .map(crate::session_manager::sanitize_session_title)
-        .unwrap_or_default();
-    let new_title = match Some(sanitized.trim()).filter(|s| !s.is_empty()) {
-        Some(t) => t,
-        None => return CommandResult::error("Usage: /rename <new title>"),
-    };
-
-    if new_title.chars().count() > MAX_TITLE_LEN {
-        return CommandResult::error(format!("Title too long (max {MAX_TITLE_LEN} characters)"));
-    }
-
-    let session_id = match &app.current_session_id {
-        Some(id) => id.clone(),
-        None => {
-            return CommandResult::error(
-                "No active session. Send a message first to start a session.",
-            );
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual {
+            capabilities: codewhale_command_contract::handler::CommandCapabilities::SESSION_CONTROL,
+            handler: rename_contextual,
         }
-    };
-
-    let manager = match SessionManager::default_location() {
-        Ok(m) => m,
-        Err(e) => return CommandResult::error(format!("Could not open sessions directory: {e}")),
-    };
-
-    rename_with_manager(new_title, &session_id, &manager, app)
+    }
 }
 
-pub(crate) fn rename_with_manager(
-    new_title: &str,
-    session_id: &str,
-    manager: &SessionManager,
-    app: &mut App,
+pub(in crate::commands) fn rename_contextual(
+    contexts: CommandContexts<'_>,
+    arg: Option<&str>,
 ) -> CommandResult {
-    // Same character policy as the picker and Runtime API rename: controls
-    // and bidi/zero-width format characters never reach the persisted title.
-    let sanitized = crate::session_manager::sanitize_session_title(new_title);
-    let new_title = sanitized.trim();
-    if new_title.is_empty() {
-        return CommandResult::error("Usage: /rename <new title>");
-    }
-    let mut session = match manager.load_session(session_id) {
-        Ok(s) => s,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            match live_session_before_first_snapshot(manager, session_id, app) {
-                Some(s) => s,
-                None => {
-                    return CommandResult::error(format!("Could not load session: {err}"));
-                }
-            }
-        }
-        Err(e) => return CommandResult::error(format!("Could not load session: {e}")),
+    let mut parts = contexts.into_parts();
+    let Some(control) = parts.control.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: session_control".to_string());
     };
-
-    // Sync with current App state to avoid overwriting unsaved messages.
-    session = update_session(
-        session,
-        &app.api_messages,
-        u64::from(app.session.total_tokens),
-        app.system_prompt.as_ref(),
-    );
-    session.work_state = match app.work_state_snapshot() {
-        Ok(state) => state,
-        Err(err) => {
-            return CommandResult::error(format!(
-                "Could not snapshot Work state before rename: {err}"
-            ));
-        }
-    };
-    session.context_references = app.session_context_references.clone();
-    session.artifacts = app.session_artifacts.clone();
-    session.last_auto_route = app.auto_route_for_persistence();
-    session.metadata.model = app.model_selection_for_persistence();
-    session
-        .metadata
-        .set_model_provider_route(app.api_provider.as_str(), app.provider_id_for_persistence());
-    session.metadata.workspace.clone_from(&app.workspace);
-    session.metadata.mode = Some(app.mode.as_setting().to_string());
-    app.sync_cost_to_metadata(&mut session.metadata);
-    session.metadata.title = new_title.to_string();
-
-    match manager.save_session(&session) {
-        Ok(_) => {
-            app.current_session_metadata = Some(session.metadata.clone());
-            app.session_title = Some(new_title.to_string());
-            if let Err(err) = app.publish_pending_work_state() {
-                return CommandResult::error(format!(
-                    "Session renamed, but Work views were not published: {err}"
-                ));
-            }
-            CommandResult::message(format!("Session renamed to \"{new_title}\""))
-        }
-        Err(e) => CommandResult::error(format!("Could not save session: {e}")),
-    }
+    rename_portable(control, arg)
 }
 
-/// Recover the session document for a live turn that has not completed (and
-/// therefore persisted) its first snapshot yet (#5430).
-///
-/// Until a turn completes, `sessions/<id>.json` does not exist — only the
-/// crash checkpoint written at dispatch does — so a mid-first-turn
-/// `/rename` or `/title` used to fail outright with "Could not load
-/// session". Prefer the durable checkpoint; if even that has not been
-/// flushed yet, rebuild the document from the same in-memory `App` state the
-/// checkpoint itself was built from. Everything rename/title needs to
-/// preserve (id, created_at, fork lineage, journal) is either in the
-/// checkpoint or has never existed, and `update_session` re-syncs the
-/// conversation from `App` state immediately afterwards in both cases.
-pub(crate) fn live_session_before_first_snapshot(
-    manager: &SessionManager,
-    session_id: &str,
-    app: &App,
-) -> Option<crate::session_manager::SavedSession> {
-    if let Ok(Some(checkpoint)) = manager.load_session_checkpoint(session_id) {
-        return Some(checkpoint);
+pub(in crate::commands) fn rename_portable(
+    control: &mut dyn CommandSessionControlContext,
+    arg: Option<&str>,
+) -> CommandResult {
+    let Some(raw) = arg.map(str::trim).filter(|s| !s.is_empty()) else {
+        return CommandResult::error("Usage: /rename <new title>");
+    };
+    match control.rename_session(raw) {
+        Ok(receipt) => CommandResult::message(format!("Session renamed to \"{}\"", receipt.title)),
+        Err(error) => CommandResult::error(error),
     }
-    Some(
-        crate::session_manager::create_saved_session_with_id_and_mode(
-            session_id.to_string(),
-            &app.api_messages,
-            &app.model_selection_for_persistence(),
-            &app.workspace,
-            u64::from(app.session.total_tokens),
-            app.system_prompt.as_ref(),
-            Some(app.mode.as_setting()),
-        ),
-    )
 }
 
 #[cfg(test)]
 mod tests {
+    /// Message with the canonical "Error: " prefix removed so exact strings
+    /// compare against the baseline text.
+    fn message(result: &super::CommandResult) -> &str {
+        result
+            .message
+            .as_deref()
+            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
+            .unwrap_or("")
+    }
+
     use super::*;
-    use crate::config::Config;
-    use crate::models::Role;
-    use crate::session_manager::{SessionManager, create_saved_session_with_mode};
-    use crate::tui::app::{App, TuiOptions};
-    use tempfile::TempDir;
+    use codewhale_command_contract::facets::SessionTitleReceipt;
 
-    fn make_app(tmpdir: &TempDir) -> App {
-        App::new(
-            TuiOptions {
-                skills_dir: tmpdir.path().join("skills"),
-                memory_path: tmpdir.path().join("memory.md"),
-                notes_path: tmpdir.path().join("notes.txt"),
-                mcp_config_path: tmpdir.path().join("mcp.json"),
-                ..crate::test_support::test_tui_options(tmpdir.path())
-            },
-            &Config::default(),
-        )
-    }
-
-    fn make_session_manager(tmpdir: &TempDir) -> SessionManager {
-        SessionManager::new(tmpdir.path().join("sessions")).unwrap()
+    fn control_fake() -> super::super::control_test_support::FakeControl {
+        super::super::control_test_support::FakeControl::default()
     }
 
     #[test]
-    fn rename_without_arg_returns_error() {
-        let tmp = TempDir::new().unwrap();
-        let mut app = make_app(&tmp);
-        let r = rename(&mut app, None);
-        assert!(r.is_error);
-        assert!(r.message.unwrap().contains("Usage:"));
-    }
-
-    #[test]
-    fn rename_with_empty_arg_returns_error() {
-        let tmp = TempDir::new().unwrap();
-        let mut app = make_app(&tmp);
-        let r = rename(&mut app, Some("   "));
-        assert!(r.is_error);
-        assert!(r.message.unwrap().contains("Usage:"));
-    }
-
-    #[test]
-    fn rename_without_active_session_returns_error() {
-        let tmp = TempDir::new().unwrap();
-        let mut app = make_app(&tmp);
-        app.current_session_id = None;
-        let r = rename(&mut app, Some("My Session"));
-        assert!(r.is_error);
-        assert!(r.message.unwrap().contains("No active session"));
-    }
-
-    #[test]
-    fn rename_title_too_long_returns_error() {
-        let tmp = TempDir::new().unwrap();
-        let mut app = make_app(&tmp);
-        let long_title = "a".repeat(MAX_TITLE_LEN + 1);
-        let r = rename(&mut app, Some(&long_title));
-        assert!(r.is_error);
-        assert!(r.message.unwrap().contains("too long"));
-    }
-
-    #[test]
-    fn rename_persists_new_title() {
-        let tmp = TempDir::new().unwrap();
-        let manager = make_session_manager(&tmp);
-        let mut app = make_app(&tmp);
-
-        let stale_prompt = crate::models::SystemPrompt::Text("stale prompt".to_string());
-        let session = create_saved_session_with_mode(
-            &[],
-            "deepseek-v4-pro",
-            tmp.path(),
-            0,
-            Some(&stale_prompt),
-            None,
-        );
-        let session_id = session.metadata.id.clone();
-        manager.save_session(&session).unwrap();
-        app.set_model_selection("local-code-model".to_string());
-        app.set_provider_identity(crate::config::ApiProvider::Custom, "lm-studio");
-        app.mode = crate::tui::app::AppMode::Operate;
-        app.system_prompt = None;
-        {
-            let mut todos = app.todos.try_lock().expect("todos lock");
-            todos.add(
-                "live rename state".to_string(),
-                crate::tools::todo::TodoStatus::InProgress,
-            );
-        }
-        let expected_work_state = app.work_state_snapshot().expect("work snapshot");
-
-        let result = rename_with_manager("Brand New Title", &session_id, &manager, &mut app);
-        assert!(!result.is_error);
-        assert!(result.message.unwrap().contains("Brand New Title"));
-
-        let reloaded = manager.load_session(&session_id).unwrap();
-        assert_eq!(reloaded.metadata.title, "Brand New Title");
-        assert_eq!(reloaded.work_state, expected_work_state);
-        assert!(reloaded.system_prompt.is_none());
-        assert_eq!(reloaded.metadata.model, "local-code-model");
-        assert_eq!(reloaded.metadata.model_provider, "custom");
-        assert_eq!(
-            reloaded.metadata.model_provider_id.as_deref(),
-            Some("lm-studio")
-        );
-        assert_eq!(reloaded.metadata.workspace, app.workspace);
-        assert_eq!(reloaded.metadata.mode.as_deref(), Some("operate"));
-        assert_eq!(app.session_title.as_deref(), Some("Brand New Title"));
-        assert_eq!(
-            app.current_session_metadata
-                .as_ref()
-                .map(|metadata| metadata.title.as_str()),
-            Some("Brand New Title")
-        );
-    }
-
-    #[test]
-    fn rename_strips_terminal_controls_before_persisting() {
-        let tmp = TempDir::new().unwrap();
-        let manager = make_session_manager(&tmp);
-        let mut app = make_app(&tmp);
-        let session =
-            create_saved_session_with_mode(&[], "deepseek-v4-pro", tmp.path(), 0, None, None);
-        let session_id = session.metadata.id.clone();
-        manager.save_session(&session).unwrap();
-        app.current_session_id = Some(session_id.clone());
-
-        let result = rename_with_manager(
-            "Ev\u{1b}]0;PWNED\u{7}il\u{202e} Beta",
-            &session_id,
-            &manager,
-            &mut app,
-        );
-        assert!(!result.is_error, "{result:?}");
-        let reloaded = manager.load_session(&session_id).unwrap();
-        assert_eq!(reloaded.metadata.title, "Ev]0;PWNEDil Beta");
-        assert_eq!(app.session_title.as_deref(), Some("Ev]0;PWNEDil Beta"));
-
-        // Controls alone are the same as no title at all.
-        let result = rename_with_manager("\u{1b}\u{7}\u{200b}", &session_id, &manager, &mut app);
+    fn rename_usage_boundaries_and_success_messages_are_exact() {
+        let mut no_arg = control_fake();
+        let result = rename_portable(&mut no_arg, None);
         assert!(result.is_error);
-    }
+        assert_eq!(message(&result), "Usage: /rename <new title>");
+        assert!(no_arg.calls.is_empty(), "no delegate call for blank input");
 
-    #[test]
-    fn rename_title_at_max_length_succeeds() {
-        let tmp = TempDir::new().unwrap();
-        let manager = make_session_manager(&tmp);
-        let mut app = make_app(&tmp);
+        let mut blank = control_fake();
+        let result = rename_portable(&mut blank, Some("   "));
+        assert!(result.is_error);
+        assert_eq!(message(&result), "Usage: /rename <new title>");
 
-        let session =
-            create_saved_session_with_mode(&[], "deepseek-v4-pro", tmp.path(), 0, None, None);
-        let session_id = session.metadata.id.clone();
-        manager.save_session(&session).unwrap();
-
-        let max_title = "中".repeat(MAX_TITLE_LEN);
-        let result = rename_with_manager(&max_title, &session_id, &manager, &mut app);
+        let mut ok = control_fake();
+        ok.rename = Some(Ok(SessionTitleReceipt {
+            title: "New Name".to_string(),
+        }));
+        let result = rename_portable(&mut ok, Some("New Name"));
         assert!(!result.is_error);
-
-        let reloaded = manager.load_session(&session_id).unwrap();
-        assert_eq!(reloaded.metadata.title, max_title);
+        assert_eq!(message(&result), "Session renamed to \"New Name\"");
+        assert_eq!(ok.calls, vec!["rename_session(New Name)".to_string()]);
+        assert!(result.action.is_none(), "/rename emits no action");
     }
 
-    // #5430: until a session's first turn completes, only the crash
-    // checkpoint written at dispatch exists — `sessions/<id>.json` does not.
-    // A mid-first-turn `/rename`/`/title` must apply from that checkpoint
-    // instead of failing with "Could not load session".
     #[test]
-    fn rename_mid_first_turn_recovers_from_checkpoint_when_snapshot_missing() {
-        let tmp = TempDir::new().unwrap();
-        let manager = make_session_manager(&tmp);
-        let mut app = make_app(&tmp);
-
-        let checkpoint =
-            create_saved_session_with_mode(&[], "deepseek-v4-pro", tmp.path(), 0, None, None);
-        let session_id = checkpoint.metadata.id.clone();
-        manager.save_checkpoint(&checkpoint).unwrap();
-        app.current_session_id = Some(session_id.clone());
-        app.api_messages = vec![user_message("first turn still streaming")];
-
-        let result = rename_with_manager("Midturn Rename", &session_id, &manager, &mut app);
-        assert!(!result.is_error, "{result:?}");
-        assert_eq!(app.session_title.as_deref(), Some("Midturn Rename"));
-
-        // The rename promotes the checkpoint record to the durable session
-        // file, so the listing and the next launch see the new title.
-        let persisted = manager.load_session(&session_id).unwrap();
-        assert_eq!(persisted.metadata.title, "Midturn Rename");
-        assert_eq!(persisted.messages.len(), 1);
+    fn rename_host_errors_pass_through_exactly() {
+        let mut fake = control_fake();
+        fake.rename = Some(Err("Could not save session: boom".to_string()));
+        let result = rename_portable(&mut fake, Some("Whatever"));
+        assert!(result.is_error);
+        assert_eq!(message(&result), "Could not save session: boom");
     }
 
-    // Worst case of the same window: the user renames before even the
-    // dispatch checkpoint has been flushed. The document is then built from
-    // the same in-memory App state the checkpoint itself would carry.
     #[test]
-    fn rename_mid_first_turn_builds_from_app_state_when_nothing_persisted() {
-        let tmp = TempDir::new().unwrap();
-        let manager = make_session_manager(&tmp);
-        let mut app = make_app(&tmp);
-
-        let session_id = "live-before-first-checkpoint";
-        app.current_session_id = Some(session_id.to_string());
-        app.api_messages = vec![user_message("turn one, nothing persisted yet")];
-
-        let result = rename_with_manager("Earliest Rename", session_id, &manager, &mut app);
-        assert!(!result.is_error, "{result:?}");
-        assert_eq!(app.session_title.as_deref(), Some("Earliest Rename"));
-
-        let persisted = manager.load_session(session_id).unwrap();
-        assert_eq!(persisted.metadata.title, "Earliest Rename");
-        assert_eq!(persisted.messages.len(), 1);
-    }
-
-    fn user_message(text: &str) -> crate::models::Message {
-        crate::models::Message {
-            role: Role::User,
-            content: vec![crate::models::ContentBlock::Text {
-                text: text.to_string(),
-                cache_control: None,
-            }],
-        }
+    fn rename_missing_control_authority_fails_safely() {
+        let contexts = codewhale_command_contract::handler::CommandContexts::empty();
+        let result = rename_contextual(contexts, None);
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "Command capability unavailable: session_control"
+        );
     }
 }

--- a/crates/tui/src/commands/groups/session/resume.rs
+++ b/crates/tui/src/commands/groups/session/resume.rs
@@ -180,7 +180,7 @@ mod tests {
         assert!(!result.is_error);
         assert!(matches!(
             result.action,
-            Some(crate::tui::app::AppAction::LoadSession(path)) if path == PathBuf::from("/tmp/sessions/abc123.json")
+            Some(crate::tui::app::AppAction::LoadSession(path)) if path == *"/tmp/sessions/abc123.json"
         ));
 
         let mut fake = control_fake();

--- a/crates/tui/src/commands/groups/session/resume.rs
+++ b/crates/tui/src/commands/groups/session/resume.rs
@@ -86,16 +86,7 @@ pub(in crate::commands) fn resume_portable(
 
 #[cfg(test)]
 mod tests {
-    /// Message with the canonical "Error: " prefix removed so exact strings
-    /// compare against the baseline text.
-    fn message(result: &super::CommandResult) -> &str {
-        result
-            .message
-            .as_deref()
-            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
-            .unwrap_or("")
-    }
-
+    use super::super::control_test_support::message;
     use super::*;
     use codewhale_command_contract::facets::ResumeImportReceipt;
     use std::path::PathBuf;

--- a/crates/tui/src/commands/groups/session/resume.rs
+++ b/crates/tui/src/commands/groups/session/resume.rs
@@ -114,7 +114,11 @@ mod tests {
             message(&result),
             "Cannot resume while runtime work is active. Wait for the turn to finish, or cancel it first."
         );
-        assert!(fake.calls.is_empty(), "no route work before the gate");
+        assert_eq!(
+            fake.calls.borrow().as_slice(),
+            ["transition_blocked"],
+            "the gate executes exactly once before route work"
+        );
     }
 
     #[test]
@@ -124,7 +128,10 @@ mod tests {
         assert!(!result.is_error);
         assert!(result.action.is_none());
         assert!(result.message.is_none());
-        assert_eq!(fake.calls, vec!["open_resume_picker".to_string()]);
+        assert_eq!(
+            fake.calls.borrow().as_slice(),
+            ["transition_blocked", "open_resume_picker"]
+        );
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/session/resume.rs
+++ b/crates/tui/src/commands/groups/session/resume.rs
@@ -1,131 +1,230 @@
+//! `/resume` command — portable handler over the session-control facet.
+//!
+//! The handler owns route selection and the exact per-route messages/actions;
+//! filesystem, manager, parser, and picker machinery stay behind the facet's
+//! `resolve_resume_source` / `import_session_file` / `open_resume_picker`
+//! delegates (transition blocking is checked before any picker or I/O).
+
 use super::CommandResult;
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
-use crate::tui::app::App;
-use crate::tui::session_picker::SessionPickerView;
-use std::path::PathBuf;
-pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
+use codewhale_command_contract::facets::{CommandSessionControlContext, ResumeSource};
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{
+    CommandInfo as ContractInfo, RegisterCommand as ContractRegisterCommand,
+};
+
+pub(in crate::commands) struct ResumeCmd;
+
+pub(in crate::commands) const CONTRACT_INFO: ContractInfo = ContractInfo {
     name: "resume",
     aliases: &["r"],
     usage: "/resume [session_id|path/to/export.json]",
-    description_id: MessageId::CmdResumeDescription,
+    description_key: "cmd_resume_description",
 };
-pub(in crate::commands) struct ResumeCmd;
-impl RegisterCommand for ResumeCmd {
-    fn info() -> &'static CommandInfo {
-        &COMMAND_INFO
+
+impl ContractRegisterCommand<CommandResult> for ResumeCmd {
+    fn info() -> &'static ContractInfo {
+        &CONTRACT_INFO
     }
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        resume(app, arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual {
+            capabilities: codewhale_command_contract::handler::CommandCapabilities::SESSION_CONTROL,
+            handler: resume_contextual,
+        }
     }
 }
-fn resume(app: &mut App, arg: Option<&str>) -> CommandResult {
-    if app.session_transition_blocked() {
+
+pub(in crate::commands) fn resume_contextual(
+    contexts: CommandContexts<'_>,
+    arg: Option<&str>,
+) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let Some(control) = parts.control.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: session_control".to_string());
+    };
+    resume_portable(control, arg)
+}
+
+pub(in crate::commands) fn resume_portable(
+    control: &mut dyn CommandSessionControlContext,
+    arg: Option<&str>,
+) -> CommandResult {
+    if control.transition_blocked() {
         return CommandResult::error(
             "Cannot resume while runtime work is active. Wait for the turn to finish, or cancel it first.",
         );
     }
     let Some(raw) = arg.map(str::trim).filter(|s| !s.is_empty()) else {
-        app.view_stack
-            .push(SessionPickerView::new(&app.workspace, app.ui_locale));
+        control.open_resume_picker();
         return CommandResult::ok();
     };
-    let path = PathBuf::from(raw);
-    if path.is_file() || raw.ends_with(".json") && std::path::Path::new(raw).exists() {
-        return import_foreign(app, &path);
-    }
-    let ws_path = app.workspace.join(raw);
-    if ws_path.is_file() {
-        return import_foreign(app, &ws_path);
-    }
-    let manager = match crate::session_manager::SessionManager::default_location() {
-        Ok(m) => m,
-        Err(e) => return CommandResult::error(format!("could not open sessions directory: {e}")),
-    };
-    let session = manager
-        .load_session(raw)
-        .or_else(|_| manager.load_session_by_prefix(raw));
-    match session {
-        Ok(sess) => {
-            let path = manager
-                .sessions_dir()
-                .join(format!("{}.json", sess.metadata.id));
-            if path.exists() {
-                return CommandResult::action(crate::tui::app::AppAction::LoadSession(path));
-            }
-            CommandResult::message(format!(
-                "Resuming session {} ({})",
-                crate::session_manager::truncate_id(&sess.metadata.id),
-                sess.metadata.title
-            ))
-        }
-        Err(e) => {
-            if let Ok(container) = crate::session_tree::SessionImportContainer::from_json(raw) {
-                return import_container(app, container);
-            }
-            CommandResult::error(format!(
-                "Cannot resume '{raw}': {e}\nUse `/resume` without args to pick, or pass a session id, or a path to an exported session JSON."
-            ))
-        }
+    match control.resolve_resume_source(raw) {
+        Ok(ResumeSource::File(path)) => match control.import_session_file(path) {
+            Ok(receipt) => CommandResult::message(format!(
+                "Imported foreign session as {} ({} entries, leaf {})",
+                receipt.truncated_id, receipt.entry_count, receipt.leaf_display
+            )),
+            Err(error) => CommandResult::error(error),
+        },
+        Ok(ResumeSource::Imported(receipt)) => CommandResult::message(format!(
+            "Imported foreign session as {} ({} entries, leaf {})",
+            receipt.truncated_id, receipt.entry_count, receipt.leaf_display
+        )),
+        Ok(ResumeSource::Session {
+            load_path,
+            truncated_id,
+            title,
+        }) => match load_path {
+            Some(path) => CommandResult::action(crate::tui::app::AppAction::LoadSession(path)),
+            None => CommandResult::message(format!("Resuming session {truncated_id} ({title})")),
+        },
+        Ok(ResumeSource::NotFound { raw, error }) => CommandResult::error(format!(
+            "Cannot resume '{raw}': {error}\nUse `/resume` without args to pick, or pass a session id, or a path to an exported session JSON."
+        )),
+        Err(error) => CommandResult::error(error),
     }
 }
-fn import_foreign(app: &mut App, path: &PathBuf) -> CommandResult {
-    let content = match std::fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(e) => {
-            return CommandResult::error(format!(
-                "failed to read import file {}: {e}",
-                path.display()
-            ));
-        }
-    };
-    if let Ok(container) = crate::session_tree::SessionImportContainer::from_json(&content) {
-        return import_container(app, container);
+
+#[cfg(test)]
+mod tests {
+    /// Message with the canonical "Error: " prefix removed so exact strings
+    /// compare against the baseline text.
+    fn message(result: &super::CommandResult) -> &str {
+        result
+            .message
+            .as_deref()
+            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
+            .unwrap_or("")
     }
-    if let Ok(foreign) = serde_json::from_str::<crate::session_manager::SavedSession>(&content) {
-        let container = foreign.export_container("foreign");
-        return import_container(app, container);
+
+    use super::*;
+    use codewhale_command_contract::facets::ResumeImportReceipt;
+    use std::path::PathBuf;
+
+    fn control_fake() -> super::super::control_test_support::FakeControl {
+        super::super::control_test_support::FakeControl::default()
     }
-    CommandResult::error(format!(
-        "File {} is not a recognized session export",
-        path.display()
-    ))
-}
-fn import_container(
-    app: &mut App,
-    container: crate::session_tree::SessionImportContainer,
-) -> CommandResult {
-    let manager = match crate::session_manager::SessionManager::default_location() {
-        Ok(m) => m,
-        Err(e) => return CommandResult::error(format!("could not open sessions directory: {e}")),
-    };
-    let model = app.model.clone();
-    let workspace = app.workspace.clone();
-    let imported =
-        match crate::session_manager::SavedSession::import_foreign(container, workspace, model) {
-            Ok(s) => s,
-            Err(e) => return CommandResult::error(format!("foreign import failed: {e}")),
-        };
-    let new_id = imported.metadata.id.clone();
-    if let Err(e) = manager.save_session(&imported) {
-        return CommandResult::error(format!("imported session could not be saved: {e}"));
+
+    #[test]
+    fn resume_transition_blocking_wins_before_any_route() {
+        let mut fake = control_fake();
+        fake.blocked = true;
+        let result = resume_portable(&mut fake, Some("anything"));
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "Cannot resume while runtime work is active. Wait for the turn to finish, or cancel it first."
+        );
+        assert!(fake.calls.is_empty(), "no route work before the gate");
     }
-    app.current_session_id = Some(new_id.clone());
-    app.current_session_metadata = Some(imported.metadata.clone());
-    app.api_messages = imported.messages.clone();
-    app.view_stack.push(SessionPickerView::new_selecting(
-        &app.workspace,
-        app.ui_locale,
-        &new_id,
-    ));
-    CommandResult::message(format!(
-        "Imported foreign session as {} ({} entries, leaf {})",
-        crate::session_manager::truncate_id(&new_id),
-        imported
-            .journal
-            .as_ref()
-            .map(|j| j.entries.len())
-            .unwrap_or(0),
-        imported.leaf_id.as_deref().unwrap_or("(none)")
-    ))
+
+    #[test]
+    fn resume_bare_opens_the_picker() {
+        let mut fake = control_fake();
+        let result = resume_portable(&mut fake, None);
+        assert!(!result.is_error);
+        assert!(result.action.is_none());
+        assert!(result.message.is_none());
+        assert_eq!(fake.calls, vec!["open_resume_picker".to_string()]);
+    }
+
+    #[test]
+    fn resume_file_and_import_routes_compose_exact_receipts() {
+        let mut fake = control_fake();
+        fake.resume = Some(Ok(ResumeSource::File(PathBuf::from("/tmp/import.json"))));
+        fake.import = Some(Ok(ResumeImportReceipt {
+            truncated_id: "imp-9".to_string(),
+            entry_count: 12,
+            leaf_display: "leaf-3".to_string(),
+        }));
+        let result = resume_portable(&mut fake, Some("/tmp/import.json"));
+        assert!(!result.is_error);
+        assert_eq!(
+            message(&result),
+            "Imported foreign session as imp-9 (12 entries, leaf leaf-3)"
+        );
+
+        let mut fake = control_fake();
+        fake.resume = Some(Ok(ResumeSource::File(PathBuf::from("/tmp/x.json"))));
+        fake.import = Some(Err(
+            "File x.json is not a recognized session export".to_string()
+        ));
+        let result = resume_portable(&mut fake, Some("/tmp/x.json"));
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "File x.json is not a recognized session export"
+        );
+
+        let mut fake = control_fake();
+        fake.resume = Some(Ok(ResumeSource::Imported(ResumeImportReceipt {
+            truncated_id: "c-1".to_string(),
+            entry_count: 0,
+            leaf_display: "(none)".to_string(),
+        })));
+        let result = resume_portable(&mut fake, Some("inline-json"));
+        assert_eq!(
+            message(&result),
+            "Imported foreign session as c-1 (0 entries, leaf (none))"
+        );
+    }
+
+    #[test]
+    fn resume_session_and_not_found_routes_are_exact() {
+        let mut fake = control_fake();
+        fake.resume = Some(Ok(ResumeSource::Session {
+            load_path: Some(PathBuf::from("/tmp/sessions/abc123.json")),
+            truncated_id: "abc123".to_string(),
+            title: "Control Session".to_string(),
+        }));
+        let result = resume_portable(&mut fake, Some("abc123"));
+        assert!(!result.is_error);
+        assert!(matches!(
+            result.action,
+            Some(crate::tui::app::AppAction::LoadSession(path)) if path == PathBuf::from("/tmp/sessions/abc123.json")
+        ));
+
+        let mut fake = control_fake();
+        fake.resume = Some(Ok(ResumeSource::Session {
+            load_path: None,
+            truncated_id: "abc123".to_string(),
+            title: "Control Session".to_string(),
+        }));
+        let result = resume_portable(&mut fake, Some("abc123"));
+        assert_eq!(
+            message(&result),
+            "Resuming session abc123 (Control Session)"
+        );
+
+        let mut fake = control_fake();
+        fake.resume = Some(Ok(ResumeSource::NotFound {
+            raw: "nope".to_string(),
+            error: "no such session".to_string(),
+        }));
+        let result = resume_portable(&mut fake, Some("nope"));
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "Cannot resume 'nope': no such session\nUse `/resume` without args to pick, or pass a session id, or a path to an exported session JSON."
+        );
+    }
+
+    #[test]
+    fn resume_host_lookup_errors_pass_through() {
+        let mut fake = control_fake();
+        fake.resume = Some(Err("could not open sessions directory: boom".to_string()));
+        let result = resume_portable(&mut fake, Some("abc"));
+        assert!(result.is_error);
+        assert_eq!(message(&result), "could not open sessions directory: boom");
+    }
+
+    #[test]
+    fn resume_missing_control_authority_fails_safely() {
+        let contexts = codewhale_command_contract::handler::CommandContexts::empty();
+        let result = resume_contextual(contexts, None);
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "Command capability unavailable: session_control"
+        );
+    }
 }

--- a/crates/tui/src/commands/groups/session/title.rs
+++ b/crates/tui/src/commands/groups/session/title.rs
@@ -150,8 +150,13 @@ mod tests {
                 "Window title cleared (the config default still applies if set)"
             );
         }
-        assert_eq!(fake.calls.len(), 3);
-        assert!(fake.calls.iter().all(|c| c == "set_window_title(clear)"));
+        assert_eq!(fake.calls.borrow().len(), 3);
+        assert!(
+            fake.calls
+                .borrow()
+                .iter()
+                .all(|call| call == "set_window_title(clear)")
+        );
 
         let mut fake = control_fake();
         fake.set_title = Some(Ok(TitleSetOutcome::Set("task-7".to_string())));
@@ -176,7 +181,10 @@ mod tests {
                 .unwrap()
                 .contains("Title too long (max 100 characters)")
         );
-        assert!(fake.calls.is_empty(), "length check precedes the delegate");
+        assert!(
+            fake.calls.borrow().is_empty(),
+            "length check precedes the delegate"
+        );
 
         let mut fake = control_fake();
         fake.set_title = Some(Err(

--- a/crates/tui/src/commands/groups/session/title.rs
+++ b/crates/tui/src/commands/groups/session/title.rs
@@ -2,20 +2,16 @@
 //!
 //! Distinct from `/rename`: it sets the session *window/tab* title. The
 //! handler owns the bare-report branch, the `off|clear|none` synonyms, and
-//! the 100-character limit on the raw argument; the atomic
-//! `set_window_title` delegate owns sanitization, persistence, publication,
+//! the 100-character limit on the raw argument, sanitization, and exact
+//! messages; the atomic set/clear delegates own persistence, publication,
 //! and the redraw flag.
 
 use super::CommandResult;
-use codewhale_command_contract::facets::{
-    CommandSessionControlContext, TitleSetOutcome, TitleSource,
-};
+use codewhale_command_contract::facets::{CommandSessionControlContext, TitleSource};
 use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
 use codewhale_command_contract::metadata::{
     CommandInfo as ContractInfo, RegisterCommand as ContractRegisterCommand,
 };
-
-const MAX_TITLE_LEN: usize = 100;
 
 pub(in crate::commands) struct TitleCmd;
 
@@ -65,46 +61,42 @@ pub(in crate::commands) fn title_portable(
     };
 
     if arg == "off" || arg == "clear" || arg == "none" {
-        return match control.set_window_title(None) {
-            Ok(TitleSetOutcome::Cleared) => CommandResult::message(
+        return match control.clear_window_title() {
+            Ok(()) => CommandResult::message(
                 "Window title cleared (the config default still applies if set)",
             ),
-            Ok(TitleSetOutcome::Set(_)) => {
-                CommandResult::error("internal title-state error".to_string())
-            }
             Err(error) => CommandResult::error(error),
         };
     }
 
-    if arg.chars().count() > MAX_TITLE_LEN {
-        return CommandResult::error(format!("Title too long (max {MAX_TITLE_LEN} characters)"));
+    if arg.chars().count() > super::MAX_TITLE_LEN {
+        return CommandResult::error(format!(
+            "Title too long (max {} characters)",
+            super::MAX_TITLE_LEN
+        ));
     }
 
-    match control.set_window_title(Some(arg.to_string())) {
-        Ok(TitleSetOutcome::Set(title)) => CommandResult::message(format!(
+    let sanitized = control.sanitize_session_title(arg);
+    let title = sanitized.trim();
+    if title.is_empty() {
+        return CommandResult::error(
+            "Title cannot be empty; use /title off to clear a session title",
+        );
+    }
+
+    match control.set_window_title(title.to_string()) {
+        Ok(()) => CommandResult::message(format!(
             "Window title set to \"{title}\" — the terminal tab now reads [\"{title}\"] …"
         )),
-        Ok(TitleSetOutcome::Cleared) => {
-            CommandResult::error("internal title-state error".to_string())
-        }
         Err(error) => CommandResult::error(error),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    /// Message with the canonical "Error: " prefix removed so exact strings
-    /// compare against the baseline text.
-    fn message(result: &super::CommandResult) -> &str {
-        result
-            .message
-            .as_deref()
-            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
-            .unwrap_or("")
-    }
-
+    use super::super::control_test_support::message;
     use super::*;
-    use codewhale_command_contract::facets::{TitleReport, TitleSetOutcome};
+    use codewhale_command_contract::facets::TitleReport;
 
     fn control_fake() -> super::super::control_test_support::FakeControl {
         super::super::control_test_support::FakeControl::default()
@@ -141,7 +133,7 @@ mod tests {
     #[test]
     fn title_synonyms_clear_and_set_messages_are_exact() {
         let mut fake = control_fake();
-        fake.set_title = Some(Ok(TitleSetOutcome::Cleared));
+        fake.clear_title = Some(Ok(()));
         for synonym in ["off", "clear", "none"] {
             let result = title_portable(&mut fake, Some(synonym));
             assert!(!result.is_error, "{synonym}");
@@ -155,16 +147,20 @@ mod tests {
             fake.calls
                 .borrow()
                 .iter()
-                .all(|call| call == "set_window_title(clear)")
+                .all(|call| call == "clear_window_title")
         );
 
         let mut fake = control_fake();
-        fake.set_title = Some(Ok(TitleSetOutcome::Set("task-7".to_string())));
+        fake.set_title = Some(Ok(()));
         let result = title_portable(&mut fake, Some("task-7"));
         assert!(!result.is_error);
         assert_eq!(
             message(&result),
             "Window title set to \"task-7\" — the terminal tab now reads [\"task-7\"] …"
+        );
+        assert_eq!(
+            fake.calls.borrow().as_slice(),
+            ["sanitize_session_title(task-7)", "set_window_title(task-7)"]
         );
         assert!(result.action.is_none(), "/title emits no action");
     }
@@ -172,7 +168,10 @@ mod tests {
     #[test]
     fn title_oversized_and_host_errors_are_exact() {
         let mut fake = control_fake();
-        let result = title_portable(&mut fake, Some(&"x".repeat(MAX_TITLE_LEN + 1)));
+        let result = title_portable(
+            &mut fake,
+            Some(&"x".repeat(super::super::MAX_TITLE_LEN + 1)),
+        );
         assert!(result.is_error);
         assert!(
             result
@@ -187,15 +186,30 @@ mod tests {
         );
 
         let mut fake = control_fake();
-        fake.set_title = Some(Err(
-            "Title cannot be empty; use /title off to clear a session title".to_string(),
-        ));
+        fake.sanitized_title = Some(String::new());
         let result = title_portable(&mut fake, Some("\u{1b}\u{7}\u{200b}"));
         assert!(result.is_error);
         assert_eq!(
             message(&result),
             "Title cannot be empty; use /title off to clear a session title"
         );
+        assert_eq!(
+            fake.calls.borrow().as_slice(),
+            ["sanitize_session_title(\u{1b}\u{7}\u{200b})"],
+            "sanitized-empty validation precedes host mutation"
+        );
+
+        let mut fake = control_fake();
+        fake.set_title = Some(Err("Could not save session: set failed".to_string()));
+        let result = title_portable(&mut fake, Some("task-7"));
+        assert!(result.is_error);
+        assert_eq!(message(&result), "Could not save session: set failed");
+
+        let mut fake = control_fake();
+        fake.clear_title = Some(Err("Could not save session: clear failed".to_string()));
+        let result = title_portable(&mut fake, Some("off"));
+        assert!(result.is_error);
+        assert_eq!(message(&result), "Could not save session: clear failed");
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/session/title.rs
+++ b/crates/tui/src/commands/groups/session/title.rs
@@ -1,391 +1,203 @@
-//! `/title` command — set a distinct tab/window title for the current
-//! session, shown as `[title] …` in front of the terminal window title.
+//! `/title` command — portable handler over the session-control facet.
 //!
-//! This is deliberately separate from `/rename`, which changes the session
-//! *name* shown in the composer border and session picker. `/title` only
-//! affects the terminal window/tab title, so parallel sessions — each in
-//! its own terminal window — are identifiable at a glance while they are
-//! reasoning, using tools, or waiting.
-
-use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::localization::MessageId;
-use crate::session_manager::{SessionManager, update_session};
-use crate::tui::app::App;
+//! Distinct from `/rename`: it sets the session *window/tab* title. The
+//! handler owns the bare-report branch, the `off|clear|none` synonyms, and
+//! the 100-character limit on the raw argument; the atomic
+//! `set_window_title` delegate owns sanitization, persistence, publication,
+//! and the redraw flag.
 
 use super::CommandResult;
+use codewhale_command_contract::facets::{
+    CommandSessionControlContext, TitleSetOutcome, TitleSource,
+};
+use codewhale_command_contract::handler::{CommandContexts, CommandHandler};
+use codewhale_command_contract::metadata::{
+    CommandInfo as ContractInfo, RegisterCommand as ContractRegisterCommand,
+};
 
 const MAX_TITLE_LEN: usize = 100;
 
-pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
+pub(in crate::commands) struct TitleCmd;
+
+pub(in crate::commands) const CONTRACT_INFO: ContractInfo = ContractInfo {
     name: "title",
     aliases: &["tabtitle", "window-title"],
     usage: "/title [new title|off]",
-    description_id: MessageId::CmdTitleDescription,
+    description_key: "cmd_title_description",
 };
 
-pub(in crate::commands) struct TitleCmd;
-
-impl RegisterCommand for TitleCmd {
-    fn info() -> &'static CommandInfo {
-        &COMMAND_INFO
+impl ContractRegisterCommand<CommandResult> for TitleCmd {
+    fn info() -> &'static ContractInfo {
+        &CONTRACT_INFO
     }
-
-    fn execute(app: &mut App, arg: Option<&str>) -> CommandResult {
-        set_window_title(app, arg)
+    fn handler() -> CommandHandler<CommandResult> {
+        CommandHandler::Contextual {
+            capabilities: codewhale_command_contract::handler::CommandCapabilities::SESSION_CONTROL,
+            handler: title_contextual,
+        }
     }
 }
 
-/// Set (or clear) the current session's tab/window title.
-///
-/// - `/title <new title>` — set the window-title prefix for this session and
-///   persist it on the saved session so it survives restarts.
-/// - `/title off` — clear the session-level title; the `title` config
-///   default (if any) still applies.
-/// - `/title` with no argument — report the current effective title.
-pub fn set_window_title(app: &mut App, arg: Option<&str>) -> CommandResult {
-    let arg = arg.map(str::trim).filter(|s| !s.is_empty());
-    let Some(arg) = arg else {
-        let current = app.window_title_prefix().unwrap_or("unset");
-        let source = if app.window_title.is_some() {
-            " (session)"
-        } else if app.title_default.is_some() {
-            " (config default)"
-        } else {
-            ""
+pub(in crate::commands) fn title_contextual(
+    contexts: CommandContexts<'_>,
+    arg: Option<&str>,
+) -> CommandResult {
+    let mut parts = contexts.into_parts();
+    let Some(control) = parts.control.as_deref_mut() else {
+        return CommandResult::error("Command capability unavailable: session_control".to_string());
+    };
+    title_portable(control, arg)
+}
+
+pub(in crate::commands) fn title_portable(
+    control: &mut dyn CommandSessionControlContext,
+    arg: Option<&str>,
+) -> CommandResult {
+    let trimmed = arg.map(str::trim).filter(|s| !s.is_empty());
+    let Some(arg) = trimmed else {
+        let report = control.title_report();
+        let source = match report.source {
+            TitleSource::Session => " (session)",
+            TitleSource::ConfigDefault => " (config default)",
+            TitleSource::None => "",
         };
-        return CommandResult::message(format!("Window title: [{current}]{source}"));
+        return CommandResult::message(format!("Window title: [{}]{source}", report.effective));
     };
 
     if arg == "off" || arg == "clear" || arg == "none" {
-        let manager = match resolve_manager() {
-            Ok(manager) => manager,
-            Err(error) => return error,
+        return match control.set_window_title(None) {
+            Ok(TitleSetOutcome::Cleared) => CommandResult::message(
+                "Window title cleared (the config default still applies if set)",
+            ),
+            Ok(TitleSetOutcome::Set(_)) => {
+                CommandResult::error("internal title-state error".to_string())
+            }
+            Err(error) => CommandResult::error(error),
         };
-        return set_window_title_with_manager(app, None, &manager);
     }
 
     if arg.chars().count() > MAX_TITLE_LEN {
         return CommandResult::error(format!("Title too long (max {MAX_TITLE_LEN} characters)"));
     }
 
-    // Same character policy as `/rename` and the Runtime API: controls and
-    // bidi/zero-width format characters never reach the persisted title.
-    let sanitized = crate::session_manager::sanitize_session_title(arg);
-    let sanitized = sanitized.trim();
-    if sanitized.is_empty() {
-        return CommandResult::error(
-            "Title cannot be empty; use /title off to clear a session title",
-        );
-    }
-
-    let manager = match resolve_manager() {
-        Ok(manager) => manager,
-        Err(error) => return error,
-    };
-    set_window_title_with_manager(app, Some(sanitized.to_string()), &manager)
-}
-
-#[allow(clippy::result_large_err)]
-fn resolve_manager() -> Result<SessionManager, CommandResult> {
-    SessionManager::default_location()
-        .map_err(|e| CommandResult::error(format!("Could not open sessions directory: {e}")))
-}
-
-/// Set or clear the session-level window title with an explicit manager.
-///
-/// Mirrors the `/rename` write path (snapshot Work state and live metadata
-/// before saving so the write cannot revert unsaved messages), then updates
-/// `app.window_title` in the same step the disk write lands. The render loop
-/// syncs the resolved `[title] …` prefix into the terminal title on the next
-/// frame, which is forced immediately.
-pub(crate) fn set_window_title_with_manager(
-    app: &mut App,
-    title: Option<String>,
-    manager: &SessionManager,
-) -> CommandResult {
-    let session_id = match &app.current_session_id {
-        Some(id) => id.clone(),
-        None => {
-            return CommandResult::error(
-                "No active session. Send a message first to start a session.",
-            );
+    match control.set_window_title(Some(arg.to_string())) {
+        Ok(TitleSetOutcome::Set(title)) => CommandResult::message(format!(
+            "Window title set to \"{title}\" — the terminal tab now reads [\"{title}\"] …"
+        )),
+        Ok(TitleSetOutcome::Cleared) => {
+            CommandResult::error("internal title-state error".to_string())
         }
-    };
-
-    let mut session = match manager.load_session(&session_id) {
-        Ok(s) => s,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            match super::rename::live_session_before_first_snapshot(manager, &session_id, app) {
-                Some(s) => s,
-                None => {
-                    return CommandResult::error(format!("Could not load session: {err}"));
-                }
-            }
-        }
-        Err(e) => return CommandResult::error(format!("Could not load session: {e}")),
-    };
-
-    // Same character policy as `/rename` and the Runtime API: controls and
-    // bidi/zero-width format characters never reach the persisted title.
-    let title = title.map(|t| crate::session_manager::sanitize_session_title(&t));
-    let title = title.map(|t| t.trim().to_string());
-    if let Some(ref t) = title
-        && t.is_empty()
-    {
-        return CommandResult::error(
-            "Title cannot be empty; use /title off to clear a session title",
-        );
-    }
-
-    // Sync with current App state to avoid overwriting unsaved messages.
-    session = update_session(
-        session,
-        &app.api_messages,
-        u64::from(app.session.total_tokens),
-        app.system_prompt.as_ref(),
-    );
-    session.work_state = match app.work_state_snapshot() {
-        Ok(state) => state,
-        Err(err) => {
-            return CommandResult::error(format!(
-                "Could not snapshot Work state before setting title: {err}"
-            ));
-        }
-    };
-    session.context_references = app.session_context_references.clone();
-    session.artifacts = app.session_artifacts.clone();
-    session.last_auto_route = app.auto_route_for_persistence();
-    session.metadata.model = app.model_selection_for_persistence();
-    session
-        .metadata
-        .set_model_provider_route(app.api_provider.as_str(), app.provider_id_for_persistence());
-    session.metadata.workspace.clone_from(&app.workspace);
-    session.metadata.mode = Some(app.mode.as_setting().to_string());
-    app.sync_cost_to_metadata(&mut session.metadata);
-    session.window_title = title.clone();
-
-    match manager.save_session(&session) {
-        Ok(_) => {
-            app.window_title = title.clone();
-            // The render loop syncs the resolved prefix into the terminal
-            // title; force a frame so the change lands immediately.
-            app.needs_redraw = true;
-            if let Err(err) = app.publish_pending_work_state() {
-                return CommandResult::error(format!(
-                    "Window title saved, but Work views were not published: {err}"
-                ));
-            }
-            match title {
-                Some(title) => CommandResult::message(format!(
-                    "Window title set to \"{title}\" — the terminal tab now reads [\"{title}\"] …"
-                )),
-                None => CommandResult::message(
-                    "Window title cleared (the config default still applies if set)",
-                ),
-            }
-        }
-        Err(e) => CommandResult::error(format!("Could not save session: {e}")),
+        Err(error) => CommandResult::error(error),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    /// Message with the canonical "Error: " prefix removed so exact strings
+    /// compare against the baseline text.
+    fn message(result: &super::CommandResult) -> &str {
+        result
+            .message
+            .as_deref()
+            .map(|m| m.strip_prefix("Error: ").unwrap_or(m))
+            .unwrap_or("")
+    }
+
     use super::*;
-    use crate::config::Config;
-    use crate::models::Role;
-    use crate::session_manager::{SessionManager, create_saved_session_with_mode};
-    use crate::tui::app::{App, TuiOptions};
-    use tempfile::TempDir;
+    use codewhale_command_contract::facets::{TitleReport, TitleSetOutcome};
 
-    fn make_app(tmpdir: &TempDir) -> App {
-        App::new(
-            TuiOptions {
-                skills_dir: tmpdir.path().join("skills"),
-                memory_path: tmpdir.path().join("memory.md"),
-                notes_path: tmpdir.path().join("notes.txt"),
-                mcp_config_path: tmpdir.path().join("mcp.json"),
-                ..crate::test_support::test_tui_options(tmpdir.path())
-            },
-            &Config::default(),
-        )
-    }
-
-    fn make_session_manager(tmpdir: &TempDir) -> SessionManager {
-        SessionManager::new(tmpdir.path().join("sessions")).unwrap()
+    fn control_fake() -> super::super::control_test_support::FakeControl {
+        super::super::control_test_support::FakeControl::default()
     }
 
     #[test]
-    fn no_active_session_reports_usage_error() {
-        let tmp = TempDir::new().unwrap();
-        let mut app = make_app(&tmp);
-        app.current_session_id = None;
-        let result = set_window_title(&mut app, Some("task-7"));
-        assert!(result.is_error);
-        assert!(result.message.unwrap().contains("No active session"));
-    }
+    fn title_bare_reports_effective_title_and_source() {
+        let mut fake = control_fake();
+        fake.title_report = Some(TitleReport {
+            effective: "task-7".to_string(),
+            source: TitleSource::Session,
+        });
+        let result = title_portable(&mut fake, None);
+        assert_eq!(message(&result), "Window title: [task-7] (session)");
 
-    #[test]
-    fn set_title_persists_on_the_saved_session() {
-        let tmp = TempDir::new().unwrap();
-        let manager = make_session_manager(&tmp);
-        let mut app = make_app(&tmp);
-        let mut session =
-            create_saved_session_with_mode(&[], "deepseek-v4-pro", tmp.path(), 0, None, None);
-        session.metadata.id = "title-test".to_string();
-        session.metadata.title = "Original Name".to_string();
-        manager.save_session(&session).unwrap();
-        app.current_session_id = Some("title-test".to_string());
-
-        let result =
-            set_window_title_with_manager(&mut app, Some("parallel-task".to_string()), &manager);
-        assert!(!result.is_error, "unexpected error: {:?}", result.message);
-        assert_eq!(app.window_title.as_deref(), Some("parallel-task"));
-        // `/rename`-style session name stays untouched.
-        assert_eq!(app.session_title, None);
-
-        let reloaded = manager.load_session("title-test").unwrap();
-        assert_eq!(reloaded.window_title.as_deref(), Some("parallel-task"));
-        assert_eq!(reloaded.metadata.title, "Original Name");
-    }
-
-    #[test]
-    fn clear_title_removes_the_session_level_title() {
-        let tmp = TempDir::new().unwrap();
-        let manager = make_session_manager(&tmp);
-        let mut app = make_app(&tmp);
-        let mut session =
-            create_saved_session_with_mode(&[], "deepseek-v4-pro", tmp.path(), 0, None, None);
-        session.metadata.id = "title-clear".to_string();
-        session.window_title = Some("stale".to_string());
-        manager.save_session(&session).unwrap();
-        app.current_session_id = Some("title-clear".to_string());
-
-        let result = set_window_title_with_manager(&mut app, None, &manager);
-        assert!(!result.is_error, "unexpected error: {:?}", result.message);
-        assert_eq!(app.window_title, None);
+        fake.title_report = Some(TitleReport {
+            effective: "workspace-x".to_string(),
+            source: TitleSource::ConfigDefault,
+        });
+        let result = title_portable(&mut fake, None);
         assert_eq!(
-            manager.load_session("title-clear").unwrap().window_title,
-            None
+            message(&result),
+            "Window title: [workspace-x] (config default)"
         );
+
+        fake.title_report = Some(TitleReport {
+            effective: "unset".to_string(),
+            source: TitleSource::None,
+        });
+        let result = title_portable(&mut fake, None);
+        assert_eq!(message(&result), "Window title: [unset]");
     }
 
     #[test]
-    fn empty_argument_reports_the_effective_title() {
-        let tmp = TempDir::new().unwrap();
-        let mut app = make_app(&tmp);
-        app.title_default = Some("workspace-x".to_string());
-        let result = set_window_title(&mut app, None);
-        assert!(!result.is_error);
-        assert!(result.message.unwrap().contains("[workspace-x]"));
-
-        app.window_title = Some("session-specific".to_string());
-        let result = set_window_title(&mut app, None);
-        assert!(!result.is_error);
-        assert!(result.message.unwrap().contains("[session-specific]"));
-    }
-
-    #[test]
-    fn oversized_title_is_rejected() {
-        let tmp = TempDir::new().unwrap();
-        let mut app = make_app(&tmp);
-        app.current_session_id = Some("any".to_string());
-        let long = "x".repeat(MAX_TITLE_LEN + 1);
-        let result = set_window_title(&mut app, Some(&long));
-        assert!(result.is_error);
-        assert!(result.message.unwrap().contains("Title too long"));
-    }
-
-    #[test]
-    fn set_title_strips_terminal_controls_before_persisting() {
-        let tmp = TempDir::new().unwrap();
-        let manager = make_session_manager(&tmp);
-        let mut app = make_app(&tmp);
-        let session =
-            create_saved_session_with_mode(&[], "deepseek-v4-pro", tmp.path(), 0, None, None);
-        let session_id = session.metadata.id.clone();
-        manager.save_session(&session).unwrap();
-        app.current_session_id = Some(session_id.clone());
-
-        let result = set_window_title_with_manager(
-            &mut app,
-            Some("Ev\u{1b}]0;PWNED\u{7}il\u{202e} Beta".to_string()),
-            &manager,
-        );
-        assert!(!result.is_error, "{result:?}");
-        let reloaded = manager.load_session(&session_id).unwrap();
-        assert_eq!(reloaded.window_title.as_deref(), Some("Ev]0;PWNEDil Beta"));
-        assert_eq!(app.window_title.as_deref(), Some("Ev]0;PWNEDil Beta"));
-
-        // Controls alone are the same as no title at all.
-        let result = set_window_title_with_manager(
-            &mut app,
-            Some("\u{1b}\u{7}\u{200b}".to_string()),
-            &manager,
-        );
-        assert!(result.is_error);
-    }
-
-    // #5430: until a session's first turn completes, only the crash
-    // checkpoint written at dispatch exists — `sessions/<id>.json` does not.
-    // A mid-first-turn `/title` must apply from that checkpoint instead of
-    // failing with "Could not load session".
-    #[test]
-    fn set_title_mid_first_turn_recovers_from_checkpoint_when_snapshot_missing() {
-        let tmp = TempDir::new().unwrap();
-        let manager = make_session_manager(&tmp);
-        let mut app = make_app(&tmp);
-
-        let checkpoint =
-            create_saved_session_with_mode(&[], "deepseek-v4-pro", tmp.path(), 0, None, None);
-        let session_id = checkpoint.metadata.id.clone();
-        manager.save_checkpoint(&checkpoint).unwrap();
-        app.current_session_id = Some(session_id.clone());
-        app.api_messages = vec![user_message("first turn still streaming")];
-
-        let result =
-            set_window_title_with_manager(&mut app, Some("Midturn Title".to_string()), &manager);
-        assert!(!result.is_error, "{result:?}");
-        assert_eq!(app.window_title.as_deref(), Some("Midturn Title"));
-
-        // The write promotes the checkpoint record to the durable session
-        // file, so the listing and the next launch see the new title.
-        let persisted = manager.load_session(&session_id).unwrap();
-        assert_eq!(persisted.window_title.as_deref(), Some("Midturn Title"));
-        assert_eq!(persisted.messages.len(), 1);
-        // The session *name* is untouched: `/title` is independent of `/rename`.
-        assert_ne!(persisted.metadata.title, "Midturn Title");
-    }
-
-    // Worst case of the same window: the user sets a title before even the
-    // dispatch checkpoint has been flushed. The document is then built from
-    // the same in-memory App state the checkpoint itself would carry.
-    #[test]
-    fn set_title_mid_first_turn_builds_from_app_state_when_nothing_persisted() {
-        let tmp = TempDir::new().unwrap();
-        let manager = make_session_manager(&tmp);
-        let mut app = make_app(&tmp);
-
-        let session_id = "live-before-first-checkpoint";
-        app.current_session_id = Some(session_id.to_string());
-        app.api_messages = vec![user_message("turn one, nothing persisted yet")];
-
-        let result =
-            set_window_title_with_manager(&mut app, Some("Earliest Title".to_string()), &manager);
-        assert!(!result.is_error, "{result:?}");
-        assert_eq!(app.window_title.as_deref(), Some("Earliest Title"));
-
-        let persisted = manager.load_session(session_id).unwrap();
-        assert_eq!(persisted.window_title.as_deref(), Some("Earliest Title"));
-        assert_eq!(persisted.messages.len(), 1);
-    }
-
-    fn user_message(text: &str) -> crate::models::Message {
-        crate::models::Message {
-            role: Role::User,
-            content: vec![crate::models::ContentBlock::Text {
-                text: text.to_string(),
-                cache_control: None,
-            }],
+    fn title_synonyms_clear_and_set_messages_are_exact() {
+        let mut fake = control_fake();
+        fake.set_title = Some(Ok(TitleSetOutcome::Cleared));
+        for synonym in ["off", "clear", "none"] {
+            let result = title_portable(&mut fake, Some(synonym));
+            assert!(!result.is_error, "{synonym}");
+            assert_eq!(
+                message(&result),
+                "Window title cleared (the config default still applies if set)"
+            );
         }
+        assert_eq!(fake.calls.len(), 3);
+        assert!(fake.calls.iter().all(|c| c == "set_window_title(clear)"));
+
+        let mut fake = control_fake();
+        fake.set_title = Some(Ok(TitleSetOutcome::Set("task-7".to_string())));
+        let result = title_portable(&mut fake, Some("task-7"));
+        assert!(!result.is_error);
+        assert_eq!(
+            message(&result),
+            "Window title set to \"task-7\" — the terminal tab now reads [\"task-7\"] …"
+        );
+        assert!(result.action.is_none(), "/title emits no action");
+    }
+
+    #[test]
+    fn title_oversized_and_host_errors_are_exact() {
+        let mut fake = control_fake();
+        let result = title_portable(&mut fake, Some(&"x".repeat(MAX_TITLE_LEN + 1)));
+        assert!(result.is_error);
+        assert!(
+            result
+                .message
+                .as_deref()
+                .unwrap()
+                .contains("Title too long (max 100 characters)")
+        );
+        assert!(fake.calls.is_empty(), "length check precedes the delegate");
+
+        let mut fake = control_fake();
+        fake.set_title = Some(Err(
+            "Title cannot be empty; use /title off to clear a session title".to_string(),
+        ));
+        let result = title_portable(&mut fake, Some("\u{1b}\u{7}\u{200b}"));
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "Title cannot be empty; use /title off to clear a session title"
+        );
+    }
+
+    #[test]
+    fn title_missing_control_authority_fails_safely() {
+        let contexts = codewhale_command_contract::handler::CommandContexts::empty();
+        let result = title_contextual(contexts, None);
+        assert!(result.is_error);
+        assert_eq!(
+            message(&result),
+            "Command capability unavailable: session_control"
+        );
     }
 }

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -26,6 +26,8 @@ mod epic_discovery_acceptance;
 #[cfg(all(test, feature = "long-running-tests"))]
 mod session_acceptance;
 #[cfg(test)]
+mod session_control_regression_tests;
+#[cfg(test)]
 mod session_lifecycle_regression_tests;
 
 use std::sync::OnceLock;
@@ -33,8 +35,6 @@ use std::sync::OnceLock;
 pub use traits::CommandInfo;
 
 // Long-standing public paths that predate the group layout.
-#[cfg(test)]
-pub(crate) use contract::rename_with_manager as rename_session_with_manager;
 /// `/fleet add` and the picker's ⇧F share these gates; the UI applies them
 /// against the live `Config`.
 pub(crate) use groups::core::fleet::{fleet_catalog_rejection, fleet_provider_rejection};

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -2865,4 +2865,62 @@ mod tests {
             "{branch_usage:?}"
         );
     }
+
+    #[test]
+    fn feat024_control_commands_dispatch_through_public_seam() {
+        let mut app = create_test_app();
+        app.workspace = PathBuf::from(".");
+
+        // /relay composes through the control adapter and emits the bounded
+        // SendMessage action; only SESSION_CONTROL is exposed.
+        let relay = execute("/relay handoff notes", &mut app);
+        assert_eq!(
+            relay.message.as_deref(),
+            Some("Preparing session relay at .deepseek/handoff.md...")
+        );
+        let relay_message = match relay.action {
+            Some(AppAction::SendMessage(message)) => message,
+            other => panic!("expected SendMessage, got {other:?}"),
+        };
+        assert!(relay_message.contains("Create a compact session relay (接力)"));
+        assert!(relay_message.contains("- Requested relay focus: handoff notes"));
+
+        // /rc status reaches the remote-control service through the facet.
+        let rc = execute("/rc status", &mut app);
+        assert_eq!(rc.message.as_deref(), Some("Remote control: off"));
+
+        // /remote-env bare overview is localized through the presentation
+        // facet with the exact source-custody boundary copy.
+        let remote_env = execute("/remote-env", &mut app);
+        assert!(
+            remote_env
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Hosted Work starts a new environment"),
+            "{remote_env:?}"
+        );
+
+        // /rename and /title validation boundaries stay exact over the seam.
+        let rename = execute("/rename", &mut app);
+        assert_eq!(
+            rename.message.as_deref(),
+            Some("Error: Usage: /rename <new title>")
+        );
+        let title = execute("/title", &mut app);
+        assert!(
+            title
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Window title: [unset]"),
+            "{title:?}"
+        );
+
+        // Bare /resume opens the picker through the adapter.
+        let resume = execute("/resume", &mut app);
+        assert!(!resume.is_error);
+        assert!(resume.action.is_none());
+        assert!(resume.message.is_none());
+    }
 }

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -33,12 +33,12 @@ use std::sync::OnceLock;
 pub use traits::CommandInfo;
 
 // Long-standing public paths that predate the group layout.
+#[cfg(test)]
+pub(crate) use contract::rename_with_manager as rename_session_with_manager;
 /// `/fleet add` and the picker's ⇧F share these gates; the UI applies them
 /// against the live `Config`.
 pub(crate) use groups::core::fleet::{fleet_catalog_rejection, fleet_provider_rejection};
 pub use groups::project::share;
-#[cfg(test)]
-pub(crate) use groups::session::rename_with_manager as rename_session_with_manager;
 
 // Voice capture plumbing shared with the hotbar and the UI event loop.
 pub use groups::core::voice;
@@ -2069,6 +2069,13 @@ mod tests {
             "save",
             "sessions",
             "tree",
+            // FEAT-024 session control slice.
+            "relay",
+            "rename",
+            "resume",
+            "rc",
+            "remote-env",
+            "title",
         ];
         for info in command_infos() {
             if info.name == "feat015ctx" || MIGRATED_GROUPS.contains(&info.name) {
@@ -2746,11 +2753,62 @@ mod tests {
                 "/{name} must be pure (no host context bundle)"
             );
         }
-        // Out-of-scope session commands remain legacy for FEAT-024/025/026.
-        for name in ["export", "relay", "structcopy"] {
+        // Out-of-scope session commands remain legacy for FEAT-025/026.
+        for name in ["export", "structcopy"] {
             assert!(
                 !registry().has_contextual_handler(name),
                 "/{name} must stay on the legacy dispatch until its owning FEAT"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // FEAT-024: session control entries register through the portable bridge
+    // (D3/D6) — five declare SESSION_CONTROL only; `/remote-env` declares
+    // control plus presentation; export/structcopy remain legacy.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn feat024_control_entries_register_through_portable_bridge() {
+        use codewhale_command_contract::handler::{CommandCapabilities, CommandHandler};
+
+        for name in ["relay", "rename", "resume", "rc", "title"] {
+            assert!(
+                registry().has_contextual_handler(name),
+                "/{name} must register through the portable bridge"
+            );
+            let handler = registry()
+                .get(name)
+                .expect("entry")
+                .contextual_handler()
+                .expect("contextual handler");
+            let CommandHandler::Contextual { capabilities, .. } = handler else {
+                panic!("/{name} must be contextual");
+            };
+            assert_eq!(
+                capabilities,
+                CommandCapabilities::SESSION_CONTROL,
+                "/{name} declares control authority only"
+            );
+        }
+        let handler = registry()
+            .get("remote-env")
+            .expect("entry")
+            .contextual_handler()
+            .expect("remote-env handler");
+        let CommandHandler::Contextual { capabilities, .. } = handler else {
+            panic!("/remote-env must be contextual");
+        };
+        assert_eq!(
+            capabilities,
+            CommandCapabilities::SESSION_CONTROL.union(CommandCapabilities::PRESENTATION),
+            "/remote-env declares control plus presentation only"
+        );
+        // FEAT-025/FEAT-026 leaves remain legacy until their owning FEATs.
+        for name in ["export", "structcopy"] {
+            assert!(
+                !registry().has_contextual_handler(name),
+                "/{name} must stay on the legacy dispatch"
             );
         }
     }

--- a/crates/tui/src/commands/session_control_regression_tests.rs
+++ b/crates/tui/src/commands/session_control_regression_tests.rs
@@ -10,6 +10,7 @@ use std::process::Command;
 
 use tempfile::TempDir;
 
+use crate::commands::groups::session::MAX_TITLE_LEN;
 use crate::commands::{CommandResult, execute};
 use crate::config::{ApiProvider, Config};
 use crate::localization::{Locale, MessageId, tr};
@@ -17,8 +18,6 @@ use crate::models::{ContentBlock, Message, Role, SystemPrompt};
 use crate::session_manager::{SessionManager, create_saved_session_with_mode};
 use crate::test_support::{EnvVarGuard, TestEnvLock};
 use crate::tui::app::{App, AppAction, AppMode, TuiOptions};
-
-const MAX_TITLE_LEN: usize = 100;
 
 /// Owns the global environment lock for as long as its CODEWHALE_HOME guard.
 /// Fields are ordered so the guard restores the environment before the lock

--- a/crates/tui/src/commands/session_control_regression_tests.rs
+++ b/crates/tui/src/commands/session_control_regression_tests.rs
@@ -1,0 +1,597 @@
+//! TUI-hosted regression coverage retained from the pre-FEAT-024 control handlers.
+//!
+//! These tests dispatch through the public command seam. They deliberately
+//! stay outside `groups/session`, which FEAT-043 moves to
+//! `codewhale-commands`, while pinning persistence, sanitization, Git-target,
+//! localization, and first-snapshot behavior against the real TUI adapter.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+use crate::commands::{CommandResult, execute};
+use crate::config::{ApiProvider, Config};
+use crate::localization::{Locale, MessageId, tr};
+use crate::models::{ContentBlock, Message, Role, SystemPrompt};
+use crate::session_manager::{SessionManager, create_saved_session_with_mode};
+use crate::test_support::{EnvVarGuard, TestEnvLock};
+use crate::tui::app::{App, AppAction, AppMode, TuiOptions};
+
+const MAX_TITLE_LEN: usize = 100;
+
+/// Owns the global environment lock for as long as its CODEWHALE_HOME guard.
+/// Fields are ordered so the guard restores the environment before the lock
+/// is released and before the temporary directory is removed.
+struct ControlHarness {
+    app: App,
+    manager: SessionManager,
+    _home: EnvVarGuard,
+    _env_lock: TestEnvLock,
+    temp: TempDir,
+}
+
+impl ControlHarness {
+    fn new() -> Self {
+        let env_lock = crate::test_support::lock_test_env();
+        let temp = TempDir::new().expect("tempdir");
+        let home = EnvVarGuard::set("CODEWHALE_HOME", temp.path().join("home"));
+        let options = TuiOptions {
+            skills_dir: temp.path().join("skills"),
+            memory_path: temp.path().join("memory.md"),
+            notes_path: temp.path().join("notes.txt"),
+            mcp_config_path: temp.path().join("mcp.json"),
+            ..crate::test_support::test_tui_options(temp.path())
+        };
+        let app = App::new(options, &Config::default());
+        let manager = SessionManager::default_location().expect("session manager");
+        Self {
+            app,
+            manager,
+            _home: home,
+            _env_lock: env_lock,
+            temp,
+        }
+    }
+
+    fn seed_session(&mut self) -> String {
+        let session =
+            create_saved_session_with_mode(&[], "deepseek-v4-pro", self.temp.path(), 0, None, None);
+        let session_id = session.metadata.id.clone();
+        self.manager.save_session(&session).expect("save session");
+        self.app.current_session_id = Some(session_id.clone());
+        session_id
+    }
+}
+
+fn dispatch(app: &mut App, name: &str, arg: Option<&str>) -> CommandResult {
+    let command = match arg {
+        Some(arg) => format!("/{name} {arg}"),
+        None => format!("/{name}"),
+    };
+    execute(&command, app)
+}
+
+fn result_text(result: &CommandResult) -> &str {
+    result.message.as_deref().unwrap_or_default()
+}
+
+fn user_message(text: &str) -> Message {
+    Message {
+        role: Role::User,
+        content: vec![ContentBlock::Text {
+            text: text.to_string(),
+            cache_control: None,
+        }],
+    }
+}
+
+#[test]
+fn rename_usage_empty_active_and_oversized_boundaries_are_preserved() {
+    let mut harness = ControlHarness::new();
+
+    for arg in [None, Some("   ")] {
+        let result = dispatch(&mut harness.app, "rename", arg);
+        assert!(result.is_error);
+        assert_eq!(result_text(&result), "Error: Usage: /rename <new title>");
+    }
+
+    let no_session = dispatch(&mut harness.app, "rename", Some("task-7"));
+    assert!(no_session.is_error);
+    assert!(result_text(&no_session).contains("No active session"));
+
+    harness.seed_session();
+    let too_long = "a".repeat(MAX_TITLE_LEN + 1);
+    let result = dispatch(&mut harness.app, "rename", Some(&too_long));
+    assert!(result.is_error);
+    assert!(result_text(&result).contains("Title too long (max 100 characters)"));
+}
+
+#[test]
+fn rename_persists_all_live_metadata_through_public_dispatch() {
+    let mut harness = ControlHarness::new();
+    let stale_prompt = SystemPrompt::Text("stale prompt".to_string());
+    let session = create_saved_session_with_mode(
+        &[],
+        "deepseek-v4-pro",
+        harness.temp.path(),
+        0,
+        Some(&stale_prompt),
+        None,
+    );
+    let session_id = session.metadata.id.clone();
+    harness
+        .manager
+        .save_session(&session)
+        .expect("save session");
+    harness.app.current_session_id = Some(session_id.clone());
+    harness
+        .app
+        .set_model_selection("local-code-model".to_string());
+    harness
+        .app
+        .set_provider_identity(ApiProvider::Custom, "lm-studio");
+    harness.app.mode = AppMode::Operate;
+    harness.app.system_prompt = None;
+    harness.app.todos.try_lock().expect("todos lock").add(
+        "live rename state".to_string(),
+        crate::tools::todo::TodoStatus::InProgress,
+    );
+    let expected_work_state = harness.app.work_state_snapshot().expect("work snapshot");
+
+    let result = dispatch(&mut harness.app, "rename", Some("Brand New Title"));
+
+    assert!(!result.is_error, "{result:?}");
+    assert_eq!(
+        result_text(&result),
+        "Session renamed to \"Brand New Title\""
+    );
+    let reloaded = harness.manager.load_session(&session_id).expect("reload");
+    assert_eq!(reloaded.metadata.title, "Brand New Title");
+    assert_eq!(reloaded.work_state, expected_work_state);
+    assert!(reloaded.system_prompt.is_none());
+    assert_eq!(reloaded.metadata.model, "local-code-model");
+    assert_eq!(reloaded.metadata.model_provider, "custom");
+    assert_eq!(
+        reloaded.metadata.model_provider_id.as_deref(),
+        Some("lm-studio")
+    );
+    assert_eq!(reloaded.metadata.workspace, harness.app.workspace);
+    assert_eq!(reloaded.metadata.mode.as_deref(), Some("operate"));
+    assert_eq!(
+        harness.app.session_title.as_deref(),
+        Some("Brand New Title")
+    );
+    assert_eq!(
+        harness
+            .app
+            .current_session_metadata
+            .as_ref()
+            .map(|metadata| metadata.title.as_str()),
+        Some("Brand New Title")
+    );
+}
+
+#[test]
+fn rename_sanitizes_controls_and_accepts_exact_character_limit() {
+    let mut harness = ControlHarness::new();
+    let session_id = harness.seed_session();
+
+    let hostile = "Ev\u{1b}]0;PWNED\u{7}il\u{202e} Beta";
+    let result = dispatch(&mut harness.app, "rename", Some(hostile));
+    assert!(!result.is_error, "{result:?}");
+    let reloaded = harness.manager.load_session(&session_id).expect("reload");
+    assert_eq!(reloaded.metadata.title, "Ev]0;PWNEDil Beta");
+    assert_eq!(
+        harness.app.session_title.as_deref(),
+        Some("Ev]0;PWNEDil Beta")
+    );
+
+    let controls_only = dispatch(&mut harness.app, "rename", Some("\u{1b}\u{7}\u{200b}"));
+    assert!(controls_only.is_error);
+
+    let max_title = "中".repeat(MAX_TITLE_LEN);
+    let result = dispatch(&mut harness.app, "rename", Some(&max_title));
+    assert!(!result.is_error, "{result:?}");
+    assert_eq!(
+        harness
+            .manager
+            .load_session(&session_id)
+            .expect("reload")
+            .metadata
+            .title,
+        max_title
+    );
+}
+
+#[test]
+fn rename_recovers_first_snapshot_from_checkpoint() {
+    let mut harness = ControlHarness::new();
+    let checkpoint =
+        create_saved_session_with_mode(&[], "deepseek-v4-pro", harness.temp.path(), 0, None, None);
+    let session_id = checkpoint.metadata.id.clone();
+    harness
+        .manager
+        .save_checkpoint(&checkpoint)
+        .expect("save checkpoint");
+    harness.app.current_session_id = Some(session_id.clone());
+    harness.app.api_messages = vec![user_message("first turn still streaming")];
+
+    let result = dispatch(&mut harness.app, "rename", Some("Midturn Rename"));
+
+    assert!(!result.is_error, "{result:?}");
+    assert_eq!(harness.app.session_title.as_deref(), Some("Midturn Rename"));
+    let persisted = harness
+        .manager
+        .load_session(&session_id)
+        .expect("persisted");
+    assert_eq!(persisted.metadata.title, "Midturn Rename");
+    assert_eq!(persisted.messages.len(), 1);
+}
+
+#[test]
+fn rename_builds_from_app_state_before_any_checkpoint_exists() {
+    let mut harness = ControlHarness::new();
+    let session_id = "live-before-first-checkpoint";
+    harness.app.current_session_id = Some(session_id.to_string());
+    harness.app.api_messages = vec![user_message("turn one, nothing persisted yet")];
+
+    let result = dispatch(&mut harness.app, "rename", Some("Earliest Rename"));
+
+    assert!(!result.is_error, "{result:?}");
+    assert_eq!(
+        harness.app.session_title.as_deref(),
+        Some("Earliest Rename")
+    );
+    let persisted = harness.manager.load_session(session_id).expect("persisted");
+    assert_eq!(persisted.metadata.title, "Earliest Rename");
+    assert_eq!(persisted.messages.len(), 1);
+}
+
+#[test]
+fn title_requires_an_active_session_and_preserves_raw_length_limit() {
+    let mut harness = ControlHarness::new();
+    let no_session = dispatch(&mut harness.app, "title", Some("task-7"));
+    assert!(no_session.is_error);
+    assert!(result_text(&no_session).contains("No active session"));
+
+    harness.app.current_session_id = Some("any".to_string());
+    let too_long = "x".repeat(MAX_TITLE_LEN + 1);
+    let result = dispatch(&mut harness.app, "title", Some(&too_long));
+    assert!(result.is_error);
+    assert!(result_text(&result).contains("Title too long"));
+}
+
+#[test]
+fn title_set_and_clear_persist_without_renaming_the_session() {
+    let mut harness = ControlHarness::new();
+    let mut session =
+        create_saved_session_with_mode(&[], "deepseek-v4-pro", harness.temp.path(), 0, None, None);
+    session.metadata.id = "title-test".to_string();
+    session.metadata.title = "Original Name".to_string();
+    harness
+        .manager
+        .save_session(&session)
+        .expect("save session");
+    harness.app.current_session_id = Some("title-test".to_string());
+
+    let result = dispatch(&mut harness.app, "title", Some("parallel-task"));
+    assert!(!result.is_error, "{result:?}");
+    assert_eq!(harness.app.window_title.as_deref(), Some("parallel-task"));
+    assert!(harness.app.session_title.is_none());
+    let reloaded = harness.manager.load_session("title-test").expect("reload");
+    assert_eq!(reloaded.window_title.as_deref(), Some("parallel-task"));
+    assert_eq!(reloaded.metadata.title, "Original Name");
+
+    let result = dispatch(&mut harness.app, "title", Some("off"));
+    assert!(!result.is_error, "{result:?}");
+    assert!(harness.app.window_title.is_none());
+    assert!(
+        harness
+            .manager
+            .load_session("title-test")
+            .expect("reload")
+            .window_title
+            .is_none()
+    );
+}
+
+#[test]
+fn title_bare_reports_config_and_session_sources() {
+    let mut harness = ControlHarness::new();
+    harness.app.title_default = Some("workspace-x".to_string());
+    let result = dispatch(&mut harness.app, "title", None);
+    assert_eq!(
+        result_text(&result),
+        "Window title: [workspace-x] (config default)"
+    );
+
+    harness.app.window_title = Some("session-specific".to_string());
+    let result = dispatch(&mut harness.app, "title", None);
+    assert_eq!(
+        result_text(&result),
+        "Window title: [session-specific] (session)"
+    );
+}
+
+#[test]
+fn title_sanitizes_terminal_controls_before_persisting() {
+    let mut harness = ControlHarness::new();
+    let session_id = harness.seed_session();
+
+    let hostile = "Ev\u{1b}]0;PWNED\u{7}il\u{202e} Beta";
+    let result = dispatch(&mut harness.app, "title", Some(hostile));
+    assert!(!result.is_error, "{result:?}");
+    let reloaded = harness.manager.load_session(&session_id).expect("reload");
+    assert_eq!(reloaded.window_title.as_deref(), Some("Ev]0;PWNEDil Beta"));
+    assert_eq!(
+        harness.app.window_title.as_deref(),
+        Some("Ev]0;PWNEDil Beta")
+    );
+
+    let controls_only = dispatch(&mut harness.app, "title", Some("\u{1b}\u{7}\u{200b}"));
+    assert!(controls_only.is_error);
+}
+
+#[test]
+fn title_recovers_first_snapshot_from_checkpoint() {
+    let mut harness = ControlHarness::new();
+    let checkpoint =
+        create_saved_session_with_mode(&[], "deepseek-v4-pro", harness.temp.path(), 0, None, None);
+    let session_id = checkpoint.metadata.id.clone();
+    harness
+        .manager
+        .save_checkpoint(&checkpoint)
+        .expect("save checkpoint");
+    harness.app.current_session_id = Some(session_id.clone());
+    harness.app.api_messages = vec![user_message("first turn still streaming")];
+
+    let result = dispatch(&mut harness.app, "title", Some("Midturn Title"));
+
+    assert!(!result.is_error, "{result:?}");
+    assert_eq!(harness.app.window_title.as_deref(), Some("Midturn Title"));
+    let persisted = harness
+        .manager
+        .load_session(&session_id)
+        .expect("persisted");
+    assert_eq!(persisted.window_title.as_deref(), Some("Midturn Title"));
+    assert_eq!(persisted.messages.len(), 1);
+    assert_ne!(persisted.metadata.title, "Midturn Title");
+}
+
+#[test]
+fn title_builds_from_app_state_before_any_checkpoint_exists() {
+    let mut harness = ControlHarness::new();
+    let session_id = "live-title-before-first-checkpoint";
+    harness.app.current_session_id = Some(session_id.to_string());
+    harness.app.api_messages = vec![user_message("turn one, nothing persisted yet")];
+
+    let result = dispatch(&mut harness.app, "title", Some("Earliest Title"));
+
+    assert!(!result.is_error, "{result:?}");
+    assert_eq!(harness.app.window_title.as_deref(), Some("Earliest Title"));
+    let persisted = harness.manager.load_session(session_id).expect("persisted");
+    assert_eq!(persisted.window_title.as_deref(), Some("Earliest Title"));
+    assert_eq!(persisted.messages.len(), 1);
+}
+
+fn init_repo(workspace: &Path, origin: &str, branch: &str) {
+    let init = Command::new("git")
+        .args(["init", "--quiet"])
+        .arg(workspace)
+        .status()
+        .expect("git init");
+    assert!(init.success());
+    let origin_status = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(["remote", "add", "origin", origin])
+        .status()
+        .expect("git remote add");
+    if !origin_status.success() {
+        let update = Command::new("git")
+            .arg("-C")
+            .arg(workspace)
+            .args(["remote", "set-url", "origin", origin])
+            .status()
+            .expect("git remote set-url");
+        assert!(update.success());
+    }
+    let branch_status = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(["symbolic-ref", "HEAD"])
+        .arg(format!("refs/heads/{branch}"))
+        .status()
+        .expect("set branch");
+    assert!(branch_status.success());
+}
+
+fn external_url(result: &CommandResult) -> &str {
+    match result.action.as_ref() {
+        Some(AppAction::OpenExternalUrl { url, .. }) => url,
+        other => panic!("expected external URL action, got {other:?}"),
+    }
+}
+
+#[test]
+fn remote_env_bare_command_preserves_every_source_boundary() {
+    let mut harness = ControlHarness::new();
+    let result = dispatch(&mut harness.app, "remote-env", None);
+    assert!(!result.is_error);
+    assert!(result.action.is_none());
+    for boundary in ["unpushed", "dirty", "ignored", "secrets", "session state"] {
+        assert!(
+            result_text(&result).contains(boundary),
+            "missing boundary: {boundary}"
+        );
+    }
+}
+
+#[test]
+fn remote_env_open_encodes_branch_and_never_echoes_credentials() {
+    let mut harness = ControlHarness::new();
+    let secret = "top-secret-token";
+    init_repo(
+        harness.temp.path(),
+        &format!("https://hunter:{secret}@github.com/Hmbown/CodeWhale.git"),
+        "feature/mobile&cloud-{url}",
+    );
+
+    let result = dispatch(&mut harness.app, "remote-env", Some("open"));
+
+    assert!(!result.is_error, "{result:?}");
+    assert_eq!(
+        external_url(&result),
+        "https://app.codewhale.net/work?repo=Hmbown%2FCodeWhale&branch=feature%2Fmobile%26cloud-%7Burl%7D"
+    );
+    assert!(result_text(&result).contains("feature/mobile&cloud-{url}"));
+    assert!(!external_url(&result).contains(secret));
+    assert!(!result_text(&result).contains(secret));
+}
+
+#[test]
+fn remote_env_supported_https_ssh_and_cnb_origins_remain_accepted() {
+    for (origin, expected) in [
+        (
+            "https://github.com/Hmbown/CodeWhale.git",
+            "Hmbown%2FCodeWhale",
+        ),
+        (
+            "https://user:token@github.com/Hmbown/CodeWhale",
+            "Hmbown%2FCodeWhale",
+        ),
+        (
+            "ssh://git@github.com/Hmbown/CodeWhale.git",
+            "Hmbown%2FCodeWhale",
+        ),
+        ("git@github.com:Hmbown/CodeWhale.git", "Hmbown%2FCodeWhale"),
+        ("https://cnb.cool/whale/codewhale.git", "whale%2Fcodewhale"),
+        (
+            "ssh://git@cnb.cool:2222/whale/codewhale.git",
+            "whale%2Fcodewhale",
+        ),
+        ("git@cnb.cool:whale/codewhale.git", "whale%2Fcodewhale"),
+    ] {
+        let mut harness = ControlHarness::new();
+        init_repo(harness.temp.path(), origin, "main");
+        let result = dispatch(&mut harness.app, "remote-env", Some("open"));
+        assert!(!result.is_error, "{origin}: {result:?}");
+        assert!(
+            external_url(&result).contains(&format!("repo={expected}")),
+            "{origin}: {:?}",
+            result.action
+        );
+    }
+}
+
+#[test]
+fn remote_env_rejects_unsupported_origins_without_echoing_them() {
+    for origin in [
+        "http://github.com/acme/widgets.git",
+        "git://github.com/acme/widgets.git",
+        "https://github.com/acme/widgets/extra.git",
+        "https://github.com/acme/widgets.git?token=secret",
+        "file:///tmp/widgets.git",
+        "/tmp/widgets.git",
+    ] {
+        let mut harness = ControlHarness::new();
+        init_repo(harness.temp.path(), origin, "main");
+        let result = dispatch(&mut harness.app, "remote-env", Some("open"));
+        assert!(result.is_error, "{origin}");
+        assert!(result.action.is_none(), "{origin}");
+        assert!(!result_text(&result).contains(origin), "{origin}");
+    }
+
+    let mut harness = ControlHarness::new();
+    let secret = "do-not-echo-this-token";
+    init_repo(
+        harness.temp.path(),
+        &format!("https://user:{secret}@gitlab.com/acme/widgets.git"),
+        "main",
+    );
+    let result = dispatch(&mut harness.app, "remote-env", Some("open"));
+    assert!(result.is_error);
+    assert!(result.action.is_none());
+    assert!(!result_text(&result).contains(secret));
+}
+
+#[test]
+fn remote_env_invalid_operations_remain_read_only_rejections() {
+    let mut harness = ControlHarness::new();
+    for operation in ["upload", "migrate", "sync", "surprise"] {
+        let result = dispatch(&mut harness.app, "remote-env", Some(operation));
+        assert!(result.is_error, "{operation}");
+        assert!(result.action.is_none(), "{operation}");
+        assert!(result_text(&result).contains("does not upload, migrate, or sync"));
+        assert!(result_text(&result).contains("/remote-env open"));
+    }
+}
+
+#[test]
+fn remote_env_open_requires_a_symbolic_branch() {
+    let mut harness = ControlHarness::new();
+    init_repo(
+        harness.temp.path(),
+        "git@github.com:acme/widgets.git",
+        "main",
+    );
+    for args in [
+        ["config", "user.name", "Codewhale Test"],
+        ["config", "user.email", "test@codewhale.invalid"],
+    ] {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(harness.temp.path())
+            .args(args)
+            .status()
+            .expect("git config");
+        assert!(status.success());
+    }
+    let commit = Command::new("git")
+        .arg("-C")
+        .arg(harness.temp.path())
+        .args(["commit", "--allow-empty", "--quiet", "-m", "fixture"])
+        .status()
+        .expect("create fixture commit");
+    assert!(commit.success());
+    let detach = Command::new("git")
+        .arg("-C")
+        .arg(harness.temp.path())
+        .args(["checkout", "--detach", "--quiet", "HEAD"])
+        .status()
+        .expect("detach HEAD");
+    assert!(detach.success());
+
+    let result = dispatch(&mut harness.app, "remote-env", Some("open"));
+    assert!(result.is_error);
+    assert!(result.action.is_none());
+}
+
+#[test]
+fn remote_env_localized_copy_preserves_composed_placeholders() {
+    let cases: &[(MessageId, &[&str])] = &[
+        (MessageId::CmdRemoteEnvOverview, &["{command}"]),
+        (
+            MessageId::CmdRemoteEnvOpening,
+            &["{repo}", "{branch}", "{origin}", "{url}"],
+        ),
+        (
+            MessageId::CmdRemoteEnvUnavailable,
+            &["{origin}", "{command}"],
+        ),
+        (MessageId::CmdRemoteEnvSourceCustodyPolicy, &["{command}"]),
+    ];
+    for locale in Locale::shipped_complete() {
+        for (id, placeholders) in cases {
+            let message = tr(*locale, *id);
+            for placeholder in *placeholders {
+                assert!(
+                    message.contains(placeholder),
+                    "{} {id:?} lost {placeholder}",
+                    locale.tag()
+                );
+            }
+        }
+    }
+}

--- a/crates/tui/src/remote_control.rs
+++ b/crates/tui/src/remote_control.rs
@@ -1601,6 +1601,20 @@ impl RemoteControlController {
         }
     }
 
+    /// Test-only: advertise a validated live session link without a control
+    /// plane. Mirrors the shape the runner-lease parser installs (`Connected`
+    /// plus validated links) so `/rc link`/`/rc open` routing can be exercised
+    /// deterministically offline.
+    #[cfg(test)]
+    pub(crate) fn install_live_link_for_test(&mut self, run_url: &str, computer_url: Option<&str>) {
+        self.status = Status::Connected;
+        self.status_detail = "test link".to_string();
+        self.links = RemoteLinks {
+            run_url: Some(run_url.to_string()),
+            computer_url: computer_url.map(str::to_string),
+        };
+    }
+
     pub fn status_line(&self) -> String {
         match self.status {
             Status::Off => "Remote control: off".to_string(),

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -17570,9 +17570,10 @@ fn automatic_session_snapshot_never_reloads_existing_json_on_ui_thread() {
 
 #[test]
 fn renamed_title_survives_next_in_memory_automatic_snapshot() {
+    let _lock = crate::test_support::lock_test_env();
     let tmp = tempfile::tempdir().expect("tempdir");
-    let manager =
-        crate::session_manager::SessionManager::new(tmp.path().join("sessions")).expect("manager");
+    let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", tmp.path());
+    let manager = crate::session_manager::SessionManager::default_location().expect("manager");
     let mut session = saved_session_with_messages(vec![text_message("user", "original title")]);
     session.metadata.title = "Original Title".to_string();
     manager.save_session(&session).expect("save session");
@@ -17580,12 +17581,7 @@ fn renamed_title_survives_next_in_memory_automatic_snapshot() {
     app.current_session_id = Some(session.metadata.id.clone());
     app.api_messages.clone_from(&session.messages);
 
-    let renamed = crate::commands::rename_session_with_manager(
-        "Renamed In Memory",
-        &session.metadata.id,
-        &manager,
-        &mut app,
-    );
+    let renamed = crate::commands::execute("/rename Renamed In Memory", &mut app);
     assert!(!renamed.is_error, "{:?}", renamed.message);
     let snapshot = build_session_snapshot(&mut app, &manager).expect("automatic snapshot");
 


### PR DESCRIPTION
## Summary

FEAT-024 converts the TUI session-control slice to portable command shapes while keeping all production files in `codewhale-tui`:

- `/relay` (`/batonpass`, `/接力`)
- `/rename` (`/gaiming`, `/chongmingming`)
- `/resume` (`/r`)
- `/rc` (`/remote-control`)
- `/remote-env`
- `/title` (`/tabtitle`, `/window-title`)

**Baseline:** current `origin/main` at `19e460889`. The branch is eleven signed commits ahead with no merge commits.

This PR:

- adds contract-owned `CommandSessionControlContext` and typed session-control DTOs;
- allocates `SESSION_CONTROL = 1 << 14` while retaining `CommandCapabilities(u16)`;
- declares exactly `SESSION_CONTROL` for `/relay`, `/rename`, `/resume`, `/rc`, and `/title`;
- declares exactly `SESSION_CONTROL | PRESENTATION` for `/remote-env`;
- exposes only declared facets through the restricted command envelope;
- keeps concrete `App`, session manager, picker, persistence, Git-origin, browser, remote-service, checkpoint, and Work-state machinery in `SessionControlAdapter`;
- keeps `/rc open` synchronous through the host facet, preserving existing browser behavior;
- returns typed relay projections and formats plan-step status labels in the portable handler;
- registers all six handlers through the public contextual dispatch seam;
- retains the root `session` migration frontier for FEAT-025 and FEAT-026;
- keeps TUI-owned persistence, Git, browser, remote-service, and recovery regressions outside the future movable `groups/session` directory.

Tracking: EPIC-006 / FEAT-024 in umbrella [#5316](https://github.com/Hmbown/CodeWhale/issues/5316).

## Dependency boundary

Portable session-control handlers do not access concrete `App`, session managers, pickers, persistence services, Git wrappers, browser helpers, prompt/TODO/plan/Work-state types, configuration, or host services. Missing authority fails closed with:

```text
Command capability unavailable: session_control
```

`/remote-env` also fails safely when its separately declared presentation facet is unavailable.

The only temporary TUI-owned result/action references are the exact compatibility payloads assigned to FEAT-037:

- `CommandResult`;
- `AppAction::SendMessage(String)`;
- `AppAction::LoadSession(PathBuf)`;
- `AppAction::RemoteControl(Start | Stop)` and `RemoteControlAction`;
- `AppAction::OpenExternalUrl { url, label }`.

The remaining staged dependencies are explicit:

- FEAT-016 owns registry extraction;
- FEAT-036 owns localization ownership;
- FEAT-037 owns the shared result/action data above;
- FEAT-025 and FEAT-026 own the remaining session slices;
- FEAT-043 owns the physical session-group move and keeps host regressions TUI-side.

No new crate dependency and no physical production-file move occur here. `codewhale-command-contract` remains independent of `codewhale-tui`.

## Behavior and scope

- Structural migration only: command names, aliases, registry order, parsing, check order, messages, actions, persistence behavior, browser timing, and output remain unchanged.
- `/relay` composes the existing byte-identical relay instruction from typed semantic data.
- `/rename` and `/title` preserve checkpoint recovery, metadata and Work-state persistence, terminal-control sanitization, and existing length boundaries.
- `/remote-env` preserves HTTPS/SSH/CNB origin normalization, credential safety, branch encoding, malformed-origin rejection, detached-HEAD behavior, and localized placeholders.
- `/resume` retains transition-gate precedence and exact host call order.
- No localization extraction, shared outcome move, registry extraction, session export/structcopy migration, or physical group move is included.
- No Gherkin expectations changed.

## Review remediation included

A whole-feature critical review found and this branch resolves the following before PR creation:

- restored the complete TUI-host regression surface through public dispatch;
- removed duplicated rename production logic and made the adapter/public-dispatch path authoritative;
- replaced adapter-rendered `PlanStep.status_label: String` with contract-owned `PlanStepStatus`;
- added exact restricted-envelope coverage for control-only, unrelated, and control-plus-presentation capabilities;
- added missing-presentation coverage for `/remote-env`;
- added exact fake-facet operation counts, transition-gate precedence, and call-order assertions;
- recorded FEAT-024's exact temporary payload handoff in FEAT-037.

Final internal review verdict: **APPROVED**.

## Owner-review follow-up

The feedback reviewed at `d8e43fe1d` is resolved in `d4b68963d`:

- `/rename` now sanitizes and enforces the shared 100-character policy in the portable handler before any host mutation; `/rename`, `/title`, and the host regression suite use one `MAX_TITLE_LEN`;
- `TitleSetOutcome` and its unreachable mismatch arms are removed; explicit `set_window_title` and `clear_window_title` delegates return only host-stage errors;
- `remote_env` module visibility is private again;
- the duplicated six-module test message helper is consolidated in `control_test_support.rs`;
- `/title` manager/session error precedence is restored to the exact baseline order noted in review.

## Testing

All commands below passed on the final rebased head:

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-command-contract --locked` — 52 passed
- [x] `cargo test -p codewhale-tui --tests --locked -- --test-threads=1` — TUI library 11,784 passed / 13 ignored; Cucumber 16 passed; integration 289 passed
- [x] `cargo test --workspace --all-targets --all-features --locked -- --test-threads=1` — complete workspace matrix passed; all-feature TUI library 11,799 passed / 13 ignored; Cucumber 33 passed; integration 289 passed
- [x] `cargo build --release --workspace --locked`
- [x] strict Clippy for `codewhale-command-contract` and `codewhale-tui` with `--all-targets --all-features --locked -D warnings`
- [x] session group — 88 passed
- [x] restored public-dispatch control regressions — 18 passed
- [x] control adapter/public-dispatch coverage — 11 passed
- [x] migration fixtures — 56 passed; frontier remains `[config, core, debug, session]`
- [x] command-boundary fixtures — 8 passed
- [x] CI wiring tests — 11 passed
- [x] locale parity — all 15 non-English locales match the 2,087-key reference
- [x] `git diff --check`

The TUI and workspace runs used `RUST_MIN_STACK=8388608`, `--test-threads=1`, and removed the harness `TMUX` marker so terminal-policy tests observed their intended fixtures.

## Checklist

- [x] This PR adds a new layer/module/abstraction — `CommandSessionControlContext` replaces direct host access for exactly six session-control handlers
- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes — N/A; this is an internal structural refactor with unchanged Gherkin expectations and public-dispatch regression coverage
- [x] All eleven commits carry DCO `Signed-off-by` trailers
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address — N/A; no harvested/co-authored commits

No-Issue: FEAT-024 is tracked in umbrella issue #5316, which remains open for the remaining EPIC-006 work.

Paulo Aboim Pinto
