### PR TITLE
mcp: a token refresh that fails for a non-auth reason names the login remedy

### DIFF
--- a/crates/tui/src/mcp/oauth.rs
+++ b/crates/tui/src/mcp/oauth.rs
@@ -47,6 +47,22 @@ impl std::fmt::Display for McpAuthStatus {
     }
 }
 
+/// Context for a failed token refresh. An auth-required failure already
+/// flips the server to `◆ auth required` and offers the login tool; any
+/// other failure (a token endpoint answering something the client could
+/// not parse, a transport error) names the same remedy in words, because
+/// the operator otherwise sees only the provider's parse error (#5926).
+fn refresh_failure_context(server_name: &str, names_remedy: bool) -> String {
+    if names_remedy {
+        format!(
+            "refreshing MCP OAuth token for server {server_name}: the token endpoint did not answer the way the client expects; \
+             if this persists, run `codewhale mcp login {server_name}` (or `/mcp login {server_name}`) to re-authorize"
+        )
+    } else {
+        format!("refreshing MCP OAuth token for server {server_name}")
+    }
+}
+
 pub fn error_looks_auth_required(error: &anyhow::Error) -> bool {
     error_text_looks_auth_required(&format!("{error:#}"))
 }
@@ -430,12 +446,9 @@ impl McpOAuthRuntime {
             };
             self.clear_stored_tokens(reason).await?;
         }
-        Err(err).with_context(|| {
-            format!(
-                "refreshing MCP OAuth token for server {}",
-                self.inner.server_name
-            )
-        })
+        let server_name = self.inner.server_name.clone();
+        let names_remedy = !error_looks_auth_required(&err);
+        Err(err).with_context(|| refresh_failure_context(&server_name, names_remedy))
     }
 
     async fn try_refresh_and_persist(&self) -> Result<()> {
@@ -1615,6 +1628,18 @@ impl McpServerConfig {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_refresh_parse_failure_names_the_login_remedy_and_the_server() {
+        let text = super::refresh_failure_context("supabase", true);
+        assert!(text.contains("server supabase"));
+        assert!(text.contains("codewhale mcp login supabase"), "{text}");
+        assert!(text.contains("/mcp login supabase"), "{text}");
+        // An auth-required failure keeps the plain context: the typed state
+        // and the login tool already carry the remedy.
+        let plain = super::refresh_failure_context("supabase", false);
+        assert_eq!(plain, "refreshing MCP OAuth token for server supabase");
+    }
+
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
 


### PR DESCRIPTION
No-Issue: refresh half of #5926; the raw-response excerpt stays open there.

Refs #5926 (the refresh half; the raw-response excerpt needs rmcp to surface it and stays open)

Receipt: `Failed to connect supabase: refreshing MCP OAuth token for server supabase: OAuth token refresh failed: Failed to parse server response` — no next step. An auth-required failure already flips the server to `◆ auth required` with the login tool; a non-auth failure now reads: *the token endpoint did not answer the way the client expects; if this persists, run `codewhale mcp login supabase` (or `/mcp login supabase`) to re-authorize*.

Verified: `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- mcp::` → all passed (one new unit test pins both branches of the context).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error text only on an existing failure path; auth classification and token-clearing behavior are unchanged.
> 
> **Overview**
> When MCP OAuth token refresh fails for reasons that are **not** classified as auth-required (e.g. unparsable token endpoint responses or transport errors), the error context now explains that the endpoint did not answer as expected and tells the operator to run **`codewhale mcp login <server>`** or **`/mcp login <server>`** if the problem persists (#5926).
> 
> **Auth-required** failures still use the short context string only, because the UI already flips the server to `◆ auth required` and surfaces the login tool—avoiding duplicate remediation text.
> 
> Implementation adds `refresh_failure_context` and wires it into `refresh_and_persist` via `names_remedy = !error_looks_auth_required(&err)`. A unit test locks both message shapes for a sample server name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f16dfb8101c24db2fc5e9ae5c99272f52fdc65c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->