### PR TITLE
feat(tui): make the three Fleet views one back-navigable stack (#5954)

### DIFF
--- a/crates/tui/src/tui/ui/handlers.rs
+++ b/crates/tui/src/tui/ui/handlers.rs
@@ -27,6 +27,29 @@ pub(crate) fn sync_fleet_roster(app: &mut App, config: &Config, engine_handle: &
     });
 }
 
+/// Refresh the Fleet roster when it is parked on top of the stack after a
+/// store mutation (#5954).
+///
+/// The roster now stays open underneath the saved-teams list, so selecting or
+/// deleting a team has to update the view the user pops back to — otherwise
+/// it keeps painting the pre-change team. Cursor and detail scroll survive,
+/// because losing them is the disruption the back path exists to avoid.
+pub(crate) fn refresh_parked_fleet_roster(app: &mut App, config: &Config) {
+    if app.view_stack.top_kind() != Some(ModalKind::FleetRoster) {
+        return;
+    }
+    let Some(mut view) = app.view_stack.pop() else {
+        return;
+    };
+    if let Some(roster) = view
+        .as_any_mut()
+        .downcast_mut::<crate::tui::views::fleet_roster::FleetRosterView>()
+    {
+        roster.reload(app, config);
+    }
+    app.view_stack.push_boxed(view);
+}
+
 /// Once per event-loop iteration: deliver a pending fleet mutation to the
 /// engine and clear the flag.
 pub(crate) fn flush_stale_fleet_roster(
@@ -1415,20 +1438,31 @@ pub(crate) async fn handle_view_events(
             ViewEvent::FleetStoreChanged { message } => {
                 app.status_message = Some(message);
                 sync_fleet_roster(app, config, engine_handle);
+                refresh_parked_fleet_roster(app, config);
             }
+            // #5954: the roster emits (rather than emit-and-closes) these, so
+            // it is still on the stack right underneath. Pushing on top makes
+            // the three Fleet views one stack: `Esc` pops back to the roster,
+            // and only closes the window at the root.
             ViewEvent::FleetRosterOpenFleetsRequested => {
                 if app.view_stack.top_kind() != Some(ModalKind::FleetList) {
-                    app.view_stack
-                        .push(crate::tui::views::fleet_list::FleetListView::new(
-                            app, config,
-                        ));
+                    let over_roster = app.view_stack.top_kind() == Some(ModalKind::FleetRoster);
+                    let mut view = crate::tui::views::fleet_list::FleetListView::new(app, config);
+                    if over_roster {
+                        view = view.over_fleet_roster();
+                    }
+                    app.view_stack.push(view);
                 }
             }
             ViewEvent::FleetRosterOpenWorkersRequested => {
                 if app.view_stack.top_kind() != Some(ModalKind::SubAgents) {
+                    let over_roster = app.view_stack.top_kind() == Some(ModalKind::FleetRoster);
                     let agents = subagent_view_agents(app, &app.subagent_cache);
-                    app.view_stack
-                        .push(crate::tui::views::SubAgentsView::for_app(app, agents));
+                    let mut view = crate::tui::views::SubAgentsView::for_app(app, agents);
+                    if over_roster {
+                        view = view.over_fleet_roster();
+                    }
+                    app.view_stack.push(view);
                 }
                 app.status_message =
                     Some(tr(app.ui_locale, MessageId::SubagentsFetching).to_string());

--- a/crates/tui/src/tui/views/fleet_list.rs
+++ b/crates/tui/src/tui/views/fleet_list.rs
@@ -29,6 +29,7 @@ use crate::fleet::store::{
     FleetEntry, FleetScope, SelectedFleet, delete_fleet, list_fleets, migrate_legacy_roster,
     selected_fleet, set_selected,
 };
+use crate::localization::{Locale, MessageId, tr};
 use crate::palette;
 use crate::tui::app::App;
 use crate::tui::menu_style;
@@ -70,6 +71,14 @@ pub struct FleetListView {
     hovered_row: Cell<Option<usize>>,
     fleet_config: codewhale_config::FleetConfigToml,
     workspace: PathBuf,
+    /// UI locale, for the one hint whose wording changes with the entry path.
+    locale: Locale,
+    /// True when the Fleet roster is parked directly underneath on the view
+    /// stack (#5954), i.e. this list was opened with `f` from the roster.
+    /// `Esc` pops one view either way — the flag only decides whether the
+    /// footer promises `back` or `close`. Direct entry (`/fleet list`)
+    /// leaves it false, so `Esc` closes as before.
+    back_to_fleet_roster: bool,
 }
 
 impl FleetListView {
@@ -93,7 +102,17 @@ impl FleetListView {
             hovered_row: Cell::new(None),
             fleet_config: config.fleet_config(),
             workspace,
+            locale: app.ui_locale,
+            back_to_fleet_roster: false,
         }
+    }
+
+    /// Mark this list as pushed on top of the Fleet roster (#5954), so the
+    /// footer says `back` rather than `close`.
+    #[must_use]
+    pub fn over_fleet_roster(mut self) -> Self {
+        self.back_to_fleet_roster = true;
+        self
     }
 
     fn selected_entry(&self) -> Option<&FleetEntry> {
@@ -135,7 +154,13 @@ impl FleetListView {
         if self.banner_visible() {
             hints.push(ActionHint::new("m", "migrate"));
         }
-        hints.push(ActionHint::new("Esc", "close"));
+        // The hint has to name what `Esc` actually does: pop back to the
+        // parked roster, or close the window at the root (#5954).
+        hints.push(if self.back_to_fleet_roster {
+            ActionHint::new("Esc", tr(self.locale, MessageId::SetupActionBack))
+        } else {
+            ActionHint::new("Esc", "close")
+        });
         hints
     }
 
@@ -609,6 +634,88 @@ mod tests {
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, crossterm::event::KeyModifiers::NONE)
+    }
+
+    /// #5954: roster → `f` → saved teams → `Esc` returns to the roster, and
+    /// the footer promises `back` rather than `close` while it will.
+    #[test]
+    fn saved_teams_opened_from_the_roster_returns_there_on_esc() {
+        let ws = tempfile::TempDir::new().expect("ws");
+        save_in(ws.path(), FleetScope::Workspace, "alpha");
+        let app = app_in(ws.path().to_path_buf());
+        let config = Config::default();
+
+        let mut stack = crate::tui::views::ViewStack::new();
+        stack.push(crate::tui::views::fleet_roster::FleetRosterView::new(
+            &app, &config,
+        ));
+        let events = stack.handle_key(key(KeyCode::Char('f')));
+        assert!(
+            matches!(
+                events.as_slice(),
+                [ViewEvent::FleetRosterOpenFleetsRequested]
+            ),
+            "{events:?}"
+        );
+        assert_eq!(
+            stack.top_kind(),
+            Some(ModalKind::FleetRoster),
+            "the roster must survive the forward jump"
+        );
+
+        // What ui/handlers.rs does with that event.
+        stack.push(FleetListView::new(&app, &config).over_fleet_roster());
+        assert_eq!(stack.top_kind(), Some(ModalKind::FleetList));
+
+        stack.handle_key(key(KeyCode::Esc));
+        assert_eq!(
+            stack.top_kind(),
+            Some(ModalKind::FleetRoster),
+            "Esc in saved teams must return to the roster, not close the window"
+        );
+    }
+
+    /// #5954: `/fleet list` is the root of its own stack, so `Esc` closes.
+    #[test]
+    fn saved_teams_opened_directly_closes_on_esc() {
+        let ws = tempfile::TempDir::new().expect("ws");
+        let mut stack = crate::tui::views::ViewStack::new();
+        stack.push(FleetListView::new(
+            &app_in(ws.path().to_path_buf()),
+            &Config::default(),
+        ));
+        stack.handle_key(key(KeyCode::Esc));
+        assert!(stack.is_empty(), "direct entry must close on Esc");
+    }
+
+    /// #5954: the hint names what `Esc` actually does in each entry path.
+    #[test]
+    fn saved_teams_esc_hint_matches_the_entry_path() {
+        let ws = tempfile::TempDir::new().expect("ws");
+        save_in(ws.path(), FleetScope::Workspace, "alpha");
+        let app = app_in(ws.path().to_path_buf());
+        let config = Config::default();
+
+        // `footer_hints` is the only source the footer paints from, so
+        // asserting it is asserting what the user reads.
+        let esc_label = |view: &FleetListView| {
+            view.footer_hints()
+                .into_iter()
+                .find(|hint| hint.key == "Esc")
+                .map(|hint| hint.label.into_owned())
+                .expect("Esc hint")
+        };
+
+        assert_eq!(
+            esc_label(&FleetListView::new(&app, &config)),
+            "close",
+            "direct entry must still promise close"
+        );
+        assert_eq!(
+            esc_label(&FleetListView::new(&app, &config).over_fleet_roster()),
+            "back",
+            "over the roster the hint must promise back"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/views/fleet_roster.rs
+++ b/crates/tui/src/tui/views/fleet_roster.rs
@@ -227,6 +227,21 @@ impl FleetRosterView {
         }
     }
 
+    /// Rebuild this roster from the current workspace, keeping the cursor.
+    ///
+    /// #5954: the roster now stays parked under the saved-teams list, so a
+    /// team switch or delete has to refresh the parked view in place — the
+    /// user pops back to it, and it must not keep painting the pre-change
+    /// selection. Cursor and detail scroll survive because losing them is
+    /// exactly the disruption the back path exists to avoid.
+    pub fn reload(&mut self, app: &App, config: &Config) {
+        let selected = self.selected;
+        let detail_scroll = self.detail_scroll;
+        *self = Self::new(app, config);
+        self.selected = selected.min(self.row_count().saturating_sub(1));
+        self.detail_scroll = detail_scroll;
+    }
+
     /// Total selectable rows: the operator plus every roster member.
     fn row_count(&self) -> usize {
         1 + self.members.len()
@@ -331,12 +346,14 @@ impl ModalView for FleetRosterView {
                 ViewAction::None
             }
             KeyCode::Enter => self.activate_selected(),
+            // #5954: the roster stays on the stack under the view it opens,
+            // so `Esc` in workers / saved teams pops back here instead of
+            // closing the window. `Emit` (not `EmitAndClose`) is what makes
+            // the three Fleet views one stack.
             KeyCode::Tab | KeyCode::BackTab | KeyCode::Char('w') => {
-                ViewAction::EmitAndClose(ViewEvent::FleetRosterOpenWorkersRequested)
+                ViewAction::Emit(ViewEvent::FleetRosterOpenWorkersRequested)
             }
-            KeyCode::Char('f') => {
-                ViewAction::EmitAndClose(ViewEvent::FleetRosterOpenFleetsRequested)
-            }
+            KeyCode::Char('f') => ViewAction::Emit(ViewEvent::FleetRosterOpenFleetsRequested),
             KeyCode::Home => {
                 self.detail_scroll = 0;
                 ViewAction::None

--- a/crates/tui/src/tui/views/fleet_roster/tests.rs
+++ b/crates/tui/src/tui/views/fleet_roster/tests.rs
@@ -362,6 +362,8 @@ fn selected_named_fleet_member_shows_edit_affordance() {
     assert!(!text.contains("PgUp"), "{text}");
 }
 
+/// #5954: the forward jump `Emit`s and keeps the roster on the stack, so the
+/// view it opens is pushed on top and `Esc` there pops back here.
 #[test]
 fn tab_and_w_open_the_live_workers_tab() {
     for code in [KeyCode::Tab, KeyCode::BackTab, KeyCode::Char('w')] {
@@ -369,11 +371,21 @@ fn tab_and_w_open_the_live_workers_tab() {
         assert!(
             matches!(
                 view.handle_key(key(code)),
-                ViewAction::EmitAndClose(ViewEvent::FleetRosterOpenWorkersRequested)
+                ViewAction::Emit(ViewEvent::FleetRosterOpenWorkersRequested)
             ),
             "{code:?}"
         );
     }
+}
+
+/// #5954: same for the saved-teams jump.
+#[test]
+fn f_opens_saved_teams_without_closing_the_roster() {
+    let mut view = built_in_view();
+    assert!(matches!(
+        view.handle_key(key(KeyCode::Char('f'))),
+        ViewAction::Emit(ViewEvent::FleetRosterOpenFleetsRequested)
+    ));
 }
 
 #[test]
@@ -383,6 +395,49 @@ fn esc_closes() {
         view.handle_key(key(KeyCode::Esc)),
         ViewAction::Close
     ));
+}
+
+/// #5954, end to end on the real stack: `Tab` leaves the roster in place,
+/// the host pushes workers on top, and `Esc` there returns to the roster
+/// rather than closing the window.
+#[test]
+fn roster_tab_workers_esc_returns_to_the_roster() {
+    let mut stack = ViewStack::new();
+    stack.push(built_in_view());
+
+    let events = stack.handle_key(key(KeyCode::Tab));
+    assert!(
+        matches!(
+            events.as_slice(),
+            [ViewEvent::FleetRosterOpenWorkersRequested]
+        ),
+        "{events:?}"
+    );
+    assert_eq!(
+        stack.top_kind(),
+        Some(ModalKind::FleetRoster),
+        "the roster must survive the forward jump so it can be popped back to"
+    );
+
+    // What ui/handlers.rs does with that event.
+    stack.push(crate::tui::views::SubAgentsView::new(Vec::new()).over_fleet_roster());
+    assert_eq!(stack.top_kind(), Some(ModalKind::SubAgents));
+
+    stack.handle_key(key(KeyCode::Esc));
+    assert_eq!(
+        stack.top_kind(),
+        Some(ModalKind::FleetRoster),
+        "Esc in workers must return to the roster, not close the window"
+    );
+}
+
+/// #5954: `Esc` at the root of the Fleet stack still closes the window.
+#[test]
+fn esc_at_the_roster_root_closes_the_window() {
+    let mut stack = ViewStack::new();
+    stack.push(built_in_view());
+    stack.handle_key(key(KeyCode::Esc));
+    assert!(stack.is_empty(), "Esc at the roster must close the window");
 }
 
 #[test]

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -5356,6 +5356,13 @@ pub struct SubAgentsView {
     locale: Locale,
     /// Wall clock anchor for the working-wake frame.
     opened_at: std::time::Instant,
+    /// True when the Fleet roster is parked directly underneath on the view
+    /// stack (#5954), i.e. this view was reached with `Tab`/`w` from the
+    /// roster. `Esc` still pops exactly one view — the flag only decides
+    /// whether the footer promises `back` or `close`, and lets `F` return to
+    /// the parked roster instead of stacking a second one. Direct entry
+    /// (`/fleet workers`, the Work dock) leaves it false, so `Esc` closes.
+    back_to_fleet_roster: bool,
 }
 
 /// Build the agent rows shown by `/subagents`.
@@ -5511,6 +5518,7 @@ impl SubAgentsView {
             motion: crate::tui::motion::mode::MotionMode::Still,
             locale: Locale::En,
             opened_at: std::time::Instant::now(),
+            back_to_fleet_roster: false,
         }
     }
 
@@ -5521,6 +5529,24 @@ impl SubAgentsView {
         view.motion = app.motion_policy().mode();
         view.locale = app.ui_locale;
         view
+    }
+
+    /// Mark this view as pushed on top of the Fleet roster (#5954), so the
+    /// footer says `back` and `F` pops to the parked roster.
+    #[must_use]
+    pub fn over_fleet_roster(mut self) -> Self {
+        self.back_to_fleet_roster = true;
+        self
+    }
+
+    /// Footer label for `Esc`: `back` while the roster is parked underneath,
+    /// `close` at the root. The hint has to name what the key actually does.
+    fn esc_hint_label(&self) -> std::borrow::Cow<'static, str> {
+        if self.back_to_fleet_roster {
+            tr(self.locale, MessageId::SetupActionBack)
+        } else {
+            tr(self.locale, MessageId::SessionsActionClose)
+        }
     }
 
     /// Working-wake frame for this render: 0 unless motion is Full.
@@ -5621,6 +5647,12 @@ impl ModalView for SubAgentsView {
                     Some(agent_id) => ViewAction::Emit(ViewEvent::SidebarAgentCancel { agent_id }),
                     None => ViewAction::None,
                 }
+            }
+            // The roster is the same destination either way: pop back to the
+            // parked one when there is one (#5954) — re-running `/fleet`
+            // would stack a duplicate roster and lose its cursor.
+            KeyCode::Char('f') | KeyCode::Char('F') if self.back_to_fleet_roster => {
+                ViewAction::Close
             }
             KeyCode::Char('f') | KeyCode::Char('F') => {
                 ViewAction::Emit(ViewEvent::CommandPaletteSelected {
@@ -5841,7 +5873,7 @@ impl ModalView for SubAgentsView {
             area,
             buf,
             &[
-                ActionHint::new("Esc", tr(self.locale, MessageId::SessionsActionClose)),
+                ActionHint::new("Esc", self.esc_hint_label()),
                 ActionHint::new("↑/↓", tr(self.locale, MessageId::CtxInspActionSelect)),
                 ActionHint::new("Enter", tr(self.locale, MessageId::ExtensionsActionFocus)),
                 ActionHint::new("X", tr(self.locale, MessageId::SidebarStopControl)),
@@ -6339,6 +6371,72 @@ mod tests {
             || SubAgentsView::new(Vec::new()),
             &["close", "refresh", "setup"],
         );
+    }
+
+    /// #5954: the `Esc` hint has to name what the key does — `back` while the
+    /// Fleet roster is parked underneath, `close` on direct entry.
+    #[test]
+    fn subagents_esc_hint_says_back_over_the_roster_and_close_at_the_root() {
+        let area = Rect::new(0, 0, 160, 40);
+
+        let direct = SubAgentsView::new(Vec::new());
+        let mut direct_buf = Buffer::empty(area);
+        direct.render(area, &mut direct_buf);
+        let direct_text = buffer_text(&direct_buf, area);
+        assert!(
+            direct_text.contains("Esc close"),
+            "direct entry must still promise close: {direct_text}"
+        );
+
+        let over_roster = SubAgentsView::new(Vec::new()).over_fleet_roster();
+        let mut back_buf = Buffer::empty(area);
+        over_roster.render(area, &mut back_buf);
+        let back_text = buffer_text(&back_buf, area);
+        assert!(
+            back_text.contains("Esc back"),
+            "over the roster the hint must promise back: {back_text}"
+        );
+        assert!(
+            !back_text.contains("Esc close"),
+            "over the roster the hint must not still promise close: {back_text}"
+        );
+    }
+
+    /// #5954: workers opened directly (`/fleet workers`, the Work dock) is the
+    /// root of its own stack, so `Esc` closes the window as before.
+    #[test]
+    fn subagents_opened_directly_closes_on_esc() {
+        let mut stack = ViewStack::new();
+        stack.push(SubAgentsView::new(Vec::new()));
+        stack.handle_key(KeyEvent::new(
+            crossterm::event::KeyCode::Esc,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert!(stack.is_empty(), "direct entry must close on Esc");
+    }
+
+    /// #5954: `F` in workers is the roster door. With a roster parked below,
+    /// it pops back to it instead of re-running `/fleet` and stacking a
+    /// duplicate roster.
+    #[test]
+    fn subagents_f_pops_back_to_the_parked_roster() {
+        let mut over_roster = SubAgentsView::new(Vec::new()).over_fleet_roster();
+        assert!(matches!(
+            over_roster.handle_key(KeyEvent::new(
+                crossterm::event::KeyCode::Char('F'),
+                crossterm::event::KeyModifiers::NONE,
+            )),
+            ViewAction::Close
+        ));
+
+        let mut direct = SubAgentsView::new(Vec::new());
+        assert!(matches!(
+            direct.handle_key(KeyEvent::new(
+                crossterm::event::KeyCode::Char('F'),
+                crossterm::event::KeyModifiers::NONE,
+            )),
+            ViewAction::Emit(ViewEvent::CommandPaletteSelected { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #5954

## What was wrong

Inside `/fleet`, moving between the roster (`FleetRosterView`), live workers (`SubAgentsView`), and saved teams (`FleetListView`) was one-way. `Tab`/`w` and `f` emitted `EmitAndClose(FleetRosterOpenWorkersRequested / FleetRosterOpenFleetsRequested)`, so the roster tore itself down and the target view became the new root of the stack. `Esc` there could only close the whole window, and getting back meant re-running `/fleet` and losing the roster cursor.

## Option 1 from the issue: one stack

The roster now `Emit`s instead of `EmitAndClose`, so it stays on the view stack underneath whatever it opens, and `ui/handlers.rs` pushes the target on top. `ViewAction::Close` already pops exactly one view, so:

- `Esc` in workers / saved teams returns to the roster, cursor and scroll intact;
- `Esc` at the roster, or in a view opened directly (`/fleet workers`, `/fleet list`, the Work dock), still closes the window as today.

No second navigation stack — this is the existing `ViewStack` push/pop doing the work. A `roster → saved teams → team detail` chain already unwinds one step at a time for free.

## Hints tell the truth

Both child views carry an `over_fleet_roster()` marker set only by the roster's own forward jumps. It drives two things:

- the `Esc` footer hint reads **back** when it will go back and **close** when it will close — reusing `MessageId::SetupActionBack` and `SessionsActionClose`, both already present in all 15 locale packs, so no new strings and no parity churn;
- `F` in workers (the roster door) pops back to the parked roster instead of re-running `/fleet` and stacking a duplicate roster with a reset cursor.

## One correctness follow-on

Because the roster now survives a team switch or delete, `FleetStoreChanged` refreshes it in place via `FleetRosterView::reload` (cursor and detail scroll preserved) rather than leaving it painting the pre-change team.

## Tests

New, in the existing view test modules:

- `roster_tab_workers_esc_returns_to_the_roster` — roster → `Tab` → workers → `Esc` lands back on `ModalKind::FleetRoster`
- `saved_teams_opened_from_the_roster_returns_there_on_esc` — roster → `f` → saved teams → `Esc`, same
- `esc_at_the_roster_root_closes_the_window`
- `subagents_opened_directly_closes_on_esc`, `saved_teams_opened_directly_closes_on_esc`
- `subagents_esc_hint_says_back_over_the_roster_and_close_at_the_root`, `saved_teams_esc_hint_matches_the_entry_path`
- `subagents_f_pops_back_to_the_parked_roster`
- `tab_and_w_open_the_live_workers_tab` / `f_opens_saved_teams_without_closing_the_roster` updated to the new `Emit` contract

## Proof

```
cargo fmt -p codewhale-tui -- --check          clean
cargo check -p codewhale-tui --lib --tests     clean
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib \
  -- tui::views tui::ui::handlers localization
  => 351 passed; 0 failed; 0 ignored; 11466 filtered out
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib
  => 11803 passed; 1 failed; 13 ignored
```

The single full-suite failure is `runtime_chat_relay::tests::failed_state_writes_never_become_in_memory_authority_and_exact_retry_reopens` — unrelated to the Fleet views, and green when run on its own (parallel-run flake).

Local tests only; hosted CI has not run this branch yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XYyJaw9Mh9uSrqQBoqhm
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI modal stack and footer copy changes; no auth, persistence, or engine contract changes beyond refreshing the parked roster after store mutations.
> 
> **Overview**
> **Fleet navigation** now keeps the roster on the `ViewStack` when you open live workers (`Tab`/`w`) or saved teams (`f`). The roster **emits** those events instead of closing itself; handlers push `SubAgentsView` / `FleetListView` on top and mark them with `over_fleet_roster()` so **Esc** pops one level back to the roster (cursor and detail scroll preserved) while direct entry (`/fleet list`, `/fleet workers`) still closes the window at the root.
> 
> Child views show truthful footer hints (**back** vs **close**) via existing locale strings, and **F** in workers pops to the parked roster instead of re-running `/fleet` and duplicating the stack. On fleet store changes, `refresh_parked_fleet_roster` reloads the roster in place with `FleetRosterView::reload` when it sits under another modal.
> 
> Tests cover stack behavior, Esc hints, and the updated `Emit` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e299a7962da20d1e8cd6e09d17b2cbbb5ce7bff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->