### PR TITLE
fix(acp): advertise session list as an object and drop the nested load capability

### DIFF
--- a/crates/tui/src/acp_server.rs
+++ b/crates/tui/src/acp_server.rs
@@ -2382,8 +2382,7 @@ fn initialize_result(client_protocol_version: Option<u64>, config: &Config) -> V
                 "sse": false
             },
             "sessionCapabilities": {
-                "list": true,
-                "load": true
+                "list": {}
             }
         },
         "agentInfo": {
@@ -2822,13 +2821,11 @@ mod tests {
         // #5864: enumerating and resuming durable Codewhale sessions is now
         // served, so the capability says so rather than declining it.
         assert_eq!(result["agentCapabilities"]["loadSession"], true);
+        // ACP advertises session/list with an object, not a boolean (#5969).
+        // session/load is advertised only by the top-level loadSession above.
         assert_eq!(
-            result["agentCapabilities"]["sessionCapabilities"]["list"],
-            true
-        );
-        assert_eq!(
-            result["agentCapabilities"]["sessionCapabilities"]["load"],
-            true
+            result["agentCapabilities"]["sessionCapabilities"],
+            json!({"list": {}})
         );
         assert_eq!(
             result["agentCapabilities"]["promptCapabilities"]["embeddedContext"],


### PR DESCRIPTION
Closes #5969.

JetBrains ACP clients could not complete the handshake: `initialize` advertised `sessionCapabilities {list: true, load: true}`, but the ACP schema types `SessionCapabilities.list` as `SessionListCapabilities` (object; `{}` = supported) and serves `session/load` via top-level `loadSession`. Advertise `{"list": {}}` only.

Audit: verified against issue #5969's expected wire shape (the repo pins no ACP schema file — the shape is hand-built JSON in `acp_server.rs`). Schema-validation CI stays a follow-up per the issue.

Validation: 55/55 acp_server unit tests green locally (`RUST_MIN_STACK=16777216`, isolated `CARGO_TARGET_DIR`). Hosted CI runs on this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Wire-format-only change to ACP initialize JSON; behavior of session/list and session/load handlers is unchanged.
> 
> **Overview**
> Fixes ACP **`initialize`** capability advertisement so strict clients (e.g. JetBrains) can complete the handshake (#5969).
> 
> **`sessionCapabilities`** no longer sends boolean `list: true` and `load: true`. It now sends **`{"list": {}}`**, matching the schema where `SessionCapabilities.list` is a **`SessionListCapabilities` object** (empty object means supported). The nested **`load`** flag is removed; durable resume stays on the existing top-level **`loadSession: true`**.
> 
> The **`initialize_advertises_baseline_acp_agent`** unit test is updated to assert the new wire shape and documents the split between `session/list` and `session/load`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7856468fdfa66bfdc525c13da6f7062aed973173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->