### PR TITLE
fix(tui): isolate five load-flaky tests; sixth analyzed parallel-safe (#5929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Five of the load-flaky tests tracked in #5929 no longer depend on shared
+  state or live local daemons. Background-hook capture tests wait for the
+  capture file to hold bytes instead of merely existing (the shell's `>`
+  redirection creates the file empty before `cat` writes, which read as
+  `valid JSON: EOF` under load); the session-picker acceptance test drives
+  the real picker over a private store instead of a process-global
+  `CODEWHALE_HOME` redirect that concurrent tests could observe mid-flight;
+  the DeepSeek-Anthropic translate test holds the test env barrier so its
+  request-time and assertion-time `max_tokens` reads cannot straddle another
+  test's `CODEWHALE_MAX_OUTPUT_TOKENS` override; the unit-test binary no
+  longer probes a real local Ollama daemon (`127.0.0.1:11434`) from the
+  fire-and-forget provider catalog refresh, whose merged tags could flip
+  another test's live-snapshot assertions; and the tmux clipboard test's
+  attach/OSC 52 wait bounds tolerate a fully loaded machine (3s -> 30s)
+  without changing what they verify (#5929).
 - The posture bar states how long the session has been working and how long
-  the current turn has run, distinguishing actively working from waiting on a
-  tool, a sub-agent or the operator; the 0.9.12 shell had dropped the overall
+  the current turn has run, distinguishing actively working from waiting on
+  a tool, a sub-agent or the operator; the 0.9.12 shell had dropped the overall
   working-time indicator from the place a glancing user checks (#5914).
 
 ### Added

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -41,9 +41,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Five of the load-flaky tests tracked in #5929 no longer depend on shared
+  state or live local daemons. Background-hook capture tests wait for the
+  capture file to hold bytes instead of merely existing (the shell's `>`
+  redirection creates the file empty before `cat` writes, which read as
+  `valid JSON: EOF` under load); the session-picker acceptance test drives
+  the real picker over a private store instead of a process-global
+  `CODEWHALE_HOME` redirect that concurrent tests could observe mid-flight;
+  the DeepSeek-Anthropic translate test holds the test env barrier so its
+  request-time and assertion-time `max_tokens` reads cannot straddle another
+  test's `CODEWHALE_MAX_OUTPUT_TOKENS` override; the unit-test binary no
+  longer probes a real local Ollama daemon (`127.0.0.1:11434`) from the
+  fire-and-forget provider catalog refresh, whose merged tags could flip
+  another test's live-snapshot assertions; and the tmux clipboard test's
+  attach/OSC 52 wait bounds tolerate a fully loaded machine (3s -> 30s)
+  without changing what they verify (#5929).
 - The posture bar states how long the session has been working and how long
-  the current turn has run, distinguishing actively working from waiting on a
-  tool, a sub-agent or the operator; the 0.9.12 shell had dropped the overall
+  the current turn has run, distinguishing actively working from waiting on
+  a tool, a sub-agent or the operator; the 0.9.12 shell had dropped the overall
   working-time indicator from the place a glancing user checks (#5914).
 
 ### Added

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -2669,52 +2669,69 @@ impl DeepSeekClient {
     /// native `GET /api/tags`. The refresh is non-fatal: on failure,
     /// existing/bundled rows remain available.
     pub fn spawn_active_provider_catalog_refresh(config: &Config) {
-        let provider = config.api_provider();
-        // Only refresh for providers that serve their own model list and are
-        // not already covered by the Models.dev catalog.
-        if !matches!(
-            provider,
-            ApiProvider::Telecomjs
-                | ApiProvider::Edenai
-                | ApiProvider::Concentrate
-                | ApiProvider::Codewhale
-                | ApiProvider::Ollama
-        ) {
+        // Never probe a real provider endpoint from the unit-test binary
+        // (#5929). The spawned task merges whatever a live local daemon (for
+        // Ollama, `127.0.0.1:11434`) answers with into the process-wide
+        // provider lake, unsynchronized with `provider_lake::lock_live_snapshot`
+        // — a developer machine running Ollama can therefore change another
+        // test's catalog assertions mid-flight. Catalog refresh behavior is
+        // covered against stubbed endpoints (`fetch_catalog_delta_*`,
+        // `refresh_catalog_cache_*`); the fire-and-forget spawn adds no
+        // coverage that would justify a live probe.
+        #[cfg(test)]
+        {
+            let _ = config;
             return;
         }
-
-        let client = match DeepSeekClient::new(config) {
-            Ok(client) => client,
-            Err(err) => {
-                tracing::debug!(
-                    target: "provider_catalog",
-                    error = %err,
-                    "skipping provider catalog refresh: client creation failed"
-                );
+        #[cfg(not(test))]
+        {
+            let provider = config.api_provider();
+            // Only refresh for providers that serve their own model list and are
+            // not already covered by the Models.dev catalog.
+            if !matches!(
+                provider,
+                ApiProvider::Telecomjs
+                    | ApiProvider::Edenai
+                    | ApiProvider::Concentrate
+                    | ApiProvider::Codewhale
+                    | ApiProvider::Ollama
+            ) {
                 return;
             }
-        };
 
-        tokio::spawn(async move {
-            match client.fetch_catalog_delta().await {
-                Ok(delta) => {
-                    let count = delta.offerings.len();
-                    crate::provider_lake::merge_live_offerings(delta.offerings);
-                    tracing::debug!(
-                        target: "provider_catalog",
-                        offering_count = count,
-                        "provider catalog refresh merged {count} offerings into provider lake"
-                    );
-                }
+            let client = match DeepSeekClient::new(config) {
+                Ok(client) => client,
                 Err(err) => {
                     tracing::debug!(
                         target: "provider_catalog",
-                        error = ?err,
-                        "provider catalog refresh failed; keeping existing rows"
+                        error = %err,
+                        "skipping provider catalog refresh: client creation failed"
                     );
+                    return;
                 }
-            }
-        });
+            };
+
+            tokio::spawn(async move {
+                match client.fetch_catalog_delta().await {
+                    Ok(delta) => {
+                        let count = delta.offerings.len();
+                        crate::provider_lake::merge_live_offerings(delta.offerings);
+                        tracing::debug!(
+                            target: "provider_catalog",
+                            offering_count = count,
+                            "provider catalog refresh merged {count} offerings into provider lake"
+                        );
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            target: "provider_catalog",
+                            error = ?err,
+                            "provider catalog refresh failed; keeping existing rows"
+                        );
+                    }
+                }
+            });
+        }
     }
 
     /// Generate speech with Xiaomi MiMo TTS models.
@@ -8312,6 +8329,14 @@ mod tests {
 
     #[tokio::test]
     async fn deepseek_anthropic_translate_uses_messages_endpoint() {
+        // `translate` resolves `max_tokens` when building the request and this
+        // test recomputes the same route allowance when asserting. That value
+        // reads `CODEWHALE_MAX_OUTPUT_TOKENS`/`DEEPSEEK_MAX_OUTPUT_TOKENS` from
+        // the process environment, so a concurrent test that redirects either
+        // variable between the two reads flips one side and fails the
+        // assertion (#5929). Hold the test env barrier for the whole request
+        // so both reads observe one stable environment.
+        let _env_lock = crate::test_support::lock_test_env();
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/messages"))

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -2681,7 +2681,6 @@ impl DeepSeekClient {
         #[cfg(test)]
         {
             let _ = config;
-            return;
         }
         #[cfg(not(test))]
         {

--- a/crates/tui/src/hooks/executor.rs
+++ b/crates/tui/src/hooks/executor.rs
@@ -4638,14 +4638,7 @@ command = "echo project"
         // Background hooks cannot steer.
         assert_eq!(outcome, MessageSubmitOutcome::unchanged());
 
-        // Give the submitted child time to land.
-        for _ in 0..50 {
-            if out.exists() {
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(100));
-        }
-        let raw = std::fs::read_to_string(&out).expect("background hook wrote no stdin payload");
+        let raw = wait_for_captured_output(&out);
         let payload: serde_json::Value = serde_json::from_str(raw.trim()).expect("valid JSON");
         assert_eq!(payload["event"], "message_submit");
         assert_eq!(payload["text"], "hello world");
@@ -4686,14 +4679,34 @@ command = "echo project"
         assert_eq!(results.len(), 1);
         assert!(results[0].background);
 
-        for _ in 0..50 {
-            if out.exists() {
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(100));
-        }
-        let captured = std::fs::read_to_string(&out).expect("background hook wrote no env");
+        let captured = wait_for_captured_output(&out);
         assert_eq!(captured.trim(), "sess_test|agent|exec_shell");
+    }
+
+    /// Wait for a background hook's capture file to hold real bytes.
+    ///
+    /// The capture scripts redirect with `> out`, so the shell creates the
+    /// file — empty — before `cat`/`printf` writes the payload. Polling for
+    /// existence alone can win that race under load and read an empty capture,
+    /// which surfaced in CI as `valid JSON: EOF while parsing a value` (#5929).
+    /// Both captures are single small writes, so waiting for non-empty bytes
+    /// means the write has landed without weakening what the tests assert.
+    #[cfg(unix)]
+    fn wait_for_captured_output(path: &std::path::Path) -> String {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Ok(raw) = std::fs::read_to_string(path)
+                && !raw.trim().is_empty()
+            {
+                return raw;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "background hook wrote no output to {}",
+                path.display()
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
     }
 
     #[test]

--- a/crates/tui/src/session_control_acceptance.rs
+++ b/crates/tui/src/session_control_acceptance.rs
@@ -561,10 +561,15 @@ mod tests {
         // asserted the results matched, which proves nothing. This one drives
         // the *actual picker* — its filtering, its sort cycling, its workspace
         // scope — and compares against the API's projection of the same store.
-        let _lock = crate::test_support::lock_test_env();
+        //
+        // The store is a private directory, not `default_location()` behind a
+        // redirected `CODEWHALE_HOME`: that redirect is process-global, and a
+        // concurrent test resolving the store without the env barrier could
+        // observe it mid-test and write sessions into this fixture between the
+        // two listings (#5929). The picker is fed the same list through
+        // `new_with_sessions`, so both sides still see one store snapshot.
         let tmp = TempDir::new().expect("tempdir");
-        let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", tmp.path());
-        let manager = SessionManager::default_location().expect("manager");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("manager");
         let workspace = tmp.path().join("workspace");
         let other = tmp.path().join("other");
         std::fs::create_dir_all(&workspace).expect("workspace");
@@ -580,9 +585,10 @@ mod tests {
         }
         let all = manager.list_sessions().expect("list");
 
-        let mut picker = crate::tui::session_picker::SessionPickerView::new(
+        let mut picker = crate::tui::session_picker::SessionPickerView::new_with_sessions(
             &workspace,
             crate::localization::Locale::En,
+            all.clone(),
         );
 
         assert_eq!(

--- a/crates/tui/src/tui/clipboard.rs
+++ b/crates/tui/src/tui/clipboard.rs
@@ -1186,7 +1186,12 @@ exit 42
             }
         });
 
-        let attach_deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        // Load-tolerant bounds, not the contract under test: on a machine
+        // running a full parallel suite, tmux server startup and OSC 52
+        // forwarding can both exceed a tight 3s wall clock (#5929). The test
+        // still verifies the *content* of what reaches the attached client;
+        // only how long it is willing to wait for a loaded machine changed.
+        let attach_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         loop {
             let clients = Command::new("tmux")
                 .args(["-L", server.0.as_str(), "list-clients"])
@@ -1214,7 +1219,7 @@ exit 42
             format!("\x1b]52;;{encoded}\x1b\\").into_bytes(),
             format!("\x1b]52;c;{encoded}\x1b\\").into_bytes(),
         ];
-        let receipt_deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        let receipt_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         let mut attached_output = Vec::new();
         let receipt_received = loop {
             if expected_receipts.iter().any(|receipt| {

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -90,7 +90,30 @@ impl SessionPickerView {
         let sessions = SessionManager::default_location()
             .and_then(|manager| manager.list_sessions())
             .unwrap_or_default();
+        Self::from_session_list(workspace, locale, sessions)
+    }
 
+    /// Construct a picker scoped to `workspace` over an explicit session list.
+    ///
+    /// Test seam for acceptance coverage (#5929): production always resolves
+    /// the store via [`Self::new`], but redirecting `CODEWHALE_HOME` to point
+    /// that resolution at a temp directory is process-global state — a
+    /// concurrent test that resolves the store without the env barrier can
+    /// observe the redirect mid-test and write sessions into it, so the two
+    /// listings under comparison drift apart. Handing the picker the list from
+    /// a private store removes the shared-state window without touching what
+    /// the picker does with the list.
+    #[cfg(test)]
+    pub fn new_with_sessions(
+        workspace: &Path,
+        locale: Locale,
+        sessions: Vec<SessionMetadata>,
+    ) -> Self {
+        Self::from_session_list(workspace, locale, sessions)
+    }
+
+    /// Shared constructor: everything except where the session list came from.
+    fn from_session_list(workspace: &Path, locale: Locale, sessions: Vec<SessionMetadata>) -> Self {
         let mut view = Self {
             sessions,
             filtered: Vec::new(),


### PR DESCRIPTION
Partial fix for #5929 (five of the six tracked tests root-caused and fixed; the sixth is analyzed as already parallel-safe and not reproduced — details below and in the issue comment).

## Root cause → fix → evidence

| Test | Root cause | Fix | Green repetitions (`--test-threads 16`) |
|---|---|---|---|
| `hooks::executor::tests::background_hook_receives_the_same_stdin_payload_as_foreground` | TOCTOU on the capture file: the hook script's `> out` redirection creates the file **empty** at exec; the poll loop waited only for `out.exists()`, so under load the read landed between creation and `cat`'s write → `valid JSON: EOF while parsing a value` (the exact CI symptom at executor.rs:4649) | `wait_for_captured_output` waits for **non-empty bytes** (10s bound); same for the identical sibling `background_hook_receives_the_documented_environment` | 12/12 singles + module group 5× green |
| `session_control_acceptance::tests::tui_and_api_listings_agree` | Process-global `CODEWHALE_HOME` redirect made the fixture store reachable by any concurrent test resolving `default_location()` without the env barrier; the test read the store **twice** (`all` snapshot + the picker's own construction-time listing), so a foreign write between reads broke picker==API equality | No env mutation: private `SessionManager::new(tmp/sessions)` + `#[cfg(test)] SessionPickerView::new_with_sessions` seam feeds the picker the same list; the picker's filter/sort/scope pipeline is unchanged | 12/12 singles + module 5× green |
| `model_inventory::tests::ollama_default_prefers_live_local_tags_over_the_unresolved_marker` | A concurrent `switch_provider(..., Ollama, ...)` tokio test fires `spawn_active_provider_catalog_refresh`; its detached task probes the **real local daemon** at `127.0.0.1:11434` (one was confirmed running while debugging) and merges real tags into the process-wide provider lake with no test lock, flipping the empty-snapshot `"unknown"` assertion | `spawn_active_provider_catalog_refresh` is a no-op under `cfg(test)` — unit tests must not probe live local runtimes; refresh behavior stays covered by the stubbed-endpoint `fetch_catalog_delta_*` / `refresh_catalog_cache_*` tests | 12/12 singles + direct interference pair with the ollama-switching test 12/12 + module 5× green |
| `client::tests::deepseek_anthropic_translate_uses_messages_endpoint` | `translate` reads `CODEWHALE_MAX_OUTPUT_TOKENS`/`DEEPSEEK_MAX_OUTPUT_TOKENS` when building the request and the assertion recomputes the allowance after the round-trip; concurrent env-lock-holding tests (`outbound_seam_*`, `matched_vision_*`, engine tests) set/remove those vars between the two reads → assert mismatch | The test holds `lock_test_env()` for its whole body (the suite's existing convention) so both reads see one stable environment | 12/12 singles + direct interference pair with env mutators 12/12 + `client::tests` module 5× green |
| `tui::clipboard::tests::tmux_load_buffer_w_reaches_attached_client_with_default_passthrough_disabled` | Fixed 3s wall-clock bounds for tmux client attach and OSC 52 receipt starve under a fully loaded machine (same family as the `runtime_api::compatibility_stream_*` deadline flakes) | Bounds raised 3s → 30s; only patience changed, verified content identical | 12/12 singles + module 5× green |
| `remote_control::tests::separate_predispatch_crashes_on_one_run_get_distinct_recovery_turn_ids` | **Not reproduced / no defect found.** By construction the test is deterministic and self-contained: private tempdir journal, sequential flock ownership (released on drop before each reopen), recovery ids are SHA-256 over fresh UUIDv4 lease ids, no wall clock, no shared statics (the only test static is path-keyed), no network. | None — a change without a mechanism would be cargo-cult. Analysis recorded in the issue comment; suspected environmental (see the shared-`CARGO_TARGET_DIR` finding below) | 116 green reps total: 69 isolated, 15 module-group runs, 32 concurrent-self runs |

## Gates

- `cargo fmt --all` clean (also `--check` after rebase)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or` clean
- One full `cargo test -p codewhale-tui --lib --locked` suite run green: **11869 passed, 0 failed, 13 ignored** (the tracker's bar of three consecutive full runs was not met on this shared machine — see the honest-notes section)
- All repetition counts above were executed on a sentinel-verified private copy of the binary built by this branch, after two earlier full-run attempts were invalidated by cross-worktree artifact clobbering (see issue comment)

## Not done / honest notes

- `remote_control::tests::separate_predispatch_crashes_on_one_run_get_distinct_recovery_turn_ids` is **not root-caused**; it remains listed in #5929. 116 green reps across three stress modes and a determinism argument by construction; no fix applied.
- Two full-suite attempts during development hit mass-failure cascades (~2100 tests) that turned out to be **shared-`CARGO_TARGET_DIR` corruption**: concurrent worktrees on older bases rebuild `crates/config` (48- or 43-variant `ProviderKind` vs main's 49/50) into the same metadata-hash rlib and even overwrite the same test-binary path, producing `index out of bounds: the len is 48` panics in provider-touching tests. This is an operational hazard for every "local full run" on this machine and may explain some of the tracker's one-off sightings; details in the issue comment.

Refs #5929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are overwhelmingly test harness and `cfg(test)` guards; production catalog refresh is unchanged outside the test binary.
> 
> **Overview**
> Addresses **five parallel/CI flakes** tracked in #5929 by removing shared process state and timing races, without changing production behavior except a **`cfg(test)` no-op** on fire-and-forget catalog refresh.
> 
> **Background hook tests** now wait for capture files to contain **non-empty bytes** (not just exist), fixing empty-file reads when shell `>` creates the path before payload writes land.
> 
> **Session picker acceptance** uses a **private `SessionManager`** and a test-only **`SessionPickerView::new_with_sessions`** seam instead of redirecting process-global `CODEWHALE_HOME`, so concurrent tests cannot mutate the fixture store between listings.
> 
> **DeepSeek Anthropic translate test** holds **`lock_test_env()`** for the full test so request and assertion both read the same `max_tokens` env.
> 
> **Unit tests** no longer spawn live **Ollama/catalog probes** via `spawn_active_provider_catalog_refresh` under `cfg(test)`, avoiding unsynchronized merges into the provider lake from `127.0.0.1:11434`.
> 
> **Tmux clipboard test** attach/OSC-52 wait bounds go **3s → 30s** under load; assertions on content are unchanged.
> 
> Changelog entries document the same fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c9d78695936f83f8db4be605a31a275412743be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


No-Issue: partial — repairs 5 of the 6 flakes tracked in #5929 (the sixth is documented as already-parallel-safe in the issue comment; the tracker stays open until its 3-consecutive-full-runs bar is met)