### PR TITLE
feat(compaction): operator summarizer instructions and configurable verbatim retention (#5956)

### DIFF
--- a/crates/tui/src/compaction.rs
+++ b/crates/tui/src/compaction.rs
@@ -54,6 +54,15 @@ pub struct CompactionConfig {
     /// Workspace root, used only to re-state the user's `/anchor` file after
     /// the summary. `None` skips anchors.
     pub workspace: Option<std::path::PathBuf>,
+    /// Standing operator instructions from `[compaction] summary_instructions`
+    /// (#5956), appended to the summarizer prompt on every pass — manual and
+    /// automatic. `None` keeps the built-in prompt byte-identical. A manual
+    /// `/compact <focus>` still composes after this text.
+    pub summary_instructions: Option<String>,
+    /// Verbatim retention budget for recent plain user messages in the
+    /// replacement history (`[compaction] retained_user_message_tokens`,
+    /// #5956). Defaults to [`COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS`].
+    pub retained_user_message_tokens: usize,
 }
 
 /// Host-prepared configuration carried from compaction eligibility through
@@ -97,6 +106,8 @@ impl Default for CompactionConfig {
             focus: None,
             runtime_cost_owner: None,
             workspace: None,
+            summary_instructions: None,
+            retained_user_message_tokens: COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS,
         }
     }
 }
@@ -137,7 +148,12 @@ const RETAINED_TOOL_RESULT_MAX_CHARS: usize = 64 * 1024;
 const RETAINED_THINKING_MAX_CHARS: usize = 16 * 1024;
 /// Token budget for the recent user messages retained verbatim in the
 /// replacement history (Codex parity: COMPACT_USER_MESSAGE_MAX_TOKENS).
-pub(crate) const COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS: usize = 20_000;
+///
+/// This is now the *default* only: `[compaction] retained_user_message_tokens`
+/// overrides it per session (#5956). Aliased to the config default so the two
+/// names cannot drift apart.
+pub(crate) const COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS: usize =
+    crate::config::DEFAULT_COMPACTION_RETAINED_USER_MESSAGE_TOKENS;
 /// Handoff summarization prompt, appended to the live conversation as the
 /// final user message (ported from Codex `templates/compact/prompt.md`).
 const COMPACT_PROMPT: &str = "You are performing a context checkpoint compaction. Create a \
@@ -415,7 +431,7 @@ fn estimate_retained_floor_conservative(
     prepared: &PreparedCompactionEnvelope,
 ) -> usize {
     let config = &prepared.config;
-    let retained = retained_user_messages(messages, COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS);
+    let retained = retained_user_messages(messages, config.retained_user_message_tokens);
     let retained_tokens = estimate_tokens(&retained).saturating_mul(3).div_ceil(2);
     let framing = retained.len().saturating_mul(12).saturating_add(48);
     let anchors = user_anchors_section(config.workspace.as_deref());
@@ -1248,8 +1264,9 @@ async fn compact_messages_with_metadata(
         messages,
         &checkpoint_text,
         pinned_anchors_text(config.workspace.as_deref()).as_deref(),
+        config.retained_user_message_tokens,
     )?;
-    let coverage = last_round::measure_coverage(
+    let mut coverage = last_round::measure_coverage(
         messages,
         &retained,
         CompactionPath::Summary,
@@ -1257,6 +1274,11 @@ async fn compact_messages_with_metadata(
             .map(|text| text.chars().count())
             .unwrap_or(0),
     );
+    // Report the tuning actually in force so the receipt shows the operator
+    // their knobs took effect (#5956).
+    coverage.retained_user_message_tokens = config.retained_user_message_tokens;
+    coverage.operator_instructions_applied =
+        operator_instructions_section(config.summary_instructions.as_deref()).is_some();
     Ok((
         retained,
         Some(SystemPrompt::Blocks(vec![summary_block])),
@@ -1264,8 +1286,42 @@ async fn compact_messages_with_metadata(
     ))
 }
 
-fn compact_prompt(focus: Option<&str>) -> String {
+/// Delimiters around the operator's standing summarizer instructions. The
+/// summarizer sees a plain user message, so the section must announce itself:
+/// unfenced free text reads as more conversation to summarize.
+const OPERATOR_INSTRUCTIONS_HEADER: &str = "--- Additional instructions from the operator ---";
+const OPERATOR_INSTRUCTIONS_FOOTER: &str = "--- End of additional instructions ---";
+
+/// Render `[compaction] summary_instructions` as a delimited prompt suffix.
+///
+/// `None` (unset, or whitespace-only) produces no section at all, which is
+/// what keeps the default prompt byte-identical to the pre-#5956 constant.
+/// The cap is enforced here rather than at config load so the warning fires
+/// once per compaction pass instead of once per turn.
+fn operator_instructions_section(instructions: Option<&str>) -> Option<String> {
+    let text = instructions
+        .map(str::trim)
+        .filter(|text| !text.is_empty())?;
+    let max_chars = crate::config::COMPACTION_SUMMARY_INSTRUCTIONS_MAX_CHARS;
+    let text = if text.chars().count() > max_chars {
+        logging::warn(format!(
+            "[compaction] summary_instructions is longer than {max_chars} characters; \
+             the summarizer prompt suffix was truncated"
+        ));
+        truncate_chars(text, max_chars)
+    } else {
+        text
+    };
+    Some(format!(
+        "\n\n{OPERATOR_INSTRUCTIONS_HEADER}\n{text}\n{OPERATOR_INSTRUCTIONS_FOOTER}"
+    ))
+}
+
+fn compact_prompt(focus: Option<&str>, instructions: Option<&str>) -> String {
     let mut prompt = format!("{COMPACT_PROMPT} {COMPACTION_LANGUAGE_CONTRACT}");
+    if let Some(section) = operator_instructions_section(instructions) {
+        prompt.push_str(&section);
+    }
     if let Some(focus) = focus.map(str::trim).filter(|focus| !focus.is_empty()) {
         let _ = write!(
             prompt,
@@ -1275,13 +1331,16 @@ fn compact_prompt(focus: Option<&str>) -> String {
     prompt
 }
 
-fn compact_quality_retry_prompt(focus: Option<&str>) -> String {
+fn compact_quality_retry_prompt(focus: Option<&str>, instructions: Option<&str>) -> String {
     let mut prompt = format!(
         "The previous handoff response was empty or a placeholder. Return a substantive factual \
 continuation handoff. State the user objective, completed and current work, hard constraints, verified \
 evidence, unresolved failures, and the single next action. Do not refuse, call tools, discuss \
 checkpoint machinery, or return a placeholder. {COMPACTION_LANGUAGE_CONTRACT}"
     );
+    if let Some(section) = operator_instructions_section(instructions) {
+        prompt.push_str(&section);
+    }
     if let Some(focus) = focus.map(str::trim).filter(|focus| !focus.is_empty()) {
         let _ = write!(
             prompt,
@@ -1368,7 +1427,10 @@ async fn create_summary(
     request_messages.push(Message {
         role: Role::User,
         content: vec![ContentBlock::Text {
-            text: compact_prompt(config.focus.as_deref()),
+            text: compact_prompt(
+                config.focus.as_deref(),
+                config.summary_instructions.as_deref(),
+            ),
             cache_control: None,
         }],
     });
@@ -1473,7 +1535,10 @@ no replacement checkpoint was committed",
                 ));
             };
             instruction.content = vec![ContentBlock::Text {
-                text: compact_quality_retry_prompt(config.focus.as_deref()),
+                text: compact_quality_retry_prompt(
+                    config.focus.as_deref(),
+                    config.summary_instructions.as_deref(),
+                ),
                 cache_control: None,
             }];
             continue;

--- a/crates/tui/src/compaction/last_round.rs
+++ b/crates/tui/src/compaction/last_round.rs
@@ -9,9 +9,8 @@ use anyhow::Result;
 use crate::models::{ContentBlock, Message, SystemPrompt};
 
 use super::{
-    COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS, compaction_checkpoint_message,
-    is_compaction_checkpoint_message, retained_user_messages, truncate_retained_block,
-    user_text_of,
+    compaction_checkpoint_message, is_compaction_checkpoint_message, retained_user_messages,
+    truncate_retained_block, user_text_of,
 };
 
 const LAST_ROUND_TOOL_RESULT_MAX_CHARS: usize = 8 * 1024;
@@ -32,6 +31,13 @@ pub struct CompactionCoverage {
     pub last_round_assistant: bool,
     pub dropped_messages: usize,
     pub anchors_chars: usize,
+    /// Effective `[compaction] retained_user_message_tokens` budget this pass
+    /// spent on verbatim user messages (#5956). `0` on the prune-only path,
+    /// which never builds a replacement history.
+    pub retained_user_message_tokens: usize,
+    /// Whether `[compaction] summary_instructions` was appended to the
+    /// summarizer prompt on this pass (#5956).
+    pub operator_instructions_applied: bool,
 }
 
 impl CompactionCoverage {
@@ -52,6 +58,18 @@ impl CompactionCoverage {
         );
         if self.anchors_chars > 0 {
             clause.push_str(&format!("; anchors {} chars", self.anchors_chars));
+        }
+        // Name the tuning knobs so an operator who set them can tell they took
+        // effect without reading the log (#5956). The prune-only path builds no
+        // replacement history, so it reports no budget.
+        if self.retained_user_message_tokens > 0 {
+            clause.push_str(&format!(
+                "; verbatim user budget {} tokens",
+                self.retained_user_message_tokens
+            ));
+        }
+        if self.operator_instructions_applied {
+            clause.push_str("; operator instructions applied");
         }
         clause
     }
@@ -406,17 +424,25 @@ pub(super) fn measure_coverage(
             .any(|message| message.role.is_assistant_like()),
         dropped_messages: original.len().saturating_sub(replacement.len()),
         anchors_chars,
+        // Tuning provenance is owned by the caller that holds the
+        // `CompactionConfig`; measurement over two message lists cannot know it.
+        retained_user_message_tokens: 0,
+        operator_instructions_applied: false,
     }
 }
 
+/// Build the post-compaction history: recent plain user messages kept
+/// verbatim within `retained_user_message_tokens`, the bounded last round, and
+/// the checkpoint. The budget is `[compaction] retained_user_message_tokens`
+/// (#5956); it was a hard-coded 20 000 before that key existed.
 pub(super) fn build_replacement_history(
     messages: &[Message],
     checkpoint_text: &str,
     anchors: Option<&str>,
+    retained_user_message_tokens: usize,
 ) -> Result<Vec<Message>> {
     let (start, end) = last_round_range(messages);
-    let mut retained =
-        retained_user_messages(&messages[..start], COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS);
+    let mut retained = retained_user_messages(&messages[..start], retained_user_message_tokens);
     retained.extend(bound_last_round(&messages[start..end]));
     retained.push(compaction_checkpoint_message(&SystemPrompt::Text(
         checkpoint_text.to_string(),
@@ -626,8 +652,13 @@ mod tests {
         ];
         assert_eq!(last_round_start(&original), 0);
         let next = format!("{COMPACTION_SUMMARY_MARKER}: keep the failing test result");
-        let replaced = build_replacement_history(&original, &next, None)
-            .expect("toolless tails must not drop the last tool result");
+        let replaced = build_replacement_history(
+            &original,
+            &next,
+            None,
+            crate::compaction::COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS,
+        )
+        .expect("toolless tails must not drop the last tool result");
         assert!(replaced.iter().any(|message| {
             message.content.iter().any(|block| {
                 matches!(
@@ -716,8 +747,13 @@ mod tests {
         let next = format!(
             "{COMPACTION_SUMMARY_MARKER}: second handoff with User-pinned anchors (verbatim):\nship 0.9.12"
         );
-        let replaced = build_replacement_history(&first, &next, Some("ship 0.9.12"))
-            .expect("second compact must keep last round and one receipt");
+        let replaced = build_replacement_history(
+            &first,
+            &next,
+            Some("ship 0.9.12"),
+            crate::compaction::COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS,
+        )
+        .expect("second compact must keep last round and one receipt");
         let checkpoints = replaced
             .iter()
             .filter(|message| is_compaction_checkpoint_message(message))

--- a/crates/tui/src/compaction/tests.rs
+++ b/crates/tui/src/compaction/tests.rs
@@ -291,3 +291,152 @@ fn successor_floor_counts_retained_user_messages_not_tool_results() {
         &PreparedCompactionEnvelope::new(config),
     ));
 }
+
+/// #5956: with no `[compaction] summary_instructions` configured, the
+/// summarizer prompt must stay byte-identical to the pre-#5956 constant.
+#[test]
+fn compact_prompt_without_operator_instructions_is_unchanged() {
+    assert_eq!(
+        compact_prompt(None, None),
+        format!("{COMPACT_PROMPT} {COMPACTION_LANGUAGE_CONTRACT}")
+    );
+    // Whitespace-only is unset, not an empty section.
+    assert_eq!(
+        compact_prompt(None, Some("   \n ")),
+        compact_prompt(None, None)
+    );
+    // The one-off `/compact <focus>` line keeps its exact shape.
+    assert_eq!(
+        compact_prompt(Some("the flaky test"), None),
+        format!(
+            "{COMPACT_PROMPT} {COMPACTION_LANGUAGE_CONTRACT}\n\nThe user asked this compaction to focus on: the flaky test"
+        )
+    );
+}
+
+/// #5956: the operator suffix is a clearly delimited section, and a manual
+/// `/compact <focus>` still composes *after* it.
+#[test]
+fn compact_prompt_appends_operator_instructions_before_focus() {
+    let prompt = compact_prompt(
+        Some("the flaky test"),
+        Some("Always restate open decisions."),
+    );
+
+    assert!(prompt.starts_with(COMPACT_PROMPT));
+    assert!(prompt.contains(OPERATOR_INSTRUCTIONS_HEADER));
+    assert!(prompt.contains("Always restate open decisions."));
+    assert!(prompt.contains(OPERATOR_INSTRUCTIONS_FOOTER));
+
+    let instructions_at = prompt.find(OPERATOR_INSTRUCTIONS_HEADER).expect("section");
+    let focus_at = prompt.find("focus on: the flaky test").expect("focus");
+    assert!(
+        instructions_at < focus_at,
+        "the standing instructions come first; the one-off focus composes after them"
+    );
+
+    // The quality-retry prompt is the same summarizer call, so it carries the
+    // same standing instructions.
+    let retry = compact_quality_retry_prompt(None, Some("Always restate open decisions."));
+    assert!(retry.contains("Always restate open decisions."));
+    assert!(!compact_quality_retry_prompt(None, None).contains(OPERATOR_INSTRUCTIONS_HEADER));
+}
+
+/// #5956: an oversized standing instruction is truncated at the cap rather
+/// than failing the compaction pass that keeps the session alive.
+#[test]
+fn operator_instructions_are_truncated_at_the_cap() {
+    let max = crate::config::COMPACTION_SUMMARY_INSTRUCTIONS_MAX_CHARS;
+    let long = "é".repeat(max + 500);
+    let section = operator_instructions_section(Some(&long)).expect("section is present");
+
+    let body = section
+        .trim_start_matches('\n')
+        .trim_start_matches(OPERATOR_INSTRUCTIONS_HEADER)
+        .trim_start_matches('\n')
+        .trim_end_matches(OPERATOR_INSTRUCTIONS_FOOTER)
+        .trim_end_matches('\n');
+    assert_eq!(body.chars().count(), max);
+    assert!(operator_instructions_section(None).is_none());
+    assert!(operator_instructions_section(Some("  ")).is_none());
+}
+
+/// #5956: the replacement history spends the configured verbatim budget, so a
+/// larger budget keeps more of the user's own earlier messages.
+#[test]
+fn replacement_history_honours_the_configured_retention_budget() {
+    let user = |text: &str| Message {
+        role: Role::User,
+        content: vec![ContentBlock::Text {
+            text: text.to_string(),
+            cache_control: None,
+        }],
+    };
+    let assistant = |text: &str| Message {
+        role: Role::Assistant,
+        content: vec![ContentBlock::Text {
+            text: text.to_string(),
+            cache_control: None,
+        }],
+    };
+
+    // Each older user message is ~1 000 conservative tokens (3 chars/token).
+    let mut messages = Vec::new();
+    for idx in 0..10 {
+        messages.push(user(&format!("{idx}{}", "a".repeat(3_000))));
+        messages.push(assistant("ack"));
+    }
+    messages.push(user("the live request"));
+    messages.push(assistant("working on it"));
+
+    let checkpoint = format!("{COMPACTION_SUMMARY_MARKER} and produced this handoff.");
+    let count_verbatim = |budget: usize| {
+        last_round::build_replacement_history(&messages, &checkpoint, None, budget)
+            .expect("replacement history")
+            .len()
+    };
+
+    let small = count_verbatim(2_000);
+    let large = count_verbatim(20_000);
+    assert!(
+        large > small,
+        "a larger budget must keep more user messages verbatim ({small} vs {large})"
+    );
+    // The floor still keeps the last round plus the checkpoint.
+    assert!(
+        small >= 3,
+        "the bounded last round and checkpoint always survive"
+    );
+}
+
+/// #5956: the receipt clause names the effective budget and whether standing
+/// operator instructions were applied, so the knob is verifiable without logs.
+#[test]
+fn receipt_clause_reports_the_effective_compaction_tuning() {
+    let mut coverage = CompactionCoverage {
+        path: CompactionPath::Summary,
+        last_round_messages: 2,
+        last_round_tool_results: 0,
+        last_round_assistant: true,
+        dropped_messages: 8,
+        anchors_chars: 0,
+        retained_user_message_tokens: 60_000,
+        operator_instructions_applied: true,
+    };
+    let clause = coverage.receipt_clause();
+    assert!(
+        clause.contains("verbatim user budget 60000 tokens"),
+        "{clause}"
+    );
+    assert!(clause.contains("operator instructions applied"), "{clause}");
+
+    coverage.operator_instructions_applied = false;
+    assert!(!coverage.receipt_clause().contains("operator instructions"));
+
+    // The prune-only path builds no replacement history, so it reports no budget.
+    let prune_only = CompactionCoverage {
+        path: CompactionPath::PruneOnly,
+        ..CompactionCoverage::default()
+    };
+    assert!(!prune_only.receipt_clause().contains("verbatim user budget"));
+}

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2638,6 +2638,46 @@ pub struct ContextConfig {
     pub seam_model: Option<String>,
 }
 
+/// Maximum characters of `[compaction] summary_instructions` that are
+/// appended to the summarizer prompt. Longer values are truncated (with a
+/// warning) rather than rejected: a long standing instruction should not fail
+/// the compaction pass that keeps the session alive.
+pub const COMPACTION_SUMMARY_INSTRUCTIONS_MAX_CHARS: usize = 4_000;
+/// Default verbatim retention budget for recent plain user messages in the
+/// compaction replacement history (Codex parity). Unset config keeps this.
+pub const DEFAULT_COMPACTION_RETAINED_USER_MESSAGE_TOKENS: usize = 20_000;
+/// Lower clamp: below this the replacement history stops carrying a usable
+/// amount of the user's own words.
+pub const MIN_COMPACTION_RETAINED_USER_MESSAGE_TOKENS: usize = 2_000;
+/// Upper clamp: above this the "compacted" history is large enough to
+/// re-trigger compaction on the next turn.
+pub const MAX_COMPACTION_RETAINED_USER_MESSAGE_TOKENS: usize = 200_000;
+
+/// Compaction summarizer tuning (`[compaction]`, #5956).
+///
+/// `auto_compact` / `auto_compact_threshold_percent` (settings.toml) decide
+/// *when* compaction runs; these two keys decide *how* the pass behaves. Both
+/// are absent by default and absent means today's built-in behavior, byte for
+/// byte.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct CompactionSettings {
+    /// Standing operator instructions appended to the built-in summarizer
+    /// prompt on every pass, manual and automatic — the effort-free
+    /// counterpart to a one-off `/compact <focus>`, which still composes
+    /// after this text. Empty or whitespace-only is treated as unset;
+    /// longer than [`COMPACTION_SUMMARY_INSTRUCTIONS_MAX_CHARS`] is
+    /// truncated where it is applied.
+    #[serde(default)]
+    pub summary_instructions: Option<String>,
+    /// Token budget for the recent plain user messages kept verbatim in the
+    /// replacement history. Clamped to
+    /// [`MIN_COMPACTION_RETAINED_USER_MESSAGE_TOKENS`]..=
+    /// [`MAX_COMPACTION_RETAINED_USER_MESSAGE_TOKENS`]; unset keeps
+    /// [`DEFAULT_COMPACTION_RETAINED_USER_MESSAGE_TOKENS`].
+    #[serde(default, alias = "retained_user_message_max_tokens")]
+    pub retained_user_message_tokens: Option<usize>,
+}
+
 /// Fleet-role model overrides for delegated workers. Canonical keys in
 /// `models` are `worker`, `scout`, `planner`, `reviewer`, `builder`,
 /// `verifier`, and `custom`. Legacy sub-agent type names remain accepted for
@@ -3258,6 +3298,11 @@ pub struct Config {
     /// parsed but ignored since the 2026-07-23 removal).
     #[serde(default)]
     pub context: ContextConfig,
+
+    /// Compaction summarizer tuning (#5956). Absent keeps the built-in
+    /// summarizer prompt and the 20 000-token verbatim retention budget.
+    #[serde(default)]
+    pub compaction: Option<CompactionSettings>,
 
     /// Agent Fleet trust/security/role/exec config.
     #[serde(default)]
@@ -7311,6 +7356,55 @@ impl Config {
         self.prompt_suggestion.unwrap_or(false)
     }
 
+    /// Standing operator instructions for the compaction summarizer
+    /// (`[compaction] summary_instructions`, #5956).
+    ///
+    /// Trimmed; empty or whitespace-only reads as unset so an accidentally
+    /// blank key cannot append an empty delimited section to every prompt.
+    /// The character cap is applied where the suffix is built, so the warning
+    /// fires once per compaction pass rather than once per turn.
+    #[must_use]
+    pub fn compaction_summary_instructions(&self) -> Option<String> {
+        self.compaction
+            .as_ref()
+            .and_then(|compaction| compaction.summary_instructions.as_deref())
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(str::to_string)
+    }
+
+    /// Verbatim retention budget for recent plain user messages in the
+    /// compaction replacement history (`[compaction]
+    /// retained_user_message_tokens`, #5956).
+    ///
+    /// Unset returns the historical hard-coded 20 000. Explicit values clamp
+    /// to `2_000..=200_000`: below the floor the replacement history stops
+    /// carrying a usable amount of the user's own words, above the ceiling
+    /// the "compacted" history is large enough to re-trigger compaction on
+    /// the next turn.
+    #[must_use]
+    pub fn compaction_retained_user_message_tokens(&self) -> usize {
+        let Some(requested) = self
+            .compaction
+            .as_ref()
+            .and_then(|compaction| compaction.retained_user_message_tokens)
+        else {
+            return DEFAULT_COMPACTION_RETAINED_USER_MESSAGE_TOKENS;
+        };
+        let clamped = requested.clamp(
+            MIN_COMPACTION_RETAINED_USER_MESSAGE_TOKENS,
+            MAX_COMPACTION_RETAINED_USER_MESSAGE_TOKENS,
+        );
+        if clamped != requested {
+            tracing::warn!(
+                "[compaction] retained_user_message_tokens = {requested} is outside {}..={}; using {clamped}",
+                MIN_COMPACTION_RETAINED_USER_MESSAGE_TOKENS,
+                MAX_COMPACTION_RETAINED_USER_MESSAGE_TOKENS
+            );
+        }
+        clamped
+    }
+
     /// Return the maximum number of concurrent sub-agents.
     /// Checks `[subagents] max_concurrent` first, then top-level `max_subagents`,
     /// then falls back to `DEFAULT_MAX_SUBAGENTS`.
@@ -10612,6 +10706,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
                 .or(base.context.l3_threshold),
             seam_model: override_cfg.context.seam_model.or(base.context.seam_model),
         },
+        compaction: override_cfg.compaction.or(base.compaction),
         fleet: override_cfg.fleet.or(base.fleet),
         workflow: override_cfg.workflow.or(base.workflow),
         subagents: override_cfg.subagents.or(base.subagents),

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -13623,3 +13623,63 @@ fn picker_and_request_path_disagree_when_the_secret_slot_marker_is_missing() -> 
     println!("CAPTURED first-fix: {:?}", resolution.first_fix());
     Ok(())
 }
+
+/// #5956: `[compaction]` is absent by default, and absent must mean the
+/// historical hard-coded 20 000-token verbatim retention budget with no
+/// operator prompt suffix.
+#[test]
+fn compaction_tuning_defaults_to_todays_behavior() {
+    let config = Config::default();
+    assert_eq!(
+        config.compaction_retained_user_message_tokens(),
+        DEFAULT_COMPACTION_RETAINED_USER_MESSAGE_TOKENS
+    );
+    assert_eq!(config.compaction_retained_user_message_tokens(), 20_000);
+    assert_eq!(config.compaction_summary_instructions(), None);
+}
+
+/// #5956: an explicit budget is honored inside the clamp and pulled back to
+/// the nearest bound outside it, so neither a useless floor nor a
+/// re-triggering ceiling can be configured.
+#[test]
+fn compaction_retained_user_message_tokens_clamps_to_the_documented_range() {
+    let parse = |body: &str| toml::from_str::<Config>(body).expect("config parses");
+
+    let in_range = parse("[compaction]\nretained_user_message_tokens = 60000\n");
+    assert_eq!(in_range.compaction_retained_user_message_tokens(), 60_000);
+
+    let too_small = parse("[compaction]\nretained_user_message_tokens = 1\n");
+    assert_eq!(
+        too_small.compaction_retained_user_message_tokens(),
+        MIN_COMPACTION_RETAINED_USER_MESSAGE_TOKENS
+    );
+
+    let too_large = parse("[compaction]\nretained_user_message_tokens = 9000000\n");
+    assert_eq!(
+        too_large.compaction_retained_user_message_tokens(),
+        MAX_COMPACTION_RETAINED_USER_MESSAGE_TOKENS
+    );
+
+    // The pre-#5956 issue text spelled the key `retained_user_message_max_tokens`;
+    // it stays accepted as an alias so early adopters' files keep working.
+    let alias = parse("[compaction]\nretained_user_message_max_tokens = 40000\n");
+    assert_eq!(alias.compaction_retained_user_message_tokens(), 40_000);
+}
+
+/// #5956: a blank or whitespace-only key must read as unset, not as an empty
+/// delimited section appended to every summarizer prompt.
+#[test]
+fn compaction_summary_instructions_trims_and_treats_blank_as_unset() {
+    let configured: Config = toml::from_str(
+        "[compaction]\nsummary_instructions = \"  Always list exact file:line.  \"\n",
+    )
+    .expect("config parses");
+    assert_eq!(
+        configured.compaction_summary_instructions().as_deref(),
+        Some("Always list exact file:line.")
+    );
+
+    let blank: Config = toml::from_str("[compaction]\nsummary_instructions = \"   \\n \"\n")
+        .expect("config parses");
+    assert_eq!(blank.compaction_summary_instructions(), None);
+}

--- a/crates/tui/src/exec_agent.rs
+++ b/crates/tui/src/exec_agent.rs
@@ -155,6 +155,8 @@ pub(crate) async fn run_exec_agent(
             active_route_limits,
             settings.auto_compact_threshold_percent,
         ),
+        summary_instructions: execution_config.compaction_summary_instructions(),
+        retained_user_message_tokens: execution_config.compaction_retained_user_message_tokens(),
         ..Default::default()
     };
 

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2918,6 +2918,7 @@ fn resolve_runtime_thread_route_for_identity(
 }
 
 fn runtime_compaction_config(
+    config: &Config,
     provider: ApiProvider,
     model: &str,
     route_limits: Option<codewhale_config::route::RouteLimits>,
@@ -2939,6 +2940,8 @@ fn runtime_compaction_config(
             threshold_percent,
         ),
         effective_context_window: Some(route_context_window_tokens(provider, model, route_limits)),
+        summary_instructions: config.compaction_summary_instructions(),
+        retained_user_message_tokens: config.compaction_retained_user_message_tokens(),
         ..Default::default()
     }
 }
@@ -3390,6 +3393,7 @@ impl RuntimeThreadManager {
             let provider = route.identity.provider;
             let route_limits = known_route_limits(route.candidate.limits());
             let mut engine_compaction = runtime_compaction_config(
+                &route.config,
                 provider,
                 &route.model,
                 route_limits,
@@ -7250,6 +7254,7 @@ impl RuntimeThreadManager {
         let route_limits = known_route_limits(route.candidate.limits());
         let settings = crate::settings::Settings::load().unwrap_or_default();
         let mut compaction = runtime_compaction_config(
+            &route.config,
             provider,
             &model,
             route_limits,
@@ -7663,6 +7668,7 @@ impl RuntimeThreadManager {
         let route_limits = known_route_limits(route.candidate.limits());
         let settings = crate::settings::Settings::load().unwrap_or_default();
         let mut compaction = runtime_compaction_config(
+            &route.config,
             route_provider,
             &route_model,
             route_limits,
@@ -7915,6 +7921,7 @@ impl RuntimeThreadManager {
             // user persisted an explicit preference.
             let settings = crate::settings::Settings::load().unwrap_or_default();
             let compaction = runtime_compaction_config(
+                &cfg,
                 provider,
                 &route_model,
                 route_limits,

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -625,6 +625,7 @@ fn runtime_compaction_uses_provider_route_context() {
         output_tokens: None,
     };
     let config = runtime_compaction_config(
+        &Config::default(),
         ApiProvider::OpenaiCodex,
         "gpt-5.5",
         Some(limits),

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1712,6 +1712,13 @@ pub struct App {
     pub auto_compact: bool,
     pub auto_compact_user_configured: bool,
     pub auto_compact_threshold_percent: f64,
+    /// `[compaction] summary_instructions` resolved at startup (#5956): the
+    /// standing operator suffix appended to every summarizer prompt, manual
+    /// and automatic.
+    pub compaction_summary_instructions: Option<String>,
+    /// `[compaction] retained_user_message_tokens` resolved and clamped at
+    /// startup (#5956).
+    pub compaction_retained_user_message_tokens: usize,
     pub stopped_turn: bool,
     pub calm_mode: bool,
     pub low_motion: bool,
@@ -6367,6 +6374,8 @@ impl App {
                 model,
                 route_limits,
             )),
+            summary_instructions: self.compaction_summary_instructions.clone(),
+            retained_user_message_tokens: self.compaction_retained_user_message_tokens,
             ..Default::default()
         }
     }

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -262,6 +262,9 @@ impl App {
         let settings_auto_compact = settings.auto_compact;
         let auto_compact_user_configured = Settings::auto_compact_explicitly_configured();
         let auto_compact_threshold_percent = settings.auto_compact_threshold_percent;
+        let compaction_summary_instructions = config.compaction_summary_instructions();
+        let compaction_retained_user_message_tokens =
+            config.compaction_retained_user_message_tokens();
         let calm_mode = settings.calm_mode;
         let low_motion = settings.low_motion;
         let constrained_frame_rate = settings.constrained_frame_rate;
@@ -858,6 +861,8 @@ impl App {
             auto_compact,
             auto_compact_user_configured,
             auto_compact_threshold_percent,
+            compaction_summary_instructions,
+            compaction_retained_user_message_tokens,
             stopped_turn: false,
             calm_mode,
             low_motion,

--- a/crates/tui/src/tui/context_inspector.rs
+++ b/crates/tui/src/tui/context_inspector.rs
@@ -1459,6 +1459,8 @@ mod tests {
                 last_round_assistant: true,
                 dropped_messages: 12,
                 anchors_chars: 0,
+                retained_user_message_tokens: 20_000,
+                operator_instructions_applied: false,
             },
             messages_before: 16,
             messages_after: 4,

--- a/crates/tui/src/tui/ui/compaction_flow.rs
+++ b/crates/tui/src/tui/ui/compaction_flow.rs
@@ -316,6 +316,18 @@ pub(crate) fn apply_compaction_completed(
                 anchors_chars: crate::compaction::pinned_anchors_text(Some(&app.workspace))
                     .map(|text| text.chars().count())
                     .unwrap_or(0),
+                // Only the summary path builds a replacement history, so only
+                // it spent a verbatim budget (#5956).
+                retained_user_message_tokens: match path {
+                    crate::compaction::CompactionPath::Summary => {
+                        app.compaction_retained_user_message_tokens
+                    }
+                    crate::compaction::CompactionPath::PruneOnly => 0,
+                },
+                operator_instructions_applied: matches!(
+                    path,
+                    crate::compaction::CompactionPath::Summary
+                ) && app.compaction_summary_instructions.is_some(),
             },
             messages_before: before,
             messages_after: after,
@@ -549,6 +561,9 @@ mod config_update_tests {
             runtime_cost_owner: None,
             workspace: None,
             image_input: crate::model_profile::SupportState::Unknown,
+            summary_instructions: None,
+            retained_user_message_tokens:
+                crate::config::DEFAULT_COMPACTION_RETAINED_USER_MESSAGE_TOKENS,
         };
 
         assert!(try_apply_model_and_compaction_update(

--- a/crates/tui/src/turn_route_plan.rs
+++ b/crates/tui/src/turn_route_plan.rs
@@ -215,6 +215,10 @@ pub(crate) async fn plan_turn_route(
             &turn_route.model,
             turn_route_limits,
         )),
+        summary_instructions: request.route_config.compaction_summary_instructions(),
+        retained_user_message_tokens: request
+            .route_config
+            .compaction_retained_user_message_tokens(),
         ..Default::default()
     };
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -852,6 +852,10 @@ window it cannot justify — it falls back to a conservative value, labels it
   absolute compaction point along with it.
 - `auto_compact` (settings.toml, on/off): turns automatic compaction off
   entirely; `/compact` and Ctrl+L stay available.
+- `[compaction] summary_instructions` and
+  `[compaction] retained_user_message_tokens` (config.toml): standing
+  summarizer instructions and the verbatim user-message retention budget. See
+  the `compaction.*` entry in the config-key reference below.
 - `CODEWHALE_MAX_OUTPUT_TOKENS` (environment variable; legacy alias
   `DEEPSEEK_MAX_OUTPUT_TOKENS`): overrides the requested output cap. Without an
   override, Codewhale starts at the safe `65536` request cap and intersects it
@@ -2184,6 +2188,28 @@ reasoning contract, and all four membership ids omit generic sampling fields.
   - The former seam-manager keys (`verbatim_window_turns`, `l1_threshold`,
     `l2_threshold`, `l3_threshold`, `seam_model`) are **ignored** — parsed
     for backward compatibility but read nowhere since 2026-07-23.
+- `compaction.*` (optional, config.toml): how a compaction pass behaves once
+  it fires. `auto_compact` / `auto_compact_threshold_percent` (settings.toml)
+  still decide *when* it fires. Both keys are absent by default, and absent
+  means the built-in behaviour, unchanged:
+  - `[compaction].summary_instructions` (string, default empty): standing
+    operator instructions appended to the summarizer prompt as a clearly
+    delimited "Additional instructions from the operator" section on **every**
+    pass, manual and automatic — the effort-free counterpart to a one-off
+    `/compact <focus>`, which still composes after this text. Useful for
+    "always list exact file paths and line numbers", "always restate open
+    decisions and their trade-offs", "always write a TL;DR first". Truncated
+    at 4 000 characters with a warning naming the key; whitespace-only reads
+    as unset. The summarizer still runs with no system prompt and no tools —
+    this suffix is the only operator-authored input it sees.
+  - `[compaction].retained_user_message_tokens` (int, default `20000`, clamped
+    to `2000`–`200000`; also accepted as `retained_user_message_max_tokens`):
+    token budget for the recent plain user messages kept **verbatim** in the
+    replacement history. Raising it keeps more of the user's own earlier
+    messages instead of only whatever the lossy summary captured; the
+    last-round survival contract still applies on top. The `/compact` receipt
+    names the effective budget and whether operator instructions were applied,
+    so you can tell the knob took effect.
 - `retry.*` (optional): retry/backoff settings for API requests:
   - `[retry].enabled` (bool, default `true`)
   - `[retry].max_retries` (int, default `3`)


### PR DESCRIPTION
Closes #5956

Implements Options **A** (custom instructions suffix for the summarizer prompt) and **B** (configurable verbatim retention) from the issue. C and D are not in scope here.

## What changed

Two standing knobs in `config.toml`, declared next to the existing `[context]` table:

### `[compaction] summary_instructions` (string, default empty)

Appended to `COMPACT_PROMPT` as a clearly delimited section on **every** pass — manual `/compact` and automatic:

```
--- Additional instructions from the operator ---
Always list exact file paths and line numbers. Always restate open decisions.
--- End of additional instructions ---
```

- `/compact <focus>` keeps working and composes **after** the operator section, so the standing instruction is the baseline and the one-off focus is the emphasis on top.
- Whitespace-only reads as unset, so a blank key cannot append an empty section to every prompt.
- Capped at 4 000 characters with a `WARN` naming `[compaction] summary_instructions`. Truncation, not rejection: a long standing instruction must not fail the compaction pass that keeps the session alive. The cap is applied where the suffix is built, so the warning fires once per compaction pass rather than once per turn.
- The suffix also rides the quality-retry prompt, which is the same summarizer call.

### `[compaction] retained_user_message_tokens` (int, default `20000`, clamped `2000..=200000`)

Replaces the hard-coded `COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS` budget in `build_replacement_history` (and in the matching successor-floor estimate, which has to agree with it or the floor lies). Alias `retained_user_message_max_tokens` is accepted — that is the spelling the issue text used.

`COMPACT_RETAINED_USER_MESSAGE_MAX_TOKENS` is now an alias of the config default rather than a second literal `20_000`, so the two names cannot drift.

### Receipt

The `/compact` coverage clause now names the effective budget and whether operator instructions were applied, so an operator can tell the knob took effect without reading the log:

```
Compaction complete: 96 → 12 messages (84 removed), ~412000 → ~38000 tokens
(summary; last round kept: 4 messages (1 tool results, assistant);
 verbatim user budget 60000 tokens; operator instructions applied)
```

The prune-only path builds no replacement history, so it reports no budget.

## Safety

- The summarizer call still goes out with `system: None` and `tools: None`. The operator suffix is the only new input it sees — no system prompt, no `AGENTS.md`, no tools.
- The survival/coverage contract is untouched: a replacement that would drop the last round or the protected user messages still fails closed.
- Defaults are absent, and absent means today's behavior. With no `[compaction]` table the prompt is byte-identical to the pre-#5956 constant and the budget is still 20 000 — there is a test asserting exactly that.

Wired at every `CompactionConfig` construction site that owns a `Config`: interactive TUI (`app.rs` / `app/init.rs`), per-turn auto route (`turn_route_plan.rs`), `exec` (`exec_agent.rs`), and the runtime-thread daemon (`runtime_threads.rs`).

## Tests

Local, macOS:

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo check -p codewhale-tui` | clean |
| `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib -- compaction config::tests` | **558 passed; 0 failed; 0 ignored; 11258 filtered out** |
| `RUST_MIN_STACK=16777216 cargo test -p codewhale-tui --lib` (whole crate) | **11803 passed; 0 failed; 13 ignored** |

Eight new tests (5 compaction, 3 config):

- default prompt is byte-identical with no instructions configured, including the exact `/compact <focus>` line
- the suffix appears, is delimited, and the focus composes after it (and rides the quality-retry prompt)
- the suffix is truncated at the 4 000-character cap, on a multi-byte fixture
- a larger retention budget keeps more user messages verbatim, and the bounded last round plus checkpoint survive at the floor
- the receipt clause names the budget and the operator-instructions state
- config: defaults are 20 000 / `None`; clamping below, above, and inside the range plus the legacy alias; instructions are trimmed and blank reads as unset

One unrelated pre-existing flake, `remote_control::tests::classic_terminal_cursor_repairs_failed_canonical_clear_before_compaction`, failed once under parallel load and passed on five subsequent runs including the full-crate run above.

Docs: `docs/CONFIGURATION.md` gains a `compaction.*` reference entry and a cross-reference from the "Adjacent knobs" compaction section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XYyJaw9Mh9uSrqQBoqhm

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compaction summarizer prompts and post-compact history shape, which affects long-session continuity; defaults preserve prior behavior when `[compaction]` is absent.
> 
> **Overview**
> Adds optional **`[compaction]`** settings in `config.toml` so operators can tune summarization without changing when auto-compaction fires.
> 
> **`summary_instructions`** is appended to the handoff summarizer prompt (manual and automatic) as a delimited “Additional instructions from the operator” block, composed before any `/compact <focus>` line and included on the quality-retry prompt. Unset or whitespace-only leaves the default prompt unchanged; longer text is truncated at 4,000 characters with a warning.
> 
> **`retained_user_message_tokens`** (default 20,000, clamped 2,000–200,000; alias `retained_user_message_max_tokens`) replaces the hard-coded verbatim user-message budget in replacement history and in the retained-floor estimate. Values flow through `CompactionConfig` from TUI, runtime threads, exec, and turn routing.
> 
> Compaction receipts now report the effective verbatim budget and whether operator instructions were applied. `docs/CONFIGURATION.md` documents the new keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df9eacb190fe345e77dfc165292250f24e3ccb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->