### PR TITLE
docs(readme): link the community CodeWhale for VS Code GUI frontend

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale وكيل مفتوح المصدر للبرمجة عبر الطرفية، مبني بلغة Rust ويتطور علنًا بالتعاون مع الأشخاص الذين يستخدمونه.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 يستطيع Codewhale قراءة مستودعك وتعديل الملفات وتشغيل الأوامر وفحص النتائج ومواصلة العمل نحو هدف. وأنت من يقرر مقدار الوصول الذي تمنحه له.
+
+## الواجهة الرسومية
+
+هل تفضّل واجهة رسومية؟ إضافة CodeWhale for VS Code التي يحافظ عليها المجتمع تضع العميل نفسه في الشريط الجانبي لبرنامج VS Code — الدردشة والمحادثات المتسلسلة والفرق المباشرة وإدارة المهام، كل ذلك عبر نفس Runtime API، وتبقى الجلسات متزامنة مع الطرفية. ثبّتها من [سوق VS Code](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode)؛ المصدر على [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## لماذا Codewhale
 

--- a/README.ca.md
+++ b/README.ca.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale és un agent de programació de codi obert per al terminal, desenvolupat amb Rust i millorat públicament amb les persones que l’utilitzen.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale pot llegir el teu repositori, editar fitxers, executar ordres, inspeccionar els resultats i continuar treballant cap a un objectiu. Tu decideixes quant accés li concedeixes.
+
+## Interfície gràfica
+
+Prefereixes una interfície gràfica? L'extensió CodeWhale for VS Code, mantinguda per la comunitat, posa el mateix agent a la barra lateral del VS Code — xat, converses per fils, diffs en directe i gestió de tasques sobre la mateixa Runtime API, i les sessions es mantenen sincronitzades amb el terminal. Instal·la-la des del [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode); el codi font és a [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Per què Codewhale
 

--- a/README.de.md
+++ b/README.de.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale ist ein in Rust entwickelter Open-Source-Coding-Agent für dein Terminal, der gemeinsam mit seinen Nutzerinnen und Nutzern öffentlich weiterentwickelt wird.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale kann dein Repository lesen, Dateien bearbeiten, Befehle ausführen, Ergebnisse prüfen und auf ein Ziel hinarbeiten. Du entscheidest, wie viel Zugriff der Agent erhält.
+
+## Grafische Oberfläche
+
+Lieber eine grafische Oberfläche? Die von der Community gepflegte Erweiterung CodeWhale for VS Code bringt denselben Agenten in die VS-Code-Seitenleiste — Chat, Thread-Gespräche, Live-Diffs und Aufgabenverwaltung über dieselbe Runtime-API, sodass Sitzungen mit dem Terminal synchron bleiben. Installieren Sie sie aus dem [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode); der Quellcode liegt auf [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Warum Codewhale
 

--- a/README.es-419.md
+++ b/README.es-419.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale es un agente de programación de código abierto para tu terminal, desarrollado en Rust y mejorado públicamente junto con las personas que lo usan.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale puede leer tu repositorio, editar archivos, ejecutar comandos, revisar los resultados y seguir trabajando para alcanzar un objetivo. Tú decides cuánto acceso darle.
+
+## Interfaz gráfica
+
+¿Prefieres una interfaz gráfica? La extensión CodeWhale for VS Code, mantenida por la comunidad, envuelve al mismo agente en la barra lateral de VS Code — chat, conversaciones por hilos, diffs en vivo y gestión de tareas sobre la misma Runtime API, para que las sesiones se mantengan sincronizadas con la terminal. Instálala desde el [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode); el código fuente está en [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Por qué Codewhale
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale est un agent de programmation open source pour votre terminal, développé en Rust et amélioré publiquement avec les personnes qui l’utilisent.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale peut lire votre dépôt, modifier des fichiers, exécuter des commandes, inspecter les résultats et continuer à travailler vers un objectif. Vous choisissez le niveau d’accès que vous lui accordez.
+
+## Interface graphique
+
+Vous préférez une interface graphique ? L'extension CodeWhale for VS Code, maintenue par la communauté, intègre le même agent dans la barre latérale de VS Code — chat, conversations par fils, diff en direct et gestion des tâches via la même Runtime API, pour que les sessions restent synchronisées avec le terminal. Installez-la depuis le [marketplace VS Code](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode) ; le code source est sur [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Pourquoi Codewhale
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale आपके टर्मिनल के लिए Rust में बना एक ओपन सोर्स कोडिंग एजेंट है, जिसे इसके उपयोगकर्ताओं के साथ सार्वजनिक रूप से बेहतर बनाया जाता है।
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale आपकी रिपॉज़िटरी पढ़ सकता है, फ़ाइलें संपादित कर सकता है, कमांड चला सकता है, परिणामों की जाँच कर सकता है और लक्ष्य की ओर काम जारी रख सकता है। उसे कितना एक्सेस देना है, यह आप तय करते हैं।
+
+## GUI फ्रंटएंड
+
+क्या आप ग्राफ़िकल इंटरफ़ेस पसंद करते हैं? समुदाय द्वारा अनुरक्षित CodeWhale for VS Code एक्सटेंशन उसी एजेंट को VS Code साइडबार में लाता है — चैट, थ्रेडेड वार्तालाप, लाइव डिफ़ और कार्य प्रबंधन, सभी उसी Runtime API पर आधारित, ताकि सत्र टर्मिनल के साथ सिंक में रहें। इसे [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode) से इंस्टॉल करें; सोर्स कोड [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode) पर है।
 
 ## Codewhale क्यों
 

--- a/README.id.md
+++ b/README.id.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale adalah agen pemrograman sumber terbuka untuk terminal Anda, dibuat dengan Rust dan dikembangkan secara terbuka bersama orang-orang yang menggunakannya.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale dapat membaca repositori Anda, mengedit berkas, menjalankan perintah, memeriksa hasil, dan terus bekerja menuju tujuan. Anda menentukan seberapa besar akses yang dimilikinya.
+
+## GUI frontend
+
+Lebih suka antarmuka grafis? Ekstensi CodeWhale for VS Code yang dikelola komunitas membungkus agen yang sama ke dalam sidebar VS Code — obrolan, percakapan berutas, diff langsung, dan pengelolaan tugas melalui Runtime API yang sama, sehingga sesi tetap sinkron dengan terminal. Pasang dari [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode); kode sumber ada di [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Mengapa Codewhale
 

--- a/README.it.md
+++ b/README.it.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale è un agente di programmazione open source per il terminale, sviluppato in Rust e migliorato pubblicamente insieme alle persone che lo utilizzano.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale può leggere il tuo repository, modificare file, eseguire comandi, controllare i risultati e continuare a lavorare verso un obiettivo. Sei tu a decidere quanto accesso concedergli.
+
+## Interfaccia grafica
+
+Preferisci un'interfaccia grafica? L'estensione CodeWhale for VS Code, mantenuta dalla comunità, porta lo stesso agente nella barra laterale di VS Code — chat, conversazioni a thread, diff in tempo reale e gestione delle attività sulla stessa Runtime API, così le sessioni restano sincronizzate con il terminale. Installala dal [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode); il codice sorgente è su [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Perché Codewhale
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale は Rust で構築された、ターミナル向けのオープンソース・コーディングエージェントです。利用者とともに、公開の場で改善を続けています。
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale はリポジトリを読み、ファイルを編集し、コマンドを実行して結果を確認しながら、目標に向かって作業を続けます。どこまでアクセスを許可するかは、あなたが決められます。
+
+## GUI フロントエンド
+
+グラフィカルな操作画面を好みますか？コミュニティが保守する CodeWhale for VS Code 拡張機能は、同じエージェントを VS Code サイドバーに統合します。チャット、スレッド会話、ライブ差分、タスク管理をすべて同じ Runtime API 上で行い、セッションはターミナルと同期したままです。[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode) からインストールしてください。ソースコードは [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode) にあります。
 
 ## Codewhale を選ぶ理由
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale은 Rust로 만든 터미널용 오픈 소스 코딩 에이전트로, 사용자들과 함께 공개적으로 개선해 나갑니다.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale은 저장소를 읽고, 파일을 편집하고, 명령을 실행하고, 결과를 확인하며 목표를 향해 계속 작업할 수 있습니다. 어느 정도의 접근 권한을 줄지는 사용자가 결정합니다.
+
+## GUI 프런트엔드
+
+그래픽 인터페이스를 선호하시나요? 커뮤니티가 관리하는 CodeWhale for VS Code 확장은 동일한 에이전트를 VS Code 사이드바에 담아 채팅·스레드 대화·실시간 diff·작업 관리를 같은 Runtime API로 제공하며, 세션은 터미널과 동기화됩니다. [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode)에서 설치하세요. 소스 코드는 [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode)에 있습니다.
 
 ## Codewhale을 선택하는 이유
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ codewhale exec "fix the failing tests and explain what changed"
 Codewhale can read your repository, edit files, run commands, inspect results,
 and keep working toward a goal. You decide how much access it has.
 
+## GUI frontend
+
+Prefer a graphical interface? The community-maintained CodeWhale for VS Code
+extension wraps the same agent in a VS Code sidebar — chat, threaded
+conversations, live diffs, and task management over the same Runtime API, so
+sessions stay in sync with the terminal. Install it from the
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode);
+source code is on [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
+
 ## Why Codewhale
 
 - **Use the model you want.** Connect hosted providers or local models through

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale to agent programistyczny o otwartym kodzie źródłowym do terminala, napisany w Rust i rozwijany publicznie wspólnie z osobami, które go używają.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale może czytać Twoje repozytorium, edytować pliki, wykonywać polecenia, sprawdzać wyniki i kontynuować pracę nad celem. Ty decydujesz, jaki poziom dostępu mu przyznasz.
+
+## Interfejs graficzny
+
+Wolisz interfejs graficzny? Rozszerzenie CodeWhale for VS Code, utrzymywane przez społeczność, umieszcza tego samego agenta w bocznym panelu VS Code — czat, rozmowy w wątkach, diffy na żywo i zarządzanie zadaniami oparte na tej samej Runtime API, dzięki czemu sesje pozostają zsynchronizowane z terminalem. Zainstaluj je z [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode); kod źródłowy znajdziesz na [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Dlaczego Codewhale
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale é um agente de programação de código aberto para o seu terminal, desenvolvido em Rust e aprimorado publicamente com as pessoas que o utilizam.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 O Codewhale pode ler seu repositório, editar arquivos, executar comandos, verificar resultados e continuar trabalhando em direção a um objetivo. Você decide quanto acesso ele terá.
+
+## Interface gráfica
+
+Prefere uma interface gráfica? A extensão CodeWhale for VS Code, mantida pela comunidade, coloca o mesmo agente na barra lateral do VS Code — chat, conversas em tópicos, diffs ao vivo e gerenciamento de tarefas sobre a mesma Runtime API, mantendo as sessões sincronizadas com o terminal. Instale pelo [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode); o código-fonte está no [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Por que usar o Codewhale
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale — это агент для программирования с открытым исходным кодом, работающий в терминале. Он написан на Rust и открыто развивается вместе со своими пользователями.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale умеет читать ваш репозиторий, редактировать файлы, выполнять команды, проверять результаты и продолжать работу над целью. Вы сами решаете, какой доступ ему предоставить.
+
+## Графический интерфейс
+
+Предпочитаете графический интерфейс? Поддерживаемое сообществом расширение CodeWhale for VS Code помещает того же агента в боковую панель VS Code — чат, беседы по темам, живые diff и управление задачами поверх той же Runtime API, так что сеансы остаются синхронизированными с терминалом. Установите его из [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode); исходный код — на [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Почему Codewhale
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale, terminaliniz için Rust ile geliştirilmiş ve kullanıcılarıyla birlikte açık biçimde iyileştirilen açık kaynaklı bir kodlama ajanıdır.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale deponuzu okuyabilir, dosyaları düzenleyebilir, komutları çalıştırabilir, sonuçları inceleyebilir ve bir hedefe doğru çalışmayı sürdürebilir. Ne kadar erişime sahip olacağına siz karar verirsiniz.
+
+## Grafik arayüz
+
+Grafik bir arayüzü mü tercih edersiniz? Topluluk tarafından bakımı yapılan CodeWhale for VS Code eklentisi aynı aracıyı VS Code kenar çubuğuna taşır — sohbet, konu tabanlı görüşmeler, canlı diff ve görev yönetimi, hepsi aynı Runtime API üzerinde; oturumlar terminalle eşitlenmiş kalır. [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode) üzerinden kurun; kaynak kodu [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode) adresinde.
 
 ## Neden Codewhale
 

--- a/README.uk.md
+++ b/README.uk.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale — це агент програмування з відкритим кодом для вашого термінала, створений на Rust і вдосконалюваний публічно разом із людьми, які ним користуються.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale може читати ваш репозиторій, редагувати файли, виконувати команди, перевіряти результати й продовжувати роботу над метою. Ви самі вирішуєте, який доступ йому надати.
+
+## Графічний інтерфейс
+
+Віддаєте перевагу графічному інтерфейсу? Розширення CodeWhale for VS Code, яке підтримує спільнота, вміщує того самого агента в бічну панель VS Code — чат, тематичні розмови, живі diff та керування задачами на тій самій Runtime API, тож сеанси залишаються синхронізованими з терміналом. Установіть його з [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode); вихідний код — на [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Чому Codewhale
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale là tác nhân lập trình mã nguồn mở dành cho terminal, được xây dựng bằng Rust và được cải thiện công khai cùng những người sử dụng nó.
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale có thể đọc kho mã nguồn, chỉnh sửa tệp, chạy lệnh, kiểm tra kết quả và tiếp tục làm việc hướng đến mục tiêu. Bạn quyết định mức quyền truy cập dành cho nó.
+
+## Giao diện GUI
+
+Thích giao diện đồ họa hơn? Tiện ích CodeWhale for VS Code do cộng đồng duy trì đưa cùng một agent vào thanh bên VS Code — trò chuyện, hội thoại theo luồng, diff trực tiếp và quản lý tác vụ, đều dùng chung Runtime API, giúp phiên làm việc đồng bộ với thiết bị đầu cuối. Cài đặt từ [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode); mã nguồn có trên [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode).
 
 ## Vì sao chọn Codewhale
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale 是一款面向终端的开源编程智能体，使用 Rust 构建，并与用户一起在公开协作中不断改进。
@@ -45,6 +45,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale 可以读取你的代码仓库、编辑文件、运行命令、检查结果，并持续推进目标。由你决定授予它多少访问权限。
+
+## GUI 前端
+
+更喜欢图形界面？社区维护的 CodeWhale for VS Code 扩展把同一个智能体放进 VS Code 侧边栏——聊天、线程会话、实时 diff 与任务管理，全部基于同一个 Runtime API，会话与终端保持同步。可从 [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode) 安装；源码见 [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode)。
 
 ## 为什么选择 Codewhale
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,4 +1,4 @@
-<!-- source: README.md sha256:dcbd5aa09403 -->
+<!-- source: README.md sha256:3cc3ffc9b995 -->
 # Codewhale
 
 Codewhale 是一款在終端機中使用的開源程式設計代理，以 Rust 打造，並與使用者一起透過公開協作持續改進。
@@ -42,6 +42,10 @@ codewhale exec "fix the failing tests and explain what changed"
 ```
 
 Codewhale 可以讀取你的程式碼儲存庫、編輯檔案、執行指令、檢查結果，並持續朝目標推進。你可以決定要授予它多少存取權限。
+
+## GUI 前端
+
+偏好圖形介面？社群維護的 CodeWhale for VS Code 擴充功能把同一個智慧體放進 VS Code 側邊欄——聊天、執行緒對話、即時 diff 與任務管理，全部基於同一個 Runtime API，並與終端保持同步。可從 [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=HengQuWorld.brotherwhale-vscode) 安裝；原始碼見 [GitHub](https://github.com/HengQuWorld/CodeWhale-VSCode)。
 
 ## 為何選擇 Codewhale
 


### PR DESCRIPTION
## Summary

Adds a compact "GUI frontend" section to `README.md` right after "Use", so
terminal users who prefer a graphical interface can discover the
community-maintained **CodeWhale for VS Code** extension. Install is from
the VS Code Marketplace only; GitHub hosts the source.

The section is mirrored into all 18 translated READMEs, each with a
refreshed source stamp.

README-only; no code or behavior changes.

## Testing

- Ran `python3 scripts/check-readme-translations.py` → `README translation check OK — 18 translations in sync with README.md (sha256:3cc3ffc9b995)`.
- No cargo gates run — the change touches README files only.

## Checklist

- [ ] This PR adds a new layer/module/abstraction — it names or deletes the layer it replaces _(N/A: README-only)_
- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant _(translation drift gate, see Testing)_
- [ ] Verified TUI behavior manually if UI changes _(N/A)_
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address _(N/A)_

No-Issue: README-only contributor link to the community VS Code frontend