### PR TITLE
chore(gh): allowlist @goransh-walia in the contribution gate

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -72,3 +72,4 @@ all:M-Maciej
 all:serephus
 all:Pinvou
 all:SparkofSpike
+all:goransh-walia


### PR DESCRIPTION
No-Issue: contribution-gate allowlist config so an external contributor's CI runs start without manual approval

Every push to #5870 parked all seven workflow runs at `action_required`, so the PR read as stalled twice while nothing was actually wrong with it — the runs had simply never started, and a maintainer had to approve them by hand each time.

@goransh-walia is a genuine external contributor (first PR, fixed #3999, merged in 3f3aa9ed7) and belongs through the automated front door. `AGENTS.md` prescribes exactly this for the symptom:

> **Check the contribution gate before assuming a PR is stalled.** An unlisted author's workflow runs sit at `action_required` and never start, so the PR looks abandoned when nobody has actually looked at it. Approve the runs, then fix the cause: add them to `.github/APPROVED_CONTRIBUTORS` (`all:username`).

@gaord was already listed; this adds the second contributor whose work is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4rk4NXwyy6wmvii9Lp84P
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only extends the GitHub contribution-gate allowlist; no runtime or security-sensitive code paths change.
> 
> **Overview**
> Adds **`all:goransh-walia`** to `.github/APPROVED_CONTRIBUTORS` so the automated contribution gate lets their PR/issue workflow runs start instead of leaving them stuck at **`action_required`**.
> 
> This is a one-line allowlist update for an external contributor who already merged work; no application or CI logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1726f5070fe5e62875398a8ba262001a721c00e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->