### PR TITLE
feat(tui): /statusline composes the bottom chrome, ctx reads at every fullness (#5950)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `/statusline` drives the bottom chrome again. Since the 0.9.12 shell
+  redesign the posture bar and the metrics line were built independently of
+  `tui.status_items`, so every toggle in the picker except the balance fetch
+  was decoration. Each remaining item now shows or hides exactly one thing:
+  `model`, `context_percent`, `cost`, `balance`, `cache`, `tokens` and
+  `session_metrics` are metrics-line segments, and `mode` is the posture
+  bar's plan/act/operate chip. The `status`, `agents`, `reasoning_replay`,
+  `prefix_stability`, `git_branch`, `last_tool_elapsed` and `rate_limit`
+  items drove nothing and are retired; an existing `config.toml` still loads
+  and those keys are ignored (#5950).
+- The context reading is back on screen at every fullness. 0.9.12 painted
+  `ctx NN%` only from 50% up, which left most of a session with no context
+  signal at all; it now paints from 0% and keeps its warning colour from 80%
+  up (#5950).
+
 ### Added
 
 - The `/theme` picker now discovers valid user-authored `custom:<name>`

--- a/config.example.toml
+++ b/config.example.toml
@@ -1087,14 +1087,18 @@ turn_wall_clock_secs = 3600  # cumulative wall clock for one turn, excluding tim
 stream_max_content_mb = 10   # per-step cap on streamed content (0 = default, 1-512)
 stream_max_duration_secs = 1800 # per-step cap on one stream's duration (0 = default, 10-86400)
 osc8_links = true            # emit OSC 8 escapes around URLs (Cmd+click in iTerm2/Ghostty/Kitty/WezTerm/Terminal.app 13+); set false for terminals that misrender
-# Ordered footer chips shown in the TUI status line. Omit the key to use the
-# built-in default; set [] to hide all configurable chips. You can also edit
-# this interactively with `/statusline`.
-# Supported keys: mode, model, cost, balance (DeepSeek / DeepSeekCN only),
-# status, agents,
-# reasoning_replay, prefix_stability, cache, context_percent, git_branch,
-# last_tool_elapsed (reserved), rate_limit (reserved), tokens.
-# status_items = ["mode", "model", "status", "git_branch", "tokens", "cache"]
+# What the bottom chrome shows. Each key is one thing on screen: `mode` is the
+# posture bar's plan/act/operate chip, everything else is a segment of the
+# metrics line under it. Omit the key to use the built-in default; set [] to
+# strip the metrics line down to the help hint. You can also edit this
+# interactively with `/statusline`.
+# Supported keys: mode, model, context_percent, cost,
+# balance (prepaid providers only: DeepSeek, DeepSeekCN, OpenRouter,
+# SiliconFlow), cache, tokens, session_metrics.
+# Retired in 0.9.13: status, agents, reasoning_replay, prefix_stability,
+# git_branch, last_tool_elapsed, rate_limit — they drove nothing. Old files
+# keep loading; the retired keys are ignored.
+# status_items = ["mode", "model", "context_percent", "cost", "tokens"]
 # notification_condition = "unfocused" # unfocused | always | never
 #                                    "unfocused" = notify only after this terminal has been
 #                                    in the background for two seconds (default);

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `/statusline` drives the bottom chrome again. Since the 0.9.12 shell
+  redesign the posture bar and the metrics line were built independently of
+  `tui.status_items`, so every toggle in the picker except the balance fetch
+  was decoration. Each remaining item now shows or hides exactly one thing:
+  `model`, `context_percent`, `cost`, `balance`, `cache`, `tokens` and
+  `session_metrics` are metrics-line segments, and `mode` is the posture
+  bar's plan/act/operate chip. The `status`, `agents`, `reasoning_replay`,
+  `prefix_stability`, `git_branch`, `last_tool_elapsed` and `rate_limit`
+  items drove nothing and are retired; an existing `config.toml` still loads
+  and those keys are ignored (#5950).
+- The context reading is back on screen at every fullness. 0.9.12 painted
+  `ctx NN%` only from 50% up, which left most of a session with no context
+  signal at all; it now paints from 0% and keeps its warning colour from 80%
+  up (#5950).
+
 ### Added
 
 - The `/theme` picker now discovers valid user-authored `custom:<name>`

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2346,21 +2346,31 @@ pub struct ReasoningOnlyConfig {
     pub reprompt_message: Option<String>,
 }
 
-/// One configurable footer item.
+/// One configurable bottom-chrome item.
 ///
-/// Order in the user's `Vec<StatusItem>` is preserved: items in the left
-/// cluster (`Mode`, `Model`, `Cost`, `Status`) render in the order given;
-/// right-cluster chips (`Agents`, `ReasoningReplay`, `PrefixStability`,
-/// `Cache`, `ContextPercent`, `GitBranch`, `LastToolElapsed`, `RateLimit`)
-/// likewise honour ordering inside their cluster. The split between left and right is deliberate — left holds steady
-/// identity (mode/model/cost), right holds transient signals — so we route
-/// each variant to the correct side rather than letting users reorder across
-/// the spacer.
+/// Every variant owns exactly one thing on screen, and `/statusline` turns
+/// that thing on or off:
 ///
-/// Variants without a current data source (`RateLimit`, `LastToolElapsed`)
-/// are intentionally exposed today so the picker is forward-compatible; they
-/// render empty until the supporting fields land. Empty spans don't take
-/// up footer width, so the user sees no visual artifact.
+/// | Variant | What it paints |
+/// | --- | --- |
+/// | `Mode` | the posture bar's `plan`/`act`/`operate` chip |
+/// | `Model` | the metrics line's route segment |
+/// | `ContextPercent` | the metrics line's `ctx NN%` reading |
+/// | `Cost` | the metrics line's session price |
+/// | `SessionMetrics` | the metrics line's `ttft` and `tok/s` |
+/// | `Cache` | the metrics line's `cache NN%` |
+/// | `Tokens` | the metrics line's `↓ NNN` output tokens |
+/// | `Balance` | the metrics line's prepaid-credit reading (also gates the fetch) |
+///
+/// A variant that paints nothing does not belong here. Eight variants were
+/// retired in #5950 because the 0.9.12 shell gave their facts to a surface
+/// `/statusline` does not own — the posture bar's clock and live counts
+/// (`Status`, `Agents`), the launch header and git dock (`GitBranch`) — or
+/// because they were never wired at all (`ReasoningReplay`,
+/// `PrefixStability`, `LastToolElapsed`, `RateLimit`). Their keys still
+/// parse out of an old `config.toml`: [`StatusItem::from_key`] returns
+/// `None` and `deser_status_items` skips them with a warning, so an
+/// upgrader's file keeps loading.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum StatusItem {
@@ -2370,30 +2380,16 @@ pub enum StatusItem {
     Model,
     /// Session cost in the configured display currency.
     Cost,
-    /// Activity label: "idle" / "busy" / "draft" / "working".
-    Status,
-    /// Sub-agent count chip ("3 agents").
-    Agents,
-    /// Reasoning-replay token count ("rsn 12.3k").
-    ReasoningReplay,
-    /// Prefix stability ("cache prefix 100%").
-    PrefixStability,
     /// Cache hit rate ("cache 73%").
     Cache,
-    /// Context-window utilisation percent ("48%").
+    /// Context-window utilisation percent ("ctx 48%").
     ContextPercent,
-    /// Current git branch name.
-    GitBranch,
-    /// Elapsed time of the most recent tool call (placeholder until wired).
-    LastToolElapsed,
-    /// Remaining rate-limit budget (placeholder until wired).
-    RateLimit,
-    /// Session token usage: input / cache-hit / output.
+    /// Output tokens of the live or last turn ("↓ 1.2K").
     Tokens,
     /// Prepaid remaining credit, refreshed once per turn completion.
     Balance,
-    /// Session metrics strip: turns · steps │ LLM · tools │ TTFT · tok/s │
-    /// cache │ in — sourced from engine timings and provider usage.
+    /// The metrics line's latency pair: `ttft NNNms` and `NN tok/s`, from
+    /// the same engine timings and provider usage `/status` prints in full.
     SessionMetrics,
 }
 
@@ -2407,12 +2403,9 @@ impl StatusItem {
         vec![
             StatusItem::Mode,
             StatusItem::Model,
+            StatusItem::ContextPercent,
             StatusItem::Cost,
-            StatusItem::Status,
-            StatusItem::Agents,
-            StatusItem::ReasoningReplay,
             StatusItem::Cache,
-            StatusItem::GitBranch,
             StatusItem::Tokens,
             StatusItem::SessionMetrics,
         ]
@@ -2425,15 +2418,8 @@ impl StatusItem {
             StatusItem::Mode => "mode",
             StatusItem::Model => "model",
             StatusItem::Cost => "cost",
-            StatusItem::Status => "status",
-            StatusItem::Agents => "agents",
-            StatusItem::ReasoningReplay => "reasoning_replay",
-            StatusItem::PrefixStability => "prefix_stability",
             StatusItem::Cache => "cache",
             StatusItem::ContextPercent => "context_percent",
-            StatusItem::GitBranch => "git_branch",
-            StatusItem::LastToolElapsed => "last_tool_elapsed",
-            StatusItem::RateLimit => "rate_limit",
             StatusItem::Tokens => "tokens",
             StatusItem::Balance => "balance",
             StatusItem::SessionMetrics => "session_metrics",
@@ -2449,16 +2435,13 @@ impl StatusItem {
             "mode" => Some(Self::Mode),
             "model" => Some(Self::Model),
             "cost" => Some(Self::Cost),
-            "status" => Some(Self::Status),
-            "agents" => Some(Self::Agents),
-            "reasoning_replay" => Some(Self::ReasoningReplay),
-            "prefix_stability" => Some(Self::PrefixStability),
             "cache" => Some(Self::Cache),
             "context_percent" => Some(Self::ContextPercent),
-            "git_branch" => Some(Self::GitBranch),
-            "last_tool_elapsed" => Some(Self::LastToolElapsed),
-            "rate_limit" => Some(Self::RateLimit),
             "tokens" => Some(Self::Tokens),
+            // Retired in #5950; skipped rather than rejected so an old
+            // `config.toml` still parses. See the type's doc comment.
+            "status" | "agents" | "reasoning_replay" | "prefix_stability" | "git_branch"
+            | "last_tool_elapsed" | "rate_limit" => None,
             "balance" => Some(Self::Balance),
             "session_metrics" => Some(Self::SessionMetrics),
             _ => None,
@@ -2472,16 +2455,9 @@ impl StatusItem {
             StatusItem::Mode => "Mode",
             StatusItem::Model => "Model",
             StatusItem::Cost => "Session cost",
-            StatusItem::Status => "Activity (idle/busy/draft/working)",
-            StatusItem::Agents => "Sub-agents in flight",
-            StatusItem::ReasoningReplay => "Reasoning replay tokens",
-            StatusItem::PrefixStability => "Prefix stability",
             StatusItem::Cache => "Prompt cache hit rate",
             StatusItem::ContextPercent => "Context window %",
-            StatusItem::GitBranch => "Git branch",
-            StatusItem::LastToolElapsed => "Last tool elapsed",
-            StatusItem::RateLimit => "Rate-limit remaining",
-            StatusItem::Tokens => "Session tokens",
+            StatusItem::Tokens => "Output tokens",
             StatusItem::Balance => "Account balance",
             StatusItem::SessionMetrics => "Session metrics",
         }
@@ -2495,18 +2471,11 @@ impl StatusItem {
             StatusItem::Mode => "plan · act · operate",
             StatusItem::Model => "the model id you'll send to",
             StatusItem::Cost => "running total for this session",
-            StatusItem::Status => "what the agent is doing right now",
-            StatusItem::Agents => "agents or RLM work in progress",
-            StatusItem::ReasoningReplay => "thinking tokens replayed each turn",
-            StatusItem::PrefixStability => "whether system/tools stayed cacheable",
             StatusItem::Cache => "% of prompt served from cache",
             StatusItem::ContextPercent => "tokens used / model context window",
-            StatusItem::GitBranch => "current workspace branch",
-            StatusItem::LastToolElapsed => "ms of the most recent tool call (reserved)",
-            StatusItem::RateLimit => "remaining requests in the budget (reserved)",
-            StatusItem::Tokens => "input / cache-hit / output token totals",
+            StatusItem::Tokens => "output tokens of the live or last turn",
             StatusItem::Balance => "remaining prepaid credit from the active provider",
-            StatusItem::SessionMetrics => "turns · steps · LLM/tool time · TTFT · tok/s · input",
+            StatusItem::SessionMetrics => "time to first token and output rate",
         }
     }
 
@@ -2516,17 +2485,10 @@ impl StatusItem {
         &[
             StatusItem::Mode,
             StatusItem::Model,
+            StatusItem::ContextPercent,
             StatusItem::Cost,
             StatusItem::Balance,
-            StatusItem::Status,
-            StatusItem::Agents,
-            StatusItem::ReasoningReplay,
-            StatusItem::PrefixStability,
             StatusItem::Cache,
-            StatusItem::ContextPercent,
-            StatusItem::GitBranch,
-            StatusItem::LastToolElapsed,
-            StatusItem::RateLimit,
             StatusItem::Tokens,
             StatusItem::SessionMetrics,
         ]

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -11519,7 +11519,7 @@ fn status_items_scenario() {
         // future "cost_saving" chip).
         let toml_str = r#"
             alternate_screen = "auto"
-            status_items = ["mode", "model", "unknown_future_item", "cost", "another_unknown", "status"]
+            status_items = ["mode", "model", "unknown_future_item", "cost", "another_unknown", "cache"]
         "#;
         let tui: TuiConfig = toml::from_str(toml_str).expect("should parse without error");
         let items = tui.status_items.expect("status_items should be Some");
@@ -11527,7 +11527,21 @@ fn status_items_scenario() {
         assert_eq!(items[0], StatusItem::Mode);
         assert_eq!(items[1], StatusItem::Model);
         assert_eq!(items[2], StatusItem::Cost);
-        assert_eq!(items[3], StatusItem::Status);
+        assert_eq!(items[3], StatusItem::Cache);
+    }
+    // A config written before #5950 retired the inert items keeps loading:
+    // the retired keys are skipped, the live ones survive in order.
+    {
+        let toml_str = r#"
+            status_items = ["mode", "status", "model", "git_branch", "rate_limit", "tokens"]
+        "#;
+        let tui: TuiConfig = toml::from_str(toml_str).expect("legacy items should parse");
+        let items = tui.status_items.expect("status_items should be Some");
+        assert_eq!(
+            items,
+            vec![StatusItem::Mode, StatusItem::Model, StatusItem::Tokens],
+            "retired keys should drop out without failing the whole file"
+        );
     }
     // from status_items_deser_allows_missing_field
     {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2021,10 +2021,15 @@ pub struct App {
     /// `/config mini_window.keep_*`. The renderer reads this instead of the
     /// parsed Config so runtime changes apply without a restart.
     pub(crate) mini_window: crate::config::MiniWindowConfig,
-    /// Ordered list of footer items the user wants visible. Sourced from
-    /// `tui.status_items` in `~/.deepseek/config.toml` at startup; mutated
-    /// live by `/statusline`. The renderer iterates this slice; no item is
-    /// hardcoded in the footer code path.
+    /// What the bottom chrome shows. Sourced from `tui.status_items` in
+    /// `~/.deepseek/config.toml` at startup; mutated live by `/statusline`.
+    ///
+    /// Read by [`crate::tui::ui::frame::info_segments`] for every segment of
+    /// the metrics line, by `tideline_footer_from_app` for the posture bar's
+    /// mode chip, and by `should_fetch_provider_balance` for the balance
+    /// fetch. Every variant in the list paints exactly one of those; the
+    /// items that painted nothing were retired in #5950 rather than left as
+    /// toggles that lie.
     pub status_items: Vec<crate::config::StatusItem>,
     /// Optional header items enabled from `tui.header_items` in `config.toml`
     /// at startup. Built-in header content remains independent of this list.

--- a/crates/tui/src/tui/infoline.rs
+++ b/crates/tui/src/tui/infoline.rs
@@ -23,11 +23,18 @@
 //! blank between turns once a turn has reported them.
 //!
 //! The context reading is painted here and only here — the posture bar above
-//! used to print the same percentage a second time from the same snapshot.
+//! used to print the same percentage a second time from the same snapshot —
+//! and at every fullness, not only from 50% up (#5950).
 //!
 //! Shed order as width drops: `tok/s`, `ttft`, `↓ tokens`, the help hint,
-//! then the cost ([`InfoSegmentId::shed_priority`]). The model and `ctx NN%`
-//! never shed; below that floor the row clips at its right edge.
+//! then the cost, then the balance ([`InfoSegmentId::shed_priority`]). The
+//! model and `ctx NN%` never shed; below that floor the row clips at its
+//! right edge.
+//!
+//! Which segments exist at all is the user's call: `/statusline` and
+//! `tui.status_items` compose the row, and [`crate::tui::ui::frame::info_segments`]
+//! builds only the ones that are on. Shedding decides what survives the
+//! width that is left.
 //!
 //! Interaction: segment geometry is recorded for parity tests, but only the
 //! model/route segment and the context reading advertise an action in the
@@ -74,6 +81,10 @@ pub enum InfoSegmentId {
     Rate,
     /// Prompt cache hit percent (`cache 85%`).
     Cache,
+    /// Prepaid credit left on the active route (`balance $4.32`). Opt-in:
+    /// only painted when `/statusline` has the balance item on, which is
+    /// also what authorises the fetch behind it.
+    Balance,
 }
 
 impl InfoSegmentId {
@@ -89,6 +100,9 @@ impl InfoSegmentId {
             Self::Ttft => 8,
             Self::OutputTokens => 7,
             Self::Cost => 6,
+            // The balance outlives the cost: it is off by default, so a row
+            // that shows one is a row whose owner asked for it by name.
+            Self::Balance => 5,
             Self::Model | Self::Context => 0,
         }
     }

--- a/crates/tui/src/tui/phase_strip.rs
+++ b/crates/tui/src/tui/phase_strip.rs
@@ -1191,7 +1191,13 @@ pub(crate) fn tideline_footer_from_app(app: &mut App, width: u16) -> TidelineFoo
     let permission_chip = permission_chip
         .map(|(text, ink)| (text.into_owned(), ink))
         .unwrap_or_else(|| (String::new(), ChromeInk::PermissionAsk));
-    let mode_chip = mode_chip.map(|(text, ink)| (text.into_owned(), ink));
+    // The mode chip is the one posture fact `/statusline` composes (#5950):
+    // its `StatusItem::Mode` toggle used to be inert. The permission chip,
+    // the working clocks (#5914) and the live counts are the bar's own
+    // posture statement and stay unconditional.
+    let mode_chip = mode_chip
+        .filter(|_| app.status_items.contains(&crate::config::StatusItem::Mode))
+        .map(|(text, ink)| (text.into_owned(), ink));
     // Cycle keys come from the binding table and only when that binding is
     // live for the current focus.
     let live_chord = |id: ShellBindingId| -> Option<&'static str> {

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -57,57 +57,70 @@ fn output_figures(app: &App) -> Option<(u64, Option<f64>)> {
 
 /// Build the metrics line's segments from live `App` state. Shedding is the
 /// widget's job; this only states the facts, in display order: model,
-/// context, cost, time to first token, output rate, output tokens.
+/// context, cost, balance, time to first token, output rate, output tokens.
 ///
 /// Repository and branch left this row (2026-09-02): the launch header and
 /// the git bottom view own them. Fleet, whale and automation counts left too —
 /// the posture bar's live counts own activity.
+///
+/// Composition is the user's (#5950): every segment here is gated on the
+/// matching [`StatusItem`] in `app.status_items`, which is what `/statusline`
+/// edits and `tui.status_items` persists. Between 0.9.12 and this change the
+/// row ignored that list entirely and the picker's toggles did nothing.
 pub(crate) fn info_segments(app: &App, width: u16) -> Vec<InfoSegment> {
+    use crate::config::StatusItem;
     use crate::localization::MessageId;
     use crate::palette::ChromeInk;
     let mut segments = Vec::new();
     let tier = crate::tui::underwater::ShellTier::for_chrome_width(width);
+    let shows = |item: StatusItem| app.status_items.contains(&item);
 
     // Route identity — the old identity band's fact, same shed discipline:
     // provider first, then effort, whole names or none. When no model is
     // configured the segment says so and waits.
-    let (_, model) = app.effective_route_identity_display();
-    if model.is_empty() {
-        segments.push(InfoSegment::new(
-            InfoSegmentId::Model,
-            app.tr(MessageId::StartupDefaultSubjectModel).as_ref(),
-            app.tr(MessageId::InfoLineNotConnected).as_ref(),
-            ChromeInk::Waiting,
-        ));
-    } else {
-        // The context reading and the metrics claim the rest of the row;
-        // the route sheds its own qualifiers first.
-        let budget = crate::tui::phase_strip::info_route_budget(width);
-        let fields = crate::tui::phase_strip::route_identity_fields(app, tier, budget)
-            .unwrap_or_else(|| {
-                vec![crate::tui::phase_strip::RouteIdentityField {
-                    kind: crate::tui::phase_strip::RouteFieldKind::Model,
-                    text: model,
-                }]
-            });
-        segments.push(InfoSegment::new(
-            InfoSegmentId::Model,
-            "",
-            fields
-                .iter()
-                .map(|field| field.text.as_str())
-                .collect::<Vec<_>>()
-                .join(ROUTE_FIELD_JOIN),
-            ChromeInk::Identity,
-        ));
+    // Off the row when the user says so: `/model`, the picker and the launch
+    // header all still name the route.
+    if shows(StatusItem::Model) {
+        let (_, model) = app.effective_route_identity_display();
+        if model.is_empty() {
+            segments.push(InfoSegment::new(
+                InfoSegmentId::Model,
+                app.tr(MessageId::StartupDefaultSubjectModel).as_ref(),
+                app.tr(MessageId::InfoLineNotConnected).as_ref(),
+                ChromeInk::Waiting,
+            ));
+        } else {
+            // The context reading and the metrics claim the rest of the row;
+            // the route sheds its own qualifiers first.
+            let budget = crate::tui::phase_strip::info_route_budget(width);
+            let fields = crate::tui::phase_strip::route_identity_fields(app, tier, budget)
+                .unwrap_or_else(|| {
+                    vec![crate::tui::phase_strip::RouteIdentityField {
+                        kind: crate::tui::phase_strip::RouteFieldKind::Model,
+                        text: model,
+                    }]
+                });
+            segments.push(InfoSegment::new(
+                InfoSegmentId::Model,
+                "",
+                fields
+                    .iter()
+                    .map(|field| field.text.as_str())
+                    .collect::<Vec<_>>()
+                    .join(ROUTE_FIELD_JOIN),
+                ChromeInk::Identity,
+            ));
+        }
     }
 
-    // The context reading: painted here and nowhere else. Only displayed
-    // when context fullness >= 50%; below 50% it remains silent. At the 80%
-    // cap the whole reading turns to the error token — it is the one fact on
-    // this row that becomes a problem rather than a status.
+    // The context reading: painted here and nowhere else, at every
+    // fullness. The 0.9.12 row went silent below 50% and left most of a
+    // session with no context signal at all (#5950); watching the number
+    // climb from 4% is the whole point of the reading. At the 80% cap the
+    // whole reading turns to the error token — it is the one fact on this
+    // row that becomes a problem rather than a status.
     let pct = info_context_percent(app);
-    if pct >= 50 {
+    if shows(StatusItem::ContextPercent) {
         segments.push(InfoSegment::new(
             InfoSegmentId::Context,
             app.tr(MessageId::InfoLineContext).as_ref(),
@@ -121,7 +134,7 @@ pub(crate) fn info_segments(app: &App, width: u16) -> Vec<InfoSegment> {
     }
 
     let cost = session_cost_label(app);
-    if !cost.is_empty() {
+    if shows(StatusItem::Cost) && !cost.is_empty() {
         segments.push(InfoSegment::new(
             InfoSegmentId::Cost,
             "",
@@ -130,10 +143,30 @@ pub(crate) fn info_segments(app: &App, width: u16) -> Vec<InfoSegment> {
         ));
     }
 
+    // The prepaid-credit reading: opt-in, and the same status item that
+    // authorises the background fetch (`should_fetch_provider_balance`), so
+    // the row can only show a number this session actually asked for.
+    if shows(StatusItem::Balance)
+        && let Some(balance) = app.balance_cell.lock().ok().and_then(|guard| {
+            guard
+                .as_ref()
+                .and_then(crate::pricing::BalanceInfo::chip_label)
+        })
+    {
+        segments.push(InfoSegment::new(
+            InfoSegmentId::Balance,
+            app.tr(MessageId::FooterBalancePrefix).as_ref(),
+            balance,
+            ChromeInk::MetadataValue,
+        ));
+    }
+
     // The DeepSeek-harness session metrics, from the same accumulators
     // `/cost` prints: nothing here is estimated except the live stream's
     // running token count, which the provider's receipt replaces.
-    if let Some(ttft) = app.session_metrics.ttft_average() {
+    if shows(StatusItem::SessionMetrics)
+        && let Some(ttft) = app.session_metrics.ttft_average()
+    {
         segments.push(InfoSegment::new(
             InfoSegmentId::Ttft,
             app.tr(MessageId::InfoLineTtft).as_ref(),
@@ -142,7 +175,7 @@ pub(crate) fn info_segments(app: &App, width: u16) -> Vec<InfoSegment> {
         ));
     }
     if let Some((tokens, rate)) = output_figures(app) {
-        if let Some(rate) = rate {
+        if let Some(rate) = rate.filter(|_| shows(StatusItem::SessionMetrics)) {
             segments.push(InfoSegment::new(
                 InfoSegmentId::Rate,
                 "",
@@ -157,7 +190,7 @@ pub(crate) fn info_segments(app: &App, width: u16) -> Vec<InfoSegment> {
         let hit = u64::from(app.session.displayed_total_cache_hit_tokens());
         let miss = u64::from(app.session.displayed_total_cache_miss_tokens());
         let cache_total = hit + miss;
-        if cache_total > 0 {
+        if shows(StatusItem::Cache) && cache_total > 0 {
             let cache_pct = (hit * 100 + cache_total / 2)
                 .checked_div(cache_total)
                 .and_then(|pct| u8::try_from(pct).ok())
@@ -169,17 +202,19 @@ pub(crate) fn info_segments(app: &App, width: u16) -> Vec<InfoSegment> {
                 ChromeInk::MetadataValue,
             ));
         }
-        segments.push(InfoSegment::new(
-            InfoSegmentId::OutputTokens,
-            "↓",
-            crate::tui::session_metrics::format_tokens(tokens),
-            ChromeInk::MetadataValue,
-        ));
+        if shows(StatusItem::Tokens) {
+            segments.push(InfoSegment::new(
+                InfoSegmentId::OutputTokens,
+                "↓",
+                crate::tui::session_metrics::format_tokens(tokens),
+                ChromeInk::MetadataValue,
+            ));
+        }
     } else {
         let hit = u64::from(app.session.displayed_total_cache_hit_tokens());
         let miss = u64::from(app.session.displayed_total_cache_miss_tokens());
         let cache_total = hit + miss;
-        if cache_total > 0 {
+        if shows(StatusItem::Cache) && cache_total > 0 {
             let cache_pct = (hit * 100 + cache_total / 2)
                 .checked_div(cache_total)
                 .and_then(|pct| u8::try_from(pct).ok())
@@ -2188,6 +2223,199 @@ mod tests {
     #[test]
     fn leaves_short_titles_untouched() {
         assert_eq!(short_title_truncate("short", 10), "short");
+    }
+
+    // ── #5950: the bottom chrome is the user's to compose ─────────────
+
+    use crate::config::StatusItem;
+    use crate::tui::app::App;
+    use crate::tui::infoline::{InfoLine, InfoSegmentId};
+
+    /// A session whose context is `pct` full, by pinning the route's window
+    /// to a multiple of what this conversation actually estimates. Nothing
+    /// here fakes the reading itself — it goes through
+    /// `context_usage_snapshot` like the live shell does.
+    fn app_with_context_percent(pct: u8) -> App {
+        use crate::models::{ContentBlock, Message};
+        let mut app =
+            crate::test_support::test_app_with_options(crate::test_support::test_tui_options("."));
+        app.api_messages = vec![Message {
+            role: crate::models::Role::User,
+            content: vec![ContentBlock::Text {
+                text: "context ".repeat(400),
+                cache_control: None,
+            }],
+        }];
+        let (used, _, _) =
+            super::context_usage_snapshot(&app).expect("a conversation has a context reading");
+        let window = (used as f64 * 100.0 / f64::from(pct)).round().max(1.0);
+        app.active_route_limits = Some(codewhale_config::route::RouteLimits {
+            context_tokens: Some(window as u64),
+            ..Default::default()
+        });
+        assert_eq!(
+            super::info_context_percent(&app),
+            pct,
+            "fixture should land exactly on {pct}%"
+        );
+        app
+    }
+
+    /// The metrics line as the user reads it, at `width`.
+    fn metrics_row(app: &App, width: u16) -> String {
+        let segments = super::info_segments(app, width);
+        let hint = crate::tui::shell_key_routing::info_help_hint(app.ui_locale);
+        let backend = TestBackend::new(width, 1);
+        let mut terminal = Terminal::new(backend).expect("metrics-line terminal");
+        terminal
+            .draw(|frame| {
+                use ratatui::widgets::Widget as _;
+                let area = frame.area();
+                InfoLine::new(&app.ui_theme, &hint, &segments).render(area, frame.buffer_mut());
+            })
+            .expect("draw");
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol().to_string())
+            .collect::<String>()
+    }
+
+    /// The reading used to go silent below 50% fullness, which is most of a
+    /// session (#5950). It is a reading, not an alarm: it states 10% as
+    /// readily as 60%, and only the ink changes at the thresholds.
+    #[test]
+    fn context_reading_paints_at_every_fullness() {
+        for pct in [10u8, 60] {
+            let app = app_with_context_percent(pct);
+            let segment = super::info_segments(&app, 160)
+                .into_iter()
+                .find(|segment| segment.id == InfoSegmentId::Context)
+                .unwrap_or_else(|| panic!("{pct}%: the context reading must be on the row"));
+            assert_eq!(segment.value, format!("{pct}%"));
+            assert_eq!(
+                segment.ink,
+                crate::palette::ChromeInk::Info,
+                "{pct}%: below the cap the reading is a status, not a failure"
+            );
+            // Narrow rows keep it too: the reading is the row's floor and
+            // sheds after everything else, including the help hint.
+            for width in [40u16, 80, 160] {
+                let row = metrics_row(&app, width);
+                assert!(
+                    row.contains(&format!("ctx {pct}%")),
+                    "{pct}% at {width} columns: {row:?}"
+                );
+            }
+        }
+    }
+
+    /// The warning ink still belongs to the thresholds it always used: the
+    /// error token from 80% up, and not one percent earlier.
+    #[test]
+    fn context_reading_keeps_its_warning_threshold() {
+        for (pct, expected) in [
+            (10u8, crate::palette::ChromeInk::Info),
+            (79, crate::palette::ChromeInk::Info),
+            (80, crate::palette::ChromeInk::Failure),
+        ] {
+            let app = app_with_context_percent(pct);
+            let segment = super::info_segments(&app, 160)
+                .into_iter()
+                .find(|segment| segment.id == InfoSegmentId::Context)
+                .expect("context reading");
+            assert_eq!(segment.ink, expected, "{pct}%");
+        }
+    }
+
+    /// `/statusline` drives this row. Between 0.9.12 and #5950 the picker
+    /// persisted a list nothing read, so every toggle in it was a lie.
+    #[test]
+    fn statusline_toggle_removes_its_segment_on_the_next_frame() {
+        use crate::tui::views::{ModalView, ViewAction, ViewEvent};
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let mut app = app_with_context_percent(10);
+        assert!(
+            metrics_row(&app, 160).contains("ctx 10%"),
+            "the reading starts on the row"
+        );
+
+        let mut picker = crate::tui::views::status_picker::StatusPickerView::new(
+            &app.status_items,
+            app.api_provider,
+            app.ui_locale,
+        );
+        // Walk to the context row the way a user does, then uncheck it.
+        let context_row = StatusItem::all()
+            .iter()
+            .filter(|item| item.is_available_for(app.api_provider))
+            .position(|item| *item == StatusItem::ContextPercent)
+            .expect("the picker offers the context reading");
+        for _ in 0..context_row {
+            picker.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        }
+        let action = picker.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        let ViewAction::Emit(ViewEvent::StatusItemsUpdated { items, .. }) = action else {
+            panic!("space should emit a live preview: {action:?}");
+        };
+        assert!(!items.contains(&StatusItem::ContextPercent));
+
+        // What the handler does with the event, and then the next frame.
+        app.status_items = items;
+        let row = metrics_row(&app, 160);
+        assert!(
+            !row.contains("ctx "),
+            "the toggle must take it off: {row:?}"
+        );
+        assert!(
+            row.contains("deepseek"),
+            "and must take nothing else with it: {row:?}"
+        );
+    }
+
+    /// Every remaining status item owns a segment, and an empty list leaves
+    /// the row with nothing but the help hint — no toggle in `/statusline`
+    /// paints something no toggle can remove.
+    #[test]
+    fn every_metrics_segment_answers_to_a_status_item() {
+        let mut app = app_with_context_percent(60);
+        app.session.last_prompt_tokens = Some(1_000);
+        app.session_metrics
+            .record_model_call(1_200, 30_000, Some(400), Some(30_400));
+        app.streaming_output_token_estimate = 1_200;
+        app.is_loading = true;
+        app.turn_started_at = Some(std::time::Instant::now() - std::time::Duration::from_secs(30));
+        *app.balance_cell.lock().expect("balance cell") = Some(crate::pricing::BalanceInfo {
+            currency: "USD".to_string(),
+            total_balance: "4.32".to_string(),
+            topped_up_balance: String::new(),
+            granted_balance: String::new(),
+        });
+        app.status_items = StatusItem::all().to_vec();
+
+        let ids: Vec<InfoSegmentId> = super::info_segments(&app, 200)
+            .iter()
+            .map(|segment| segment.id)
+            .collect();
+        for expected in [
+            InfoSegmentId::Model,
+            InfoSegmentId::Context,
+            InfoSegmentId::Balance,
+            InfoSegmentId::Ttft,
+            InfoSegmentId::Rate,
+            InfoSegmentId::OutputTokens,
+        ] {
+            assert!(ids.contains(&expected), "{expected:?} missing from {ids:?}");
+        }
+
+        app.status_items = Vec::new();
+        assert!(
+            super::info_segments(&app, 200).is_empty(),
+            "an empty status list leaves the metrics line empty"
+        );
     }
 }
 

--- a/crates/tui/src/tui/ui/frame/one_owner_tests.rs
+++ b/crates/tui/src/tui/ui/frame/one_owner_tests.rs
@@ -128,8 +128,8 @@ fn composed_frame_paints_each_fact_in_exactly_one_row() {
         let (mode, permission) = crate::tui::underwater::posture_chips(&app);
         let mode = mode.expect("mode chip").0.into_owned();
         let permission = permission.expect("permission chip").0.into_owned();
-        // The context reading stays silent below 50% fullness and paints
-        // exactly once at or above it.
+        // The context reading paints exactly once, at every fullness
+        // (#5950 — it used to go silent below 50%).
         let mut facts = vec![
             ("mode chip", format!("· {mode} (")),
             ("permission chip", format!("▶▶ {permission} (")),
@@ -143,17 +143,7 @@ fn composed_frame_paints_each_fact_in_exactly_one_row() {
             ("output rate", "40 tok/s".to_string()),
             ("ttft", "ttft 400ms".to_string()),
         ];
-        if pct >= 50 {
-            facts.push(("context reading", format!("ctx {pct}%")));
-            facts.push(("context percent", format!("{pct}%")));
-        } else {
-            assert_eq!(
-                count_rows_containing(&rows, "ctx "),
-                0,
-                "{width}x{height}: ctx stays silent below 50%:\n{}",
-                rows.join("\n")
-            );
-        }
+        facts.push(("context reading", format!("ctx {pct}%")));
         for (name, needle) in facts {
             if needle.is_empty() {
                 continue;
@@ -234,9 +224,10 @@ fn idle_frame_keeps_two_chrome_rows_and_last_turn_metrics() {
     let rows = draw(&mut app, 100, 32);
     let composer = app.viewport.last_composer_area.unwrap().bottom() as usize;
     assert!(rows[composer].starts_with("▶▶"), "{}", rows[composer]);
-    // The idle fixture sits at 0% context, so the reading stays silent.
+    // The idle fixture sits at 0% context and says so: the reading is on
+    // the row at every fullness (#5950), not only once it is a problem.
     assert!(
-        !rows[composer + 1].contains("ctx "),
+        rows[composer + 1].contains("ctx 0%"),
         "{}",
         rows[composer + 1]
     );

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -21747,10 +21747,6 @@ fn default_footer_excludes_provider_specific_diagnostic_chips() {
     let items = crate::config::StatusItem::default_footer();
 
     assert!(
-        !items.contains(&crate::config::StatusItem::PrefixStability),
-        "prefix stability is a diagnostic chip and should not crowd the default footer"
-    );
-    assert!(
         !items.contains(&crate::config::StatusItem::Balance),
         "balance is an opt-in prepaid chip and should not crowd the default footer"
     );
@@ -21759,8 +21755,8 @@ fn default_footer_excludes_provider_specific_diagnostic_chips() {
         "default footer should still include provider-reported cache hit rate"
     );
     assert!(
-        items.contains(&crate::config::StatusItem::GitBranch),
-        "default footer should surface the current workspace branch"
+        items.contains(&crate::config::StatusItem::ContextPercent),
+        "the context reading is on by default: it is the row's always-on signal (#5950)"
     );
 }
 

--- a/crates/tui/src/tui/views/status_picker.rs
+++ b/crates/tui/src/tui/views/status_picker.rs
@@ -1,13 +1,16 @@
 //! `/statusline` multi-select picker.
 //!
 //! Mirrors codex-rs's `bottom_pane::status_line_setup` ergonomically: a
-//! checklist of footer items the user can toggle on/off with Space (or
-//! Enter), reordered by ↑/↓, applied immediately so the live footer
+//! checklist of bottom-chrome items the user can toggle on/off with Space (or
+//! Enter), moved through with ↑/↓, applied immediately so the live chrome
 //! reflects every change. Enter saves to `~/.deepseek/config.toml` under
 //! `tui.status_items`; Esc reverts to the snapshot taken on open.
 //!
-//! The picker enumerates [`StatusItem::all`] so adding a new variant in
-//! `crates/tui/src/config.rs` automatically surfaces a new row here.
+//! Every row here changes what is on screen (#5950): the metrics line's
+//! segments ([`crate::tui::ui::frame::info_segments`]) and the posture bar's
+//! mode chip. Between 0.9.12 and that fix the list was persisted and never
+//! read, so the checklist was decoration — a new variant belongs in
+//! `crates/tui/src/config.rs` only once something paints it.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
@@ -392,17 +395,18 @@ mod tests {
 
     #[test]
     fn selected_row_text_fills_available_width() {
-        let text = status_row_text("▸", "[ ]", &StatusItem::LastToolElapsed, 40);
+        let text = status_row_text("▸", "[ ]", &StatusItem::Cache, 40);
         assert_eq!(text.width(), 40);
-        assert!(text.starts_with(" ▸ [ ] Last tool elapsed"));
+        assert!(text.starts_with(" ▸ [ ] Prompt cache hit rate"));
     }
 
     #[test]
     fn selected_row_text_semantically_truncates_hint_at_narrow_width() {
-        let text = status_row_text("▸", "[ ]", &StatusItem::LastToolElapsed, 49);
-        assert_eq!(text.width(), 49);
-        assert!(text.contains("ms of the most…"), "{text:?}");
-        assert!(!text.contains("ms of the most r"), "{text:?}");
+        let text = status_row_text("▸", "[ ]", &StatusItem::Cache, 44);
+        assert_eq!(text.width(), 44);
+        // Cut at a word boundary, never mid-word.
+        assert!(text.contains("% of…"), "{text:?}");
+        assert!(!text.contains("% of p"), "{text:?}");
     }
 
     #[test]

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -220,26 +220,31 @@ The interactive TUI has a few stable regions:
 - Status and footer areas: live activity, queued follow-ups, and short command
   hints.
 
-The footer status line is configurable. Run `/statusline` to choose which
-footer chips are visible, or set `[tui].status_items` in `config.toml` to
-control both selection and order. Supported keys currently include `mode`,
-`model`, `cost`, `balance` (DeepSeek / DeepSeekCN only), `status`, `agents`,
-`reasoning_replay`, `prefix_stability`, `cache`, `context_percent`,
-`git_branch`, `last_tool_elapsed` (reserved), `rate_limit` (reserved),
-`tokens`, and `session_metrics`. Omit `status_items` to keep the built-in
-default order; set it to `[]` to hide configurable chips.
+The bottom chrome is configurable. Run `/statusline` to choose what is
+visible, or set `[tui].status_items` in `config.toml`. Each key owns exactly
+one thing on screen: `mode` is the posture bar's plan/act/operate chip, and
+`model`, `context_percent`, `cost`, `balance` (prepaid providers only:
+DeepSeek, DeepSeekCN, OpenRouter, SiliconFlow), `cache`, `tokens` and
+`session_metrics` are segments of the metrics line below it. Omit
+`status_items` to keep the built-in default; set it to `[]` to strip the
+metrics line down to the help hint.
 
-`session_metrics` (on by default) paints the session metrics strip on the
-phase row: `4 turns · 108 steps │ LLM 11m46s · Tool call 1m52s │ TTFT avg
-1.5s · 120 tok/s │ Cache hit 99% │ Input 9.3M`. Turns are user turns; steps
-are model calls plus tool calls; `LLM` is the summed wall time of model
-calls and `Tool call` the summed wall time of tools; `TTFT avg` is the mean
-time to first streamed token; `tok/s` is provider-reported output tokens over
-streamed seconds; `Cache hit` and `Input` are provider-reported token
-classes. A cell whose provider or runtime evidence has not arrived is
-omitted rather than estimated, and on narrow rows the strip drops its
-lowest-value groups (steps and tool time first, then latency, turns, LLM
-time) instead of truncating a number. `/status` prints the untrimmed line.
+`context_percent` is on by default and shows `ctx NN%` at every fullness —
+0.9.12 went silent below 50% and left most of a session with no context
+signal at all. The reading keeps its warning colour from 80% up.
+
+The keys `status`, `agents`, `reasoning_replay`, `prefix_stability`,
+`git_branch`, `last_tool_elapsed` and `rate_limit` were retired in 0.9.13:
+they drove nothing. Old configuration files still load — the retired keys are
+ignored with a warning in the log.
+
+`session_metrics` (on by default) paints the latency pair on the metrics
+line: `ttft 1.5s` — the mean time to first streamed token — and `120 tok/s`,
+provider-reported output tokens over streamed seconds. Both come from the
+same accumulators `/status` prints in full (turns, steps, LLM and tool wall
+time, cache hit, input), and a figure whose provider or runtime evidence has
+not arrived is omitted rather than estimated. On narrow rows the pair sheds
+before the cost and the context reading rather than truncating a number.
 
 The transcript is the audit trail. When Codewhale reads files, runs commands,
 or edits code, the action appears there. If a command fails, use the visible

--- a/docs/zh_hans/GUIDE.md
+++ b/docs/zh_hans/GUIDE.md
@@ -169,13 +169,14 @@ JSON 把凭据的 `source`（来源）与字面的 `availability`（可用性）
 - 工作栏（Work bar）：转录区上方的一条（或可选的侧栏），承载活动目标、待办列表和子智能体。行会保持整个会话——已完成的工作显示为"已完成"而不是消失——点击某一行（或对它按 `Enter`）会打开它的详情。
 - 状态与底部区域：实时活动、排队的后续动作和简短命令提示。
 
-底部状态行可配置。运行 `/statusline` 选择哪些底部的片区可见，或在 `config.toml` 里设置 `[tui].status_items` 同时控制选择和顺序。
-当前支持的键包括 `mode`、`model`、`cost`、`balance`（仅 DeepSeek / DeepSeekCN）、`status`、`agents`、`reasoning_replay`、`prefix_stability`、`cache`、`context_percent`、`git_branch`、`last_tool_elapsed`（保留）、`rate_limit`（保留）、`tokens` 和 `session_metrics`。
-省略 `status_items` 以保持内置默认顺序；把它设为 `[]` 以隐藏可配置的片区。
+底部区域可配置。运行 `/statusline` 选择哪些内容可见，或在 `config.toml` 里设置 `[tui].status_items`。每个键只对应屏幕上的一样东西：`mode` 是姿态栏的 plan/act/operate 片区，而 `model`、`context_percent`、`cost`、`balance`（仅限预付费提供商：DeepSeek、DeepSeekCN、OpenRouter、SiliconFlow）、`cache`、`tokens` 和 `session_metrics` 是它下方指标行的片区。
+省略 `status_items` 以保持内置默认；把它设为 `[]` 只保留帮助提示。
 
-`session_metrics`（默认开启）在阶段行上绘制会话指标条带：
-`4 turns · 108 steps │ LLM 11m46s · Tool call 1m52s │ TTFT avg 1.5s · 120 tok/s │ Cache hit 99% │ Input 9.3M`
-Turns 是用户回合；steps 是模型调用加工具调用；`LLM` 是模型调用墙钟时间的总和，`Tool call` 是工具墙钟时间的总和；`TTFT avg` 是到首个流式 token 的平均时间；`tok/s` 是提供商报告的输出 token 除以流式秒数；`Cache hit` 和 `Input` 是提供商报告的 token 类别。提供商或运行时证据尚未到达的单元格会被省略而不是估算，在窄行上，指标条会丢弃价值最低的组（先是 steps 和工具时间，然后是延迟、turns、LLM 时间），而不是截断某个数字。`/status` 打印未裁剪的完整行。
+`context_percent` 默认开启，并在任何占用率下都显示 `ctx NN%`——0.9.12 在 50% 以下保持沉默，使会话的大部分时间都没有上下文信号。该读数从 80% 起仍使用警示配色。
+
+`status`、`agents`、`reasoning_replay`、`prefix_stability`、`git_branch`、`last_tool_elapsed` 和 `rate_limit` 这些键在 0.9.13 中已退役：它们不驱动任何东西。旧的配置文件仍可加载——已退役的键会被忽略并在日志中给出警告。
+
+`session_metrics`（默认开启）在指标行上绘制这一对延迟读数：`ttft 1.5s`（到首个流式 token 的平均时间）和 `120 tok/s`（提供商报告的输出 token 除以流式秒数）。两者来自 `/status` 完整打印的同一批累加器（turns、steps、LLM 与工具墙钟时间、缓存命中、输入）；提供商或运行时证据尚未到达的数字会被省略而不是估算。在窄行上，这一对会先于成本和上下文读数被舍弃，而不是截断某个数字。
 
 转录区（对话记录）就是审计轨迹。当 Codewhale 读文件、跑命令或改代码时，动作会出现在那里。如果某条命令失败，把可见的失败输出作为你下一条指令的一部分，而不是从头再来。
 


### PR DESCRIPTION
No-Issue: first slice of #5950 (ctx always visible, /statusline drives the metrics line, dead toggles retired); the row presets and auto-omission of unavailable segments stay open on #5950.

The 0.9.12 shell built the two rows under the composer without ever reading
`app.status_items`, so `/statusline` was a checklist that changed nothing —
`status_items` had exactly one reader in the whole renderer
(`should_fetch_provider_balance` in `tui/ui/provider_routes.rs`). And the
metrics line's context reading was gated at 50% fullness, which is most of a
session spent with no context signal at all.

## What changed

**1. `ctx NN%` at every fullness.** `info_segments` (`tui/ui/frame.rs`) no
longer drops the reading below 50%. The warning styling keeps the thresholds
it had: `ChromeInk::Info` below 80%, `ChromeInk::Failure` from 80% up. The
reading is still the row's floor — it sheds after everything else, including
the help hint.

**2. `/statusline` drives the metrics line.** Every segment in
`info_segments` is gated on its `StatusItem`, and one item that was not a
metrics-line fact is wired where it does live:

| `StatusItem` | What the toggle now shows/hides |
| --- | --- |
| `Model` | `InfoSegmentId::Model` (route identity) |
| `ContextPercent` | `InfoSegmentId::Context` (`ctx NN%`) |
| `Cost` | `InfoSegmentId::Cost` |
| `Balance` | `InfoSegmentId::Balance` — new segment, see below |
| `Cache` | `InfoSegmentId::Cache` |
| `Tokens` | `InfoSegmentId::OutputTokens` |
| `SessionMetrics` | `InfoSegmentId::Ttft` + `InfoSegmentId::Rate` |
| `Mode` | the posture bar's plan/act/operate chip (`tideline_footer_from_app`) |

`Balance` previously only authorised a background fetch whose result nothing
in the chrome painted. It now paints too: `InfoSegmentId::Balance`, label from
the existing `MessageId::FooterBalancePrefix` (already in all 15 locale packs
— no new user-visible strings in this PR), value from
`BalanceInfo::chip_label`, shed priority 5 so it outlives the cost, which is
right for a reading that is off by default and only on because its owner asked
for it by name. The same status item still gates the fetch, so the row can
only show a number this session asked for.

The posture bar's permission chip, working clocks (#5914 / #5920) and live
counts stay unconditional — they are the bar's own posture statement, and the
shed ladder and clock order in `phase_strip.rs` are untouched (the only change
in that file is a one-line `.filter()` on the already-optional `mode_chip`).

**3. Retired toggles, with receipts.** Eight items were checkboxes that could
not change anything, so they are gone rather than left lying:

| Retired | Receipt |
| --- | --- |
| `ReasoningReplay` | zero references outside `config.rs` — never rendered by anything |
| `RateLimit`, `LastToolElapsed` | the enum's own doc said "placeholder until wired" / "(reserved)"; never wired |
| `PrefixStability` | only reference was a test asserting it stays out of the default footer |
| `GitBranch` | `infoline.rs` module doc, 2026-09-02: "the repository and branch moved to the launch header and the git bottom view" — wiring it back would reverse that call and, since it was in `default_footer`, would put a branch on everyone's metrics line by default |
| `Status` | the posture bar's turn clock carries the activity word (`working 1m 15s`), and that clock is #5914/#5920's core statement, not a composable chip |
| `Agents` | the posture bar's live counts own the agent count, and each count is also the click target that opens the dock |

Old config files keep loading: `StatusItem::from_key` returns `None` for the
retired keys and `deser_status_items` skips them with a warning, which is the
same forward/backward-compatible path that already existed. A test covers a
pre-#5950 `status_items` list surviving the upgrade.

**4. No second config key.** `tui.status_items` already existed, is already
persisted by `config_persistence::persist_status_items`, and is already loaded
in `app/init.rs`. It is reused as-is; the issue's proposed `[tui.bottom]`
schema is deliberately *not* added. `default_footer()` gains
`ContextPercent` so the reading is on out of the box.

## Not in this slice

#5950 also asks for `compact`/`hidden` presets for small windows and for
omitting `→ effective unavailable` / `cost: unknown` on providers that cannot
price a turn. Neither is here. The cost half is now reachable — a custom
provider can turn the cost segment off in `/statusline` — but "omit the
segment automatically when the value cannot be proven" is a separate
behavioural change, and the row-count presets are a layout change.

## Verification

```
cargo fmt -p codewhale-tui                                     clean
cargo check -p codewhale-tui --lib --tests                     clean
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- \
  tui::ui::frame tui::phase_strip tui::views::status_picker \
  tui::infoline localization                                   119 passed, 0 failed
RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- \
  config::tests config_persistence tui::ui::tests::default_footer \
  tui::ui::tests::should_fetch tui::widgets                     708 passed, 0 failed
```

New tests: `context_reading_paints_at_every_fullness` (10% and 60%, asserted
at 40, 80 and 160 columns), `context_reading_keeps_its_warning_threshold`
(10 / 79 / 80), `statusline_toggle_removes_its_segment_on_the_next_frame`
(drives the real `StatusPickerView` with key events and re-renders),
`every_metrics_segment_answers_to_a_status_item` (all items on paints every
segment; an empty list paints none), plus a config test for a pre-#5950
`status_items` list still loading.

No golden needed re-blessing: the `infoline_*` and `footer_*` goldens render
synthetic segments and default status items, and both stayed byte-identical.
The two `one_owner_tests` assertions that encoded the 50% silence were
updated to assert the reading paints once at every fullness.

Buffer-level evidence only: no run against a real provider and no live
terminal session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XYyJaw9Mh9uSrqQBoqhm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI presentation and config parsing only; retired keys are ignored rather than failing load, with no auth or data-path changes.
> 
> **Overview**
> **`/statusline` and `tui.status_items` actually control the bottom chrome again.** After the 0.9.12 shell split, most picker toggles did nothing because `info_segments` ignored the list; each remaining `StatusItem` now gates exactly one on-screen element (metrics segments for model, context, cost, balance, cache, tokens, session metrics; posture bar plan/act/operate for `mode`). Eight keys that never drove UI (`status`, `agents`, `reasoning_replay`, `prefix_stability`, `git_branch`, `last_tool_elapsed`, `rate_limit`) are removed from the enum but still parse safely from old configs.
> 
> **Context and balance behavior changes on the metrics line.** `ctx NN%` is shown at every fullness (not only ≥50%), with warning styling still from 80% up; `context_percent` is added to the default footer. **Balance** gets a new metrics segment when enabled—the same toggle still authorizes the prepaid balance fetch—plus updated shed order so balance outlives cost on narrow widths.
> 
> Docs, `config.example.toml`, and tests cover legacy `status_items` lists, picker integration, and frame invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f088718f15fb4bf916034a1b9715932658c30295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->