### PR TITLE
fix(test): wait for the startup composer before pointer assertions

### DIFF
--- a/crates/tui/tests/cucumber/active_composer_pointer_pty.rs
+++ b/crates/tui/tests/cucumber/active_composer_pointer_pty.rs
@@ -98,12 +98,17 @@ fn run_pointer_submit_case(rows: u16, cols: u16) {
         &format!("{size}: offline explore ready"),
     );
     tui.send(keys::key::enter()).expect("leave onboarding");
-    wait_or_panic(
-        &mut tui,
-        "New session",
+    // PTY reads can split a redraw: the launch header arrives before the
+    // composer, with onboarding rows still on screen (Buildkite #1861/#1867).
+    // Wait for the input surface as well as the header before asserting it.
+    tui.wait_for(
+        |frame| {
+            let text = frame.text();
+            text.contains("New session") && text.contains('❯') && !text.contains("You're ready.")
+        },
         STARTUP_WAIT,
-        &format!("{size}: show the launch card"),
-    );
+    )
+    .unwrap_or_else(|error| panic!("{size}: show the launch card and composer: {error}"));
     tui.pump();
     assert_startup_contract(tui.frame(), rows, cols, &size);
     // Typing goes straight to the composer; Enter sends the first message


### PR DESCRIPTION
Test-only fix for the Buildkite/Linux PTY flake (#1861/#1867 died asserting mid-redraw: the launch header arrives before the composer, with onboarding rows still on screen).

Waits for the launch header + composer + cleared onboarding before asserting the existing startup contract. All startup and pointer-queue assertions preserved — it still catches the failure mode, after the redraw settles.

Audit: verified honest (see codewhale-ops/AUDIT-REPORT-V0913-20260907.md).

Validation: focused all-features cucumber test 1 passed / 0 failed across five PTY sizes; cargo fmt clean. Hosted CI runs on this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness timing only; no application or security-sensitive code paths changed.
> 
> **Overview**
> Addresses a **Buildkite/Linux PTY flake** (#1861/#1867) in `active_composer_pointer_pty.rs` where the harness asserted startup state while a redraw was still in flight: the **“New session”** launch header could appear before the composer, with **“You're ready.”** onboarding still on screen.
> 
> After leaving onboarding, the test no longer waits only for **“New session”** via `wait_or_panic`. It uses **`wait_for`** with a frame predicate that requires **“New session”**, the composer prompt **`❯`**, and **no** **“You're ready.”** before `assert_startup_contract` and the pointer-submit flow. Timeout and panic messaging were updated accordingly; **test-only**—no production behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23c1fc4d9e60473c8833a51349923d11b67c8637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

No-Issue: PTY readiness flake harness fix (evidence in body; tracker #5988/#5929 families)