### PR TITLE
feat(tools): make request_user_input question/option limits configurable

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -211,6 +211,13 @@ memory_path = "~/.codewhale/memory.md"
 # through ToolSearch and loaded on first use.
 # [tools]
 # always_load = ["git_show", "notify"]
+#
+# `request_user_input` payload ceilings (#5949). The model may ask up to
+# `user_input_max_questions` questions per call, each offering up to
+# `user_input_max_options` options. Out-of-range values are clamped to the
+# supported ranges (1..=10 and 2..=10) with a warning.
+# user_input_max_questions = 6
+# user_input_max_options = 4
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # Product telemetry — opt-in, off by default

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2305,6 +2305,19 @@ pub struct ToolsConfig {
     /// Each override replaces or disables the named tool.
     #[serde(default)]
     pub overrides: Option<HashMap<String, ToolOverride>>,
+
+    /// Ceiling on how many questions one `request_user_input` call may ask
+    /// (#5949). `None` uses
+    /// [`crate::tools::user_input::DEFAULT_MAX_QUESTIONS`] (6). Values outside
+    /// `1..=10` are clamped with a warning rather than failing the load.
+    #[serde(default)]
+    pub user_input_max_questions: Option<u32>,
+
+    /// Ceiling on how many options each `request_user_input` question may
+    /// offer. `None` uses [`crate::tools::user_input::DEFAULT_MAX_OPTIONS`]
+    /// (4). Values outside `2..=10` are clamped with a warning.
+    #[serde(default)]
+    pub user_input_max_options: Option<u32>,
 }
 
 /// Persistent-goal loop controls (`[goal]` table in config.toml, #5052).
@@ -4785,6 +4798,18 @@ impl Config {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    /// Effective `request_user_input` payload ceilings for this session
+    /// (#5949). Resolved once per engine build; out-of-range `[tools]` values
+    /// clamp with a single warning naming the key and the value used.
+    #[must_use]
+    pub fn user_input_limits(&self) -> crate::tools::user_input::UserInputLimits {
+        let tools = self.tools.as_ref();
+        crate::tools::user_input::UserInputLimits::from_config_values(
+            tools.and_then(|t| t.user_input_max_questions),
+            tools.and_then(|t| t.user_input_max_options),
+        )
     }
 
     #[must_use]

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -1397,6 +1397,41 @@ fn tools_always_load_parses_and_trims_names() {
 }
 
 #[test]
+fn user_input_limits_default_when_tools_table_is_absent() {
+    let parsed: ConfigFile = toml::from_str("").expect("empty config");
+    let limits = parsed.base.user_input_limits();
+    assert_eq!(limits.max_questions, 6);
+    assert_eq!(limits.max_options, 4);
+}
+
+#[test]
+fn user_input_limits_read_from_tools_table_and_clamp() {
+    let parsed: ConfigFile = toml::from_str(
+        r#"
+        [tools]
+        user_input_max_questions = 9
+        user_input_max_options = 6
+        "#,
+    )
+    .expect("tools config");
+    let limits = parsed.base.user_input_limits();
+    assert_eq!(limits.max_questions, 9);
+    assert_eq!(limits.max_options, 6);
+
+    let clamped: ConfigFile = toml::from_str(
+        r#"
+        [tools]
+        user_input_max_questions = 50
+        user_input_max_options = 0
+        "#,
+    )
+    .expect("tools config");
+    let clamped = clamped.base.user_input_limits();
+    assert_eq!(clamped.max_questions, 10);
+    assert_eq!(clamped.max_options, 2);
+}
+
+#[test]
 fn explicit_duckduckgo_search_provider_is_preserved() {
     let config: Config = toml::from_str(
         r#"

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -471,6 +471,10 @@ pub struct EngineConfig {
     /// Native tools that should stay in the model-visible catalog even when
     /// they are outside the small default core surface (#2076).
     pub tools_always_load: HashSet<String>,
+    /// Effective `request_user_input` payload ceilings resolved from `[tools]`
+    /// (#5949). One authority for the validator, the tool schema, and the
+    /// tool description.
+    pub user_input_limits: crate::tools::user_input::UserInputLimits,
     /// When true and `/usr/bin/bwrap` is executable on Linux, route exec_shell
     /// through bubblewrap (#2184).
     pub prefer_bwrap: bool,
@@ -596,6 +600,7 @@ impl Default for EngineConfig {
                 crate::config::DEFAULT_SUBAGENT_HEARTBEAT_TIMEOUT_SECS,
             ),
             tools_always_load: HashSet::new(),
+            user_input_limits: crate::tools::user_input::UserInputLimits::default(),
             prefer_bwrap: false,
             bwrap_extensions: crate::sandbox::BwrapMountExtensions::default(),
             // Fail-closed (F7): `Engine::new` unconditionally installs this

--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -560,7 +560,7 @@ mod schema_json_container_tests {
 
     #[test]
     fn decodes_nested_containers_and_passes_tool_validation() {
-        let schema = crate::tools::user_input::RequestUserInputTool.input_schema();
+        let schema = crate::tools::user_input::RequestUserInputTool::default().input_schema();
         let encoded_options = serde_json::to_string(&json!([
             { "label": "Repository", "description": "Inspect the current repository" },
             { "label": "Workspace", "description": "Inspect the whole workspace" }

--- a/crates/tui/src/core/engine/tool_setup.rs
+++ b/crates/tui/src/core/engine/tool_setup.rs
@@ -28,6 +28,7 @@ impl Engine {
         options.speech_output_dir = self.config.speech_output_dir.clone();
         options.goal_state = Some(self.config.goal_state.clone());
         options.verify_tool_enabled = self.config.features.enabled(Feature::Verify);
+        options.user_input_limits = self.config.user_input_limits;
         options
     }
 
@@ -112,7 +113,7 @@ impl Engine {
 
         builder = builder
             .with_review_tool(client.clone(), model.to_string())
-            .with_user_input_tool();
+            .with_user_input_tool(self.config.user_input_limits);
 
         if self.config.features.enabled(Feature::WebSearch) {
             builder = builder.with_web_tools();

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -3667,7 +3667,10 @@ impl Engine {
                     if tool_name == REQUEST_USER_INPUT_NAME {
                         let started_at = Instant::now();
                         let result = if *questions_allowed {
-                            match UserInputRequest::from_value(&tool_input) {
+                            match UserInputRequest::from_value_with_limits(
+                                &tool_input,
+                                self.config.user_input_limits,
+                            ) {
                                 Ok(request) => self
                                     .await_user_input(&tool_id, request)
                                     .await

--- a/crates/tui/src/exec_agent.rs
+++ b/crates/tui/src/exec_agent.rs
@@ -331,6 +331,7 @@ pub(crate) async fn run_exec_agent(
         } else {
             execution_config.tools_always_load()
         },
+        user_input_limits: execution_config.user_input_limits(),
         tools: if fleet_authority_active {
             None
         } else {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -8134,6 +8134,7 @@ impl RuntimeThreadManager {
                 } else {
                     cfg.tools_always_load()
                 },
+                user_input_limits: cfg.user_input_limits(),
                 tools: (!isolated_chat).then(|| cfg.tools.clone()).flatten(),
                 verbosity: cfg.verbosity.clone(),
                 workspace_follow_symlinks: settings.workspace_follow_symlinks,

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -695,6 +695,10 @@ pub struct AgentToolSurfaceOptions {
     /// Register the agent-callable `verify` self-critique tool (#4196).
     /// Gated by `Feature::Verify` (`[features] verify_tool`), default on.
     pub verify_tool_enabled: bool,
+    /// `request_user_input` payload ceilings from `[tools]` (#5949). Carried on
+    /// the surface options so model-spawned children inherit the parent's
+    /// configured limits instead of silently falling back to the defaults.
+    pub user_input_limits: super::user_input::UserInputLimits,
 }
 
 impl AgentToolSurfaceOptions {
@@ -709,6 +713,7 @@ impl AgentToolSurfaceOptions {
             speech_output_dir: None,
             goal_state: None,
             verify_tool_enabled: true,
+            user_input_limits: super::user_input::UserInputLimits::default(),
         }
     }
 }
@@ -1036,11 +1041,14 @@ impl ToolRegistryBuilder {
         )))
     }
 
-    /// Include request_user_input tool.
+    /// Include request_user_input tool under the session's configured payload
+    /// ceilings (`[tools] user_input_max_questions` / `user_input_max_options`,
+    /// #5949). The limits ride the tool instance so the validator, the JSON
+    /// schema, and the model-visible description cannot drift apart.
     #[must_use]
-    pub fn with_user_input_tool(self) -> Self {
+    pub fn with_user_input_tool(self, limits: super::user_input::UserInputLimits) -> Self {
         use super::user_input::RequestUserInputTool;
-        self.with_tool(Arc::new(RequestUserInputTool))
+        self.with_tool(Arc::new(RequestUserInputTool::new(limits)))
     }
 
     /// Include patch tools (`apply_patch`).
@@ -1248,12 +1256,16 @@ impl ToolRegistryBuilder {
 
     /// Include all agent tools under a typed shell policy.
     #[must_use]
-    pub fn with_agent_tools_policy(self, shell_policy: crate::worker_profile::ShellPolicy) -> Self {
+    pub fn with_agent_tools_policy(
+        self,
+        shell_policy: crate::worker_profile::ShellPolicy,
+        user_input_limits: super::user_input::UserInputLimits,
+    ) -> Self {
         let builder = self
             .with_file_tools()
             .with_note_tool()
             .with_search_tools()
-            .with_user_input_tool()
+            .with_user_input_tool(user_input_limits)
             .with_git_tools()
             .with_git_history_tools()
             .with_diagnostics_tool()
@@ -1297,7 +1309,7 @@ impl ToolRegistryBuilder {
         let verify_client = client.clone();
         let verify_model = model.clone();
         let mut builder = self
-            .with_agent_tools_policy(options.shell_policy)
+            .with_agent_tools_policy(options.shell_policy, options.user_input_limits)
             .with_todo_tool(todo_list)
             .with_plan_tool(plan_state)
             .with_review_tool(client.clone(), model.clone())

--- a/crates/tui/src/tools/registry/tests.rs
+++ b/crates/tui/src/tools/registry/tests.rs
@@ -787,7 +787,10 @@ fn readonly_verifier_context(workspace: &std::path::Path) -> ToolContext {
 fn machine_verifier_catalog_and_dispatch_add_only_bounded_run() {
     let tmp = tempdir().expect("tempdir");
     let registry = ToolRegistryBuilder::new()
-        .with_agent_tools_policy(crate::worker_profile::ShellPolicy::None)
+        .with_agent_tools_policy(
+            crate::worker_profile::ShellPolicy::None,
+            crate::tools::user_input::UserInputLimits::default(),
+        )
         .with_web_tools()
         .with_todo_tool(crate::tools::todo::new_shared_todo_list())
         .build(readonly_verifier_context(tmp.path()));
@@ -1376,7 +1379,10 @@ fn test_builder_with_agent_tools_policy_includes_finance() {
     let ctx = ToolContext::new(tmp.path().to_path_buf());
 
     let registry = ToolRegistryBuilder::new()
-        .with_agent_tools_policy(crate::worker_profile::ShellPolicy::None)
+        .with_agent_tools_policy(
+            crate::worker_profile::ShellPolicy::None,
+            crate::tools::user_input::UserInputLimits::default(),
+        )
         .build(ctx);
 
     assert!(registry.contains("finance"));
@@ -1388,7 +1394,10 @@ fn agent_tools_with_shell_policy_none_excludes_shell_tools() {
     let ctx = ToolContext::new(tmp.path().to_path_buf());
 
     let registry = ToolRegistryBuilder::new()
-        .with_agent_tools_policy(crate::worker_profile::ShellPolicy::None)
+        .with_agent_tools_policy(
+            crate::worker_profile::ShellPolicy::None,
+            crate::tools::user_input::UserInputLimits::default(),
+        )
         .build(ctx);
 
     assert!(!registry.contains("bash"));
@@ -1413,7 +1422,10 @@ fn agent_tools_with_shell_policy_readonly_exposes_only_run_only_bash() {
     let ctx = ToolContext::new(tmp.path().to_path_buf());
 
     let registry = ToolRegistryBuilder::new()
-        .with_agent_tools_policy(crate::worker_profile::ShellPolicy::ReadOnly)
+        .with_agent_tools_policy(
+            crate::worker_profile::ShellPolicy::ReadOnly,
+            crate::tools::user_input::UserInputLimits::default(),
+        )
         .build(ctx);
 
     assert!(registry.contains("bash"));
@@ -1460,7 +1472,10 @@ fn agent_tools_with_shell_policy_readonly_exposes_only_run_only_bash() {
 fn machine_readonly_catalog_is_exactly_the_evidence_profile() {
     let tmp = tempdir().expect("tempdir");
     let registry = ToolRegistryBuilder::new()
-        .with_agent_tools_policy(crate::worker_profile::ShellPolicy::ReadOnly)
+        .with_agent_tools_policy(
+            crate::worker_profile::ShellPolicy::ReadOnly,
+            crate::tools::user_input::UserInputLimits::default(),
+        )
         .with_web_tools()
         .with_todo_tool(crate::tools::todo::new_shared_todo_list())
         .build(readonly_scout_context(tmp.path(), true));
@@ -1527,7 +1542,10 @@ fn agent_tools_with_shell_policy_full_includes_shell_tools() {
     let ctx = ToolContext::new(tmp.path().to_path_buf());
 
     let registry = ToolRegistryBuilder::new()
-        .with_agent_tools_policy(crate::worker_profile::ShellPolicy::Full)
+        .with_agent_tools_policy(
+            crate::worker_profile::ShellPolicy::Full,
+            crate::tools::user_input::UserInputLimits::default(),
+        )
         .build(ctx);
 
     assert!(registry.contains("bash"));

--- a/crates/tui/src/tools/user_input.rs
+++ b/crates/tui/src/tools/user_input.rs
@@ -7,6 +7,85 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+/// Default ceiling on `request_user_input.questions` (#5949). Raised from the
+/// former hard-coded 3 so research/planning turns that need four or more
+/// clarifications are not rejected outright.
+pub const DEFAULT_MAX_QUESTIONS: usize = 6;
+/// Default ceiling on options per question.
+pub const DEFAULT_MAX_OPTIONS: usize = 4;
+/// Inclusive bounds a configured `user_input_max_questions` is clamped into.
+pub const MIN_CONFIGURABLE_QUESTIONS: usize = 1;
+pub const MAX_CONFIGURABLE_QUESTIONS: usize = 10;
+/// Inclusive bounds a configured `user_input_max_options` is clamped into.
+/// The floor is 2 because a one-option question is not a choice.
+pub const MIN_CONFIGURABLE_OPTIONS: usize = 2;
+pub const MAX_CONFIGURABLE_OPTIONS: usize = 10;
+
+/// Config key naming used in both the clamp WARN and the rejection message, so
+/// a model that hits the ceiling is told exactly where to raise it.
+pub const MAX_QUESTIONS_KEY: &str = "[tools] user_input_max_questions";
+pub const MAX_OPTIONS_KEY: &str = "[tools] user_input_max_options";
+
+/// Effective `request_user_input` payload ceilings for one session.
+///
+/// Resolved once from `[tools]` in config.toml (see
+/// [`crate::config::Config::user_input_limits`]) and carried to the three
+/// places that must agree: the validator, the tool's JSON schema, and its
+/// model-visible description.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UserInputLimits {
+    pub max_questions: usize,
+    pub max_options: usize,
+}
+
+impl Default for UserInputLimits {
+    fn default() -> Self {
+        Self {
+            max_questions: DEFAULT_MAX_QUESTIONS,
+            max_options: DEFAULT_MAX_OPTIONS,
+        }
+    }
+}
+
+impl UserInputLimits {
+    /// Resolve raw `[tools]` values, clamping each into its supported range.
+    /// An out-of-range value is honoured as far as it can be rather than
+    /// failing the load, and says so once with the key and the value used.
+    #[must_use]
+    pub fn from_config_values(max_questions: Option<u32>, max_options: Option<u32>) -> Self {
+        Self {
+            max_questions: clamp_with_warn(
+                max_questions,
+                DEFAULT_MAX_QUESTIONS,
+                MIN_CONFIGURABLE_QUESTIONS,
+                MAX_CONFIGURABLE_QUESTIONS,
+                MAX_QUESTIONS_KEY,
+            ),
+            max_options: clamp_with_warn(
+                max_options,
+                DEFAULT_MAX_OPTIONS,
+                MIN_CONFIGURABLE_OPTIONS,
+                MAX_CONFIGURABLE_OPTIONS,
+                MAX_OPTIONS_KEY,
+            ),
+        }
+    }
+}
+
+fn clamp_with_warn(raw: Option<u32>, default: usize, min: usize, max: usize, key: &str) -> usize {
+    let Some(raw) = raw else {
+        return default;
+    };
+    let raw = raw as usize;
+    let clamped = raw.clamp(min, max);
+    if clamped != raw {
+        tracing::warn!(
+            "`{key}` = {raw} is outside the supported range {min}..={max}; using {clamped}"
+        );
+    }
+    clamped
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserInputOption {
     pub label: String,
@@ -35,24 +114,43 @@ pub struct UserInputRequest {
 }
 
 impl UserInputRequest {
+    /// Parse and validate against the built-in default limits. Call sites that
+    /// hold a session's resolved config use [`Self::from_value_with_limits`].
     pub fn from_value(value: &Value) -> Result<Self, ToolError> {
+        Self::from_value_with_limits(value, UserInputLimits::default())
+    }
+
+    pub fn from_value_with_limits(
+        value: &Value,
+        limits: UserInputLimits,
+    ) -> Result<Self, ToolError> {
         let request: UserInputRequest = serde_json::from_value(value.clone()).map_err(|e| {
             ToolError::invalid_input(format!("Invalid request_user_input payload: {e}"))
         })?;
-        request.validate()?;
+        request.validate_with_limits(limits)?;
         Ok(request)
     }
 
     pub fn validate(&self) -> Result<(), ToolError> {
+        self.validate_with_limits(UserInputLimits::default())
+    }
+
+    pub fn validate_with_limits(&self, limits: UserInputLimits) -> Result<(), ToolError> {
         if self.questions.is_empty() {
             return Err(ToolError::invalid_input(
                 "request_user_input.questions must be non-empty",
             ));
         }
-        if self.questions.len() > 3 {
-            return Err(ToolError::invalid_input(
-                "request_user_input.questions must contain 1 to 3 items",
-            ));
+        if self.questions.len() > limits.max_questions {
+            // Name the ceiling *and* where to raise it: a rejection the model
+            // cannot act on just burns another turn (#5949).
+            return Err(ToolError::invalid_input(format!(
+                "request_user_input.questions must contain 1 to {max} items (got {got}); \
+                 raise the ceiling with `{MAX_QUESTIONS_KEY}` in config.toml \
+                 (supported range {MIN_CONFIGURABLE_QUESTIONS}..={MAX_CONFIGURABLE_QUESTIONS})",
+                max = limits.max_questions,
+                got = self.questions.len(),
+            )));
         }
         for q in &self.questions {
             if q.header.trim().is_empty() {
@@ -70,10 +168,15 @@ impl UserInputRequest {
                     "request_user_input.questions.question cannot be empty",
                 ));
             }
-            if q.options.len() < 2 || q.options.len() > 4 {
-                return Err(ToolError::invalid_input(
-                    "request_user_input.questions.options must contain 2 to 4 items",
-                ));
+            if q.options.len() < MIN_CONFIGURABLE_OPTIONS || q.options.len() > limits.max_options {
+                return Err(ToolError::invalid_input(format!(
+                    "request_user_input.questions.options must contain \
+                     {MIN_CONFIGURABLE_OPTIONS} to {max} items (got {got}); \
+                     raise the ceiling with `{MAX_OPTIONS_KEY}` in config.toml \
+                     (supported range {MIN_CONFIGURABLE_OPTIONS}..={MAX_CONFIGURABLE_OPTIONS})",
+                    max = limits.max_options,
+                    got = q.options.len(),
+                )));
             }
             for opt in &q.options {
                 if opt.label.trim().is_empty() {
@@ -104,7 +207,31 @@ pub struct UserInputResponse {
     pub answers: Vec<UserInputAnswer>,
 }
 
-pub struct RequestUserInputTool;
+pub struct RequestUserInputTool {
+    limits: UserInputLimits,
+    /// Rendered once at construction: `description` hands out a borrow, and the
+    /// effective ceiling only changes when the registry is rebuilt.
+    description: String,
+}
+
+impl Default for RequestUserInputTool {
+    fn default() -> Self {
+        Self::new(UserInputLimits::default())
+    }
+}
+
+impl RequestUserInputTool {
+    #[must_use]
+    pub fn new(limits: UserInputLimits) -> Self {
+        Self {
+            description: format!(
+                "Ask the user 1-{} short questions and return their selections.",
+                limits.max_questions
+            ),
+            limits,
+        }
+    }
+}
 
 #[async_trait]
 impl ToolSpec for RequestUserInputTool {
@@ -112,8 +239,8 @@ impl ToolSpec for RequestUserInputTool {
         "request_user_input"
     }
 
-    fn description(&self) -> &'static str {
-        "Ask the user 1-3 short questions and return their selections."
+    fn description(&self) -> &str {
+        &self.description
     }
 
     fn input_schema(&self) -> Value {
@@ -138,8 +265,8 @@ impl ToolSpec for RequestUserInputTool {
                                     },
                                     "required": ["label", "description"]
                                 },
-                                "minItems": 2,
-                                "maxItems": 4
+                                "minItems": MIN_CONFIGURABLE_OPTIONS,
+                                "maxItems": self.limits.max_options
                             },
                             "allow_free_text": {
                                 "type": "boolean",
@@ -155,7 +282,7 @@ impl ToolSpec for RequestUserInputTool {
                         "required": ["header", "id", "question", "options"]
                     },
                     "minItems": 1,
-                    "maxItems": 3
+                    "maxItems": self.limits.max_questions
                 }
             },
             "required": ["questions"]
@@ -296,16 +423,123 @@ mod tests {
         }
     }
 
+    fn questions(count: usize) -> UserInputRequest {
+        UserInputRequest {
+            questions: (1..=count)
+                .map(|i| yes_no_question(&format!("Q{i}"), &format!("q{i}")))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn default_limits_are_six_questions_and_four_options() {
+        let limits = UserInputLimits::default();
+        assert_eq!(limits.max_questions, 6);
+        assert_eq!(limits.max_options, 4);
+        // An empty `[tools]` table resolves to the same ceilings.
+        assert_eq!(UserInputLimits::from_config_values(None, None), limits);
+        assert_eq!(
+            RequestUserInputTool::default().description(),
+            "Ask the user 1-6 short questions and return their selections."
+        );
+    }
+
+    #[test]
+    fn accepts_six_questions_by_default() {
+        assert!(questions(6).validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_seven_questions_and_names_the_config_key() {
+        let err = questions(7)
+            .validate()
+            .expect_err("7 questions exceeds the default ceiling of 6");
+        let msg = err.to_string();
+        assert!(msg.contains("1 to 6 items"), "{msg}");
+        assert!(msg.contains("got 7"), "{msg}");
+        assert!(msg.contains("[tools] user_input_max_questions"), "{msg}");
+        assert!(msg.contains("config.toml"), "{msg}");
+    }
+
+    #[test]
+    fn rejected_option_count_names_the_config_key() {
+        let input = json!({
+            "questions": [{
+                "header": "Pick",
+                "id": "choice",
+                "question": "Which?",
+                "options": [
+                    { "label": "A", "description": "a" },
+                    { "label": "B", "description": "b" },
+                    { "label": "C", "description": "c" },
+                    { "label": "D", "description": "d" },
+                    { "label": "E", "description": "e" }
+                ]
+            }]
+        });
+        let msg = UserInputRequest::from_value(&input)
+            .expect_err("5 options must fail")
+            .to_string();
+        assert!(msg.contains("[tools] user_input_max_options"), "{msg}");
+    }
+
+    #[test]
+    fn configured_limits_widen_and_narrow_the_validator() {
+        let wide = UserInputLimits::from_config_values(Some(9), Some(6));
+        assert!(questions(9).validate_with_limits(wide).is_ok());
+
+        let narrow = UserInputLimits::from_config_values(Some(2), None);
+        let msg = questions(3)
+            .validate_with_limits(narrow)
+            .expect_err("3 questions exceeds a configured ceiling of 2")
+            .to_string();
+        assert!(msg.contains("1 to 2 items"), "{msg}");
+    }
+
+    #[test]
+    fn out_of_range_config_values_clamp() {
+        // Below the floor and far above the ceiling both clamp instead of
+        // failing the config load.
+        let low = UserInputLimits::from_config_values(Some(0), Some(0));
+        assert_eq!(low.max_questions, MIN_CONFIGURABLE_QUESTIONS);
+        assert_eq!(low.max_options, MIN_CONFIGURABLE_OPTIONS);
+
+        let high = UserInputLimits::from_config_values(Some(50), Some(50));
+        assert_eq!(high.max_questions, MAX_CONFIGURABLE_QUESTIONS);
+        assert_eq!(high.max_options, MAX_CONFIGURABLE_OPTIONS);
+    }
+
+    #[test]
+    fn schema_and_description_reflect_configured_limits() {
+        let tool = RequestUserInputTool::new(UserInputLimits::from_config_values(Some(8), Some(5)));
+        assert_eq!(
+            tool.description(),
+            "Ask the user 1-8 short questions and return their selections."
+        );
+        let schema = tool.input_schema();
+        let questions = &schema["properties"]["questions"];
+        assert_eq!(questions["minItems"], json!(1));
+        assert_eq!(questions["maxItems"], json!(8));
+        let options = &questions["items"]["properties"]["options"];
+        assert_eq!(options["minItems"], json!(2));
+        assert_eq!(options["maxItems"], json!(5));
+
+        // Defaults land on the documented 6 / 4 pair.
+        let default_schema = RequestUserInputTool::default().input_schema();
+        assert_eq!(
+            default_schema["properties"]["questions"]["maxItems"],
+            json!(6)
+        );
+        assert_eq!(
+            default_schema["properties"]["questions"]["items"]["properties"]["options"]["maxItems"],
+            json!(4)
+        );
+    }
+
     #[test]
     fn rejects_too_many_questions() {
-        let request = UserInputRequest {
-            questions: vec![
-                yes_no_question("Q1", "q1"),
-                yes_no_question("Q2", "q2"),
-                yes_no_question("Q3", "q3"),
-                yes_no_question("Q4", "q4"),
-            ],
-        };
-        assert!(request.validate().is_err());
+        // Seven is one past the default ceiling; four now parses (#5949).
+        assert!(questions(4).validate().is_ok());
+        assert!(questions(7).validate().is_err());
     }
 }

--- a/crates/tui/src/tui/command_palette.rs
+++ b/crates/tui/src/tui/command_palette.rs
@@ -193,7 +193,7 @@ pub fn build_entries_with_plugins(
         .with_shell_tools()
         .with_web_tools()
         .with_git_tools()
-        .with_user_input_tool()
+        .with_user_input_tool(crate::tools::user_input::UserInputLimits::default())
         .with_patch_tools()
         .with_note_tool()
         .with_diagnostics_tool()

--- a/crates/tui/src/tui/ui/frame.rs
+++ b/crates/tui/src/tui/ui/frame.rs
@@ -820,6 +820,7 @@ pub(crate) fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         search_api_key: config.search.as_ref().and_then(|s| s.api_key.clone()),
         search_base_url: config.search.as_ref().and_then(|s| s.base_url.clone()),
         tools_always_load: config.tools_always_load(),
+        user_input_limits: config.user_input_limits(),
         tools: config.tools.clone(),
         workspace_follow_symlinks: app.workspace_follow_symlinks,
         exec_policy_engine: config.exec_policy_engine.clone(),

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2622,6 +2622,24 @@ tools loaded on every request, add them to `[tools].always_load`:
 always_load = ["Git", "notify"]
 ```
 
+### `request_user_input` limits
+
+`request_user_input` asks the user a short batch of multiple-choice questions.
+Both ceilings are configurable (#5949): raise `user_input_max_questions` when a
+research or planning workflow legitimately needs more clarifications, lower it
+when interactive triage should stay terse.
+
+```toml
+[tools]
+user_input_max_questions = 6   # default 6, clamped to 1..=10
+user_input_max_options = 4     # default 4, clamped to 2..=10
+```
+
+The effective values are applied in three places at once: the tool's JSON
+schema (`minItems` / `maxItems`), its model-visible description, and the
+payload validator. A rejected payload names the key to raise, so the model can
+either resize the batch or tell the user which setting to change.
+
 ## Feature Flags
 
 Feature flags live under the `[features]` table and are merged across profiles.


### PR DESCRIPTION
Closes #5949

## What

`request_user_input` hard-capped payloads at **1-3 questions** with **2-4 options** each, in three places that had to be kept in sync by hand: the validator in `crates/tui/src/tools/user_input.rs`, the JSON schema's `minItems`/`maxItems`, and the tool description. A research or planning turn that needed four clarifications had its whole call rejected, so the tokens were spent and the user saw an error instead of a question modal.

This adds two `[tools]` knobs and raises the question default to 6:

```toml
[tools]
user_input_max_questions = 6   # default 6, clamped to 1..=10
user_input_max_options = 4     # default 4, clamped to 2..=10
```

## How

- `UserInputLimits` (in `tools/user_input.rs`) is the single authority. `Config::user_input_limits()` resolves it from `[tools]`, next to the existing `tools_always_load()` accessor, clamping out-of-range values with **one WARN naming the key and the value used** rather than failing the config load.
- The resolved limits ride `EngineConfig.user_input_limits` and `AgentToolSurfaceOptions.user_input_limits`, so the turn loop's validator, the registered `RequestUserInputTool`'s `input_schema()`, and its `description()` all read one value — and model-spawned children inherit the parent's ceilings instead of falling back to defaults.
- `RequestUserInputTool` is now constructed with its limits (`RequestUserInputTool::new(limits)`, `Default` = 6/4) and renders its description once: `"Ask the user 1-N short questions and return their selections."`.
- A rejected payload names the ceiling **and** the fix:

  ```
  request_user_input.questions must contain 1 to 6 items (got 7); raise the ceiling with `[tools] user_input_max_questions` in config.toml (supported range 1..=10)
  ```

  The options rejection names `[tools] user_input_max_options` the same way.
- Documented in `config.example.toml` and `docs/CONFIGURATION.md`.

`codewhale_config::SETTINGS_SCHEMA` was checked and deliberately left alone: it enumerates no `[tools]` keys at all today (not even `tools.always_load`), and every row there requires an i18n label/hint key. Adding these two would have been the only `[tools]` rows in the `/config` view.

## Acceptance criteria

- [x] Accepts N questions where N = configured max; >=4 works out of the box (default 6).
- [x] Over-limit requests fail fast with a model-visible message naming the key to raise.
- [x] Tool description and JSON schema reflect the effective limit.

## Tests

| command | result |
| --- | --- |
| `cargo fmt` | clean |
| `cargo check -p codewhale-tui` | clean (`-D warnings`) |
| `cargo clippy -p codewhale-tui --lib --all-targets` | clean |
| `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- tools::user_input config::tests` | **449 passed, 0 failed**, 11368 filtered out |
| `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib` | 11803 passed, **1 failed**, 13 ignored |

New coverage: defaults are 6/4; a 6-question payload is accepted; a 7-question payload is rejected with `[tools] user_input_max_questions` in the message; an over-limit option list names `[tools] user_input_max_options`; `0` and `50` clamp to the range floors/ceilings; schema `minItems`/`maxItems` and the description track the configured limits.

The one failure in the full-suite run is `remote_control::tests::separate_predispatch_crashes_on_one_run_get_distinct_recovery_turn_ids`, which is unrelated to this change and passes when run on its own — it is flaky under a fully parallel run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XYyJaw9Mh9uSrqQBoqhm
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-driven validation and schema limits for an interactive TUI tool only; no auth, sandbox, or network behavior changes.
> 
> **Overview**
> **`request_user_input` no longer hard-caps at 1–3 questions and 2–4 options.** Defaults move to **6 questions / 4 options**, and `[tools] user_input_max_questions` and `user_input_max_options` let operators tune batch size (clamped to 1..=10 and 2..=10 with a load-time warning, not a config failure).
> 
> A single **`UserInputLimits`** value is resolved via `Config::user_input_limits()` and threaded through the engine, tool registry, and sub-agent surface options so validation, the tool JSON schema, and the model-visible description stay aligned. **`RequestUserInputTool`** is built with those limits; over-limit payloads fail with messages that name the config key to raise.
> 
> Docs and `config.example.toml` document the new knobs; tests cover defaults, clamping, schema/description sync, and actionable errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 532d7224c085237a7074cee348e2dbfc6f268544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

