### PR TITLE
fix(session): skip runtime handoffs when deriving the auto title

### DIFF
--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -2303,10 +2303,16 @@ pub fn create_saved_session_with_id_and_mode(
 ) -> SavedSession {
     let now = Utc::now();
 
-    // Generate title from first user message
+    // Generate title from the first real user message. Chat-template
+    // compatibility forces runtime-owned control traffic (sub-agent handoffs,
+    // the Operate contract, restore checkpoints) through `role = "user"`, but
+    // an internal envelope is not what the person typed. Skip those messages
+    // so the auto-generated title comes from the actual prompt; this is the
+    // same recognizer the session peek uses, so title and preview agree about
+    // what counts as conversation.
     let title = messages
         .iter()
-        .find(|m| m.role == "user")
+        .find(|m| m.role == "user" && !crate::runtime_handoff::is_internal_runtime_handoff(m))
         .and_then(|m| {
             m.content.iter().find_map(|block| match block {
                 ContentBlock::Text { text, .. } => {
@@ -4045,6 +4051,41 @@ mod tests {
         assert_eq!(
             session.metadata.title,
             "Fix the session picker history pane"
+        );
+    }
+
+    #[test]
+    fn create_saved_session_skips_runtime_handoffs_when_deriving_title() {
+        let tmp = tempdir().expect("tempdir");
+        // Operate/automation sessions start with runtime-owned control traffic
+        // as the first `user` message. The auto-title must come from the real
+        // prompt that follows, never from the internal envelope.
+        let messages = vec![
+            crate::runtime_handoff::operate_contract_runtime_message(),
+            make_test_message("user", "Ship the session-title fix"),
+        ];
+        let session = create_saved_session(&messages, "test-model", tmp.path(), 100, None);
+        assert_eq!(session.metadata.title, "Ship the session-title fix");
+        assert!(
+            !session.metadata.title.contains("codewhale:runtime"),
+            "internal envelope leaked into the session title: {}",
+            session.metadata.title
+        );
+    }
+
+    #[test]
+    fn create_saved_session_with_only_runtime_traffic_keeps_placeholder_title() {
+        let tmp = tempdir().expect("tempdir");
+        let messages = vec![
+            crate::runtime_handoff::operate_contract_runtime_message(),
+            crate::runtime_handoff::waiting_for_subagents_runtime_message(2),
+        ];
+        let session = create_saved_session(&messages, "test-model", tmp.path(), 100, None);
+        assert_eq!(session.metadata.title, DEFAULT_SESSION_TITLE);
+        assert!(
+            !session.metadata.title.contains("codewhale:runtime"),
+            "internal envelope leaked into the session title: {}",
+            session.metadata.title
         );
     }
 

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -875,16 +875,10 @@ impl SavedSession {
         let messages = journal.to_messages();
         let now = Utc::now();
         let spawn_depth = journal.spawn_depth.saturating_add(1);
-        let title = messages
-            .iter()
-            .find(|m| m.role == "user")
-            .and_then(|m| {
-                m.content.iter().find_map(|b| match b {
-                    ContentBlock::Text { text, .. } => Some(text.as_str()),
-                    _ => None,
-                })
-            })
-            .map(|s| crate::session_manager::truncate_title(s, 50))
+        // Reuse the conversation-derived title so an imported session that
+        // opens with runtime-owned control traffic (Operate contract, restore
+        // checkpoint) is named after the real prompt, not the envelope.
+        let title = conversation_derived_title(&messages)
             .unwrap_or_else(|| crate::session_manager::DEFAULT_SESSION_TITLE.to_string());
         let metadata = SessionMetadata {
             id: Uuid::new_v4().to_string(),
@@ -2303,30 +2297,11 @@ pub fn create_saved_session_with_id_and_mode(
 ) -> SavedSession {
     let now = Utc::now();
 
-    // Generate title from the first real user message. Chat-template
-    // compatibility forces runtime-owned control traffic (sub-agent handoffs,
-    // the Operate contract, restore checkpoints) through `role = "user"`, but
-    // an internal envelope is not what the person typed. Skip those messages
-    // so the auto-generated title comes from the actual prompt; this is the
-    // same recognizer the session peek uses, so title and preview agree about
-    // what counts as conversation.
-    let title = messages
-        .iter()
-        .find(|m| m.role == "user" && !crate::runtime_handoff::is_internal_runtime_handoff(m))
-        .and_then(|m| {
-            m.content.iter().find_map(|block| match block {
-                ContentBlock::Text { text, .. } => {
-                    let prompt = extract_user_prompt(text);
-                    if prompt.is_empty() {
-                        None
-                    } else {
-                        Some(truncate_title(prompt, 50))
-                    }
-                }
-                _ => None,
-            })
-        })
-        .unwrap_or_else(|| DEFAULT_SESSION_TITLE.to_string());
+    // Generate title from the first real user message (runtime-owned control
+    // traffic is skipped by `conversation_derived_title`). Fall back to the
+    // placeholder when no user-authored prompt exists yet.
+    let title =
+        conversation_derived_title(messages).unwrap_or_else(|| DEFAULT_SESSION_TITLE.to_string());
 
     let journal = SessionJournal::from_messages(messages.to_vec(), 0);
     let leaf_id = journal.leaf_id.clone();
@@ -2627,6 +2602,37 @@ fn truncate_title(s: &str, max_len: usize) -> String {
     }
 }
 
+/// Derive the auto-title from the first real user message of a conversation.
+///
+/// Returns `None` when no user-authored message exists to name the session
+/// after (an empty transcript, or one holding only runtime-owned control
+/// traffic); callers fall back to [`DEFAULT_SESSION_TITLE`].
+///
+/// Chat-template compatibility forces runtime-owned control traffic
+/// (sub-agent handoffs, the Operate contract, restore checkpoints) through
+/// `role = "user"`, but an internal envelope is not what the person typed.
+/// Skip those messages — the same recognizer the session peek uses, so every
+/// caller agrees about what counts as conversation — and strip any leading
+/// `<turn_meta>` envelope from the surviving prompt.
+fn conversation_derived_title(messages: &[Message]) -> Option<String> {
+    messages
+        .iter()
+        .find(|m| m.role == "user" && !crate::runtime_handoff::is_internal_runtime_handoff(m))
+        .and_then(|m| {
+            m.content.iter().find_map(|block| match block {
+                ContentBlock::Text { text, .. } => {
+                    let prompt = extract_user_prompt(text);
+                    if prompt.is_empty() {
+                        None
+                    } else {
+                        Some(truncate_title(prompt, 50))
+                    }
+                }
+                _ => None,
+            })
+        })
+}
+
 /// Format a session for display in a picker
 pub fn format_session_line(meta: &SessionMetadata) -> String {
     let age = format_age(&meta.updated_at);
@@ -2691,6 +2697,11 @@ mod tests {
                 cache_control: None,
             }],
         }
+    }
+
+    fn container_with(messages: Vec<Message>, dir: &std::path::Path) -> SessionImportContainer {
+        let session = create_saved_session(&messages, "test-model", dir, 100, None);
+        session.export_container("test-session.json")
     }
 
     #[test]
@@ -4076,9 +4087,20 @@ mod tests {
     #[test]
     fn create_saved_session_with_only_runtime_traffic_keeps_placeholder_title() {
         let tmp = tempdir().expect("tempdir");
+        let waiting = crate::runtime_handoff::waiting_for_subagents_runtime_message(2);
+        let restored =
+            crate::runtime_handoff::project_messages_for_restore(std::slice::from_ref(&waiting))
+                .into_iter()
+                .next()
+                .expect("restore projection yields one message");
+        // Every runtime handoff shape the session peek filters must also stay
+        // out of the auto-title: the Operate contract, a waiting/restored
+        // sub-agent checkpoint, and a background shell completion.
         let messages = vec![
             crate::runtime_handoff::operate_contract_runtime_message(),
-            crate::runtime_handoff::waiting_for_subagents_runtime_message(2),
+            waiting,
+            restored,
+            crate::runtime_handoff::shell_completion_runtime_message(&[]),
         ];
         let session = create_saved_session(&messages, "test-model", tmp.path(), 100, None);
         assert_eq!(session.metadata.title, DEFAULT_SESSION_TITLE);
@@ -4087,6 +4109,49 @@ mod tests {
             "internal envelope leaked into the session title: {}",
             session.metadata.title
         );
+    }
+
+    #[test]
+    fn import_foreign_derives_title_from_the_first_real_user_message() {
+        let tmp = tempdir().expect("tempdir");
+        // Importing a session whose transcript opens with the Operate contract
+        // (the shape this bug produced on export) must not re-derive the
+        // envelope as the imported title.
+        let container = container_with(
+            vec![
+                crate::runtime_handoff::operate_contract_runtime_message(),
+                make_test_message("user", "Fix the session picker"),
+            ],
+            tmp.path(),
+        );
+        let imported = crate::session_manager::SavedSession::import_foreign(
+            container,
+            tmp.path().to_path_buf(),
+            "test-model".to_string(),
+        )
+        .expect("import succeeds");
+        assert_eq!(imported.metadata.title, "Fix the session picker");
+        assert!(
+            !imported.metadata.title.contains("codewhale:runtime"),
+            "internal envelope leaked into the imported session title: {}",
+            imported.metadata.title
+        );
+    }
+
+    #[test]
+    fn import_foreign_keeps_placeholder_when_only_runtime_traffic() {
+        let tmp = tempdir().expect("tempdir");
+        let container = container_with(
+            vec![crate::runtime_handoff::operate_contract_runtime_message()],
+            tmp.path(),
+        );
+        let imported = crate::session_manager::SavedSession::import_foreign(
+            container,
+            tmp.path().to_path_buf(),
+            "test-model".to_string(),
+        )
+        .expect("import succeeds");
+        assert_eq!(imported.metadata.title, DEFAULT_SESSION_TITLE);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Session titles auto-generated from the conversation were showing internal runtime envelopes such as `<codewhale:runtime_event kind="operate_contract" ...>` instead of the real prompt. Chat-template compatibility forces runtime-owned control traffic (sub-agent handoffs and completions, the Operate contract, restore checkpoints) through `role = "user"`, and `create_saved_session_with_id_and_mode` derived the title from the first `role == "user"` message with only a `<turn_meta>` prefix stripped. In Operate/automation sessions whose transcript opens with an internal envelope, the envelope text became the title (truncated to 50 chars with `...`), and once such a title was persisted the snapshot priority rules kept it pinned until a manual `/rename`. `SavedSession::import_foreign` carried the same stale logic, so importing such an exported session re-derived the envelope as its title.

## Changes

- **fix(session): skip internal runtime handoffs during title derivation** (`session_manager.rs`): the auto-title now comes from the first message that is both `role = "user"` and not `is_internal_runtime_handoff(m)`, reusing the exact recognizer the session peek already uses (`runtime_handoff.rs`), so title generation and preview agree about what counts as conversation. When no real user message exists yet, the `DEFAULT_SESSION_TITLE` placeholder is kept and the existing snapshot healing logic promotes a real prompt title once one arrives.

- **fix(session): apply the same derivation on foreign import** (`session_manager.rs`): the logic is extracted into a shared `conversation_derived_title()` used by both `create_saved_session_with_id_and_mode` and `SavedSession::import_foreign`, closing the import-side copy of the bug (review follow-up).

- **test(session): regression coverage** (`session_manager.rs` tests): `create_saved_session_skips_runtime_handoffs_when_deriving_title` — an Operate-contract-first session titles from the real prompt that follows it; `create_saved_session_with_only_runtime_traffic_keeps_placeholder_title` — covers every handoff shape the peek filters (Operate contract, waiting/restored checkpoint, shell completion) and asserts the placeholder is kept; plus two `import_foreign` tests for the same guarantees on the import path. All fail on the old code.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (not run: full-workspace gate; the change is a shared title-derivation helper plus unit tests, and the crate compiles cleanly through the test build)
- [x] `cargo test -p codewhale-tui --lib create_saved_session` — 3 passed (regression tests + existing turn_meta title test)
- [x] `cargo test -p codewhale-tui --lib "session_manager::"` — 72 passed (incl. new import_foreign tests)
- [x] `cargo test -p codewhale-tui --lib import_foreign` — 2 passed
- [x] `cargo test -p codewhale-tui --lib "import"` (RUST_MIN_STACK=16MB) — 52 passed (contract import integration surface unaffected)
- [x] `cargo test -p codewhale-tui --lib "runtime_handoff::"` — 14 passed
- [x] `cargo test -p codewhale-tui --lib "session_peek::"` — 15 passed
- [x] `cargo test --no-fail-fast -p codewhale-tui --lib` (RUST_MIN_STACK=16MB) — 11651 passed; 9 failures verified unrelated on the unmodified baseline via `git stash` (missing `sh`/`bash` on this Windows host, live-network Anthropic SSE test, one rendering-surface baseline, one zai-stream thread test). One additional acp_server test overflows the default Windows test-thread stack and passes with `RUST_MIN_STACK=16MB` — also reproduced on the unmodified baseline.

Independent review: a reviewer sub-agent returned APPROVE-WITH-NITS; its single MAJOR finding (stale duplicate logic in `SavedSession::import_foreign`) was fixed in the follow-up commit above, and its suggested test-coverage extension (all peek-filtered handoff shapes) was folded into the runtime-traffic regression test.

## Checklist

- [x] Updated docs or comments as needed (doc comment on the title-derivation lookup explaining why runtime handoffs are skipped and that the recognizer is shared with the session peek)
- [x] Added or updated tests where relevant (2 regression tests, both shown failing without the fix)
- [ ] Verified TUI behavior manually if UI changes (title derivation is exercised by automatic snapshots in automation/headless flows; covered by the unit-level regression tests above)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A — no external contributor work is landed here)

## Related Issues

No-Issue: auto-generated session titles leak `<codewhale:runtime_...>` internal envelopes when runtime control traffic is the first user-role message (reported in-session 2026-09-08; no matching GitHub issue or PR found at report time; branch `codex/fix-title-runtime-envelope`, commits eeee8b9f1 and 14147f664).
