### PR TITLE
fix(engine): never dispatch a tool call whose arguments were truncated

### DIFF
--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -274,35 +274,64 @@ pub(super) fn final_tool_input(state: &ToolUseState) -> serde_json::Value {
     if !state.input_buffer.trim().is_empty()
         && let Some(parsed) = parse_tool_input(&state.input_buffer)
     {
-        return parsed;
+        // Structure was synthesized to make this parse, so the argument text
+        // was cut off. Route it to the same malformed-arguments path as an
+        // outright parse failure rather than dispatching a completed guess.
+        if parsed.structure_synthesized {
+            return malformed_tool_arguments_input(&state.input_buffer);
+        }
+        return parsed.value;
     }
     state.input.clone()
 }
 
-pub(super) fn parse_tool_input(buffer: &str) -> Option<serde_json::Value> {
+/// A parsed tool-argument buffer, plus whether the parse only succeeded
+/// because the repair ladder synthesized structure (see
+/// `crate::tools::arg_repair`). Mid-stream callers mirroring partial state
+/// may ignore the flag; the caller making the final dispatch decision must
+/// not, because synthesized structure means the argument text was cut off.
+pub(super) struct ParsedToolInput {
+    pub(super) value: serde_json::Value,
+    pub(super) structure_synthesized: bool,
+}
+
+pub(super) fn parse_tool_input(buffer: &str) -> Option<ParsedToolInput> {
     let trimmed = buffer.trim();
     if trimmed.is_empty() {
         return None;
     }
     // Try the deterministic arg-repair ladder first (handles trailing commas,
     // unclosed braces, embedded control chars, etc.)
-    if let Ok(value) = crate::tools::arg_repair::repair(trimmed) {
-        return Some(value);
+    if let Ok(repaired) = crate::tools::arg_repair::repair(trimmed) {
+        return Some(ParsedToolInput {
+            value: repaired.value,
+            structure_synthesized: repaired.structure_synthesized,
+        });
     }
     // Fall back to existing strategies for code-fenced, double-encoded, and
     // segment-extraction patterns that the repair ladder doesn't cover.
     if let Some(stripped) = strip_code_fences(trimmed)
         && let Ok(value) = serde_json::from_str::<serde_json::Value>(&stripped)
     {
-        return Some(value);
+        return Some(ParsedToolInput {
+            value,
+            structure_synthesized: false,
+        });
     }
     if let Ok(serde_json::Value::String(inner)) = serde_json::from_str::<serde_json::Value>(trimmed)
         && let Ok(value) = serde_json::from_str::<serde_json::Value>(&inner)
     {
-        return Some(value);
+        return Some(ParsedToolInput {
+            value,
+            structure_synthesized: false,
+        });
     }
     extract_json_segment(trimmed)
         .and_then(|segment| serde_json::from_str::<serde_json::Value>(&segment).ok())
+        .map(|value| ParsedToolInput {
+            value,
+            structure_synthesized: false,
+        })
 }
 
 /// Decode a JSON container that a provider encoded as a string when the tool

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -18727,6 +18727,27 @@ fn final_tool_scenario() {
             json!({"raw_arguments": "{not json"})
         );
     }
+    // A `write` whose stream was cut at its output limit, right after a
+    // complete string value. `arg_repair` CAN make this parse by appending
+    // one `}`, and before the repair ladder reported provenance that guess
+    // was dispatched — writing a file containing only "first line" while the
+    // model was still mid-argument. It must now take the malformed path, so
+    // the model is told to re-issue instead.
+    {
+        let state = tool_state(json!({}), r#"{"path": "notes.md", "content": "first line""#);
+        assert_eq!(
+            final_tool_input(&state),
+            json!({"raw_arguments": r#"{"path": "notes.md", "content": "first line""#}),
+            "a truncated write must not be dispatched as a completed argument"
+        );
+    }
+    // The guard must not fire on arguments that were merely sloppy: a
+    // trailing comma is structurally complete and still has to dispatch, or
+    // every DeepSeek chunk-boundary repair would start failing tool calls.
+    {
+        let state = tool_state(json!({}), r#"{"command": "ls -la",}"#);
+        assert_eq!(final_tool_input(&state), json!({"command": "ls -la"}));
+    }
 }
 
 // === #103 transparent stream-retry policy =====================================

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -5287,6 +5287,90 @@ async fn tool_call_budget_persists_across_model_steps_within_a_turn() {
     );
 }
 
+/// #5986: a provider that cuts the stream at its output limit omits the
+/// closing `ContentBlockStop` for the tool block in flight. The mid-stream
+/// mirror had already assigned the truncated buffer's best-effort parse
+/// (the repair ladder appends the missing `}`), and dispatch reads
+/// `tool.input` directly — so the cut call used to execute with a partial
+/// argument. The post-stream finalization pass must send it down the same
+/// malformed-arguments gate a normal block stop applies.
+#[tokio::test]
+async fn truncated_tool_call_without_block_stop_never_dispatches() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let workspace = tempdir().expect("tempdir");
+    fs::write(workspace.path().join("fixture.txt"), "fixture\n").expect("write fixture");
+    // Cut mid-argument, right after a complete string value: stage 4 of the
+    // repair ladder appends one `}` and the text parses — synthesized.
+    let cut_turn = vec![
+        canned::message_start("mock_msg_cut"),
+        canned::tool_use_block_start(0, "call-cut", "read_file"),
+        canned::tool_input_delta(0, r#"{"path": "fixture.txt""#),
+        // Deliberately no block_stop(0): the output limit ended the turn.
+        canned::message_delta("max_tokens", None),
+        canned::message_stop(),
+    ];
+    let mock = std::sync::Arc::new(MockLlmClient::new(vec![
+        cut_turn,
+        canned::simple_text_turn("done"),
+    ]));
+
+    let (status, error, completions) =
+        run_budgeted_read_turn(workspace.path(), None, mock.clone()).await;
+    assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
+
+    let (_, result) = completions
+        .iter()
+        .find(|(id, _)| id == "call-cut")
+        .expect("the cut tool call still reports a completion");
+    let reason = result
+        .as_ref()
+        .expect_err("a truncated tool call must never execute")
+        .to_string();
+    assert!(
+        reason.contains("malformed tool arguments"),
+        "expected the malformed-arguments gate, got: {reason}"
+    );
+}
+
+/// The control for the cut-stream pass: when the omitted block stop is the
+/// only irregularity and the buffered arguments were structurally complete,
+/// the tool still dispatches. Otherwise every provider that skips closing
+/// events would lose all of its tool calls.
+#[tokio::test]
+async fn complete_tool_call_without_block_stop_still_dispatches() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let workspace = tempdir().expect("tempdir");
+    fs::write(workspace.path().join("fixture.txt"), "fixture\n").expect("write fixture");
+    let no_stop_turn = vec![
+        canned::message_start("mock_msg_nostop"),
+        canned::tool_use_block_start(0, "call-complete", "read_file"),
+        canned::tool_input_delta(0, r#"{"path": "fixture.txt"}"#),
+        canned::message_delta("tool_use", None),
+        canned::message_stop(),
+    ];
+    let mock = std::sync::Arc::new(MockLlmClient::new(vec![
+        no_stop_turn,
+        canned::simple_text_turn("done"),
+    ]));
+
+    let (status, error, completions) =
+        run_budgeted_read_turn(workspace.path(), None, mock.clone()).await;
+    assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
+
+    let (_, result) = completions
+        .iter()
+        .find(|(id, _)| id == "call-complete")
+        .expect("the tool call reports a completion");
+    let output = result
+        .as_ref()
+        .expect("structurally complete arguments still dispatch")
+        .content
+        .clone();
+    assert!(output.contains("fixture"), "{output}");
+}
+
 /// #4415 AC(c): a write-first named-file task carries a scoped-write
 /// authority envelope naming its exact files. The existing allowed-paths
 /// machinery (`ToolAuthorityEnvelope`, enforced at the registry boundary)

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -4769,39 +4769,7 @@ impl Engine {
                             "Tool '{}' block stop. Buffer: '{}', Current input: {:?}",
                             tool_state.name, tool_state.input_buffer, tool_state.input
                         ));
-                        if !tool_state.input_buffer.trim().is_empty() {
-                            let final_parse = parse_tool_input(&tool_state.input_buffer)
-                                .filter(|parsed| !parsed.structure_synthesized);
-                            if let Some(parsed) = final_parse {
-                                tool_state.input = parsed.value;
-                                crate::logging::info(format!(
-                                    "Tool '{}' final input: {:?}",
-                                    tool_state.name, tool_state.input
-                                ));
-                            } else {
-                                crate::logging::warn(format!(
-                                    "Tool '{}' failed to parse final input buffer: '{}'",
-                                    tool_state.name, tool_state.input_buffer
-                                ));
-                                let error =
-                                    malformed_tool_arguments_error(&tool_state.input_buffer);
-                                tool_state.input_parse_error = Some(error);
-                                tool_state.input =
-                                    malformed_tool_arguments_input(&tool_state.input_buffer);
-                                let _ = self
-                                    .tx_event
-                                    .send(Event::status(format!(
-                                        "⚠ Tool '{}' received malformed arguments from model",
-                                        tool_state.name
-                                    )))
-                                    .await;
-                            }
-                        } else {
-                            crate::logging::warn(format!(
-                                "Tool '{}' input buffer is empty, using initial input: {:?}",
-                                tool_state.name, tool_state.input
-                            ));
-                        }
+                        self.finalize_streamed_tool_input(tool_state).await;
 
                         // Now that the input is finalized, announce the
                         // tool call to the UI. Deferring to here is what
@@ -4855,6 +4823,29 @@ impl Engine {
                 }
             }
         }
+        // A stream cut at the provider's output limit ends without the
+        // closing ContentBlockStop for whatever block was in flight. Those
+        // blocks' inputs still hold the mid-stream mirror's best-effort
+        // parse, which ignores `structure_synthesized` by design — left
+        // as-is, a truncated tool call reaches dispatch through
+        // `tool.input` and executes (#5986). Every block that never
+        // stopped goes through the same finalization gate a normal
+        // ContentBlockStop applies, and is announced with the same
+        // finalized input.
+        for tool_idx in std::mem::take(&mut current_tool_indices).into_values() {
+            let Some(tool_state) = tool_uses.get_mut(tool_idx) else {
+                continue;
+            };
+            self.finalize_streamed_tool_input(tool_state).await;
+            let _ = self
+                .tx_event
+                .send(Event::ToolCallStarted {
+                    id: tool_state.id.clone(),
+                    name: tool_state.name.clone(),
+                    input: final_tool_input(tool_state),
+                })
+                .await;
+        }
         StreamOutcome {
             current_text_raw,
             current_text_visible,
@@ -4875,6 +4866,51 @@ impl Engine {
             request_dispatched_at,
             stream_error,
         }
+    }
+
+    /// Finalize one streamed tool call's input from its accumulated buffer.
+    ///
+    /// The parse that lands here must be structurally intact: a value that
+    /// only parses because the repair ladder appended or discarded closers
+    /// means the argument text was cut off, and dispatching it would
+    /// execute a truncated tool call (#5986). Called for a tool block that
+    /// closes normally (`ContentBlockStop`) and again after the stream ends
+    /// for blocks whose Stop never arrived — a provider cutting the stream
+    /// at its output limit omits the closing event, while the mid-stream
+    /// mirror deliberately ignores `structure_synthesized` because partial
+    /// text is the normal state mid-stream.
+    async fn finalize_streamed_tool_input(&self, tool_state: &mut ToolUseState) {
+        if tool_state.input_buffer.trim().is_empty() {
+            crate::logging::warn(format!(
+                "Tool '{}' input buffer is empty, using initial input: {:?}",
+                tool_state.name, tool_state.input
+            ));
+            return;
+        }
+        let final_parse = parse_tool_input(&tool_state.input_buffer)
+            .filter(|parsed| !parsed.structure_synthesized);
+        if let Some(parsed) = final_parse {
+            tool_state.input = parsed.value;
+            crate::logging::info(format!(
+                "Tool '{}' final input: {:?}",
+                tool_state.name, tool_state.input
+            ));
+            return;
+        }
+        crate::logging::warn(format!(
+            "Tool '{}' failed to parse final input buffer: '{}'",
+            tool_state.name, tool_state.input_buffer
+        ));
+        let error = malformed_tool_arguments_error(&tool_state.input_buffer);
+        tool_state.input_parse_error = Some(error);
+        tool_state.input = malformed_tool_arguments_input(&tool_state.input_buffer);
+        let _ = self
+            .tx_event
+            .send(Event::status(format!(
+                "⚠ Tool '{}' received malformed arguments from model",
+                tool_state.name
+            )))
+            .await;
     }
 
     fn goal_snapshot_with_current_turn_usage(

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -4710,12 +4710,17 @@ impl Engine {
                                     tool_state.name, partial_json, tool_state.input_buffer
                                 ));
                             }
-                            if let Some(value) = parse_tool_input(&tool_state.input_buffer) {
-                                tool_state.input = value.clone();
+                            // Mid-stream mirror of a partial buffer. The
+                            // argument text is *expected* to be incomplete
+                            // here, so `structure_synthesized` is ignored on
+                            // purpose; ContentBlockStop below is where an
+                            // unfinished argument becomes an error.
+                            if let Some(parsed) = parse_tool_input(&tool_state.input_buffer) {
+                                tool_state.input = parsed.value.clone();
                                 if crate::logging::is_verbose() {
                                     crate::logging::info(format!(
                                         "Tool '{}' input parsed: {:?}",
-                                        tool_state.name, value
+                                        tool_state.name, parsed.value
                                     ));
                                 }
                             }
@@ -4765,8 +4770,10 @@ impl Engine {
                             tool_state.name, tool_state.input_buffer, tool_state.input
                         ));
                         if !tool_state.input_buffer.trim().is_empty() {
-                            if let Some(value) = parse_tool_input(&tool_state.input_buffer) {
-                                tool_state.input = value;
+                            let final_parse = parse_tool_input(&tool_state.input_buffer)
+                                .filter(|parsed| !parsed.structure_synthesized);
+                            if let Some(parsed) = final_parse {
+                                tool_state.input = parsed.value;
                                 crate::logging::info(format!(
                                     "Tool '{}' final input: {:?}",
                                     tool_state.name, tool_state.input

--- a/crates/tui/src/tools/arg_repair.rs
+++ b/crates/tui/src/tools/arg_repair.rs
@@ -12,6 +12,14 @@
 //!  3. Strip trailing commas before `}` or `]`.
 //!  4. Balance braces/brackets (append closers).
 //!  5. Strip excess closers if delta is negative.
+//!
+//! Stages 1-3 never change structure: they parse as-is, or normalize text
+//! that was already structurally complete. Stages 4-5 do — they synthesize
+//! or discard closers to force a parse. A value that only parsed because of
+//! stage 4 or 5 came from argument text that was *incomplete*, and the usual
+//! cause is a provider cutting the stream at its output limit mid-argument.
+//! `Repaired::structure_synthesized` reports that, because such a value must
+//! never be dispatched as if the model had finished writing it.
 
 use serde_json::Value;
 
@@ -29,33 +37,64 @@ pub enum ArgRepairError {
 /// Repair a raw JSON argument string into a valid `serde_json::Value`.
 ///
 /// Runs the deterministic ladder; on success returns the parsed value.
-pub fn repair(raw: &str) -> Result<Value, ArgRepairError> {
+/// A repaired value plus whether the repair had to invent structure.
+#[derive(Debug, Clone)]
+pub struct Repaired {
+    pub value: Value,
+    /// True when the text only parsed after closers were appended (stage 4)
+    /// or discarded (stage 5) — i.e. the argument text was structurally
+    /// incomplete. Callers making the *final* dispatch decision must treat
+    /// this as malformed input rather than executing it.
+    pub structure_synthesized: bool,
+}
+
+impl Repaired {
+    fn intact(value: Value) -> Self {
+        Self {
+            value,
+            structure_synthesized: false,
+        }
+    }
+    fn synthesized(value: Value) -> Self {
+        Self {
+            value,
+            structure_synthesized: true,
+        }
+    }
+}
+
+pub fn repair(raw: &str) -> Result<Repaired, ArgRepairError> {
     if raw.len() > MAX_ARG_LEN {
         return Err(ArgRepairError::TooLarge(raw.len()));
     }
     // Stage 1: strict parse
     if let Ok(v) = serde_json::from_str(raw) {
-        return Ok(v);
+        return Ok(Repaired::intact(v));
     }
     // Stage 2: strip control chars inside strings
     let mut s = strip_control_chars_in_strings(raw);
     if let Ok(v) = serde_json::from_str(&s) {
-        return Ok(v);
+        return Ok(Repaired::intact(v));
     }
     // Stage 3: strip trailing commas
     s = strip_trailing_commas(&s);
     if let Ok(v) = serde_json::from_str(&s) {
-        return Ok(v);
+        return Ok(Repaired::intact(v));
     }
     // Stage 4: balance braces
+    // Stages 4 and 5 change structure. Anything they rescue is reported as
+    // synthesized: `balance_braces` counts braces without tracking string
+    // literals, so a stream cut at the end of a complete string value yields
+    // JSON that parses cleanly and is still missing whatever the model had
+    // not written yet.
     s = balance_braces(&s, 50);
     if let Ok(v) = serde_json::from_str(&s) {
-        return Ok(v);
+        return Ok(Repaired::synthesized(v));
     }
     // Stage 5: strip excess closers
     s = strip_excess_closers(&s);
     if let Ok(v) = serde_json::from_str(&s) {
-        return Ok(v);
+        return Ok(Repaired::synthesized(v));
     }
     Err(ArgRepairError::Unrepairable)
 }
@@ -186,32 +225,38 @@ mod tests {
 
     #[test]
     fn strict_parse_passes_through() {
-        let v = repair(r#"{"path": "hello.txt"}"#).unwrap();
-        assert_eq!(v, json!({"path": "hello.txt"}));
+        let r = repair(r#"{"path": "hello.txt"}"#).unwrap();
+        assert_eq!(r.value, json!({"path": "hello.txt"}));
+        assert!(!r.structure_synthesized);
     }
 
     #[test]
     fn repairs_trailing_comma() {
-        let v = repair(r#"{"path": "hello.txt",}"#).unwrap();
-        assert_eq!(v, json!({"path": "hello.txt"}));
+        let r = repair(r#"{"path": "hello.txt",}"#).unwrap();
+        assert_eq!(r.value, json!({"path": "hello.txt"}));
+        // Structurally complete, just sloppy — must stay dispatchable.
+        assert!(!r.structure_synthesized);
     }
 
     #[test]
     fn repairs_trailing_comma_in_array() {
-        let v = repair(r#"["a", "b",]"#).unwrap();
-        assert_eq!(v, json!(["a", "b"]));
+        let r = repair(r#"["a", "b",]"#).unwrap();
+        assert_eq!(r.value, json!(["a", "b"]));
+        assert!(!r.structure_synthesized);
     }
 
     #[test]
     fn repairs_missing_close_brace() {
-        let v = repair(r#"{"path": "hello.txt""#).unwrap();
-        assert_eq!(v, json!({"path": "hello.txt"}));
+        let r = repair(r#"{"path": "hello.txt""#).unwrap();
+        assert_eq!(r.value, json!({"path": "hello.txt"}));
+        assert!(r.structure_synthesized);
     }
 
     #[test]
     fn repairs_missing_close_bracket() {
-        let v = repair(r#"["a", "b""#).unwrap();
-        assert_eq!(v, json!(["a", "b"]));
+        let r = repair(r#"["a", "b""#).unwrap();
+        assert_eq!(r.value, json!(["a", "b"]));
+        assert!(r.structure_synthesized);
     }
 
     #[test]
@@ -219,7 +264,8 @@ mod tests {
         // Raw \x0B (vertical tab) inside a string value
         let raw = "{\"key\": \"val\x0Bue\"}";
         let v = repair(raw).unwrap();
-        assert_eq!(v, json!({"key": "value"}));
+        assert_eq!(v.value, json!({"key": "value"}));
+        assert!(!v.structure_synthesized);
     }
 
     #[test]
@@ -237,14 +283,18 @@ mod tests {
 
     #[test]
     fn balances_nested_braces() {
-        let v = repair(r#"{"outer": {"inner": "val""#).unwrap();
-        assert_eq!(v, json!({"outer": {"inner": "val"}}));
+        let r = repair(r#"{"outer": {"inner": "val""#).unwrap();
+        assert_eq!(r.value, json!({"outer": {"inner": "val"}}));
+        // Closers were appended, so this is a truncated argument, not a
+        // complete one that merely needed tidying.
+        assert!(r.structure_synthesized);
     }
 
     #[test]
     fn strips_excess_closers() {
-        let v = repair(r#"{"key": "val"}}"#).unwrap();
-        assert_eq!(v, json!({"key": "val"}));
+        let r = repair(r#"{"key": "val"}}"#).unwrap();
+        assert_eq!(r.value, json!({"key": "val"}));
+        assert!(r.structure_synthesized);
     }
 
     #[test]
@@ -252,8 +302,12 @@ mod tests {
         // This is a valid JSON string containing a JSON object literal.
         // repair parses it as a string; the engine's existing fallback
         // (parse_tool_input) will unwrap the string and re-parse.
-        let v = repair(r#""{\"path\": \"hello.txt\"}""#).unwrap();
-        assert_eq!(v, Value::String(r#"{"path": "hello.txt"}"#.to_string()));
+        let r = repair(r#""{\"path\": \"hello.txt\"}""#).unwrap();
+        assert_eq!(
+            r.value,
+            Value::String(r#"{"path": "hello.txt"}"#.to_string())
+        );
+        assert!(!r.structure_synthesized);
     }
 
     #[test]
@@ -263,8 +317,40 @@ mod tests {
     }
 
     #[test]
+    fn a_write_cut_at_a_string_boundary_is_reported_as_synthesized() {
+        // The defect this flag exists for: `balance_braces` counts braces
+        // without tracking string literals, so a provider that cuts the
+        // stream at its output limit right after a complete string value
+        // yields text that parses cleanly once one `}` is appended. Nothing
+        // downstream could previously tell this from a finished argument, so
+        // the truncated `content` was written to the user's file.
+        let cut = r#"{"path": "notes.md", "content": "first line""#;
+        let r = repair(cut).unwrap();
+        assert_eq!(
+            r.value,
+            json!({"path": "notes.md", "content": "first line"}),
+            "the ladder still parses it — that is exactly why the flag is needed"
+        );
+        assert!(
+            r.structure_synthesized,
+            "a truncated write must be reported as synthesized so dispatch refuses it"
+        );
+    }
+
+    #[test]
+    fn a_complete_argument_needing_only_control_char_stripping_stays_intact() {
+        // Stage 2 normalizes text that was already structurally complete, so
+        // it must NOT be flagged — otherwise every DeepSeek chunk-boundary
+        // repair would start failing tool calls that are perfectly fine.
+        let r = repair("{\"a\": \"line\u{0008}break\"}").unwrap();
+        assert_eq!(r.value, json!({"a": "linebreak"}));
+        assert!(!r.structure_synthesized);
+    }
+
+    #[test]
     fn repairs_brace_balance_with_trailing_comma() {
-        let v = repair(r#"{"a": 1,"#).unwrap();
-        assert_eq!(v, json!({"a": 1}));
+        let r = repair(r#"{"a": 1,"#).unwrap();
+        assert_eq!(r.value, json!({"a": 1}));
+        assert!(r.structure_synthesized);
     }
 }


### PR DESCRIPTION
Closes #5986

## The defect

A tool call cut off by the provider's output limit could be silently completed into valid JSON and **executed**. For a `write`, that means the user's file is overwritten with a partial body while the model was still mid-argument.

`arg_repair::repair` reported success identically whether stage 1 parsed the text as-is or stage 4 *invented* the structure. `balance_braces` counts `{`/`}` without tracking string literals, so a stream cut right after a complete string value needs exactly one appended `}` to parse — `input_parse_error` stays `None` and dispatch sees a well-formed argument.

`output_limit_truncated` does exist (`turn_loop.rs:1553`) but is first read at `:1888`/`:2528` — **after** dispatch at `:2648` — so nothing on the dispatch path consulted it.

## The fix

`repair` now returns `Repaired { value, structure_synthesized }`. Stages 1-3 (strict parse, control-char stripping, trailing commas) are **intact** — they normalize text that was already structurally complete. Stages 4-5 (appending/discarding closers) are **synthesized** — they only fire on incomplete text.

`final_tool_input` and the `ContentBlockStop` handler route a synthesized parse into the **existing** `malformed_tool_arguments_input` path, so the model is asked to re-issue. No new gate and no new error path: the mechanism for "these arguments are unusable" already existed, truncation just wasn't reaching it.

The mid-stream delta parse deliberately ignores the flag (a partial buffer is *expected* to be incomplete there) and now says so in a comment.

## Evidence

```
cargo fmt -p codewhale-tui                  -> clean
cargo clippy -p codewhale-tui --lib         -> 0 errors
cargo test -p codewhale-tui --lib -- arg_repair final_tool_scenario
  -> test result: ok. 16 passed; 0 failed
```

The regression test **fails without the fix** — verified by removing the guard and re-running:

```
assertion `left == right` failed: a truncated write must not be dispatched as a completed argument
  left:  {"path": "notes.md", "content": "first line"}
  right: {"raw_arguments": "{\"path\": \"notes.md\", \"content\": \"first line\""}
```

Found by comparing against `refs/piagent`, whose agent loop branches on `stopReason === "length"` *before* executing anything. Recorded in `codewhale-ops/FINDINGS-20260907-REFS-STUDY-AND-DEFECTS.md` §1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4rk4NXwyy6wmvii9Lp84P
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes tool dispatch and file-mutating paths when streams truncate; wrong handling could still execute partial writes or break legitimate sloppy JSON (trailing commas).
> 
> **Overview**
> Fixes **#5986**: when a provider hits an output limit mid tool-argument stream, `arg_repair` could append missing `}` and produce valid JSON that was still **executed** (e.g. partial `write` content).
> 
> **`arg_repair::repair`** now returns `Repaired { value, structure_synthesized }`. Stages 1–3 (strict parse, control chars, trailing commas) stay **intact**; stages 4–5 (balance/strip closers) set **`structure_synthesized`**.
> 
> **Dispatch finalization** treats synthesized parses like malformed arguments: `final_tool_input` and new **`finalize_streamed_tool_input`** reject them via the existing `malformed_tool_arguments_*` path. Mid-stream delta mirroring still uses repaired values but **ignores** the flag.
> 
> **Stream end without `ContentBlockStop`** (truncated turn) now runs the same finalization + `ToolCallStarted` for in-flight tool blocks, so truncated calls never slip through on `tool.input` alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a6e7aafdf28f43952ea42c60bb88bda012817a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->