### PR TITLE
fix(tui): align model-facing docs and tool gating

### DIFF
--- a/crates/tui/assets/skills/fleet-manager/SKILL.md
+++ b/crates/tui/assets/skills/fleet-manager/SKILL.md
@@ -14,8 +14,8 @@ and leave a ledgered receipt or a safe escalation draft.
 ## Authority Boundary
 
 - Prefer typed fleet surfaces over shell spelunking: `codewhale fleet status`,
-  `inspect`, `logs`, `artifacts`, `interrupt`, `restart`, `stop`, and the
-  Runtime API endpoints.
+  `inspect`, `logs`, `artifacts`, `interrupt`, `restart`, `resume`, `stop`
+  (stop requires `--all`), and the Runtime API endpoints.
 - Do not read `.codewhale/fleet.jsonl`, host logs, or remote files directly
   unless the typed command or API is missing required evidence.
 - Do not send Slack, webhook, PagerDuty, email, or chat messages unless the
@@ -27,11 +27,13 @@ and leave a ledgered receipt or a safe escalation draft.
 
 1. Identify the run and worker from the user request, run receipt, or fleet
    status output. If no worker is named, start with `codewhale fleet status`.
-2. Inspect the worker with `codewhale fleet inspect <worker-id>` or the matching
-   Runtime API worker endpoint.
+2. Inspect the worker with `codewhale fleet inspect <worker-id>` or the
+   matching Runtime API worker endpoint (`GET /v1/fleet/workers/{worker_id}`).
 3. Review bounded evidence with `codewhale fleet logs <worker-id>` and
-   `codewhale fleet artifacts <worker-id>`. Summarize artifact refs, not full
-   payloads.
+   `codewhale fleet artifacts <worker-id>`, or the Runtime API equivalents
+   (`GET /v1/fleet/runs/{run_id}/receipts/{task_id}/evidence` and
+   `GET /v1/fleet/runs/{run_id}/events/replay`). Summarize artifact refs,
+   not full payloads.
 4. Classify the state before acting:
    - `transient failure`: transport error, timeout, stale heartbeat, host
      unavailable, or retryable provider/network failure.
@@ -43,6 +45,8 @@ and leave a ledgered receipt or a safe escalation draft.
      action, repeated restart exhaustion, ambiguous product decision, or
      conflict between artifacts and verifier.
 5. Choose one typed action:
+   - run has orphaned leases after a manager restart:
+     `codewhale fleet resume <run-id>` (idempotent reconcile).
    - transient and retry budget remains: `codewhale fleet restart <worker-id>`.
    - transient but unsafe to retry: draft escalation and mark needs-human.
    - task failure: preserve artifacts, summarize the failure, and avoid restart
@@ -99,7 +103,7 @@ Fleet receipt
 Run: <run-id>
 Workers checked: <count/list>
 Classification: <state>
-Action: <restart/interrupt/stop/escalation draft/no-op>
+Action: <restart/interrupt/stop/resume/escalation draft/no-op>
 Ledger expectation: <typed action should be recorded | draft only, no send>
 Artifacts reviewed: <refs>
 Follow-up owner: <manager | task owner | human>

--- a/crates/tui/src/tools/finance.rs
+++ b/crates/tui/src/tools/finance.rs
@@ -14,6 +14,7 @@ use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
     optional_str, optional_u64,
 };
+use crate::network_policy::Decision;
 
 const DEFAULT_TIMEOUT_MS: u64 = 10_000;
 const MAX_TIMEOUT_MS: u64 = 60_000;
@@ -188,7 +189,7 @@ impl ToolSpec for FinanceTool {
     }
 
     fn description(&self) -> &'static str {
-        "Fetch a live market quote for a stock, ETF, or crypto ticker using Yahoo Finance-style public endpoints."
+        "Fetch a live market quote for a stock, ETF, or crypto ticker using Yahoo Finance-style public endpoints. Network-policy aware: both endpoint hosts are checked against the session network policy before any request, and policy rejections fail closed."
     }
 
     fn input_schema(&self) -> Value {
@@ -240,7 +241,7 @@ impl ToolSpec for FinanceTool {
         true
     }
 
-    async fn execute(&self, input: Value, _context: &ToolContext) -> Result<ToolResult, ToolError> {
+    async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
         let raw_ticker = match optional_str(&input, "ticker")? {
             Some(ticker) => Some(ticker),
             None => optional_str(&input, "symbol")?,
@@ -258,6 +259,11 @@ impl ToolSpec for FinanceTool {
 
         let request = normalize_request(raw_ticker, type_hint);
         let timeout = Duration::from_millis(timeout_ms);
+
+        // #135: quote and chart hosts are both vetted before any transport
+        // fires, so a tightened session (e.g. network.default = "deny")
+        // cannot leak a request through the chart fallback.
+        check_network_policy(context, &self.endpoints)?;
 
         let quote_result =
             fetch_quote_endpoint(&self.client, timeout, &self.endpoints, &request).await;
@@ -278,6 +284,39 @@ impl ToolSpec for FinanceTool {
             }
         }
     }
+}
+
+/// Fail closed when the session network policy denies (or has not approved)
+/// either endpoint host. Mirrors the Web/web_search/speech family: `Deny`
+/// and an undecided `Prompt` both stop before any request is made; no
+/// attached policy falls through permissively for back-compat.
+fn check_network_policy(
+    context: &ToolContext,
+    endpoints: &FinanceEndpoints,
+) -> Result<(), ToolError> {
+    let Some(decider) = context.network_policy.as_ref() else {
+        return Ok(());
+    };
+    for base in [&endpoints.quote_base, &endpoints.chart_base] {
+        let Some(host) = crate::network_policy::host_from_url(base) else {
+            continue;
+        };
+        match decider.evaluate(&host, "finance") {
+            Decision::Allow => {}
+            Decision::Deny => {
+                return Err(ToolError::permission_denied(format!(
+                    "finance lookup to '{host}' blocked by network policy"
+                )));
+            }
+            Decision::Prompt => {
+                return Err(ToolError::permission_denied(format!(
+                    "finance lookup to '{host}' requires approval; \
+                     re-run after `/network allow {host}` or set network.default = \"allow\" in config"
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn normalize_request(raw_ticker: &str, type_hint: Option<&str>) -> FinanceRequest {
@@ -951,5 +990,97 @@ mod tests {
         assert_eq!(any_of.len(), 2);
         assert_eq!(any_of[0]["required"], json!(["ticker"]));
         assert_eq!(any_of[1]["required"], json!(["symbol"]));
+    }
+
+    fn denied_context_for(host: &str) -> (ToolContext, tempfile::TempDir) {
+        use crate::network_policy::{NetworkPolicy, NetworkPolicyDecider};
+        let (ctx, tmp) = context();
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: vec![host.to_string()],
+            proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
+            audit: false,
+        };
+        (
+            ctx.with_network_policy(NetworkPolicyDecider::new(policy, None)),
+            tmp,
+        )
+    }
+
+    #[tokio::test]
+    async fn finance_fails_closed_when_network_policy_denies_endpoint_host() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "quoteResponse": {"result": []}
+            })))
+            .mount(&server)
+            .await;
+
+        let host = reqwest::Url::parse(&server.uri())
+            .expect("mock server URL")
+            .host_str()
+            .expect("mock server host")
+            .to_string();
+        let (blocked, _tmp) = denied_context_for(&host);
+
+        let tool = tool_with_server(&server);
+        let error = tool
+            .execute(json!({"ticker": "AAPL"}), &blocked)
+            .await
+            .expect_err("denied host must fail closed");
+        assert!(
+            error.to_string().contains("blocked by network policy"),
+            "{error}"
+        );
+        assert_eq!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded requests")
+                .len(),
+            0,
+            "no request may leave before the policy check"
+        );
+    }
+
+    #[tokio::test]
+    async fn finance_fails_closed_on_prompt_when_default_is_prompt() {
+        let server = MockServer::start().await;
+
+        // default = prompt with no allow list: the undecided host must fail
+        // closed with the approval hint, never with a silent request.
+        let (ctx, tmp) = context();
+        use crate::network_policy::{NetworkPolicy, NetworkPolicyDecider};
+        let policy = NetworkPolicy {
+            default: Decision::Prompt.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
+            audit: false,
+        };
+        let blocked = ctx.with_network_policy(NetworkPolicyDecider::new(policy, None));
+        drop(tmp);
+
+        let tool = tool_with_server(&server);
+        let error = tool
+            .execute(json!({"ticker": "AAPL"}), &blocked)
+            .await
+            .expect_err("undecided host must not reach the endpoint");
+        assert!(
+            error.to_string().contains("requires approval"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded requests")
+                .len(),
+            0
+        );
     }
 }

--- a/crates/tui/src/tools/notify.rs
+++ b/crates/tui/src/tools/notify.rs
@@ -6,7 +6,9 @@
 //! the tool is intended for "long task done, come back" beats and
 //! sub-agent-completion pings, not chatter.
 //!
-//! Auto-suppresses when `[notifications].method = "off"`. Output messages
+//! Honors the user's `[notifications]` config: `method = "off"` silences
+//! the tool entirely, and `quiet` / `events.model-notify = false` gate the
+//! category through the process-wide [`NotificationGate`]. Output messages
 //! are length-capped so a runaway model can't paint a paragraph into the
 //! terminal title bar.
 
@@ -124,6 +126,10 @@ impl ToolSpec for NotifyTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tui::notifications::{
+        Method, configured_method, current_notification_gate, install_configured_method,
+        notify_done_to,
+    };
     use std::path::Path;
 
     fn ctx() -> ToolContext {
@@ -192,5 +198,61 @@ mod tests {
         let required = schema.get("required").unwrap().as_array().unwrap();
         assert!(required.iter().any(|v| v.as_str() == Some("title")));
         assert!(!required.iter().any(|v| v.as_str() == Some("body")));
+    }
+
+    /// Restores the process-wide configured method after a test mutates it,
+    /// mirroring `NotificationGateRestore` in `tui::notifications`.
+    struct ConfiguredMethodRestore(Method);
+
+    impl ConfiguredMethodRestore {
+        fn capture() -> Self {
+            Self(configured_method())
+        }
+    }
+
+    impl Drop for ConfiguredMethodRestore {
+        fn drop(&mut self) {
+            install_configured_method(self.0);
+        }
+    }
+
+    #[test]
+    fn configured_method_off_silences_the_tool_emission() {
+        let _restore = ConfiguredMethodRestore::capture();
+        install_configured_method(Method::Off);
+
+        // The emission chain `execute` drives: the installed method decides
+        // suppression before any sink write, with the gate loaded from the
+        // process-wide state.
+        let payload = NotificationPayload::model_notify("done", None);
+        let mut sink = Vec::new();
+        notify_done_to(
+            configured_method(),
+            false,
+            &payload,
+            std::time::Duration::ZERO,
+            std::time::Duration::from_secs(1),
+            current_notification_gate(),
+            &mut sink,
+        );
+        assert!(
+            sink.is_empty(),
+            "configured method=off must silence the notify tool path"
+        );
+    }
+
+    #[tokio::test]
+    async fn configured_method_off_still_reports_success_to_the_model() {
+        // The description promises a *silent* no-op: the model sees success
+        // (nothing to retry), the user's desktop stays quiet.
+        let _restore = ConfiguredMethodRestore::capture();
+        install_configured_method(Method::Off);
+
+        let result = NotifyTool
+            .execute(json!({"title": "done"}), &ctx())
+            .await
+            .expect("ok");
+        assert!(result.success);
+        assert!(result.content.contains("done"));
     }
 }

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -4652,7 +4652,7 @@ impl ToolSpec for BashTool {
                 },
                 "background": {
                     "type": "boolean",
-                    "description": "Temporary background; killed at session exit. Surviving headless services need background:true,persist:true."
+                    "description": "Temporary background; killed at session exit. Surviving headless services need background:true,persist:true. It is not killed at timeout_ms; plan to poll it with action=wait or stop it with action=cancel."
                 },
                 "interactive": {
                     "type": "boolean",

--- a/crates/tui/src/tools/verifier.rs
+++ b/crates/tui/src/tools/verifier.rs
@@ -652,7 +652,7 @@ fn start_background_gates(
         "completion_surface": "task_status",
         "background_policy": "nonblocking",
         "task_ids": task_ids,
-        "poll_with": ["exec_shell_wait", "task_shell_wait"]
+        "poll_with": ["task_shell_wait"]
     })))
 }
 

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -140,7 +140,10 @@ fn method_to_u8(method: Method) -> u8 {
     }
 }
 
-fn install_configured_method(method: Method) {
+/// Install `method` as the process-wide notification method for paths that
+/// do not resolve a method of their own (the `notify` tool); `pub(crate)`
+/// so the tool's tests can arrange the installed method.
+pub(crate) fn install_configured_method(method: Method) {
     CONFIGURED_METHOD.store(method_to_u8(method), Ordering::SeqCst);
 }
 
@@ -1753,6 +1756,68 @@ mod tests {
         assert!(gate.quiet);
         assert!(!gate.approval_needed);
         assert!(gate.turn_complete);
+    }
+
+    /// Restores the process-wide configured method after a test mutates it.
+    struct ConfiguredMethodRestore(Method);
+
+    impl ConfiguredMethodRestore {
+        fn capture() -> Self {
+            Self(configured_method())
+        }
+    }
+
+    impl Drop for ConfiguredMethodRestore {
+        fn drop(&mut self) {
+            install_configured_method(self.0);
+        }
+    }
+
+    /// Same single-place contract as the gate: `settings()` must install the
+    /// configured `[notifications].method` so the `notify` tool (which has
+    /// no method of its own) honors it — including `off` (#1322 promise).
+    #[test]
+    fn settings_installs_configured_method_from_config() {
+        let _lock = env_lock();
+        let _method_restore = ConfiguredMethodRestore::capture();
+        let off: crate::config::Config = toml::from_str(
+            r#"
+            [notifications]
+            method = "off"
+            "#,
+        )
+        .expect("method=off config should parse");
+        let _ = settings(&off);
+        assert_eq!(configured_method(), Method::Off);
+
+        let osc9: crate::config::Config = toml::from_str(
+            r#"
+            [notifications]
+            method = "osc9"
+            "#,
+        )
+        .expect("method=osc9 config should parse");
+        let _ = settings(&osc9);
+        assert_eq!(configured_method(), Method::Osc9);
+    }
+
+    /// The installed encoding must round-trip every method so an install/read
+    /// pair can never silently fall back to `Auto`.
+    #[test]
+    fn configured_method_round_trips_every_variant() {
+        let _restore = ConfiguredMethodRestore::capture();
+        for method in [
+            Method::Auto,
+            Method::Osc9,
+            Method::Bel,
+            Method::MacOS,
+            Method::Kitty,
+            Method::Ghostty,
+            Method::Off,
+        ] {
+            install_configured_method(method);
+            assert_eq!(configured_method(), method);
+        }
     }
 
     /// #5041 copy contract: interactive banners lead with the action and


### PR DESCRIPTION
## Summary

Five verified audit fixes for model-facing documentation and tool gating:

1. **finance bypassed the network policy** — the tool declares the `Network` capability but `execute` never consulted `context.network_policy`, so a `network.default = "deny"` session still reached `query1.finance.yahoo.com`. Both endpoint hosts (quote and chart) are now checked up front via `NetworkPolicyDecider::evaluate(host, "finance")` in the exact shape `web_search`/`speech` use: `Deny` and an undecided `Prompt` fail closed with the shared permission-error wording (including the `/network allow <host>` hint); no attached policy falls through permissively for back-compat. The chart fallback can no longer leak a request past a tightened session.
2. **verifier taught a retired name** — background-start metadata advertised `poll_with: ["exec_shell_wait", "task_shell_wait"]`, but `exec_shell_wait` is retired and cannot dispatch. Now `["task_shell_wait"]`, matching the shell timeout-recovery metadata precedent.
3. **notify `method = "off"` contract unpinned** — the promise that a configured `off` silences the tool is now regression-pinned: the emission is silenced before any sink write while the tool result still reports success to the model (nothing to retry), `settings()` installs the configured method alongside the gate, and the installed encoding round-trips every method variant. Known limitation (shared with the gate): install happens on the first `settings()` call, so a first-turn `notify` in a fresh process predates it.
4. **shell `background` description** now states that background tasks are not killed at `timeout_ms` and how to bound/stop them (`action=wait` timeout, `action=cancel`) — matching the dispatcher's actual behavior.
5. **fleet-manager skill** documents `codewhale fleet resume <run-id>` (orphaned-lease reconcile) and that `stop` requires `--all`, and names the concrete Runtime API evidence endpoints (`GET /v1/fleet/workers/{id}`, `.../receipts/{task}/evidence`, `.../events/replay`).

## Tests

- `finance_fails_closed_when_network_policy_denies_endpoint_host` — deny-listed host with a wiremock server asserting **zero** requests left before the policy check
- `finance_fails_closed_on_prompt_when_default_is_prompt` — undecided host fails closed with the approval hint, zero requests
- `configured_method_off_silences_the_tool_emission`, `configured_method_off_still_reports_success_to_the_model`, `settings_installs_configured_method_from_config`, `configured_method_round_trips_every_variant`
- existing verifier/notify/finance suites extended where noted

Verified on this branch: the affected suites (finance + notify + notifications + verifier + the retired-name guard) — 88 passed; `cargo fmt --all -- --check` clean.

## Credits

Original implementation by @asto18089 (co-authored); audit re-verified against the current tree before submission.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/6052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->