### PR TITLE
engine: a mid-turn MCP refresh keeps the pool deferred and the active set narrow

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -806,6 +806,9 @@ pub struct Engine {
     /// transient `ToolContext` (#4475).
     file_read_tracker: SharedFileReadTracker,
     mcp_pool: Option<Arc<AsyncMutex<McpPool>>>,
+    /// The tool-surface budget the current turn's catalog was shaped with,
+    /// so a mid-turn MCP refresh reshapes its slice the same way (#5939).
+    turn_tool_surface_budget: Option<crate::model_profile::ToolSurfaceBudget>,
     /// Last connection diagnosis for each configured MCP server.
     ///
     /// Failed transports are intentionally absent from `McpPool::connections`,
@@ -1683,6 +1686,7 @@ impl Engine {
             shell_manager,
             file_read_tracker,
             mcp_pool: None,
+            turn_tool_surface_budget: None,
             mcp_connection_errors: HashMap::new(),
             mcp_boot_in_flight: false,
             mcp_boot_rx: None,
@@ -4553,6 +4557,7 @@ impl Engine {
         // which is not necessarily the installed one under auto routing.
         let capability = route.capability_profile();
         let always_load = self.config.tools_always_load.clone();
+        self.turn_tool_surface_budget = Some(capability.tool_surface_budget);
         let mut catalog = build_model_tool_catalog_with_surface(
             tool_registry.to_api_tools_with_cache(true),
             mcp_tools,

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -8201,18 +8201,30 @@ fn runtime_mcp_refresh_replaces_the_pool_slice() {
         .into_iter()
         .map(str::to_string)
         .collect();
+    let always_load: HashSet<String> = [
+        "mcp_static_read",
+        "mcp_dynamic_render",
+        "mcp_alpha_authenticate",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect();
     replace_runtime_mcp_tools(
         &mut catalog,
         &mut active,
         &universe,
         vec![api_tool("mcp_static_read"), api_tool("mcp_dynamic_render")],
+        AppMode::Agent,
+        &always_load,
+        crate::model_profile::ToolSurfaceBudget::Standard,
     );
 
     let names: Vec<&str> = catalog.iter().map(|tool| tool.name.as_str()).collect();
     assert_eq!(
         names,
-        vec!["exec_shell", "mcp_static_read", "mcp_dynamic_render"],
-        "the synthetic authenticate tool leaves after its own login; engine tools stay"
+        vec!["exec_shell", "mcp_dynamic_render", "mcp_static_read"],
+        "the synthetic authenticate tool leaves after its own login; engine tools stay; \
+         the refreshed slice is name-sorted like the initial catalog (#5939)"
     );
     assert!(active.contains("mcp_static_read"));
     assert!(active.contains("mcp_dynamic_render"));
@@ -8233,6 +8245,9 @@ fn runtime_mcp_refresh_replaces_the_pool_slice() {
         &mut active,
         &universe,
         vec![api_tool("mcp_alpha_authenticate")],
+        AppMode::Agent,
+        &always_load,
+        crate::model_profile::ToolSurfaceBudget::Standard,
     );
     let names: Vec<&str> = catalog.iter().map(|tool| tool.name.as_str()).collect();
     assert_eq!(
@@ -8242,6 +8257,69 @@ fn runtime_mcp_refresh_replaces_the_pool_slice() {
     );
     assert!(active.contains("mcp_alpha_authenticate"));
     assert!(!active.contains("mcp_dynamic_render"));
+}
+
+#[test]
+fn runtime_mcp_refresh_keeps_the_pool_deferred_and_the_active_set_narrow() {
+    // #5939: a mid-turn MCP refresh must not flip the whole pool into the
+    // request. Seed a catalog with N deferred MCP tools (one activated by a
+    // ToolSearch earlier in the turn) plus one default-active native tool.
+    let native = api_tool("exec_shell");
+    let mut catalog = vec![native];
+    let mut universe: HashSet<String> = HashSet::new();
+    for index in 0..6 {
+        let name = format!("mcp_server_tool_{index}");
+        let mut tool = api_tool(&name);
+        tool.defer_loading = Some(true);
+        universe.insert(name);
+        catalog.push(tool);
+    }
+    let mut active: HashSet<String> = ["exec_shell", "mcp_server_tool_2"]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    let requested_before = active_tools_for_step(&catalog, &active).len();
+    assert_eq!(requested_before, 2);
+
+    // The pool's raw projection: seven tools (one new), every one of them
+    // `defer_loading = false`.
+    let refreshed: Vec<Tool> = (0..7)
+        .map(|index| api_tool(&format!("mcp_server_tool_{index}")))
+        .collect();
+    universe.insert("mcp_server_tool_6".to_string());
+    let always_load: HashSet<String> = HashSet::new();
+    replace_runtime_mcp_tools(
+        &mut catalog,
+        &mut active,
+        &universe,
+        refreshed,
+        AppMode::Agent,
+        &always_load,
+        crate::model_profile::ToolSurfaceBudget::Standard,
+    );
+
+    let requested_after = active_tools_for_step(&catalog, &active);
+    let names: Vec<&str> = requested_after
+        .iter()
+        .map(|tool| tool.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["exec_shell", "mcp_server_tool_2"],
+        "only the previously activated MCP tool and the native head stay in the request"
+    );
+    assert!(
+        catalog
+            .iter()
+            .filter(|tool| tool.name.starts_with("mcp_server_tool_"))
+            .all(|tool| tool.defer_loading == Some(true)),
+        "the refreshed pool is deferred like the initial catalog"
+    );
+    assert_eq!(
+        catalog.len(),
+        8,
+        "the new tool joined the catalog, deferred"
+    );
 }
 
 #[test]

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -230,7 +230,7 @@ pub(super) fn apply_registry_first_shell_guidance(catalog: &mut [Tool]) {
     shell.description.push_str(REGISTRY_FIRST_SHELL_GUIDANCE);
 }
 
-fn apply_tool_surface_budget(
+pub(super) fn apply_tool_surface_budget(
     catalog: &mut [Tool],
     surface_budget: ToolSurfaceBudget,
     always_load: &HashSet<String>,

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -326,22 +326,42 @@ fn registered_tool_requires_non_bypassable_approval(tool_name: &str) -> bool {
 /// killed by a live 401 would stay callable in name. `universe` is every
 /// name the pool can own; entries inside it are the pool's to manage, and
 /// the refreshed list is the new truth.
+///
+/// The refreshed slice is shaped exactly like the turn's initial catalog —
+/// the same deferral pass, the same surface budget, the same always-load
+/// set — and only the names that were active before the replacement (or
+/// that shaping leaves non-deferred) come back active. The pool's raw
+/// projection carries `defer_loading = false` on every tool, so pushing it
+/// in unshaped put every MCP tool definition into every remaining request
+/// of the turn (#5939).
 pub(super) fn replace_runtime_mcp_tools(
     tool_catalog: &mut Vec<Tool>,
     active_tool_names: &mut std::collections::HashSet<String>,
     universe: &std::collections::HashSet<String>,
-    refreshed: Vec<Tool>,
+    mut refreshed: Vec<Tool>,
+    mode: AppMode,
+    always_load: &std::collections::HashSet<String>,
+    surface_budget: crate::model_profile::ToolSurfaceBudget,
 ) -> usize {
     let before = tool_catalog.len();
+    let mut previously_active = std::collections::HashSet::new();
     tool_catalog.retain(|tool| {
         let owned = universe.contains(&tool.name);
-        if owned {
-            active_tool_names.remove(&tool.name);
+        if owned && active_tool_names.remove(&tool.name) {
+            previously_active.insert(tool.name.clone());
         }
         !owned
     });
+    super::tool_catalog::apply_mcp_tool_deferral(&mut refreshed, mode, always_load);
+    super::tool_catalog::apply_tool_surface_budget(&mut refreshed, surface_budget, always_load);
+    refreshed.sort_by(|a, b| a.name.cmp(&b.name));
     for tool in refreshed {
-        active_tool_names.insert(tool.name.clone());
+        let stays_active = previously_active.contains(&tool.name)
+            || always_load.contains(&tool.name)
+            || !tool.defer_loading.unwrap_or(false);
+        if stays_active {
+            active_tool_names.insert(tool.name.clone());
+        }
         tool_catalog.push(tool);
     }
     tool_catalog.len().abs_diff(before)
@@ -4046,11 +4066,17 @@ impl Engine {
                             let pool = pool.lock().await;
                             (pool.model_tool_names(), pool.to_api_tools())
                         };
+                        let surface_budget = self
+                            .turn_tool_surface_budget
+                            .unwrap_or(crate::model_profile::ToolSurfaceBudget::Standard);
                         tool_surface_changed |= replace_runtime_mcp_tools(
                             tool_catalog,
                             active_tool_names,
                             &universe,
                             refreshed,
+                            self.current_mode,
+                            &self.config.tools_always_load,
+                            surface_budget,
                         ) > 0;
                     }
                     // Any of the legitimate mid-turn tool-surface changes above


### PR DESCRIPTION
Closes #5939

A completed OAuth login (or a live 401) mid-turn re-inserted the pool's raw projection into the turn catalog: every MCP tool with `defer_loading = false`, every name marked active. For the rest of that turn the model's `tools` array carried the whole MCP surface.

`replace_runtime_mcp_tools` now shapes the refreshed slice with the same deferral and surface-budget passes the initial catalog got (the engine records the turn's `ToolSurfaceBudget` at catalog build), sorts it by name like the initial catalog, and re-marks active only names that were active before the replacement, the always-load set, and whatever shaping leaves non-deferred.

Verified: `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- runtime_mcp replace_runtime_mcp tool_catalog` → 72 passed, 0 failed; the new `runtime_mcp_refresh_keeps_the_pool_deferred_and_the_active_set_narrow` seeds six deferred MCP tools with one activated, refreshes with seven, and asserts the request stays at the native head plus that one tool. The existing replace test's expected order changed to name-sorted, matching the initial catalog. Not verified: a live login mid-turn against a populated pool.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mid-turn tool catalog and active-tool selection for MCP refreshes, which affects what the model can call for the rest of a turn; behavior is covered by new/updated unit tests but live mid-turn login was not manually verified.
> 
> **Overview**
> Fixes a bug where **mid-turn MCP catalog updates** (e.g. after OAuth login or a 401) replaced the turn’s MCP slice with the pool’s raw tools—everything non-deferred and all names marked active—so later steps in the same turn sent the full MCP surface to the model.
> 
> The engine now **stores the turn’s `ToolSurfaceBudget`** when the initial catalog is built. **`replace_runtime_mcp_tools`** reshapes refreshed MCP tools with the same **deferral**, **compact surface budget**, and **`tools_always_load`** rules as the initial catalog, **name-sorts** the slice, and only puts tools back in the **active set** if they were active before the refresh, are always-load, or remain non-deferred after shaping. **`apply_tool_surface_budget`** is exposed to `turn_loop` for that pass.
> 
> Tests were updated for the new signature and name-sorted order, plus a case that refreshes seven pool tools while only one stayed activated and asserts the request still carries just the native head plus that tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7244e7b68ff49522cb502ab0cead2013ec754974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->