### PR TITLE
feat(build): opt-in rusty_alloc global allocator feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The `rusty-alloc` cargo feature on `codewhale-tui` and `codewhale-cli`
+  opts the binaries into the `rusty_alloc` global allocator (the mimalloc
+  v2.4.5 architecture remade in pure Rust — no C compiler or build script
+  on that path) instead of the default mimalloc. It is off by default and
+  the default build is unchanged; build with
+  `cargo build -p codewhale-tui --features rusty-alloc` (#5872).
 - The `/theme` picker now discovers valid user-authored `custom:<name>`
   overlays, previews their colors, highlights the active overlay, and preserves
   it when the picker is opened and committed without navigation (#5901).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "mimalloc",
  "reqwest 0.13.4",
  "rustls",
+ "rusty_alloc-api",
  "semver",
  "serde",
  "serde_json",
@@ -1106,6 +1107,7 @@ dependencies = [
  "rusqlite",
  "rust-i18n",
  "rustls",
+ "rusty_alloc-api",
  "schemars",
  "semver",
  "serde",
@@ -4695,6 +4697,25 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty_alloc"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c93620fee9935a120a50df2086fe48fa072f7d391f129a5e04bf20ea9b83097d"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rusty_alloc-api"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ce52d7f72842a590e4588013d70ea02d27edbf6b6af9bc193f6e1ac173845a"
+dependencies = [
+ "rusty_alloc",
+]
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,12 @@ tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uuid = { version = "1.11", features = ["v4"] }
 mimalloc = { version = "0.1", default-features = false }
+# Off-by-default alternative to mimalloc behind the `rusty-alloc` feature in
+# codewhale-tui / codewhale-cli (#5872): the pure-Rust mimalloc v2.4.5
+# remake — no C compiler, no build script on that path. `rusty_alloc-api` is
+# the crate's documented surface; it pulls the `rusty_alloc` core transitively
+# at the same version.
+rusty_alloc-api = "1.1.6"
 
 # The everyday `--release` gate (AGENTS.md pre-push build): optimized but
 # fast to produce. Shipping artifacts use `--profile dist` below — fat LTO on

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,6 +10,13 @@ description = "Agentic terminal facade for open-source and open-weight coding mo
 [lints]
 workspace = true
 
+[features]
+# Opt-in global-allocator swap (#5872): build on rusty_alloc (the pure-Rust
+# mimalloc v2.4.5 remake — no C compiler, no build script) instead of the
+# default mimalloc. Off by default; the default build is unchanged.
+# Build with: cargo build -p codewhale-cli --features rusty-alloc
+rusty-alloc = ["dep:rusty_alloc-api"]
+
 [[bin]]
 name = "codewhale"
 path = "src/main.rs"
@@ -42,6 +49,7 @@ rustls.workspace = true
 semver.workspace = true
 tokio.workspace = true
 mimalloc.workspace = true
+rusty_alloc-api = { workspace = true, optional = true }
 sha2.workspace = true
 tempfile.workspace = true
 tracing.workspace = true

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,13 @@
+// Default allocator: mimalloc. `--features rusty-alloc` swaps it for
+// rusty_alloc (pure-Rust mimalloc v2.4.5 remake, #5872); the default build
+// is unchanged.
+#[cfg(not(feature = "rusty-alloc"))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(feature = "rusty-alloc")]
+#[global_allocator]
+static GLOBAL: rusty_alloc_api::RustyAlloc = rusty_alloc_api::RustyAlloc;
 
 fn main() -> std::process::ExitCode {
     // Reset SIGPIPE to SIG_DFL so piping codewhale output into a command that

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The `rusty-alloc` cargo feature on `codewhale-tui` and `codewhale-cli`
+  opts the binaries into the `rusty_alloc` global allocator (the mimalloc
+  v2.4.5 architecture remade in pure Rust — no C compiler or build script
+  on that path) instead of the default mimalloc. It is off by default and
+  the default build is unchanged; build with
+  `cargo build -p codewhale-tui --features rusty-alloc` (#5872).
 - The `/theme` picker now discovers valid user-authored `custom:<name>`
   overlays, previews their colors, highlights the active overlay, and preserves
   it when the picker is opened and committed without navigation (#5901).

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -14,6 +14,11 @@ workspace = true
 [features]
 default = []
 long-running-tests = []
+# Opt-in global-allocator swap (#5872): build on rusty_alloc (the pure-Rust
+# mimalloc v2.4.5 remake — no C compiler, no build script) instead of the
+# default mimalloc. Off by default; the default build is unchanged.
+# Build with: cargo build -p codewhale-tui --features rusty-alloc
+rusty-alloc = ["dep:rusty_alloc-api"]
 
 [lib]
 name = "codewhale_tui"
@@ -104,6 +109,7 @@ semver.workspace = true
 rust-i18n = "4.1.0"
 shell-words = "1.1.1"
 mimalloc.workspace = true
+rusty_alloc-api = { workspace = true, optional = true }
 
 [build-dependencies]
 codewhale-build-support = { path = "../build-support", version = "0.9.12" }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1,5 +1,13 @@
+// Default allocator: mimalloc. `--features rusty-alloc` swaps it for
+// rusty_alloc (pure-Rust mimalloc v2.4.5 remake, #5872); the default build
+// is unchanged.
+#[cfg(not(feature = "rusty-alloc"))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(feature = "rusty-alloc")]
+#[global_allocator]
+static GLOBAL: rusty_alloc_api::RustyAlloc = rusty_alloc_api::RustyAlloc;
 
 fn main() -> std::process::ExitCode {
     codewhale_tui::run(std::env::args().collect())

--- a/docs/BUILD_PERFORMANCE.md
+++ b/docs/BUILD_PERFORMANCE.md
@@ -33,7 +33,9 @@ Structural facts behind those numbers:
   no default features). `cargo tree -d` shows only routine duplicates
   (`toml` 0.8/1.1, `thiserror` 1/2, `strum` 0.27/0.28, `syn` 2/3,
   `sha2` 0.10/0.11) that come from third-party crates, not from workspace
-  choices.
+  choices. The global allocator is mimalloc by default; the off-by-default
+  `rusty-alloc` cargo feature on `codewhale-tui`/`codewhale-cli` swaps it for
+  the pure-Rust `rusty_alloc` remake (no C toolchain on that path, #5872).
 - `[profile.dev] debug = "line-tables-only"` is already set (#5246) and
   Cargo already uses `split-debuginfo = unpacked` on macOS.
 - `target/debug` grows past 50 GB only through accumulation across

--- a/web/lib/changelog.generated.ts
+++ b/web/lib/changelog.generated.ts
@@ -47,6 +47,7 @@ export const CHANGELOG: ChangelogRelease[] = [
       {
         "heading": "Added",
         "items": [
+          "The rusty-alloc cargo feature on codewhale-tui and codewhale-cli opts the binaries into the rusty_alloc global allocator (the mimalloc v2.4.5 architecture remade in pure Rust — no C compiler or build script on that path) instead of the default mimalloc. It is off by default and the default build is unchanged; build with cargo build -p codewhale-tui --features rusty-alloc (#5872).",
           "The /theme picker now discovers valid user-authored custom:<name> overlays, previews their colors, highlights the active overlay, and preserves it when the picker is opened and committed without navigation (#5901).",
           "Compaction has two standing knobs next to [context] in config.toml: [compaction] summary_instructions (appended to the summarizer prompt on every manual and automatic pass; /compact <focus> still composes after it) and [compaction] retained_user_message_tokens (default 20 000, clamped 2 000..=200 000) for the verbatim user-message budget. Both are absent by default and absent means the pre-existing behavior. The /compact receipt names the effective budget and whether…",
           "[tools] user_input_max_questions (default 6, 1..=10) and [tools] user_input_max_options (default 4, 2..=10) replace the hard-coded request_user_input limits; the validator, the tool schema and its description read one value, spawned children inherit the parent's ceilings, and a rejected payload names the ceiling it hit and the key to raise (#5949).",
@@ -57,10 +58,9 @@ export const CHANGELOG: ChangelogRelease[] = [
           "codewhale account api-keys create --scope now accepts models:infer alongside account:read and agent:run, and an omitted --scope sends all three explicitly. --use saves the new secret as this machine's local codewhale provider credential in the same secret store codewhale auth uses; nothing is uploaded.",
           "sandbox_backend = \"shannon\": shell commands run as signed ShannonNet capability invocations (cap://sandbox/exec) on a worker that may live on another tailnet node. Codewhale opens a Task World per session for its durable codewhale Agent and every command leaves a receipt in shannon trace. New keys sandbox_shannon_home and sandbox_shannon_capability; tool metadata now reports the actual external backend kind instead of always opensandbox.",
           "/shannon [world|trace|children] inspects the session's ShannonNet World: agent, projected capabilities, children, and receipts.",
-          "ShannonNet sub-agents get compiled context: the session's native-memory hits are imported with provenance and the child's projected World decides what it sees (confidential notes never cross); the session World is checkpointed and closed when the backend drops.",
-          "Sub-agents under delegated authority: with the ShannonNet backend the agent tool spawns a child identity with a World projected from the session World, the child's shell commands are signed as that child, and a join receipt is recorded when it finishes. SandboxBackend::for_child / child_joined default to sharing the parent backend for other backends."
+          "ShannonNet sub-agents get compiled context: the session's native-memory hits are imported with provenance and the child's projected World decides what it sees (confidential notes never cross); the session World is checkpointed and closed when the backend drops."
         ],
-        "itemCount": 13
+        "itemCount": 14
       }
     ]
   },


### PR DESCRIPTION
Closes #5872

## What

Adds `rusty_alloc` (the pure-Rust mimalloc v2.4.5 remake — no C compiler,
no build script on that path) as an **off-by-default** alternative global
allocator next to the existing mimalloc default, exactly as the issue asks.

- Workspace pins `rusty_alloc-api = "1.1.6"`. The issue's sketch pinned
  `rusty_alloc` but used `rusty_alloc_api::RustyAlloc` — the `GlobalAlloc`
  impl actually lives in the `rusty_alloc-api` crate (the project's
  documented "start here" surface), so that is the dependency; it pulls the
  `rusty_alloc` 1.1.6 core transitively at the same version. Verified on
  crates.io: both crates at 1.1.6, MIT, no further transitive deps.
- `rusty-alloc = ["dep:rusty_alloc-api"]` feature added to `codewhale-tui`
  and `codewhale-cli` — the two crates whose `src/main.rs` owns the
  `#[global_allocator]` static.
- Behind the feature the static maps to
  `rusty_alloc_api::RustyAlloc` (the README quick start); without it the
  mimalloc static compiles exactly as before behind
  `#[cfg(not(feature = "rusty-alloc"))]` — the default build is unchanged.
- Doc line in `docs/BUILD_PERFORMANCE.md` (the only allocator-config doc
  hit), CHANGELOG `[Unreleased]` entry, `sync-changelog.sh`, and
  `web/lib/changelog.generated.ts` regenerated via
  `web/scripts/derive-changelog.mjs` (idempotent; keeps the web drift gate
  green).

## Build with the feature

```sh
cargo build -p codewhale-tui --features rusty-alloc
cargo build -p codewhale-cli --features rusty-alloc
```

## Gates (real counts)

| Gate | Result |
| --- | --- |
| `cargo fmt --all` | clean |
| `cargo check -p codewhale-tui --locked` (default) | clean, 2m31s (re-verified post-rebase, 7m20s) |
| `cargo check -p codewhale-tui --locked --features rusty-alloc` | clean, 5m10s (re-verified post-rebase, 9m03s) |
| `cargo check -p codewhale-cli --locked --features rusty-alloc` | clean, 2m04s |
| `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings ...` | clean (exercises the new feature), 5m20s |
| `cargo deny check` | advisories ok, bans ok, licenses ok, sources ok — **no deny.toml entry needed** (both new crates MIT, crates.io source) |
| `cargo test -p codewhale-tui --lib --locked` | **11868 passed, 1 failed, 13 ignored** (357s) |

The one failure,
`remote_control::tests::separate_predispatch_crashes_on_one_run_get_distinct_recovery_turn_ids`,
passes on isolated rerun (1 passed / 0 failed) — a load/timing flake, not an
allocator effect: the lib test target does not compile the changed
`src/main.rs`. Reported rather than hidden.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default allocator and runtime behavior are unchanged; the swap only applies when the feature is explicitly enabled at compile time.
> 
> **Overview**
> Adds an **off-by-default** `rusty-alloc` Cargo feature on `codewhale-cli` and `codewhale-tui` so builds can use the pure-Rust `rusty_alloc` global allocator (`rusty_alloc-api` 1.1.6) instead of mimalloc, avoiding a C toolchain on that path.
> 
> Each binary’s `main.rs` now selects the `#[global_allocator]` static with `cfg(feature = "rusty-alloc")`; default builds still use mimalloc unchanged. Workspace `Cargo.toml`/`Cargo.lock` pin the optional dependency, and changelog plus `docs/BUILD_PERFORMANCE.md` document how to enable it (`cargo build -p codewhale-tui --features rusty-alloc`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fdc59f3ae9c46d35a1bd4b6989f5271a23b5fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->