### PR TITLE
test(plugins): pin the computer-use embed list to the vendored tree

### DIFF
--- a/crates/tui/src/plugins/builtin.rs
+++ b/crates/tui/src/plugins/builtin.rs
@@ -191,6 +191,55 @@ mod tests {
 
     use crate::plugins::types::{PluginScope, PluginTrustStatus};
 
+    /// The vendored tree and the embed list are two views of one bundle.
+    /// This pins them together so a refreshed bundle can never leave a
+    /// runtime file out of `COMPUTER_USE_FILES` — the materialized server
+    /// would crash at import the first time it needed the missing module —
+    /// and an embed entry can never outlive its file. Development-only
+    /// files stay out of the binary by the documented policy on
+    /// `COMPUTER_USE_FILES`.
+    #[test]
+    fn computer_use_embed_list_matches_the_vendored_runtime_tree() {
+        const DEV_ONLY: &[&str] = &["package.json", "README.md", "scripts/smoke.mjs"];
+
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("plugins/computer-use");
+        let mut on_disk: Vec<String> = Vec::new();
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            for entry in fs::read_dir(&dir).unwrap() {
+                let entry = entry.unwrap();
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                let relative = path
+                    .strip_prefix(&root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                if relative.starts_with("tests/") || DEV_ONLY.contains(&relative.as_str()) {
+                    continue;
+                }
+                on_disk.push(relative);
+            }
+        }
+        on_disk.sort();
+
+        let mut embedded: Vec<&str> = COMPUTER_USE_FILES
+            .iter()
+            .map(|(relative, _)| *relative)
+            .collect();
+        embedded.sort_unstable();
+
+        let expected: Vec<&str> = on_disk.iter().map(String::as_str).collect();
+        assert_eq!(
+            embedded, expected,
+            "COMPUTER_USE_FILES and crates/tui/plugins/computer-use disagree — sync the embed \
+             list with the vendored runtime tree"
+        );
+    }
+
     #[test]
     fn computer_use_is_discovered_but_never_auto_enabled() {
         let _lock = crate::test_support::lock_test_env();


### PR DESCRIPTION
No-Issue: anti-rot guard ahead of the CU bundle refresh (see codewhale-ops CU-PLUGIN-PACKAGE-PLAN-20260907)

The vendored computer-use bundle and the `COMPUTER_USE_FILES` embed list are two views of one runtime, and nothing tied them together — the tree already drifted once (five upstream runtime files the list never learned about; a naive refresh would crash the materialized server at import). This test walks `crates/tui/plugins/computer-use/` and asserts set equality with the embed list, excluding the documented dev-only files.

Evidence: `cargo nextest run -p codewhale-tui --lib -E 'test(plugins::builtin)'` → 4 passed, 0 failed (guard included); fmt clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production behavior impact.
> 
> **Overview**
> Adds a regression test so **`COMPUTER_USE_FILES`** cannot drift from **`crates/tui/plugins/computer-use`**.
> 
> The test recursively collects runtime files on disk (skipping **`tests/`** and the documented dev-only paths: **`package.json`**, **`README.md`**, **`scripts/smoke.mjs`**), sorts them, and asserts exact equality with the embed list. A mismatch fails with a message to sync the list—covering both missing embeds (runtime import crashes) and stale embed entries for deleted files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf4231095597e6c4f4eac07dbe6d6cf0af11700d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->