### PR TITLE
docs: the legacy project was DeepSeek-TUI, not "DeepSeek CLI"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 DeepSeek CLI Contributors
+Copyright (c) 2024-2025 DeepSeek-TUI Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -36,7 +36,7 @@ pub mod daemon_socket;
 
 /// Legacy DeepSeek-era naming kept for external compatibility.
 ///
-/// CodeWhale began life as a DeepSeek CLI; existing health probes, SDK
+/// CodeWhale began life as DeepSeek-TUI; existing health probes, SDK
 /// harnesses, and on-disk layouts still key off these names. Every remaining
 /// legacy reference in this crate routes through this shim so a future
 /// coordinated migration touches exactly one place (repo policy: preserve

--- a/extensions/vscode/LICENSE
+++ b/extensions/vscode/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 DeepSeek CLI Contributors
+Copyright (c) 2024-2025 DeepSeek-TUI Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
No-Issue: corrects a project name in a copyright attribution line; no behaviour change and no tracker entry

Both `LICENSE` files and one app-server doc comment attributed copyright to **"DeepSeek CLI Contributors"** — a project name that never existed. The lineage is **DeepSeek-TUI**, which is also what the retained legacy npm package is called (`npm/deepseek-tui`, kept private and never republished).

This corrects a project name, not the license.

**Verified:** with line 3 removed, both `LICENSE` files are byte-identical to their previous contents, so the MIT text, the year range and the copyright-holder shape are untouched.

```
LICENSE:3                     Copyright (c) 2024-2025 [-DeepSeek CLI-]{+DeepSeek-TUI+} Contributors
extensions/vscode/LICENSE:3   Copyright (c) 2024-2025 [-DeepSeek CLI-]{+DeepSeek-TUI+} Contributors
crates/app-server/src/lib.rs  /// CodeWhale began life as [-a DeepSeek CLI-]{+DeepSeek-TUI+}; ...
```

**Deliberately not changed**, because they are not attribution:
- `crates/tui/src/tools/review.rs` — `deepseek-ai/deepseek-cli` is a test URL for the PR-URL parser
- `crates/cli/src/lib.rs` — `deepseek-cli-auth-*-test` are temp filenames
- `npm/deepseek-tui/package.json` — the deprecated legacy package name

No build impact: the Rust change is prose inside a `///` comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4rk4NXwyy6wmvii9Lp84P
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and copyright attribution only; no executable code or license terms changed.
> 
> **Overview**
> Fixes **incorrect attribution** to a non-existent **"DeepSeek CLI"** project by renaming the copyright holder to **DeepSeek-TUI Contributors** in the root `LICENSE` and `extensions/vscode/LICENSE`. Only line 3 of each license file changes; MIT terms, year range, and holder wording stay the same.
> 
> Updates the `legacy_deepseek_compat` doc comment in `crates/app-server/src/lib.rs` so it says CodeWhale began as **DeepSeek-TUI**, matching the real lineage and the legacy `npm/deepseek-tui` package. **No runtime or API behavior changes**—comment-only in Rust.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d5f95edde2d483b874233d7afd57ab0a529904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->