### PR TITLE
fix: five recorded defects — queue data loss, ACP schema, metrics path, fleet roles, goal-loop bound

### DIFF
--- a/crates/cli/src/metrics.rs
+++ b/crates/cli/src/metrics.rs
@@ -1,10 +1,15 @@
 //! `codewhale metrics` — reads the audit log and session/task stores and prints
 //! a human-readable usage rollup.
 //!
-//! Data sources:
-//! - `~/.deepseek/audit.log`   — one JSON line per event (approvals, credentials)
-//! - `~/.deepseek/sessions/`   — saved session JSON files (tool call history)
-//! - `~/.deepseek/tasks/runtime/events/` — runtime thread JSONL event streams
+//! Data sources, all resolved through the shared Codewhale state resolvers so
+//! the reader lands on the same files the writers use:
+//! - `~/.codewhale/audit.log`   — one JSON line per event (approvals, credentials)
+//! - `~/.codewhale/sessions/`   — saved session JSON files (tool call history)
+//! - `~/.codewhale/tasks/runtime/events/` — runtime thread JSONL event streams
+//!
+//! An install that never migrated off the DeepSeek-era `~/.deepseek` root still
+//! reads there, but only for a path that actually exists — see
+//! `resolve_state_file`.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -27,17 +32,22 @@ pub struct MetricsArgs {
 }
 
 pub fn run(args: MetricsArgs) -> Result<()> {
-    let base = deepseek_home();
+    // `resolve_state_dir` is the shared read-path resolver already used by
+    // `doctor` and the session store; the runtime thread store hangs its event
+    // streams off `<tasks>/runtime`. Resolving the home is fallible, and a
+    // rollup of zeros is indistinguishable from real emptiness, so a home we
+    // cannot resolve is an error rather than a silent all-zero report.
+    let audit_log = resolve_state_file("audit.log")?;
+    let sessions = codewhale_config::resolve_state_dir("sessions")?;
+    let runtime_events = codewhale_config::resolve_state_dir("tasks")?
+        .join("runtime")
+        .join("events");
 
     // Collect data from every source; treat missing files as empty.
     let mut rollup = Rollup::default();
-    read_audit_log(&base.join("audit.log"), args.since, &mut rollup);
-    read_session_files(&base.join("sessions"), args.since, &mut rollup);
-    read_runtime_events(
-        &base.join("tasks").join("runtime").join("events"),
-        args.since,
-        &mut rollup,
-    );
+    read_audit_log(&audit_log, args.since, &mut rollup);
+    read_session_files(&sessions, args.since, &mut rollup);
+    read_runtime_events(&runtime_events, args.since, &mut rollup);
 
     if args.json {
         print_json(&rollup)?;
@@ -822,16 +832,26 @@ fn print_human(rollup: &Rollup) {
 // Helpers
 // ──────────────────────────────────────────────────────────────────────────────
 
-fn deepseek_home() -> PathBuf {
-    // This reader preserves the legacy DEEPSEEK_HOME/default-root precedence,
-    // but delegates every environment and platform-home decision to the shared
-    // runtime path authority.
-    codewhale_paths::codewhale_home_override()
-        .ok()
-        .flatten()
-        .or_else(codewhale_paths::legacy_deepseek_home_override)
-        .or_else(codewhale_paths::legacy_deepseek_home)
-        .unwrap_or_else(|| PathBuf::from(codewhale_paths::LEGACY_APP_DIR))
+/// Resolve a file that lives directly in the state root, preferring the
+/// canonical Codewhale root.
+///
+/// This is the file-shaped twin of `codewhale_config::resolve_state_dir` (and
+/// of `default_config_path`, which resolves `config.toml` the same way): the
+/// primary path wins whenever it exists, the legacy DeepSeek path is used only
+/// when it is the *only* one present, and with neither present the primary is
+/// returned so an empty rollup names the canonical location. An explicit
+/// `CODEWHALE_HOME` is an isolation boundary and never falls back.
+///
+/// The two roots are never unioned. `ensure_state_dir` may migrate legacy state
+/// by *copying* it (`StateMigrationKind::Copied` leaves the legacy tree in
+/// place), so summing both roots would double-count every migrated record.
+fn resolve_state_file(name: &str) -> Result<PathBuf> {
+    let primary = codewhale_config::codewhale_home()?.join(name);
+    if codewhale_config::codewhale_home_is_explicit() || primary.exists() {
+        return Ok(primary);
+    }
+    let legacy = codewhale_config::legacy_deepseek_home()?.join(name);
+    Ok(if legacy.exists() { legacy } else { primary })
 }
 
 /// Parse a timestamp from a JSON value field (tries RFC3339).
@@ -1021,5 +1041,101 @@ mod tests {
         rollup.tool_mut("read_file").calls = 4_012;
         rollup.tool_mut("exec_shell").calls = 1_118;
         assert_eq!(rollup.total_tool_calls(), 5_130);
+    }
+
+    // ── State-root resolution ──
+    //
+    // These pin *which* files the rollup reads. Before the fix the reader
+    // resolved `$HOME/.deepseek`, which nothing has written since the v0.8.44
+    // rename, so `codewhale metrics` printed an all-zero rollup as truth.
+
+    /// Isolate the ambient home so the resolver sees a clean, empty install.
+    ///
+    /// The returned guards must stay bound for the life of the test: dropping
+    /// them restores the previous environment. Destructure the tuple so the
+    /// bindings drop in reverse order — the environment is restored *before*
+    /// the lock is released, or a concurrent env-mutating test sees a torn HOME.
+    fn isolated_home() -> (
+        tempfile::TempDir,
+        std::sync::MutexGuard<'static, ()>,
+        Vec<crate::tests::ScopedEnvVar>,
+    ) {
+        let guard = crate::tests::env_lock();
+        let home = tempfile::TempDir::new().expect("tempdir");
+        let vars = vec![
+            crate::tests::ScopedEnvVar::set("HOME", &home.path().to_string_lossy()),
+            crate::tests::ScopedEnvVar::set("USERPROFILE", &home.path().to_string_lossy()),
+            crate::tests::ScopedEnvVar::remove("CODEWHALE_HOME"),
+            crate::tests::ScopedEnvVar::remove("DEEPSEEK_HOME"),
+        ];
+        (home, guard, vars)
+    }
+
+    #[test]
+    fn state_files_resolve_under_the_codewhale_root_on_a_clean_install() {
+        let (home, _lock, _env) = isolated_home();
+        assert_eq!(
+            resolve_state_file("audit.log").expect("resolves"),
+            home.path().join(".codewhale").join("audit.log"),
+            "the reader must land on the root the audit writer actually writes"
+        );
+    }
+
+    #[test]
+    fn a_legacy_file_is_used_only_when_it_is_the_one_that_exists() {
+        let (home, _lock, _env) = isolated_home();
+        let legacy = home.path().join(".deepseek");
+        std::fs::create_dir_all(&legacy).expect("legacy root");
+        std::fs::write(legacy.join("audit.log"), b"{}\n").expect("legacy log");
+
+        assert_eq!(
+            resolve_state_file("audit.log").expect("resolves"),
+            legacy.join("audit.log"),
+            "real DeepSeek-era receipts must not be dropped on the floor"
+        );
+
+        // Once the canonical file exists it wins outright; the two roots are
+        // never summed, because legacy state may have been migrated by copy.
+        let primary = home.path().join(".codewhale");
+        std::fs::create_dir_all(&primary).expect("primary root");
+        std::fs::write(primary.join("audit.log"), b"{}\n").expect("primary log");
+        assert_eq!(
+            resolve_state_file("audit.log").expect("resolves"),
+            primary.join("audit.log")
+        );
+    }
+
+    #[test]
+    fn an_explicit_codewhale_home_is_an_isolation_boundary() {
+        let (home, _lock, _env) = isolated_home();
+        let legacy = home.path().join(".deepseek");
+        std::fs::create_dir_all(&legacy).expect("legacy root");
+        std::fs::write(legacy.join("audit.log"), b"{}\n").expect("legacy log");
+
+        let explicit = tempfile::TempDir::new().expect("tempdir");
+        let _pin =
+            crate::tests::ScopedEnvVar::set("CODEWHALE_HOME", &explicit.path().to_string_lossy());
+
+        assert_eq!(
+            resolve_state_file("audit.log").expect("resolves"),
+            explicit.path().join("audit.log"),
+            "an explicit home must never reach outside its own root"
+        );
+    }
+
+    #[test]
+    fn the_legacy_deepseek_home_variable_is_no_longer_honoured() {
+        // docs/CONFIGURATION.md tells upgraders to rename DEEPSEEK_HOME to
+        // CODEWHALE_HOME; every other subsystem already ignores it, and this
+        // reader was the last consumer of the legacy alias.
+        let (home, _lock, _env) = isolated_home();
+        let stale = tempfile::TempDir::new().expect("tempdir");
+        let _stale =
+            crate::tests::ScopedEnvVar::set("DEEPSEEK_HOME", &stale.path().to_string_lossy());
+
+        assert_eq!(
+            resolve_state_file("audit.log").expect("resolves"),
+            home.path().join(".codewhale").join("audit.log")
+        );
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2041,8 +2041,9 @@ impl FleetSlot {
             "summarizer" | "reducer" => Self::Summarizer,
             "general" | "" => Self::General,
             // Removed slots (e.g. the old "tool-heavy") and unknown names parse
-            // as Custom, which dispatches on the General surface — identical to
-            // the behavior the removed variants had.
+            // as Custom. Note the runtime side no longer treats an undeclared
+            // role as write-capable: it fails closed to the read-only `explore`
+            // posture (#5575), so this is narrower than the removed variants.
             other => Self::Custom(other.to_string()),
         }
     }

--- a/crates/tui/src/acp_server.rs
+++ b/crates/tui/src/acp_server.rs
@@ -2381,9 +2381,16 @@ fn initialize_result(client_protocol_version: Option<u64>, config: &Config) -> V
                 "http": false,
                 "sse": false
             },
+            // ACP `SessionCapabilities` fields are objects, never booleans:
+            // `{}` means "supported", absent/null means "not supported"
+            // (#5969 — a boolean here made JetBrains' strictly-typed client
+            // fail the handshake and kill the agent). `session/load` support
+            // is advertised by the top-level `loadSession` above; it is not a
+            // field of `sessionCapabilities`. We only claim `list` because
+            // `session/list` is the only one of the optional session methods
+            // this server dispatches.
             "sessionCapabilities": {
-                "list": true,
-                "load": true
+                "list": {}
             }
         },
         "agentInfo": {
@@ -2821,14 +2828,22 @@ mod tests {
         assert_eq!(result["agentInfo"]["name"], "codewhale");
         // #5864: enumerating and resuming durable Codewhale sessions is now
         // served, so the capability says so rather than declining it.
+        // #5969: this test used to assert `list == true` and `load == true`,
+        // certifying the wire format that broke every strictly-typed client.
+        // `loadSession` is the top-level boolean that advertises
+        // `session/load`; inside `sessionCapabilities` every field is a
+        // capability *object*, and `load` is not a field at all. Comparing the
+        // whole object pins both halves: a boolean `list` or a resurrected
+        // `load` key fails here.
         assert_eq!(result["agentCapabilities"]["loadSession"], true);
         assert_eq!(
-            result["agentCapabilities"]["sessionCapabilities"]["list"],
-            true
+            result["agentCapabilities"]["sessionCapabilities"],
+            json!({"list": {}})
         );
-        assert_eq!(
-            result["agentCapabilities"]["sessionCapabilities"]["load"],
-            true
+        assert!(
+            result["agentCapabilities"]["sessionCapabilities"]["list"].is_object(),
+            "sessionCapabilities.list must be a SessionListCapabilities object, got {}",
+            result["agentCapabilities"]["sessionCapabilities"]["list"]
         );
         assert_eq!(
             result["agentCapabilities"]["promptCapabilities"]["embeddedContext"],

--- a/crates/tui/src/fleet/exact.rs
+++ b/crates/tui/src/fleet/exact.rs
@@ -1765,8 +1765,17 @@ permissions = "read_only"
         }
     }
 
+    /// #5575: a free-form member role keeps its identity and **fails closed**.
+    ///
+    /// This test previously asserted the opposite — `posture_role == "custom"`
+    /// and `write_authority == "workspace_write"` — which is exactly the defect:
+    /// `audit-lead` is a name nobody declared, and the exact driver answered it
+    /// with the widest posture there is while the durable driver answered the
+    /// same class of name with `general`. Identity is still preserved verbatim
+    /// (`member_role`), but an undeclared label now buys the narrowest useful
+    /// posture, not write authority.
     #[test]
-    fn a_free_form_member_role_maps_to_runtime_custom_without_losing_identity() {
+    fn a_free_form_member_role_fails_closed_without_losing_identity() {
         const AUDIT_FLEET: &str = r#"
 name = "audit"
 schema = "exact"
@@ -1784,11 +1793,17 @@ permissions = "read_only"
             .expect("bind");
 
         assert_eq!(binding.member_role, "audit-lead");
-        assert_eq!(binding.authority.posture_role, "custom");
+        assert_eq!(binding.authority.posture_role, "explore");
         assert_eq!(
-            binding.authority.write_authority, "workspace_write",
-            "authority comes from Runtime custom under the session ceiling; \
-             the Fleet permissions block grants nothing"
+            binding.authority.write_authority, "read_only",
+            "an undeclared role name must never grant write authority; an \
+             operator who wants the parent's posture spells the role `custom`"
+        );
+
+        // The escape hatch is a declared role, not a typo.
+        assert_eq!(
+            ChildAuthority::from_runtime_role("custom", full_session()).write_authority,
+            "workspace_write"
         );
     }
 
@@ -2650,7 +2665,8 @@ call_reasoning = "low"
     /// A member's semantic role and its Runtime posture are separate
     /// facts and the receipt keeps both. An operator who named a member
     /// `auditor` must see `auditor` on the receipt, while the surface actually
-    /// selected (`custom`) is disclosed rather than substituted for the name.
+    /// selected (`explore`, the fail-closed posture an undeclared role gets
+    /// since #5575) is disclosed rather than substituted for the name.
     #[tokio::test]
     async fn a_receipt_records_the_posture_without_renaming_the_members_role() {
         const AUDIT_FLEET: &str = r#"
@@ -2672,7 +2688,7 @@ permissions = "read_only"
 
         // Enforcement uses the posture; it is not the operator's role name.
         assert_eq!(binding.member_role, "auditor");
-        assert_eq!(binding.authority.posture_role, "custom");
+        assert_eq!(binding.authority.posture_role, "explore");
 
         let launch = workflow
             .route_admitted_task(&binding, "review the queue")
@@ -2681,9 +2697,9 @@ permissions = "read_only"
         let receipt = &launch.receipt;
 
         assert_eq!(receipt.member_role, "auditor");
-        assert_eq!(receipt.posture_role.as_deref(), Some("custom"));
+        assert_eq!(receipt.posture_role.as_deref(), Some("explore"));
         let line = receipt.line();
         assert!(line.contains("(role auditor)"), "{line}");
-        assert!(line.contains("posture=custom"), "{line}");
+        assert!(line.contains("posture=explore"), "{line}");
     }
 }

--- a/crates/tui/src/fleet/role.rs
+++ b/crates/tui/src/fleet/role.rs
@@ -652,12 +652,78 @@ impl ChildAuthority {
     }
 }
 
+/// Org-chart aliases for Fleet **member** role labels: roster slot names and
+/// coordination titles that select a runtime posture but are not part of the
+/// model-facing spawn vocabulary.
+///
+/// Deliberately *not* folded into [`migrate_legacy_role_token`]. That table
+/// feeds [`FleetRole::from_str`], which is also the closed vocabulary the
+/// `agent` tool validates its `type` against, and — decisively — the test the
+/// spawn parser uses to decide whether a `role` string is a posture alias or a
+/// roster profile key. Teaching `from_str` about `manager` or `smoke-runner`
+/// would stop those names resolving as roster members there. So the aliases
+/// live here, one step out, and reach exactly the one consumer that wants
+/// them: [`runtime_role_for_member`].
+///
+/// Every entry maps to the posture the durable Fleet driver already gave it,
+/// so folding them in only ever *narrows* the exact driver (which previously
+/// dropped all of these into write-capable `custom`); none of them widens
+/// authority on either path.
+fn member_role_alias(token: &str) -> Option<FleetRole> {
+    match token {
+        // Coordination happens through delegation, which needs the full
+        // General surface (#fleet-roster cutover (v0.8.67)). The operator is
+        // the helm of the overall work (it assigns managers to Workflows);
+        // the manager is the middle manager of one Workflow. Both coordinate,
+        // so both get the General surface — explicitly, not by fall-through.
+        "manager" | "coordinator" | "operator" => Some(FleetRole::Worker),
+        // Synthesis is read-only (planner posture: network reads and
+        // read-only probes, never workspace writes). It must never fall
+        // through to General's full-write posture (#fleet-roster cutover
+        // (v0.8.67)).
+        "synthesizer" | "summarizer" | "reducer" => Some(FleetRole::Planner),
+        // Documented Fleet task role spellings (`docs/FLEET.md`).
+        "smoke-runner" => Some(FleetRole::Verifier),
+        "read-only" => Some(FleetRole::Scout),
+        _ => None,
+    }
+}
+
 /// Map the Fleet's open semantic role label onto Runtime's closed role policy.
-/// Unknown labels remain useful identity (`auditor`, `research-lead`, …) but
-/// execute under Runtime `custom`, whose capabilities still intersect with the
-/// live parent.
+///
+/// **This is the only name → posture mapper.** Both Fleet drivers resolve
+/// through it: the exact/named-Fleet driver via
+/// [`ChildAuthority::from_runtime_role`], and the durable driver via
+/// `worker_runtime::roster_member_agent_type` and the task-role call sites.
+/// A second table anywhere is the defect this function exists to prevent —
+/// before #5575 the durable driver carried its own alias list, so the same
+/// string (`synthesizer`, `smoke-runner`, `read-only`) resolved to a
+/// read-only posture on one driver and to write-capable `custom` on the other.
+///
+/// Resolution order, and nothing else:
+/// 1. an empty label means *unspecified*, which is the documented general
+///    default a Fleet task without a `role` has always had;
+/// 2. [`FleetRole::from_str`] — the declared closed vocabulary plus its
+///    documented legacy aliases ([`VALID_ROLE_ALIASES`]);
+/// 3. [`member_role_alias`] — the org-chart/slot spellings above;
+/// 4. **fail closed.**
+///
+/// Step 4 is the privilege boundary. An unrecognized label is still useful
+/// identity (`auditor`, `release-lead`, …) and keeps its name on every receipt
+/// via [`public_role_label`], but a name nobody declared must not be able to
+/// hand a worker write authority. It therefore executes on the narrowest
+/// posture that can still do useful work — `explore`: no workspace writes, no
+/// raw shell, network reads and classifier-bounded `Bash` inspection. An
+/// operator who genuinely wants "inherit whatever the parent has" spells that
+/// `custom`, which is a declared role and resolves at step 2.
 pub(crate) fn runtime_role_for_member(role: &str) -> FleetRole {
-    FleetRole::from_str(role).unwrap_or(FleetRole::Custom)
+    let token = role.trim().to_ascii_lowercase();
+    if token.is_empty() {
+        return FleetRole::Worker;
+    }
+    FleetRole::from_str(&token)
+        .or_else(|| member_role_alias(&token))
+        .unwrap_or(FleetRole::Scout)
 }
 
 fn runtime_permission_ceiling(role: &FleetRole) -> PermissionCeiling {

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -28,6 +28,7 @@ use super::profile::{
     AgentProfile, FleetDelegationHints, FleetLoadout, FleetProfile, FleetProfilePermissions,
     FleetRole as FleetProfileRole, FleetSlot, ProfileOrigin, canonical_public_role_name,
 };
+use super::role::runtime_role_for_member;
 use crate::config::{ApiProvider, Config};
 use crate::route_runtime::{resolve_route_candidate, resolve_runtime_route};
 use crate::tools::subagent::{AgentWorkerSpec, AgentWorkerToolProfile, FleetRole};
@@ -415,7 +416,7 @@ pub fn fleet_task_to_worker_spec_with_profiles(
     let agent_profile = agent_profile.as_deref();
     let worker_profile = task_spec.worker.as_ref();
     let role = effective_fleet_role(worker_profile, agent_profile);
-    let agent_type = fleet_role_to_agent_type(role.as_deref());
+    let agent_type = runtime_role_for_member(role.as_deref().unwrap_or_default());
     let tool_profile = fleet_tool_profile(worker_profile);
     let objective = fleet_task_prompt_with_profile(task_spec, agent_profile);
     let max_spawn_depth = codewhale_config::FleetExecConfig::default().max_spawn_depth;
@@ -1198,7 +1199,8 @@ fn effective_fleet_reasoning_effort_for_role(
 ) -> Option<String> {
     effective_fleet_reasoning_effort(agent_profile).or_else(|| {
         let role = effective_fleet_role(worker_profile, agent_profile);
-        WorkerRuntimeProfile::for_role(fleet_role_to_agent_type(role.as_deref())).reasoning_effort
+        WorkerRuntimeProfile::for_role(runtime_role_for_member(role.as_deref().unwrap_or_default()))
+            .reasoning_effort
     })
 }
 
@@ -1281,51 +1283,15 @@ fn fleet_route_model_selector_with_source(
     }
 }
 
-/// Map a fleet role name to a `FleetRole`. Unknown roles default to `General`.
-pub(crate) fn fleet_role_to_agent_type(role: Option<&str>) -> FleetRole {
-    match role {
-        Some("smoke-runner") => FleetRole::Verifier,
-        Some("explore") | Some("scout") => FleetRole::Scout,
-        Some("read-only") => FleetRole::Scout,
-        Some("reviewer") => FleetRole::Reviewer,
-        Some("implement") | Some("builder") => FleetRole::Builder,
-        Some("test") | Some("verifier") | Some("tester") => FleetRole::Verifier,
-        // Every canonical dispatch posture is also a seeded roster member
-        // (#5285); the explicit arms keep the roster→runtime mapping 1:1.
-        Some("planner") => FleetRole::Planner,
-        Some("custom") => FleetRole::Custom,
-        // Advisory counsel (#4752). `oracle` and `consultant` are compatibility
-        // aliases for the canonical public role name, `advisor`.
-        Some("consultant") | Some("oracle") | Some("advisor") => FleetRole::Consultant,
-        Some("explorer") => FleetRole::Scout,
-        // Coordination happens through delegation, which needs the full
-        // General surface (#fleet-roster cutover (v0.8.67)). The operator is
-        // the helm of the overall work (it assigns managers to Workflows);
-        // the manager is the middle manager of one Workflow. Both coordinate,
-        // so both get the General surface — explicitly, not by fall-through.
-        Some("manager") | Some("coordinator") | Some("operator") => FleetRole::Worker,
-        // Synthesis is read-only (planner posture: network reads and
-        // read-only probes, never workspace writes). It must never fall
-        // through to General's full-write posture (#fleet-roster cutover
-        // (v0.8.67)).
-        Some("synthesizer") | Some("summarizer") | Some("reducer") => FleetRole::Planner,
-        Some("general") | None => FleetRole::Worker,
-        Some(other) => {
-            // Try parsing as a FleetRole directly
-            FleetRole::from_str(other).unwrap_or(FleetRole::Worker)
-        }
-    }
-}
-
 /// Runtime agent type for a roster member: role name first, falling back to
 /// the org-chart slot name when the role name is empty (#fleet-roster cutover
 /// (v0.8.67)).
 pub(crate) fn roster_member_agent_type(member: &AgentProfile) -> FleetRole {
     let role_name = member.profile.role.name.trim();
     if role_name.is_empty() {
-        fleet_role_to_agent_type(Some(member.profile.slot.as_str()))
+        runtime_role_for_member(member.profile.slot.as_str())
     } else {
-        fleet_role_to_agent_type(Some(role_name))
+        runtime_role_for_member(role_name)
     }
 }
 
@@ -1525,7 +1491,7 @@ pub(crate) fn network_posture_warning_for_task(
     let agent_profile = agent_profile.as_deref();
     let worker_profile = task.worker.as_ref();
     let role = effective_fleet_role(worker_profile, agent_profile);
-    let agent_type = fleet_role_to_agent_type(role.as_deref());
+    let agent_type = runtime_role_for_member(role.as_deref().unwrap_or_default());
     let tool_profile = fleet_tool_profile(worker_profile);
     let (model, model_source) = effective_fleet_model_with_source(
         session_model.unwrap_or("auto"),
@@ -1906,48 +1872,38 @@ mod tests {
 
     #[test]
     fn fleet_role_smoke_runner_maps_to_verifier() {
-        assert_eq!(
-            fleet_role_to_agent_type(Some("smoke-runner")),
-            FleetRole::Verifier
-        );
+        assert_eq!(runtime_role_for_member("smoke-runner"), FleetRole::Verifier);
     }
 
     #[test]
     fn fleet_role_read_only_maps_to_explore() {
-        assert_eq!(
-            fleet_role_to_agent_type(Some("read-only")),
-            FleetRole::Scout
-        );
+        assert_eq!(runtime_role_for_member("read-only"), FleetRole::Scout);
     }
 
     #[test]
     fn fleet_role_reviewer_maps_to_review() {
-        assert_eq!(
-            fleet_role_to_agent_type(Some("reviewer")),
-            FleetRole::Reviewer
-        );
+        assert_eq!(runtime_role_for_member("reviewer"), FleetRole::Reviewer);
     }
 
     #[test]
     fn fleet_role_builder_maps_to_implementer() {
-        assert_eq!(
-            fleet_role_to_agent_type(Some("builder")),
-            FleetRole::Builder
-        );
+        assert_eq!(runtime_role_for_member("builder"), FleetRole::Builder);
     }
 
+    /// An *absent* role is not an *unknown* role: a Fleet task with no `role`
+    /// field has always run on the documented general default, and #5575's
+    /// fail-closed rule is about labels nobody declared, not about the
+    /// unspecified case.
     #[test]
-    fn fleet_role_none_maps_to_general() {
-        assert_eq!(fleet_role_to_agent_type(None), FleetRole::Worker);
+    fn an_unspecified_role_still_maps_to_general() {
+        assert_eq!(runtime_role_for_member(""), FleetRole::Worker);
+        assert_eq!(runtime_role_for_member("   "), FleetRole::Worker);
     }
 
     #[test]
     fn fleet_role_manager_and_coordinator_map_to_general() {
-        assert_eq!(fleet_role_to_agent_type(Some("manager")), FleetRole::Worker);
-        assert_eq!(
-            fleet_role_to_agent_type(Some("coordinator")),
-            FleetRole::Worker
-        );
+        assert_eq!(runtime_role_for_member("manager"), FleetRole::Worker);
+        assert_eq!(runtime_role_for_member("coordinator"), FleetRole::Worker);
     }
 
     #[test]
@@ -1955,10 +1911,7 @@ mod tests {
         // The operator coordinates the overall work (assigns managers to
         // workflows), so it needs the full General surface — by an explicit
         // match arm, not the unknown-role fall-through.
-        assert_eq!(
-            fleet_role_to_agent_type(Some("operator")),
-            FleetRole::Worker
-        );
+        assert_eq!(runtime_role_for_member("operator"), FleetRole::Worker);
     }
 
     #[test]
@@ -2136,7 +2089,7 @@ mod tests {
     fn consultant_and_legacy_advisory_aliases_share_the_consultant_posture() {
         for role in ["consultant", "oracle", "advisor"] {
             assert_eq!(
-                fleet_role_to_agent_type(Some(role)),
+                runtime_role_for_member(role),
                 FleetRole::Consultant,
                 "role {role}"
             );
@@ -2146,10 +2099,10 @@ mod tests {
     #[test]
     fn fleet_role_synthesizer_family_maps_to_read_only_plan() {
         // A synthesizer must never fall through to General's full-write
-        // posture; Plan is read-only with no shell.
+        // posture; Planner is read-only (reads plus read-only shell probes).
         for role in ["synthesizer", "summarizer", "reducer"] {
             assert_eq!(
-                fleet_role_to_agent_type(Some(role)),
+                runtime_role_for_member(role),
                 FleetRole::Planner,
                 "role {role}"
             );
@@ -2207,12 +2160,63 @@ mod tests {
         }
     }
 
+    /// #5575: an undeclared role name must not be able to hand a worker write
+    /// authority. Before this fix the durable driver answered `Worker` here and
+    /// the exact driver answered `Custom` — two different tables, both
+    /// write-capable and full-shell, for a string nobody declared.
     #[test]
-    fn unknown_role_maps_to_general() {
-        assert_eq!(
-            fleet_role_to_agent_type(Some("nonexistent-role")),
-            FleetRole::Worker
-        );
+    fn unknown_role_fails_closed_to_the_read_only_explore_posture() {
+        for unknown in ["nonexistent-role", "audit-lead", "release-checker"] {
+            assert_eq!(
+                runtime_role_for_member(unknown),
+                FleetRole::Scout,
+                "unknown role {unknown:?} must fail closed, never to a write-capable posture"
+            );
+            assert!(
+                !WorkerRuntimeProfile::for_role(runtime_role_for_member(unknown))
+                    .permissions
+                    .write,
+                "unknown role {unknown:?} must never carry write authority"
+            );
+        }
+
+        // The escape hatch is a *declared* role, not a typo: an operator who
+        // wants "inherit whatever the parent has" spells it `custom`.
+        assert_eq!(runtime_role_for_member("custom"), FleetRole::Custom);
+    }
+
+    /// #5575: both Fleet drivers resolve names through the same mapper, so the
+    /// aliases the durable driver used to own privately now resolve to the same
+    /// posture on the exact/named-Fleet driver — which previously dropped every
+    /// one of them into write-capable `custom`.
+    #[test]
+    fn the_two_fleet_drivers_agree_on_every_member_role_alias() {
+        let session = codewhale_workflow::PermissionCeiling {
+            write: true,
+            network_tool: true,
+            shell: codewhale_workflow::ShellCeiling::Full,
+            delegation_depth: 2,
+            tools: true,
+        };
+        for (role, expected, expected_write) in [
+            ("smoke-runner", FleetRole::Verifier, "read_only"),
+            ("read-only", FleetRole::Scout, "read_only"),
+            ("synthesizer", FleetRole::Planner, "read_only"),
+            ("summarizer", FleetRole::Planner, "read_only"),
+            ("reducer", FleetRole::Planner, "read_only"),
+            ("manager", FleetRole::Worker, "workspace_write"),
+            ("coordinator", FleetRole::Worker, "workspace_write"),
+            ("operator", FleetRole::Worker, "workspace_write"),
+        ] {
+            assert_eq!(runtime_role_for_member(role), expected, "role {role}");
+            // The exact driver's authority comes from the same mapper.
+            assert_eq!(
+                crate::fleet::role::ChildAuthority::from_runtime_role(role, session)
+                    .write_authority,
+                expected_write,
+                "role {role} must resolve the same authority on the exact driver"
+            );
+        }
     }
 
     #[test]
@@ -3673,7 +3677,11 @@ mod tests {
             Some("reviewer")
         );
         assert_eq!(
-            fleet_role_to_agent_type(effective_fleet_role(task.worker.as_ref(), None).as_deref()),
+            runtime_role_for_member(
+                effective_fleet_role(task.worker.as_ref(), None)
+                    .as_deref()
+                    .unwrap_or_default()
+            ),
             FleetRole::Reviewer
         );
     }

--- a/crates/tui/src/goal_loop.rs
+++ b/crates/tui/src/goal_loop.rs
@@ -12,13 +12,16 @@
 //!
 //! Scope: **decision logic + types**. The engine (`core/engine.rs`) reads the
 //! `SharedGoalState` snapshot after each turn and calls `decide_continuation`
-//! to decide whether to re-dispatch. For operate-mode goals the only terminal
-//! stops are a verified completion, a blocked report, or the continuation
-//! backstop (`[goal] max_continuations`); token/time accounting stays visible
-//! as telemetry but does not gate continuation — the run is unbounded like
-//! grokbuild (`DEFAULT_AGENT_BUDGET` as call cap) and kimicode swarm
-//! (`turnBudget` per-task, resumable after budget-reached). Log when the
-//! backstop fires.
+//! to decide whether to re-dispatch. For operate-mode goals the terminal stops
+//! are a verified completion, a blocked report, the stall pause that fires
+//! when a critical verifier reports the same gap set
+//! [`MAX_REPEATED_GAP_PASSES`] times running (enforced in
+//! `GoalState::record_not_achieved`), and the opt-in continuation backstop
+//! (`[goal] max_continuations`); token/time accounting stays visible as
+//! telemetry but does not gate continuation — spend is bounded by stalling,
+//! not by a pass count, like grokbuild (`DEFAULT_AGENT_BUDGET` as call cap)
+//! and kimicode swarm (`turnBudget` per-task, resumable after
+//! budget-reached). Log when the backstop fires.
 
 use std::time::Duration;
 
@@ -28,6 +31,27 @@ use std::time::Duration;
 /// user control ends the run. Operators who want a circuit breaker can opt in
 /// with `[goal] max_continuations`; `0` keeps the default unlimited behavior.
 pub const DEFAULT_MAX_GOAL_CONTINUATIONS: u32 = 0;
+
+/// How many consecutive critical `not_achieved` reviews naming the *same*
+/// normalized gap set a goal may accumulate before it pauses itself with
+/// `GoalPauseReason::NoProgress`.
+///
+/// This is the bound the continuation prompt promises the model, and it is the
+/// only default stop on a goal run: `DEFAULT_MAX_GOAL_CONTINUATIONS` is `0`, so
+/// without it the loop runs until the model volunteers a terminal status.
+/// Enforcement lives in `GoalState::record_not_achieved`, and it reuses the
+/// existing pause authority rather than adding a second one — both continuation
+/// dispatchers already refuse to re-dispatch a non-active goal, and
+/// `RuntimeThreadManager` already mirrors a non-limit pause into the durable
+/// `ThreadGoalStatus::Paused`, so the stop survives a restart and needs an
+/// explicit resume.
+///
+/// The counter is `1` on the first report of a gap set, so `3` means the
+/// verifier named identical remaining work three times running: two whole
+/// continuation passes that moved nothing the verifier can see. Two is too
+/// eager — one pass legitimately fails to land a fix and retries — and anything
+/// larger just buys more identical passes.
+pub const MAX_REPEATED_GAP_PASSES: u32 = 3;
 
 /// Upper bound for one between-turn quiet period. A day is long enough for
 /// coordinator cadences while preventing an accidental giant integer from

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -3712,9 +3712,10 @@ struct CleanPlan {
 fn collect_clean_targets(checkpoints_dir: &Path) -> CleanPlan {
     // Every `*.json` file in the checkpoints directory is checkpoint state:
     // per-session crash checkpoints (`<session_id>.json`), the legacy
-    // single-slot checkpoint (`latest.json`), and the offline input queue
-    // (`offline_queue.json`). Non-JSON files and subdirectories are left
-    // alone.
+    // single-slot checkpoint (`latest.json`), and the per-session offline
+    // input queue (`<session_id>.offline_queue.json`, plus any leftover
+    // pre-migration `offline_queue.json`). Non-JSON files and subdirectories
+    // are left alone.
     let mut targets: Vec<PathBuf> = std::fs::read_dir(checkpoints_dir)
         .map(|entries| {
             entries

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -88,8 +88,9 @@ pub struct QueuedSessionMessage {
 pub struct OfflineQueueState {
     #[serde(default = "default_queue_schema_version")]
     pub schema_version: u32,
-    /// Session ID this queue belongs to. Queue is only restored when
-    /// resuming the same session to prevent stale messages leaking into new chats.
+    /// Session ID this queue belongs to. Redundant with the per-session file
+    /// name it is stored under; the UI's restore path still compares it
+    /// against the live session before adopting the messages.
     #[serde(default)]
     pub session_id: Option<String>,
     #[serde(default)]
@@ -934,6 +935,11 @@ fn serialize_saved_session(session: &SavedSession) -> io::Result<String> {
 pub struct SessionManager {
     /// Directory where sessions are stored
     sessions_dir: PathBuf,
+    /// Which session this manager last parked or restored an offline queue
+    /// for. `clear_offline_queue_state` has no session argument (the
+    /// persistence actor's clear request carries none), so this is what a
+    /// bare clear resolves to — never another instance's session.
+    queue_owner: std::sync::Mutex<Option<String>>,
 }
 
 /// Origin of a crash-recovery checkpoint file.
@@ -956,7 +962,10 @@ pub struct CheckpointRef {
 
 /// File names in `checkpoints/` that are never per-session checkpoints.
 const LEGACY_CHECKPOINT_FILE: &str = "latest.json";
+/// Pre-per-session global offline queue, still read once for migration.
 const OFFLINE_QUEUE_FILE: &str = "offline_queue.json";
+/// Per-session offline queue file: `checkpoints/<session_id>.offline_queue.json`.
+const OFFLINE_QUEUE_SUFFIX: &str = ".offline_queue.json";
 
 impl SessionManager {
     fn approval_receipt_store(&self) -> ApprovalReceiptStore {
@@ -1095,7 +1104,10 @@ impl SessionManager {
         let sessions_dir = normalize_managed_dir(sessions_dir)?;
         // Ensure the sessions directory exists
         fs::create_dir_all(&sessions_dir)?;
-        Ok(Self { sessions_dir })
+        Ok(Self {
+            sessions_dir,
+            queue_owner: std::sync::Mutex::new(None),
+        })
     }
 
     /// Create a `SessionManager` using the default location.
@@ -1401,7 +1413,9 @@ impl SessionManager {
             };
             let source = if name == LEGACY_CHECKPOINT_FILE {
                 CheckpointSource::Legacy
-            } else if name == OFFLINE_QUEUE_FILE {
+            } else if name == OFFLINE_QUEUE_FILE || name.ends_with(OFFLINE_QUEUE_SUFFIX) {
+                // Parked offline queues live in this directory but are not
+                // crash-recovery checkpoints.
                 continue;
             } else {
                 let session_id = name.trim_end_matches(".json").to_string();
@@ -1440,33 +1454,96 @@ impl SessionManager {
         Ok(true)
     }
 
-    /// Save offline queue state (queued + draft messages).
+    /// Park this session's offline queue (queued + draft messages).
+    ///
+    /// Queues are keyed per session (`checkpoints/<session_id>.offline_queue.json`)
+    /// for exactly the reason checkpoints are: concurrent Codewhale instances
+    /// must never overwrite — or delete — each other's unsent user text.
+    ///
+    /// A queue with no session id has no owner to restore it to, so parking is
+    /// refused rather than written to a shared file where the next boot would
+    /// destroy it.
     pub fn save_offline_queue_state(
         &self,
         state: &OfflineQueueState,
         session_id: Option<&str>,
     ) -> std::io::Result<PathBuf> {
-        let checkpoints = self.sessions_dir.join("checkpoints");
-        fs::create_dir_all(&checkpoints)?;
-        let path = checkpoints.join("offline_queue.json");
-        let mut state_with_id = state.clone();
-        state_with_id.session_id = session_id.map(|s| s.to_string());
-        let content = serde_json::to_string_pretty(&state_with_id)
+        let session_id = session_id.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Offline queue cannot be parked without a session id",
+            )
+        })?;
+        let path = self.validated_offline_queue_path(session_id)?;
+        fs::create_dir_all(self.checkpoints_dir())?;
+        let mut owned = state.clone();
+        // The stamp is redundant with the file name; it stays because the UI's
+        // restore path still compares it against the live session id.
+        owned.session_id = Some(self.validated_session_id(session_id)?.to_string());
+        let content = serde_json::to_string_pretty(&owned)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         write_atomic(&path, content.as_bytes())?;
+        self.remember_queue_owner(session_id);
         Ok(path)
     }
 
-    /// Load offline queue state if present.
-    pub fn load_offline_queue_state(&self) -> std::io::Result<Option<OfflineQueueState>> {
-        let path = self
-            .sessions_dir
-            .join("checkpoints")
-            .join("offline_queue.json");
-        if !path.exists() {
-            return Ok(None);
+    /// Load one session's parked offline queue if present.
+    pub fn load_offline_queue_state(
+        &self,
+        session_id: &str,
+    ) -> std::io::Result<Option<OfflineQueueState>> {
+        let path = self.validated_offline_queue_path(session_id)?;
+        let state = match Self::read_offline_queue_file(&path)? {
+            Some(state) => Some(state),
+            None => self.adopt_legacy_offline_queue(session_id, &path)?,
+        };
+        if state.is_some() {
+            self.remember_queue_owner(session_id);
         }
-        let content = fs::read_to_string(&path)?;
+        Ok(state)
+    }
+
+    /// Remove the parked offline queue for the session this manager last
+    /// parked or restored one for.
+    ///
+    /// The persistence actor's clear request carries no session id, so the
+    /// owner is whichever session this manager instance last wrote a queue
+    /// for. It can therefore never reach another session's parked text.
+    pub fn clear_offline_queue_state(&self) -> std::io::Result<()> {
+        let Some(session_id) = self.queue_owner() else {
+            return Ok(());
+        };
+        self.clear_offline_queue_state_for(&session_id)
+    }
+
+    /// Remove one named session's parked offline queue.
+    pub fn clear_offline_queue_state_for(&self, session_id: &str) -> std::io::Result<()> {
+        let path = self.validated_offline_queue_path(session_id)?;
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        let mut owner = self.lock_queue_owner();
+        if owner.as_deref() == Some(session_id.trim()) {
+            *owner = None;
+        }
+        Ok(())
+    }
+
+    fn validated_offline_queue_path(&self, session_id: &str) -> std::io::Result<PathBuf> {
+        let trimmed = self.validated_session_id(session_id)?;
+        Ok(self
+            .checkpoints_dir()
+            .join(format!("{trimmed}{OFFLINE_QUEUE_SUFFIX}")))
+    }
+
+    fn read_offline_queue_file(path: &Path) -> std::io::Result<Option<OfflineQueueState>> {
+        let content = match fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
         let state: OfflineQueueState = serde_json::from_str(&content)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         if state.schema_version > CURRENT_QUEUE_SCHEMA_VERSION {
@@ -1481,16 +1558,46 @@ impl SessionManager {
         Ok(Some(state))
     }
 
-    /// Remove persisted offline queue state.
-    pub fn clear_offline_queue_state(&self) -> std::io::Result<()> {
-        let path = self
-            .sessions_dir
-            .join("checkpoints")
-            .join("offline_queue.json");
-        if path.exists() {
-            fs::remove_file(path)?;
+    /// Migrate the pre-per-session global queue (`checkpoints/offline_queue.json`).
+    ///
+    /// It holds user-authored text, so it is adopted only by the session it was
+    /// stamped for, and it is removed only once this session's copy is durably
+    /// written. A queue stamped for someone else — or for nobody — is left
+    /// exactly where it is, still readable, for its owner to claim.
+    fn adopt_legacy_offline_queue(
+        &self,
+        session_id: &str,
+        path: &Path,
+    ) -> std::io::Result<Option<OfflineQueueState>> {
+        let legacy = self.checkpoints_dir().join(OFFLINE_QUEUE_FILE);
+        // A corrupt or future-schema legacy file must not fail this session's
+        // boot: leave it on disk untouched and start with an empty queue.
+        let Ok(Some(state)) = Self::read_offline_queue_file(&legacy) else {
+            return Ok(None);
+        };
+        if state.session_id.as_deref() != Some(self.validated_session_id(session_id)?) {
+            return Ok(None);
         }
-        Ok(())
+        let content = serde_json::to_string_pretty(&state)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        fs::create_dir_all(self.checkpoints_dir())?;
+        write_atomic(path, content.as_bytes())?;
+        fs::remove_file(&legacy)?;
+        Ok(Some(state))
+    }
+
+    fn lock_queue_owner(&self) -> std::sync::MutexGuard<'_, Option<String>> {
+        self.queue_owner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn remember_queue_owner(&self, session_id: &str) {
+        *self.lock_queue_owner() = Some(session_id.trim().to_string());
+    }
+
+    fn queue_owner(&self) -> Option<String> {
+        self.lock_queue_owner().clone()
     }
 
     /// Read a session snapshot without repairing tool call/result pairs.
@@ -4237,7 +4344,12 @@ mod tests {
         manager.save_checkpoint(&session).expect("save checkpoint");
         let checkpoints = tmp.path().join("sessions").join("checkpoints");
         fs::write(checkpoints.join("latest.json"), "{}").expect("write legacy slot");
-        fs::write(checkpoints.join("offline_queue.json"), "{}").expect("write offline queue");
+        fs::write(checkpoints.join("offline_queue.json"), "{}").expect("write legacy queue");
+        fs::write(
+            checkpoints.join(format!("{}.offline_queue.json", session.metadata.id)),
+            "{}",
+        )
+        .expect("write per-session queue");
 
         let refs = manager.list_checkpoints().expect("list checkpoints");
         assert_eq!(refs.len(), 2, "offline queue must not be a candidate");
@@ -4324,7 +4436,7 @@ mod tests {
             .save_offline_queue_state(&state, Some("test-session"))
             .expect("save queue state");
         let loaded = manager
-            .load_offline_queue_state()
+            .load_offline_queue_state("test-session")
             .expect("load queue state")
             .expect("queue state exists");
         assert_eq!(loaded.messages.len(), 1);
@@ -4336,64 +4448,170 @@ mod tests {
             .expect("clear queue state");
         assert!(
             manager
-                .load_offline_queue_state()
+                .load_offline_queue_state("test-session")
                 .expect("load queue state")
+                .is_none()
+        );
+
+        // A queue with no owning session has nowhere to be restored to, so it
+        // is refused rather than written where another session would find it.
+        let unowned = manager.save_offline_queue_state(&state, None);
+        assert!(unowned.is_err(), "unowned queue must not be parked");
+    }
+
+    fn parked(text: &str) -> OfflineQueueState {
+        OfflineQueueState {
+            messages: vec![QueuedSessionMessage {
+                display: text.to_string(),
+                skill_instruction: None,
+                skill_provenance: None,
+            }],
+            ..OfflineQueueState::default()
+        }
+    }
+
+    #[test]
+    fn offline_queues_are_keyed_per_session() {
+        // Replaces the #487 single-slot test, which pinned the shared
+        // `checkpoints/offline_queue.json`: two concurrent Codewhale
+        // instances raced on it and the loser's unsent text was destroyed.
+        // Queues are keyed per session for the same reason checkpoints are.
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+
+        manager
+            .save_offline_queue_state(&parked("A text"), Some("session-A"))
+            .expect("park A");
+        manager
+            .save_offline_queue_state(&parked("B text"), Some("session-B"))
+            .expect("park B");
+
+        let a = manager
+            .load_offline_queue_state("session-A")
+            .expect("load A")
+            .expect("A still parked");
+        assert_eq!(a.messages[0].display, "A text");
+        assert_eq!(a.session_id.as_deref(), Some("session-A"));
+        let b = manager
+            .load_offline_queue_state("session-B")
+            .expect("load B")
+            .expect("B still parked");
+        assert_eq!(b.messages[0].display, "B text");
+
+        // Clearing one session's queue leaves the other's alone.
+        manager
+            .clear_offline_queue_state_for("session-A")
+            .expect("clear A");
+        assert!(
+            manager
+                .load_offline_queue_state("session-A")
+                .expect("load A")
+                .is_none()
+        );
+        assert!(
+            manager
+                .load_offline_queue_state("session-B")
+                .expect("load B")
+                .is_some(),
+            "clearing one session must never delete another's unsent text"
+        );
+
+        // A session with nothing parked reads back nothing — it can never
+        // inherit, or destroy, a sibling's queue.
+        assert!(
+            manager
+                .load_offline_queue_state("session-C")
+                .expect("load C")
                 .is_none()
         );
     }
 
     #[test]
-    fn test_offline_queue_stamps_session_id_on_save() {
-        // #487: save_offline_queue_state must stamp the supplied
-        // session id so the load path's mismatch check has something
-        // to compare against. A queue persisted without a session id
-        // is the legacy unscoped form which the load path treats as
-        // stale-risky and refuses to restore.
+    fn bare_clear_only_reaches_this_managers_own_queue() {
+        // The persistence actor's clear request carries no session id, so a
+        // bare clear resolves to whichever session this manager last parked
+        // or restored a queue for.
         let tmp = tempdir().expect("tempdir");
-        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+        let sessions_dir = tmp.path().join("sessions");
+        let mine = SessionManager::new(sessions_dir.clone()).expect("new");
+        let theirs = SessionManager::new(sessions_dir).expect("new");
 
-        let state = OfflineQueueState {
-            messages: vec![QueuedSessionMessage {
-                display: "first parked".to_string(),
-                skill_instruction: None,
-                skill_provenance: None,
-            }],
-            ..OfflineQueueState::default()
-        };
+        theirs
+            .save_offline_queue_state(&parked("their text"), Some("session-B"))
+            .expect("park B");
+        mine.save_offline_queue_state(&parked("my text"), Some("session-A"))
+            .expect("park A");
 
-        manager
-            .save_offline_queue_state(&state, Some("session-A"))
-            .expect("save with session id");
-        let loaded = manager
-            .load_offline_queue_state()
-            .expect("ok")
-            .expect("present");
-        assert_eq!(loaded.session_id.as_deref(), Some("session-A"));
-
-        // Re-saving with a different session id replaces the stamp.
-        manager
-            .save_offline_queue_state(&state, Some("session-B"))
-            .expect("re-save");
-        let reloaded = manager
-            .load_offline_queue_state()
-            .expect("ok")
-            .expect("present");
-        assert_eq!(reloaded.session_id.as_deref(), Some("session-B"));
-
-        // Saving without a session id explicitly (None) clears the
-        // stamp — UI's load path treats that as legacy-unscoped and
-        // fails closed.
-        manager
-            .save_offline_queue_state(&state, None)
-            .expect("save without session id");
-        let unscoped = manager
-            .load_offline_queue_state()
-            .expect("ok")
-            .expect("present");
+        mine.clear_offline_queue_state().expect("clear mine");
         assert!(
-            unscoped.session_id.is_none(),
-            "save with None must persist a missing session_id"
+            mine.load_offline_queue_state("session-A")
+                .expect("load A")
+                .is_none()
         );
+        assert!(
+            theirs
+                .load_offline_queue_state("session-B")
+                .expect("load B")
+                .is_some(),
+            "a bare clear must not reach another instance's parked text"
+        );
+
+        // Nothing parked through this manager: a bare clear is a no-op.
+        let bystander = SessionManager::new(tmp.path().join("sessions")).expect("new");
+        bystander.clear_offline_queue_state().expect("no-op clear");
+        assert!(
+            theirs
+                .load_offline_queue_state("session-B")
+                .expect("load B")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn legacy_global_queue_is_adopted_only_by_its_own_session() {
+        let tmp = tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("new");
+        let checkpoints = sessions_dir.join("checkpoints");
+        fs::create_dir_all(&checkpoints).expect("create checkpoints dir");
+        let legacy = checkpoints.join("offline_queue.json");
+        let mut state = parked("text from the old global queue");
+        state.session_id = Some("session-A".to_string());
+        fs::write(
+            &legacy,
+            serde_json::to_string_pretty(&state).expect("serialize"),
+        )
+        .expect("write legacy queue");
+
+        // A different session must not inherit it, and must not delete it.
+        assert!(
+            manager
+                .load_offline_queue_state("session-B")
+                .expect("load B")
+                .is_none()
+        );
+        assert!(legacy.exists(), "another session's text must survive");
+
+        // Its own session adopts it, and the global file is retired only
+        // after the per-session copy is durably written.
+        let adopted = manager
+            .load_offline_queue_state("session-A")
+            .expect("load A")
+            .expect("adopted");
+        assert_eq!(
+            adopted.messages[0].display,
+            "text from the old global queue"
+        );
+        assert!(!legacy.exists(), "adopted legacy queue is retired");
+        assert!(
+            checkpoints.join("session-A.offline_queue.json").exists(),
+            "adoption writes the per-session file"
+        );
+        let again = manager
+            .load_offline_queue_state("session-A")
+            .expect("reload A")
+            .expect("still parked");
+        assert_eq!(again.messages[0].display, "text from the old global queue");
     }
 
     #[test]
@@ -4775,7 +4993,7 @@ mod tests {
         let manager = SessionManager::new(sessions_dir.clone()).expect("new");
         let checkpoints = sessions_dir.join("checkpoints");
         fs::create_dir_all(&checkpoints).expect("create checkpoints dir");
-        let path = checkpoints.join("offline_queue.json");
+        let path = checkpoints.join("session-A.offline_queue.json");
         fs::write(
             &path,
             r#"{
@@ -4787,11 +5005,23 @@ mod tests {
         .expect("write queue");
 
         let err = manager
-            .load_offline_queue_state()
+            .load_offline_queue_state("session-A")
             .expect_err("should reject schema");
         assert!(
             err.to_string().contains("newer than supported"),
             "unexpected error: {err}"
         );
+
+        // An unreadable *legacy* global queue is somebody else's problem to
+        // recover: it must not fail this session's boot, and must survive.
+        let legacy = checkpoints.join("offline_queue.json");
+        fs::write(&legacy, r#"{"schema_version": 999}"#).expect("write legacy queue");
+        assert!(
+            manager
+                .load_offline_queue_state("session-B")
+                .expect("legacy corruption must not fail the boot")
+                .is_none()
+        );
+        assert!(legacy.exists(), "unreadable legacy queue is left in place");
     }
 }

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -1582,7 +1582,16 @@ impl SessionManager {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         fs::create_dir_all(self.checkpoints_dir())?;
         write_atomic(path, content.as_bytes())?;
-        fs::remove_file(&legacy)?;
+        match fs::remove_file(&legacy) {
+            Ok(()) => {}
+            // A second instance of the same session can win the adoption
+            // race: both read the legacy file, both write this session's
+            // per-session copy, and the twin's remove already retired the
+            // legacy one. The queue is durably adopted either way, so a
+            // vanished legacy file is success here, not a boot error.
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
         Ok(Some(state))
     }
 

--- a/crates/tui/src/tools/goal.rs
+++ b/crates/tui/src/tools/goal.rs
@@ -354,6 +354,11 @@ pub struct GoalState {
     advisories: Vec<GoalAdvisoryNote>,
     last_gap_fingerprint: Option<String>,
     repeated_gap_count: u32,
+    /// The continuation pass the repeated-gap counter last advanced on.
+    /// The bound is "equivalent gaps on consecutive PASSES", so a verifier
+    /// reporting the same gap several times inside one turn must not trip it
+    /// before any continuation has happened.
+    last_gap_pass: Option<u32>,
 }
 
 impl GoalState {
@@ -402,6 +407,7 @@ impl GoalState {
                     self.advisories.clear();
                     self.last_gap_fingerprint = None;
                     self.repeated_gap_count = 0;
+                    self.last_gap_pass = None;
                 } else if self.token_budget != token_budget {
                     self.token_budget = token_budget;
                 }
@@ -413,6 +419,7 @@ impl GoalState {
                     self.completion_verification = None;
                     self.last_gap_fingerprint = None;
                     self.repeated_gap_count = 0;
+                    self.last_gap_pass = None;
                 }
 
                 if changed || status_changed || self.status.is_none() {
@@ -458,6 +465,7 @@ impl GoalState {
         self.advisories.clear();
         self.last_gap_fingerprint = None;
         self.repeated_gap_count = 0;
+        self.last_gap_pass = None;
         Ok(())
     }
 
@@ -503,6 +511,7 @@ impl GoalState {
             advisories: Vec::new(),
             last_gap_fingerprint: None,
             repeated_gap_count: 0,
+            last_gap_pass: None,
         }
     }
 
@@ -572,11 +581,21 @@ impl GoalState {
 
         let fingerprint = gap_fingerprint(&verification.gaps)
             .ok_or("Critical not-achieved verification requires at least one concrete gap.")?;
-        self.repeated_gap_count = if self.last_gap_fingerprint.as_deref() == Some(&fingerprint) {
-            self.repeated_gap_count.saturating_add(1)
-        } else {
+        // Advance at most once per continuation pass. `record_not_achieved`
+        // runs per `update_goal` tool call, so counting calls would let a
+        // verifier that reports one gap three times in a single turn pause the
+        // goal before a single continuation had been spent — stopping valid
+        // work rather than a stall.
+        let same_gap = self.last_gap_fingerprint.as_deref() == Some(&fingerprint);
+        let already_counted_this_pass = self.last_gap_pass == Some(self.continuation_count);
+        self.repeated_gap_count = if !same_gap {
             1
+        } else if already_counted_this_pass {
+            self.repeated_gap_count
+        } else {
+            self.repeated_gap_count.saturating_add(1)
         };
+        self.last_gap_pass = Some(self.continuation_count);
         self.last_gap_fingerprint = Some(fingerprint);
 
         // The stall bound the continuation prompt promises. Pausing *is* the
@@ -1753,6 +1772,9 @@ mod tests {
                 &["first gap"],
             ))
             .expect("first critical review");
+        // Two reports of one gap only count twice when they land on separate
+        // continuation passes; several inside one turn are one pass.
+        state.record_continuation();
         state
             .record_not_achieved(not_achieved_review(
                 GoalReviewRole::Critical,
@@ -1806,6 +1828,10 @@ mod tests {
                 snapshot.is_active(),
                 "pass {pass} is under the bound and must keep working",
             );
+            // The bound counts continuation PASSES, so each iteration has to
+            // actually be one. Without this the loop would be several reports
+            // inside a single turn, which deliberately no longer advances it.
+            state.record_continuation();
         }
 
         // Reordered and re-cased wording is the same gap set, so restating the
@@ -1837,6 +1863,37 @@ mod tests {
             ))
             .expect_err("a paused goal takes no further verifier progress");
         assert!(err.contains("active goal"));
+    }
+
+    #[test]
+    fn repeating_one_gap_inside_a_single_turn_does_not_trip_the_stall_bound() {
+        // `record_not_achieved` runs per `update_goal` tool call. Counting
+        // calls rather than passes meant a verifier that restated the same gap
+        // three times in ONE turn paused the goal before a single continuation
+        // had been spent — stopping valid work and calling it a stall.
+        let mut state = GoalState::default();
+        state
+            .create("one turn, several reports".to_string(), None)
+            .expect("create goal");
+
+        for _ in 0..(crate::goal_loop::MAX_REPEATED_GAP_PASSES + 2) {
+            state
+                .record_not_achieved(not_achieved_review(
+                    GoalReviewRole::Critical,
+                    &["provider copy still wrong"],
+                ))
+                .expect("repeated reports inside one turn are recorded");
+        }
+
+        let snapshot = state.snapshot();
+        assert_eq!(
+            snapshot.repeated_gap_count, 1,
+            "many reports in one turn are still one pass",
+        );
+        assert!(
+            snapshot.is_active(),
+            "no continuation was spent, so there is no stall to pause on",
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/tools/goal.rs
+++ b/crates/tui/src/tools/goal.rs
@@ -470,6 +470,13 @@ impl GoalState {
     /// the engine is rehydrating, not re-declaring, the goal. Evidence,
     /// blockers, and review notes are runtime-only and start empty; the
     /// durable loop re-derives them on the next pass.
+    ///
+    /// The stall fingerprint is deliberately runtime-only too: a stall does not
+    /// need to be replayed, because
+    /// [`crate::goal_loop::MAX_REPEATED_GAP_PASSES`] already converted it into a
+    /// pause, and a paused goal is what gets persisted and restored here. A
+    /// resume therefore starts a fresh stall window — which is correct, since a
+    /// resume is someone deciding the goal is worth continuing.
     #[must_use]
     pub fn from_persisted(
         objective: &str,
@@ -571,6 +578,22 @@ impl GoalState {
             1
         };
         self.last_gap_fingerprint = Some(fingerprint);
+
+        // The stall bound the continuation prompt promises. Pausing *is* the
+        // stop: both continuation dispatchers refuse to re-dispatch a goal
+        // whose snapshot is not "active", and the runtime host mirrors a
+        // non-limit pause into the durable `ThreadGoalStatus::Paused`, so this
+        // needs no second gate in `decide_continuation` and survives a restart
+        // until someone explicitly resumes.
+        if self.repeated_gap_count >= crate::goal_loop::MAX_REPEATED_GAP_PASSES {
+            tracing::warn!(
+                repeated_gap_count = self.repeated_gap_count,
+                max_repeated_gap_passes = crate::goal_loop::MAX_REPEATED_GAP_PASSES,
+                "goal stall pause: critical verifier reported an equivalent gap set on \
+                 consecutive passes; pausing for inspection instead of spending further"
+            );
+            self.mark_paused(GoalPauseReason::NoProgress)?;
+        }
 
         Ok(())
     }
@@ -790,10 +813,11 @@ pub fn thread_goal_status_projection(
 pub fn render_continuation_prompt(snapshot: &GoalSnapshot, continuation_index: u32) -> String {
     let goal_json = serde_json::to_string_pretty(snapshot).unwrap_or_else(|_| "{}".to_string());
     format!(
-        "{}\n\n## Active Goal State\n\n```json\n{}\n```\n\nContinuation pass #{}.\nIf a critical verifier finds remaining work, call `update_goal` with `status: \"not_achieved\"` and its concrete `verification.gaps`; repeated equivalent gap sets pause the loop for inspection instead of spending indefinitely. If the goal is complete, first run or cite a concrete verifier/check when one applies, then call `update_goal` with `status: \"complete\"`, concrete evidence, and `verification: {{\"status\":\"passed\",\"check\":\"...\",\"summary\":\"...\"}}`. For non-verifiable work (docs, research, writing), use `verification: {{\"status\":\"not_applicable\",\"check\":\"...\",\"summary\":\"...\"}}` with a clear rationale instead of fabricating a verifier receipt. If it is blocked, call `update_goal` with `status: \"blocked\"` and the blocker. Otherwise continue making progress toward the objective.",
+        "{}\n\n## Active Goal State\n\n```json\n{}\n```\n\nContinuation pass #{}.\nIf a critical verifier finds remaining work, call `update_goal` with `status: \"not_achieved\"` and its concrete `verification.gaps`; {} equivalent gap sets in a row pause this goal (`no progress`) for inspection instead of spending indefinitely, so report what actually still fails rather than restating the previous pass. If the goal is complete, first run or cite a concrete verifier/check when one applies, then call `update_goal` with `status: \"complete\"`, concrete evidence, and `verification: {{\"status\":\"passed\",\"check\":\"...\",\"summary\":\"...\"}}`. For non-verifiable work (docs, research, writing), use `verification: {{\"status\":\"not_applicable\",\"check\":\"...\",\"summary\":\"...\"}}` with a clear rationale instead of fabricating a verifier receipt. If it is blocked, call `update_goal` with `status: \"blocked\"` and the blocker. Otherwise continue making progress toward the objective.",
         crate::prompts::GOAL_CONTINUATION_PROMPT.trim(),
         goal_json,
         continuation_index,
+        crate::goal_loop::MAX_REPEATED_GAP_PASSES,
     )
 }
 
@@ -1759,6 +1783,62 @@ mod tests {
         assert_eq!(progressed.status, "active");
     }
 
+    #[test]
+    fn repeated_equivalent_gap_sets_pause_the_loop_for_no_progress() {
+        // The continuation prompt promises this stop, and until it existed the
+        // default Operate goal had none: `DEFAULT_MAX_GOAL_CONTINUATIONS` is 0,
+        // so only the model volunteering complete/blocked ended a run.
+        let mut state = GoalState::default();
+        state
+            .create("stall on purpose".to_string(), None)
+            .expect("create goal");
+
+        for pass in 1..crate::goal_loop::MAX_REPEATED_GAP_PASSES {
+            state
+                .record_not_achieved(not_achieved_review(
+                    GoalReviewRole::Critical,
+                    &["provider copy still wrong", "  Regression   test MISSING "],
+                ))
+                .expect("critical review below the stall bound");
+            let snapshot = state.snapshot();
+            assert_eq!(snapshot.repeated_gap_count, pass);
+            assert!(
+                snapshot.is_active(),
+                "pass {pass} is under the bound and must keep working",
+            );
+        }
+
+        // Reordered and re-cased wording is the same gap set, so restating the
+        // previous pass cannot buy another pass.
+        state
+            .record_not_achieved(not_achieved_review(
+                GoalReviewRole::Critical,
+                &["Regression test missing", "PROVIDER copy still wrong"],
+            ))
+            .expect("stall review is recorded, not rejected");
+
+        let stalled = state.snapshot();
+        assert_eq!(
+            stalled.repeated_gap_count,
+            crate::goal_loop::MAX_REPEATED_GAP_PASSES
+        );
+        assert_eq!(stalled.status, "paused");
+        assert_eq!(stalled.pause_reason, Some(GoalPauseReason::NoProgress));
+        assert!(
+            !stalled.is_active(),
+            "an inactive goal is what stops both continuation dispatchers",
+        );
+
+        // The pause holds: a stalled goal cannot keep reporting gaps at itself.
+        let err = state
+            .record_not_achieved(not_achieved_review(
+                GoalReviewRole::Critical,
+                &["provider copy still wrong"],
+            ))
+            .expect_err("a paused goal takes no further verifier progress");
+        assert!(err.contains("active goal"));
+    }
+
     #[tokio::test]
     async fn update_goal_rejects_model_resume() {
         let state = new_shared_goal_state_from_host_status(
@@ -1914,6 +1994,16 @@ mod tests {
         assert!(prompt.contains("Goal Continuation"));
         assert!(prompt.contains("finish issue 2199"));
         assert!(prompt.contains("Continuation pass #2"));
+        // The named bound has to be the one the state machine actually
+        // enforces; the prompt used to promise a stall stop that nothing
+        // implemented.
+        assert!(
+            prompt.contains(&format!(
+                "{} equivalent gap sets in a row",
+                crate::goal_loop::MAX_REPEATED_GAP_PASSES
+            )),
+            "{prompt}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -18910,9 +18910,10 @@ fn the_launched_authority_is_the_one_the_spawn_boundary_accepts() {
         "auditor",
         codewhale_workflow::PermissionCeiling::preset("analyst").expect("preset"),
     );
-    // Free-form Fleet identity maps to Runtime `custom`; the read-only parent
-    // still narrows the effective capability envelope.
-    assert_eq!(authority.posture_role, "custom");
+    // A free-form Fleet identity is undeclared, so it now fails closed to the
+    // read-only `explore` posture rather than inheriting write-capable
+    // `custom` (#5575). The read-only parent narrows on top of that.
+    assert_eq!(authority.posture_role, "explore");
     assert_eq!(authority.write_authority, "read_only");
 
     let mut deny = authority.disallowed_tools.clone();

--- a/crates/tui/src/tools/workflow/mod.rs
+++ b/crates/tui/src/tools/workflow/mod.rs
@@ -6570,10 +6570,11 @@ reasoning = "high"
 permissions = "read_only"
 "#;
         let operation = exact_workflow_with(AUDIT_FLEET, None);
-        // Free-form Fleet roles map to Runtime `custom`, whose baseline is
-        // write-capable under this full parent. Keep the production write-scope
-        // gate intact by declaring an exact scope in the fixture.
-        let mut request = exact_write_task_request("auditor");
+        // The member declares `permissions = "read_only"`, and an undeclared
+        // role name no longer hands the child a write-capable posture (#5575),
+        // so a declared write scope is now correctly refused at bind time.
+        // Ask for no write scope, which is what this member actually has.
+        let mut request = exact_task_request("auditor");
         let binding =
             bind_exact_fleet_task_request(&operation, exact_session(), &mut request).expect("bind");
         let receipt = route_admitted_exact_task(&operation, &binding, &mut request)
@@ -6584,8 +6585,8 @@ permissions = "read_only"
         // the posture role, because that is what picked the child's tool
         // surface.
         let posture = binding.authority.posture_role.to_string();
-        assert_eq!(posture, "custom");
-        assert_eq!(receipt.posture_role.as_deref(), Some("custom"));
+        assert_eq!(posture, "explore");
+        assert_eq!(receipt.posture_role.as_deref(), Some("explore"));
 
         // What the run displays is the member's role, not that posture.
         assert_eq!(

--- a/crates/tui/src/tui/persistence_actor.rs
+++ b/crates/tui/src/tui/persistence_actor.rs
@@ -496,7 +496,12 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let sessions_dir = tmp.path().join("sessions");
         let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
-        let queue_path = sessions_dir.join("checkpoints").join("offline_queue.json");
+        // The queue is keyed per session now (#5715-adjacent data-loss fix):
+        // two concurrent instances used to share one global file and the loser
+        // lost its unsent text. The request below carries session-A.
+        let queue_path = sessions_dir
+            .join("checkpoints")
+            .join("session-A.offline_queue.json");
         let (handle, task) = spawn_persistence_actor(manager);
 
         let state = OfflineQueueState {

--- a/crates/tui/src/tui/persistence_actor.rs
+++ b/crates/tui/src/tui/persistence_actor.rs
@@ -61,7 +61,13 @@ pub enum PersistRequest {
         session_id: Option<String>,
     },
     /// Remove the queued/draft offline input file.
-    ClearOfflineQueue,
+    ClearOfflineQueue {
+        /// The session whose queue is being cleared. Carried for the same
+        /// reason `ClearCheckpoint` carries one: the queue is keyed per
+        /// session, so a clear must name its own session or it can drain
+        /// against whichever session this manager instance last wrote for.
+        session_id: Option<String>,
+    },
     /// Remove one session's crash-recovery checkpoint file. Scoped: cannot
     /// remove another session's checkpoint.
     ClearCheckpoint { session_id: String },
@@ -105,7 +111,9 @@ enum PendingOfflineQueue {
         state: Box<OfflineQueueState>,
         session_id: Option<String>,
     },
-    Clear,
+    Clear {
+        session_id: Option<String>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -186,7 +194,7 @@ fn request_label(request: &PersistRequest) -> &'static str {
         PersistRequest::SessionSnapshot(_) => "SessionSnapshot",
         PersistRequest::CompletedCommit { .. } => "CompletedCommit",
         PersistRequest::OfflineQueue { .. } => "OfflineQueue",
-        PersistRequest::ClearOfflineQueue => "ClearOfflineQueue",
+        PersistRequest::ClearOfflineQueue { .. } => "ClearOfflineQueue",
         PersistRequest::ClearCheckpoint { .. } => "ClearCheckpoint",
         PersistRequest::FlushAndReport { .. } => "FlushAndReport",
         PersistRequest::Shutdown => "Shutdown",
@@ -302,7 +310,13 @@ struct PendingState {
     /// as a completion (or vice versa) and the clear intent stays bound to
     /// exactly the session that completed.
     completed_commits: BTreeMap<String, SavedSession>,
-    offline_queue: Option<PendingOfflineQueue>,
+    /// Latest-wins per session id, for the same reason `sessions` above is:
+    /// a single global slot dropped session A's queued text when session B
+    /// queued before the actor drained, which defeats the per-session file
+    /// naming entirely. `None` keys a save with no session id, which
+    /// `save_offline_queue_state` rejects — kept as a key so that error is
+    /// still reported rather than silently coalesced away.
+    offline_queue: BTreeMap<Option<String>, PendingOfflineQueue>,
 }
 
 /// What the actor loop should do after absorbing a request.
@@ -360,13 +374,20 @@ impl PendingState {
                 self.completed_commits.insert(id, session);
             }
             PersistRequest::OfflineQueue { state, session_id } => {
-                self.offline_queue = Some(PendingOfflineQueue::Save {
-                    state: Box::new(state),
-                    session_id,
-                });
+                self.offline_queue.insert(
+                    session_id.clone(),
+                    PendingOfflineQueue::Save {
+                        state: Box::new(state),
+                        session_id,
+                    },
+                );
             }
-            PersistRequest::ClearOfflineQueue => {
-                self.offline_queue = Some(PendingOfflineQueue::Clear);
+            PersistRequest::ClearOfflineQueue { session_id } => {
+                // A clear supersedes a pending save for its OWN session only.
+                self.offline_queue.insert(
+                    session_id.clone(),
+                    PendingOfflineQueue::Clear { session_id },
+                );
             }
             PersistRequest::ClearCheckpoint { session_id } => {
                 // A clear supersedes a pending checkpoint write for the same
@@ -436,7 +457,7 @@ fn flush_inner(manager: &SessionManager, pending: &mut PendingState) -> FlushRep
             manager.save_checkpoint(&session).map(|_| ()),
         );
     }
-    if let Some(request) = pending.offline_queue.take() {
+    for (_, request) in std::mem::take(&mut pending.offline_queue) {
         match request {
             PendingOfflineQueue::Save { state, session_id } => record(
                 "offline-queue".to_string(),
@@ -444,9 +465,15 @@ fn flush_inner(manager: &SessionManager, pending: &mut PendingState) -> FlushRep
                     .save_offline_queue_state(&state, session_id.as_deref())
                     .map(|_| ()),
             ),
-            PendingOfflineQueue::Clear => record(
+            // Prefer the session the clear named. The no-argument form falls
+            // back to whichever session THIS manager instance last saved for,
+            // which is not necessarily the caller's.
+            PendingOfflineQueue::Clear { session_id } => record(
                 "clear-offline-queue".to_string(),
-                manager.clear_offline_queue_state(),
+                match session_id.as_deref() {
+                    Some(id) => manager.clear_offline_queue_state_for(id),
+                    None => manager.clear_offline_queue_state(),
+                },
             ),
         }
     }
@@ -492,6 +519,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn two_sessions_queueing_before_a_drain_both_survive() {
+        // Per-session FILENAMES are not enough on their own: the actor
+        // coalesces pending work before those names are ever used, and the
+        // queue used one global slot while its checkpoint/session neighbours
+        // were already keyed per session. Session A's unsent text was
+        // therefore dropped whenever session B queued first.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        for (session, body) in [("session-A", "text from A"), ("session-B", "text from B")] {
+            let state = OfflineQueueState {
+                messages: vec![QueuedSessionMessage {
+                    display: body.to_string(),
+                    skill_instruction: None,
+                    skill_provenance: None,
+                }],
+                ..OfflineQueueState::default()
+            };
+            handle.try_send(PersistRequest::OfflineQueue {
+                state,
+                session_id: Some(session.to_string()),
+            });
+        }
+
+        let checkpoints = sessions_dir.join("checkpoints");
+        for (session, body) in [("session-A", "text from A"), ("session-B", "text from B")] {
+            let path = checkpoints.join(format!("{session}.offline_queue.json"));
+            // wait_until panics on timeout, which is the failure signal: a
+            // coalesced-away queue never appears.
+            wait_until(|| std::fs::read_to_string(&path).is_ok_and(|f| f.contains(body))).await;
+        }
+
+        // A clear names its own session and must not touch the other's.
+        handle.try_send(PersistRequest::ClearOfflineQueue {
+            session_id: Some("session-A".to_string()),
+        });
+        let a = checkpoints.join("session-A.offline_queue.json");
+        wait_until(|| !a.exists()).await;
+        assert!(
+            checkpoints.join("session-B.offline_queue.json").exists(),
+            "clearing one session must not delete another session's queued text"
+        );
+
+        drop(handle);
+        let _ = task.await;
+    }
+
+    #[tokio::test]
     async fn actor_persists_and_clears_offline_queue_requests() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let sessions_dir = tmp.path().join("sessions");
@@ -523,7 +600,9 @@ mod tests {
         })
         .await;
 
-        handle.try_send(PersistRequest::ClearOfflineQueue);
+        handle.try_send(PersistRequest::ClearOfflineQueue {
+            session_id: Some("session-A".to_string()),
+        });
         wait_until(|| !queue_path.exists()).await;
         handle.try_send(PersistRequest::Shutdown);
         task.await.expect("persistence actor join");

--- a/crates/tui/src/tui/ui/event_loop.rs
+++ b/crates/tui/src/tui/ui/event_loop.rs
@@ -622,19 +622,25 @@ pub async fn run_tui(
         app.status_message = Some(notice);
     }
 
-    if let Ok(manager) = SessionManager::default_location() {
-        match manager.load_offline_queue_state() {
+    // The parked offline queue is keyed per session, so this reads back only
+    // *this* session's own unsent text: a fresh session has none, and a
+    // concurrent instance's queue is a different file that nothing here can
+    // reach. A session that is not being resumed has nothing parked yet.
+    let mut restored_offline_queue = false;
+    if let Some(session_id) = app.current_session_id.clone()
+        && let Ok(manager) = SessionManager::default_location()
+    {
+        match manager.load_offline_queue_state(&session_id) {
             Ok(Some(state)) => {
-                if restore_matching_offline_queue_state(&mut app, state) {
-                    if app.status_message.is_none() && app.queued_message_count() > 0 {
-                        app.status_message = Some(format!(
-                            "Restored {} queued message(s) from previous session — ↑ to edit, Ctrl+X to discard",
-                            app.queued_message_count()
-                        ));
-                    }
-                } else {
-                    // Session mismatch - clear the stale queue
-                    let _ = manager.clear_offline_queue_state();
+                restored_offline_queue = restore_matching_offline_queue_state(&mut app, state);
+                if restored_offline_queue
+                    && app.status_message.is_none()
+                    && app.queued_message_count() > 0
+                {
+                    app.status_message = Some(format!(
+                        "Restored {} queued message(s) from previous session — ↑ to edit, Ctrl+X to discard",
+                        app.queued_message_count()
+                    ));
                 }
             }
             Ok(None) => {}
@@ -789,6 +795,14 @@ pub async fn run_tui(
             persistence_actor::init_actor(handle.clone());
             (handle, task)
         });
+
+    // Re-park the queue restored above, now that the actor exists. Its clear
+    // request carries no session id, so the actor learns which session owns
+    // the parked file from a save — without this, draining a restored queue
+    // to empty would leave the file behind and resend it on the next boot.
+    if restored_offline_queue {
+        persist_offline_queue_state(&app);
+    }
 
     // Returning users recovering a missing key open the picker immediately so
     // recovery cannot silently replace a persisted route. First-run users

--- a/crates/tui/src/tui/ui/session_state.rs
+++ b/crates/tui/src/tui/ui/session_state.rs
@@ -437,7 +437,9 @@ pub(crate) fn record_turn_activity(app: &mut App, event: &EngineEvent, now: Inst
 
 pub(crate) fn persist_offline_queue_state(app: &App) {
     if app.queued_messages.is_empty() && app.queued_draft.is_none() {
-        persistence_actor::persist(PersistRequest::ClearOfflineQueue);
+        persistence_actor::persist(PersistRequest::ClearOfflineQueue {
+            session_id: app.current_session_id.clone(),
+        });
         return;
     }
     let state = OfflineQueueState {


### PR DESCRIPTION
Closes #5969

Five defects recorded with file:line evidence in `codewhale-ops/FINDINGS-20260907-REFS-STUDY-AND-DEFECTS.md`, each fixed in isolation and then adversarially audited as a composition before landing.

### 1. Concurrent sessions destroyed each other's unsent text — P0

The offline input queue used one global `checkpoints/offline_queue.json` for the whole sessions directory, and boot **cleared** it on session-id mismatch. A second instance therefore deleted the first's queued, user-authored text.

Keyed per session — the shape `session_manager.rs:1183-1198` already documents for checkpoints two hundred lines above. An existing global file is **adopted** into the current session (`write_atomic`, legacy file removed only on success), not discarded.

### 2. ACP `initialize` violated the schema, and a green test pinned it — #5969

`sessionCapabilities` emitted `{"list": true, "load": true}`. `list` must be a `SessionListCapabilities` **object**; `load` is not a field at all. Reported by @Lujc0523 — Codewhale is unusable from JetBrains because of it.

The unit test asserted the wrong shape, so it changed with the code: two field probes became a whole-object assertion, which also catches a resurrected `load` key.

### 3. `codewhale metrics` read a directory nothing has written since 2024

A private `deepseek_home()` resolved `$HOME/.deepseek` **unconditionally, with no existence check**, so the only reader of Codewhale's receipts read an empty tree and printed an all-zero rollup as truth — while `audit.rs:73` writes `~/.codewhale/audit.log` from ~24 call sites. Now primary with a *checked* legacy fallback, deleting the repo's third path-resolution policy.

### 4. Fleet role names resolved to different AUTHORITY per driver — part of #5575

`fleet_role_to_agent_type` was a second alias table `role.rs` and the docs knew nothing about:

| role string | durable Fleet | exact Fleet |
|---|---|---|
| `synthesizer` | Planner → write=false | Custom → **write=true, raw shell Full** |
| `smoke-runner` | Verifier → write=false | Custom → **write=true** |
| unknown | Worker → **write** | Custom → **write** |

`FleetRole::from_str` is now the only mapper, the second table is deleted, and an undeclared role **fails closed** to read-only `explore`.

**Privilege audit:** eight role strings traced through both drivers. The change is **monotonically narrowing** — no widening anywhere. All twelve built-in roster roles still resolve; only free-form names reach the fail-closed branch.

Note the user-visible break: an operator with a free-form role in an exact Fleet who expected write access is now refused. That is the boundary closing, loudly rather than silently.

### 5. The goal loop told the model it would be stopped, and nothing stopped it

The continuation prompt promised "repeated equivalent gap sets pause the loop", but `GoalPauseReason::NoProgress` was **never constructed anywhere**, `repeated_gap_count` had no reader, `last_gap_fingerprint` reset on resume, and `DEFAULT_MAX_GOAL_CONTINUATIONS` is 0. Implemented the promised stop rather than deleting the sentence, because the alternative leaves a real unbounded-spend path open.

## Cross-unit repairs

Three test breaks were flagged by the fixing agents in files they did not own, and are fixed here: the persistence-actor queue path, and two fleet posture assertions that **encoded the old privilege grant**. The second workflow failure is the fix working — a member declaring `permissions = "read_only"` can no longer have an undeclared role name hand its child a write scope.

## Evidence

```
cargo fmt                                          -> clean
cargo clippy -p tui -p cli -p config --lib         -> 0 errors
cargo test -p codewhale-tui --lib -- <the above>   -> 79 passed; 0 failed
cargo test -p codewhale-cli --lib -- metrics ...   -> 18 passed; 0 failed
```

Run with `RUST_MIN_STACK=8388608` to match nextest's per-process stack — see **#5988**, two pre-existing tests overflow the 2 MiB libtest thread stack and abort the binary locally while passing in CI. Not caused by this PR; reproduced on clean `origin/main`.

Test counts went **up** in every changed file; no assertion was weakened. The audit verified each regression test fails without its fix.

## Not done

Docs still describe the single global queue file (`ARCHITECTURE.md:239`, `OPERATIONS_RUNBOOK.md:41`, `CONFIGURATION.md:2885` + zh_hans mirror) and `FLEET.md:534` does not yet say undeclared roles fail closed. A follow-up should thread a session id through `PersistRequest::ClearOfflineQueue` so the queue-owner mutex can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4rk4NXwyy6wmvii9Lp84P
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/5989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span session persistence and Fleet write authority (privilege narrowing with a user-visible break for undeclared exact-Fleet roles), plus ACP wire format; fixes are well-tested but touch security-adjacent posture mapping.
> 
> **Overview**
> This PR bundles five defect fixes that were audited together: **offline queue data loss**, **ACP handshake schema**, **metrics reading the wrong state root**, **split Fleet role authority**, and **goal loops that never paused on repeated verifier gaps**.
> 
> **Offline input** moves from one shared `checkpoints/offline_queue.json` to per-session `checkpoints/<session_id>.offline_queue.json`, with legacy adoption, persistence-actor coalescing keyed by session, startup restore/clear scoped to the current session, and refusing to park queues without a session id.
> 
> **ACP `initialize`** advertises `sessionCapabilities` as `{"list": {}}` instead of boolean `list`/`load`, matching strictly typed clients (e.g. JetBrains, #5969).
> 
> **`codewhale metrics`** resolves audit log, sessions, and runtime events via shared `codewhale_config` resolvers (canonical `~/.codewhale` with existence-checked legacy fallback); unresolvable home is an error instead of a silent all-zero rollup.
> 
> **Fleet** deletes the duplicate `fleet_role_to_agent_type` table and routes both drivers through `runtime_role_for_member` (#5575): documented aliases via `member_role_alias`, undeclared role names **fail closed** to read-only `explore`/`Scout` while preserving the operator’s label on receipts; explicit `custom` remains the write-capable escape hatch.
> 
> **Operate goals** implement the promised stall stop: after `MAX_REPEATED_GAP_PASSES` (3) consecutive continuation passes with the same normalized gap set, the goal pauses with `NoProgress`; counting advances at most once per pass, not per tool call in one turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd62b4ed5ce548fd0db75cc3d3a97bd68a5daec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->