### PR TITLE
fix(config): honor allow_insecure_http per provider again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `allow_insecure_http = true` under a `[providers.<name>]` table works
+  again. 0.9.12 tightened plain-HTTP base URL handling in a way that
+  silently dropped the per-provider key, leaving the process-wide env
+  var as the only opt-in — LAN llama.cpp and internal-gateway users
+  had to export `CODEWHALE_ALLOW_INSECURE_HTTP=1` to connect at all.
+  The key is honored again (parsed, settable and unsettable through
+  `codewhale config set providers.<name>.allow_insecure_http`, and
+  listed in the custom-provider field hint), it stays distinct from
+  `insecure_skip_tls_verify`, and the refusal message now leads with
+  the config key. Loopback hosts remain auto-allowed and telemetry
+  endpoint validation deliberately still consults neither switch
+  (#5991, thanks @Gabriel-Degret).
 - A Fleet task that selects a roster member with `worker.agent_profile` now
   runs with that member's posture. The launch-time resolver only consulted the
   resolved member when the legacy `worker.role` label was absent, so a task

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -175,6 +175,13 @@ pub struct ProviderConfigToml {
     pub auth_mode: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub insecure_skip_tls_verify: Option<bool>,
+    /// Explicit consent to a plain-HTTP `base_url` for this provider (a
+    /// llama.cpp box on the LAN, an internal gateway). Loopback hosts are
+    /// always allowed without it. Distinct from `insecure_skip_tls_verify`,
+    /// which skips TLS certificate verification on HTTPS URLs and does not
+    /// permit plain HTTP (#5991).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_insecure_http: Option<bool>,
     #[serde(default, skip_serializing_if = "http_headers_are_effectively_empty")]
     pub http_headers: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -209,6 +216,7 @@ impl ProviderConfigToml {
             && blank(self.wire.as_ref())
             && blank(self.auth_mode.as_ref())
             && self.insecure_skip_tls_verify.is_none()
+            && self.allow_insecure_http.is_none()
             && http_headers_are_effectively_empty(&self.http_headers)
             && blank(self.path_suffix.as_ref())
             && self.auth.is_none()
@@ -926,6 +934,7 @@ enum ProviderConfigField {
     Wire,
     AuthMode,
     InsecureSkipTlsVerify,
+    AllowInsecureHttp,
     HttpHeaders,
     PathSuffix,
 }
@@ -941,6 +950,7 @@ impl ProviderConfigField {
             "wire" | "api_style" | "protocol" | "wire_format" | "dialect" => Self::Wire,
             "auth_mode" => Self::AuthMode,
             "insecure_skip_tls_verify" => Self::InsecureSkipTlsVerify,
+            "allow_insecure_http" => Self::AllowInsecureHttp,
             "http_headers" => Self::HttpHeaders,
             "path_suffix" => Self::PathSuffix,
             _ => return None,
@@ -957,6 +967,7 @@ impl ProviderConfigField {
             Self::Wire => "wire",
             Self::AuthMode => "auth_mode",
             Self::InsecureSkipTlsVerify => "insecure_skip_tls_verify",
+            Self::AllowInsecureHttp => "allow_insecure_http",
             Self::HttpHeaders => "http_headers",
             Self::PathSuffix => "path_suffix",
         }
@@ -994,7 +1005,7 @@ fn is_builtin_provider_config_id(provider_id: &str) -> bool {
 /// Field legs a `[providers.<id>]` custom table accepts through
 /// `config set`, including the required `kind` marker.
 const CUSTOM_PROVIDER_FIELD_HINT: &str = "api_key, base_url, model, context_window, mode, wire, auth_mode, \
-     insecure_skip_tls_verify, http_headers, path_suffix, kind";
+     insecure_skip_tls_verify, allow_insecure_http, http_headers, path_suffix, kind";
 
 fn provider_config_key(provider: ProviderKind, field: ProviderConfigField) -> String {
     format!(
@@ -1019,6 +1030,9 @@ fn get_provider_config_value(
         ProviderConfigField::InsecureSkipTlsVerify => config
             .insecure_skip_tls_verify
             .map(|value| value.to_string()),
+        ProviderConfigField::AllowInsecureHttp => {
+            config.allow_insecure_http.map(|value| value.to_string())
+        }
         ProviderConfigField::HttpHeaders => serialize_http_headers(&config.http_headers),
         ProviderConfigField::PathSuffix => config.path_suffix.clone(),
     }
@@ -1097,6 +1111,12 @@ fn set_provider_config_value(
                 .for_provider_mut(provider)
                 .insecure_skip_tls_verify = Some(parse_bool(value)?);
         }
+        ProviderConfigField::AllowInsecureHttp => {
+            config
+                .providers
+                .for_provider_mut(provider)
+                .allow_insecure_http = Some(parse_bool(value)?);
+        }
         ProviderConfigField::HttpHeaders => {
             let headers = parse_http_headers(value)?;
             config.providers.for_provider_mut(provider).http_headers = headers.clone();
@@ -1152,6 +1172,12 @@ fn unset_provider_config_value(
                 .providers
                 .for_provider_mut(provider)
                 .insecure_skip_tls_verify = None;
+        }
+        ProviderConfigField::AllowInsecureHttp => {
+            config
+                .providers
+                .for_provider_mut(provider)
+                .allow_insecure_http = None;
         }
         ProviderConfigField::HttpHeaders => {
             config
@@ -1213,6 +1239,12 @@ fn insert_provider_config_values(
     if let Some(v) = config.insecure_skip_tls_verify {
         out.insert(
             provider_config_key(provider, ProviderConfigField::InsecureSkipTlsVerify),
+            v.to_string(),
+        );
+    }
+    if let Some(v) = config.allow_insecure_http {
+        out.insert(
+            provider_config_key(provider, ProviderConfigField::AllowInsecureHttp),
             v.to_string(),
         );
     }
@@ -2730,7 +2762,9 @@ impl ConfigToml {
             ProviderConfigField::ContextWindow => {
                 toml::Value::Integer(i64::from(parse_context_window(value)?))
             }
-            ProviderConfigField::InsecureSkipTlsVerify => toml::Value::Boolean(parse_bool(value)?),
+            ProviderConfigField::InsecureSkipTlsVerify | ProviderConfigField::AllowInsecureHttp => {
+                toml::Value::Boolean(parse_bool(value)?)
+            }
             ProviderConfigField::HttpHeaders => toml::Value::Table(
                 parse_http_headers(value)?
                     .into_iter()

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -1931,6 +1931,65 @@ fn insecure_skip_tls_verify_resolves_only_for_active_provider() {
     assert!(resolved.insecure_skip_tls_verify);
 }
 
+/// #5991: `allow_insecure_http` is a per-provider key again — parsed from the
+/// `[providers.<name>]` table, settable/unsettable through `config set`, and
+/// listed in the custom-provider field hint. It must stay independent of
+/// `insecure_skip_tls_verify` (which only relaxes TLS verification).
+#[test]
+fn allow_insecure_http_round_trips_and_stays_distinct_from_tls_verify() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+
+    let raw = r#"
+provider = "openai"
+[providers.openai]
+base_url = "http://192.168.0.110:8000/v1"
+allow_insecure_http = true
+insecure_skip_tls_verify = false
+"#;
+    let config: ConfigToml = toml::from_str(raw).expect("parses");
+    assert_eq!(config.providers.openai.allow_insecure_http, Some(true));
+    assert_eq!(
+        config.providers.openai.insecure_skip_tls_verify,
+        Some(false)
+    );
+
+    // `config set providers.openai.allow_insecure_http true` lands in the
+    // same field and `config get` reads it back.
+    let mut set_target = ConfigToml::default();
+    set_provider_config_value(
+        &mut set_target,
+        ProviderKind::Openai,
+        ProviderConfigField::AllowInsecureHttp,
+        "true",
+    )
+    .expect("set accepts the key");
+    assert_eq!(set_target.providers.openai.allow_insecure_http, Some(true));
+    assert!(
+        set_target
+            .providers
+            .openai
+            .insecure_skip_tls_verify
+            .is_none()
+    );
+    assert_eq!(
+        get_provider_config_value(
+            &set_target.providers.openai,
+            ProviderConfigField::AllowInsecureHttp
+        ),
+        Some("true".to_string())
+    );
+
+    unset_provider_config_value(
+        &mut set_target,
+        ProviderKind::Openai,
+        ProviderConfigField::AllowInsecureHttp,
+    );
+    assert_eq!(set_target.providers.openai.allow_insecure_http, None);
+
+    assert!(CUSTOM_PROVIDER_FIELD_HINT.contains("allow_insecure_http"));
+}
+
 #[test]
 fn openai_provider_accepts_dashscope_bailian_base_url_and_model() {
     let _lock = env_lock();

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `allow_insecure_http = true` under a `[providers.<name>]` table works
+  again. 0.9.12 tightened plain-HTTP base URL handling in a way that
+  silently dropped the per-provider key, leaving the process-wide env
+  var as the only opt-in — LAN llama.cpp and internal-gateway users
+  had to export `CODEWHALE_ALLOW_INSECURE_HTTP=1` to connect at all.
+  The key is honored again (parsed, settable and unsettable through
+  `codewhale config set providers.<name>.allow_insecure_http`, and
+  listed in the custom-provider field hint), it stays distinct from
+  `insecure_skip_tls_verify`, and the refusal message now leads with
+  the config key. Loopback hosts remain auto-allowed and telemetry
+  endpoint validation deliberately still consults neither switch
+  (#5991, thanks @Gabriel-Degret).
 - A Fleet task that selects a roster member with `worker.agent_profile` now
   runs with that member's posture. The launch-time resolver only consulted the
   resolved member when the legacy `worker.role` label was absent, so a task

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -756,13 +756,20 @@ pub(super) async fn bounded_error_text(response: reqwest::Response, max_bytes: u
     String::from_utf8_lossy(&buf).into_owned()
 }
 
-fn validate_base_url_security(base_url: &str) -> Result<()> {
+fn validate_base_url_security(base_url: &str, provider_allows_insecure_http: bool) -> Result<()> {
     let display_base_url = redact_url_for_display(base_url);
     if base_url.starts_with("https://")
         || base_url.starts_with("http://localhost")
         || base_url.starts_with("http://127.0.0.1")
         || base_url.starts_with("http://[::1]")
     {
+        return Ok(());
+    }
+
+    if base_url.starts_with("http://") && provider_allows_insecure_http {
+        logging::warn(
+            "Using insecure HTTP base URL because this provider sets allow_insecure_http = true in config.toml",
+        );
         return Ok(());
     }
 
@@ -784,10 +791,10 @@ fn validate_base_url_security(base_url: &str) -> Result<()> {
             "Refusing insecure base URL '{display_base_url}'.\n\
              \n\
              Loopback hosts (localhost, 127.0.0.1, [::1]) are auto-allowed.\n\
-             For other trusted local hosts (LAN, llama.cpp on a private IP, etc.)\n\
-             set the env var `{ALLOW_INSECURE_HTTP_ENV}=1` in the shell that runs codewhale and re-run.\n\
-             \n\
-             Example: `{ALLOW_INSECURE_HTTP_ENV}=1 codewhale` (note the underscores).",
+             For one trusted local provider (LAN, llama.cpp on a private IP, etc.) set\n\
+             `allow_insecure_http = true` under its `[providers.<name>]` table in config.toml.\n\
+             To allow it for every provider in this shell instead, set the env var\n\
+             `{ALLOW_INSECURE_HTTP_ENV}=1` and re-run.",
         );
     }
 
@@ -1216,7 +1223,7 @@ impl DeepSeekClient {
         };
         let model_bound_secret_values =
             Arc::new(configured_model_bound_secret_values(config, &api_key));
-        validate_base_url_security(&base_url)?;
+        validate_base_url_security(&base_url, config.allow_insecure_http())?;
         let retry = config.retry_policy();
         let stream_idle_timeout = Duration::from_secs(config.stream_chunk_timeout_secs());
         let http_headers = config.http_headers();
@@ -11263,7 +11270,7 @@ mod tests {
             let _guard = AllowInsecureHttpEnvGuard::capture();
             unsafe { std::env::remove_var(ALLOW_INSECURE_HTTP_ENV) };
 
-            let err = validate_base_url_security("http://api.deepseek.com")
+            let err = validate_base_url_security("http://api.deepseek.com", false)
                 .expect_err("non-local insecure HTTP should be rejected");
             assert!(err.to_string().contains("Refusing insecure base URL"));
         }
@@ -11275,6 +11282,7 @@ mod tests {
 
             let err = validate_base_url_security(
                 "http://user:secret@example.com/v1?api_key=sk-test&ok=1",
+                false,
             )
             .expect_err("non-local insecure HTTP should be rejected");
             let message = err.to_string();
@@ -11289,8 +11297,8 @@ mod tests {
             let _guard = AllowInsecureHttpEnvGuard::capture();
             unsafe { std::env::remove_var(ALLOW_INSECURE_HTTP_ENV) };
 
-            assert!(validate_base_url_security("http://localhost:8080").is_ok());
-            assert!(validate_base_url_security("http://127.0.0.1:8080").is_ok());
+            assert!(validate_base_url_security("http://localhost:8080", false).is_ok());
+            assert!(validate_base_url_security("http://127.0.0.1:8080", false).is_ok());
         }
         // from base_url_security_allows_non_local_http_with_explicit_opt_in
         {
@@ -11298,7 +11306,21 @@ mod tests {
             let _guard = AllowInsecureHttpEnvGuard::capture();
             unsafe { std::env::set_var(ALLOW_INSECURE_HTTP_ENV, "1") };
 
-            assert!(validate_base_url_security("http://192.168.0.110:8000/v1").is_ok());
+            assert!(validate_base_url_security("http://192.168.0.110:8000/v1", false).is_ok());
+        }
+        // #5991: a provider that opts in via its [providers.<name>] table may
+        // use a plain-HTTP base URL without any env var. This is the
+        // 0.9.11-and-earlier behavior the key silently stopped providing.
+        {
+            let _lock = ALLOW_INSECURE_HTTP_ENV_LOCK.lock().unwrap();
+            let _guard = AllowInsecureHttpEnvGuard::capture();
+            unsafe { std::env::remove_var(ALLOW_INSECURE_HTTP_ENV) };
+
+            assert!(validate_base_url_security("http://192.168.0.110:8000/v1", true).is_ok());
+            // The refusal message now leads with the config key.
+            let err = validate_base_url_security("http://api.deepseek.com", false)
+                .expect_err("still refused without either opt-in");
+            assert!(err.to_string().contains("allow_insecure_http = true"));
         }
     }
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -3860,6 +3860,10 @@ pub struct ProviderConfig {
     pub oauth_credential_generation: Option<String>,
     #[serde(alias = "insecureSkipTlsVerify")]
     pub insecure_skip_tls_verify: Option<bool>,
+    /// Per-provider consent to a plain-HTTP `base_url` (#5991). Loopback is
+    /// always allowed without it.
+    #[serde(default, alias = "allowInsecureHttp")]
+    pub allow_insecure_http: Option<bool>,
     #[serde(alias = "httpHeaders")]
     pub http_headers: Option<HashMap<String, String>>,
     #[serde(alias = "pathSuffix")]
@@ -6002,6 +6006,17 @@ impl Config {
     pub fn insecure_skip_tls_verify(&self) -> bool {
         self.provider_config()
             .and_then(|provider| provider.insecure_skip_tls_verify)
+            .unwrap_or(false)
+    }
+
+    /// Per-provider consent to a plain-HTTP `base_url` (#5991). Loopback is
+    /// always allowed without it; this covers named LAN/internal hosts the
+    /// user explicitly trusts. Narrower than the env-var override, which
+    /// applies to every provider in the process.
+    #[must_use]
+    pub fn allow_insecure_http(&self) -> bool {
+        self.provider_config()
+            .and_then(|provider| provider.allow_insecure_http)
             .unwrap_or(false)
     }
 
@@ -10898,6 +10913,9 @@ fn merge_provider_config(base: ProviderConfig, override_cfg: ProviderConfig) -> 
         insecure_skip_tls_verify: override_cfg
             .insecure_skip_tls_verify
             .or(base.insecure_skip_tls_verify),
+        allow_insecure_http: override_cfg
+            .allow_insecure_http
+            .or(base.allow_insecure_http),
         http_headers: override_cfg.http_headers.or(base.http_headers),
         path_suffix: override_cfg.path_suffix.or(base.path_suffix),
         reasoning_stream_style: override_cfg
@@ -11896,6 +11914,7 @@ fn provider_config_is_explicit(entry: &ProviderConfig) -> bool {
         || non_empty(entry.path_suffix.as_ref())
         || non_empty(entry.reasoning_stream_style.as_ref())
         || entry.insecure_skip_tls_verify.is_some()
+        || entry.allow_insecure_http.is_some()
         || non_empty(entry.kind.as_ref())
         || non_empty(entry.api_key_env.as_ref())
         || entry.external_credentials.is_some()


### PR DESCRIPTION
Closes #5991

0.9.12 dropped the per-provider `allow_insecure_http` key: the base-URL security gate consulted only `CODEWHALE_ALLOW_INSECURE_HTTP`, so users with plain-HTTP LAN/internal providers (llama.cpp on a private IP, FreeBSD report in the issue) had to export a process-wide env var to connect at all.

Restored end to end: TOML parsing in both config tables, `config set/get/unset` wiring, the custom-provider field hint, merge behavior, and the client gate — the refusal message now leads with the config key. Distinct from `insecure_skip_tls_verify`; loopback auto-allow unchanged; telemetry endpoint validation keeps its deliberately separate trust decision.

Evidence: codewhale-config 641 passed (new round-trip test); tui `base_url_scenario` extended and passing; clippy -D warnings clean; fmt clean; derived changelog synced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider URL trust boundaries for LAN/internal HTTP endpoints; behavior is explicit opt-in but misconfiguration could expose traffic on untrusted networks.
> 
> **Overview**
> **Restores per-provider plain-HTTP opt-in** that 0.9.12 effectively removed: `allow_insecure_http = true` under `[providers.<name>]` is parsed, merged, and exposed again via `codewhale config set/get/unset`, including the custom-provider field hint.
> 
> **Client base-URL validation** now accepts non-loopback `http://` URLs when the active provider sets that flag (still separate from `insecure_skip_tls_verify` and from the process-wide `CODEWHALE_ALLOW_INSECURE_HTTP` env var). Refusal text leads with the config key; loopback hosts stay auto-allowed.
> 
> Changelog entries and round-trip / `base_url_scenario` tests cover the regression (#5991).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 159252f8361b4ebde955f18a3a3ef032fbed4412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->