### PR TITLE
feat(session): export full-fidelity session archives as tar.xz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex 2.0.1",
 ]
 
@@ -1155,6 +1157,7 @@ dependencies = [
  "image",
  "jsonschema",
  "libc",
+ "liblzma",
  "lru",
  "mimalloc",
  "oauth2",
@@ -2856,6 +2859,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,6 +2994,26 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
+]
+
+[[package]]
+name = "liblzma"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe0a34ca854fd4f20c07f696fc8675aec78f87d88d29f5e10257a7490a1b2e1"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0dad045e4b1b7b170be4b60b54b780cafb4490165461bac7d1cf7b703f61d5f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -109,6 +109,10 @@ htmd = "0.5.4"
 lru = "0.18"
 parking_lot = "0.12"
 tar = "0.4"
+# Vendored static liblzma keeps the full-fidelity session archive export
+# (`session_export`) hermetic on every release target; no system xz headers.
+# liblzma is the maintained, API-compatible continuation of xz2.
+liblzma = { version = "0.4", features = ["static"] }
 flate2 = "1.1"
 sha2.workspace = true
 semver.workspace = true

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -124,6 +124,7 @@ mod session_diagnostics;
 mod doctor_loader_tests;
 #[cfg(test)]
 mod session_control_acceptance;
+pub mod session_export;
 #[allow(dead_code)]
 mod session_manager;
 mod session_peek;
@@ -287,7 +288,7 @@ enum Commands {
         #[arg(value_enum)]
         shell: Shell,
     },
-    /// List saved sessions
+    /// List saved sessions, or export one as a full-fidelity archive
     Sessions {
         /// Maximum number of sessions to display
         #[arg(short, long, default_value = "20")]
@@ -295,6 +296,8 @@ enum Commands {
         /// Search sessions by title
         #[arg(short, long)]
         search: Option<String>,
+        #[command(subcommand)]
+        command: Option<SessionsCommand>,
     },
     /// Create default AGENTS.md in current directory
     Init,
@@ -377,6 +380,40 @@ enum Commands {
         /// Fork the most recent session in this workspace without a picker
         #[arg(long = "last", default_value_t = false, conflicts_with = "session_id")]
         last: bool,
+    },
+}
+
+/// Subcommands of `codewhale sessions`. Without one, the command falls back
+/// to listing sessions.
+#[derive(Subcommand, Debug, Clone)]
+enum SessionsCommand {
+    /// List saved sessions (default when no subcommand is given)
+    List {
+        /// Maximum number of sessions to display
+        #[arg(short, long, default_value = "20")]
+        limit: usize,
+        /// Search sessions by title
+        #[arg(short, long)]
+        search: Option<String>,
+    },
+    /// Export a session as a full-fidelity tar.xz archive (complete context:
+    /// system prompt, messages, tool calls and results, plus artifacts)
+    Export {
+        /// Session id (or unambiguous id prefix) to export
+        #[arg(value_name = "SESSION_ID")]
+        id: String,
+        /// Destination .tar.xz path (default: codewhale-session-<id>.tar.xz)
+        #[arg(short, long, value_name = "PATH")]
+        output: Option<PathBuf>,
+        /// Exclude the session artifacts directory from the archive
+        #[arg(long, default_value_t = false)]
+        skip_artifacts: bool,
+        /// xz compression preset, 0 (fastest) through 9 (smallest)
+        #[arg(long, default_value_t = session_export::DEFAULT_XZ_COMPRESSION_LEVEL)]
+        compression: u32,
+        /// Overwrite the destination file if it already exists
+        #[arg(long, default_value_t = false)]
+        force: bool,
     },
 }
 
@@ -2213,7 +2250,23 @@ async fn run_async_main_dispatch(
                 generate_completions(shell);
                 Ok(())
             }
-            Commands::Sessions { limit, search } => list_sessions(limit, search),
+            Commands::Sessions {
+                command,
+                limit,
+                search,
+            } => match command {
+                None => list_sessions(limit, search),
+                Some(SessionsCommand::List { limit, search }) => list_sessions(limit, search),
+                Some(SessionsCommand::Export {
+                    id,
+                    output,
+                    skip_artifacts,
+                    compression,
+                    force,
+                }) => {
+                    run_sessions_export(&id, output.as_deref(), skip_artifacts, compression, force)
+                }
+            },
             Commands::Init => init_project(),
             Commands::Login { api_key } => run_login(api_key),
             Commands::Logout => run_logout(),
@@ -7899,6 +7952,86 @@ fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Export one saved session as a full-fidelity `tar.xz` archive
+/// (`session_export`). Prefers an exact session id; falls back to an
+/// unambiguous id prefix like the resume flow.
+fn run_sessions_export(
+    id: &str,
+    output: Option<&Path>,
+    skip_artifacts: bool,
+    compression: u32,
+    force: bool,
+) -> Result<()> {
+    use session_export::{SessionArchiveOptions, default_archive_file_name, write_session_archive};
+
+    let manager = SessionManager::default_location()?;
+    let session = match manager.load_session_snapshot(id) {
+        Ok(session) => session,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            manager.load_session_by_prefix(id)?
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    let output_path = output.map_or_else(
+        || PathBuf::from(default_archive_file_name(&session.metadata)),
+        Path::to_path_buf,
+    );
+    if output_path.exists() && !force {
+        bail!(
+            "{} already exists; pass --force to overwrite it",
+            output_path.display()
+        );
+    }
+
+    let artifacts_dir = if skip_artifacts {
+        None
+    } else {
+        session_export::session_artifacts_dir(manager.sessions_dir(), &session.metadata.id)
+    };
+    let summary = write_session_archive(
+        &session,
+        artifacts_dir.as_deref(),
+        &output_path,
+        SessionArchiveOptions {
+            include_artifacts: !skip_artifacts,
+            compression_level: compression,
+        },
+    )?;
+
+    println!(
+        "Exported session {} ({}) to {}",
+        truncate_id(&session.metadata.id),
+        session.metadata.title,
+        summary.output.display()
+    );
+    println!(
+        "  {} member(s), {} uncompressed -> {} archive",
+        summary.members.len(),
+        format_bytes(summary.total_member_bytes()),
+        format_bytes(summary.compressed_bytes())
+    );
+    if artifacts_dir.is_none() && !skip_artifacts {
+        println!("  (no artifacts directory found for this session)");
+    }
+    println!(
+        "  Restore (full fidelity): /load <extracted session.json> inside the TUI; /resume imports the conversation only"
+    );
+    Ok(())
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    let bytes = bytes as f64;
+    if bytes >= KIB * KIB {
+        format!("{:.1} MiB", bytes / (KIB * KIB))
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes / KIB)
+    } else {
+        format!("{bytes} B")
+    }
 }
 
 /// Initialize a new project with AGENTS.md

--- a/crates/tui/src/session_export.rs
+++ b/crates/tui/src/session_export.rs
@@ -1,0 +1,648 @@
+//! Full-fidelity session archive export (`tar.xz`).
+//!
+//! The interactive `/export` command renders a sanitized, lossy Markdown
+//! transcript for humans. This module is the machine-facing counterpart: it
+//! packs the durable session record into a compressed tar archive so a
+//! complete session log — system prompt, every user and assistant message
+//! including thinking blocks, tool calls and tool results, the branch
+//! journal, approval receipts, and the session's artifacts — can be saved
+//! with one command and restored later or attached to a bug report.
+//!
+//! Archive layout (format version 1):
+//!
+//! - `session.json` — the full [`SavedSession`] serialization, the same shape
+//!   as the on-disk session record. Extract it and open it with `/load` in
+//!   the TUI for a full-fidelity restore (system prompt included); note that
+//!   `/resume <file>` imports the conversation transcript only.
+//! - `container.json` — the portable [`SessionImportContainer`] for
+//!   version-tolerant resume across schema changes.
+//! - `artifacts/<...>` — the session-owned artifact directory, when present
+//!   and not excluded. Only regular files are archived; symlinks are skipped
+//!   so an export cannot read outside the session directory through a link.
+//! - `manifest.json` — archive format version, generator version, export
+//!   timestamp, session metadata, and the index of the preceding members.
+//!   Written last so its index covers everything above it.
+//!
+//! Contents are intentionally **not sanitized**: this is a full-fidelity log
+//! for the session owner, unlike `/export`, which redacts secrets for
+//! sharing. xz compression keeps verbose tool-heavy sessions small enough to
+//! archive or attach.
+
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use liblzma::write::XzEncoder;
+use serde::Serialize;
+use tar::Builder;
+
+use crate::artifacts::ARTIFACTS_DIR_NAME;
+use crate::session_manager::{SavedSession, SessionMetadata};
+use crate::session_tree::SessionImportContainer;
+
+/// Layout version of the exported archive. Bump when members change.
+pub const SESSION_ARCHIVE_FORMAT_VERSION: u32 = 1;
+
+/// Default xz compression preset (0–9), mirroring `xz -6`.
+pub const DEFAULT_XZ_COMPRESSION_LEVEL: u32 = 6;
+
+const SESSION_RECORD_MEMBER: &str = "session.json";
+const SESSION_CONTAINER_MEMBER: &str = "container.json";
+const ARCHIVE_MANIFEST_MEMBER: &str = "manifest.json";
+
+/// Options for [`write_session_archive`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SessionArchiveOptions {
+    /// Include the session-owned `artifacts/` directory when it exists.
+    pub include_artifacts: bool,
+    /// xz compression preset, 0 (fastest) through 9 (smallest).
+    pub compression_level: u32,
+}
+
+impl Default for SessionArchiveOptions {
+    fn default() -> Self {
+        Self {
+            include_artifacts: true,
+            compression_level: DEFAULT_XZ_COMPRESSION_LEVEL,
+        }
+    }
+}
+
+/// One archive member reported in the manifest and [`SessionArchiveSummary`].
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SessionArchiveMember {
+    /// Member path inside the archive, `/`-separated.
+    pub name: String,
+    /// Uncompressed member size in bytes.
+    pub bytes: u64,
+}
+
+/// Outcome of a successful [`write_session_archive`] call.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionArchiveSummary {
+    /// Path the `.tar.xz` archive was written to.
+    pub output: PathBuf,
+    /// Exported session id.
+    pub session_id: String,
+    /// [`SESSION_ARCHIVE_FORMAT_VERSION`] used for this archive.
+    pub archive_format_version: u32,
+    /// xz preset the archive was written with.
+    pub compression_level: u32,
+    /// Whether `artifacts/` members were included.
+    pub includes_artifacts: bool,
+    /// Member index in write order. `manifest.json` itself is excluded: it
+    /// is written last and indexes everything before it.
+    pub members: Vec<SessionArchiveMember>,
+}
+
+impl SessionArchiveSummary {
+    /// Sum of uncompressed member sizes.
+    pub fn total_member_bytes(&self) -> u64 {
+        self.members.iter().map(|member| member.bytes).sum()
+    }
+
+    /// Compressed archive size in bytes, or 0 if the file is unreadable.
+    pub fn compressed_bytes(&self) -> u64 {
+        fs::metadata(&self.output).map_or(0, |meta| meta.len())
+    }
+}
+
+#[derive(Serialize)]
+struct ArchiveManifest {
+    archive_format_version: u32,
+    generator: &'static str,
+    generator_version: &'static str,
+    exported_at: String,
+    session: SessionMetadata,
+    members: Vec<SessionArchiveMember>,
+}
+
+/// Write one session as a full-fidelity `.tar.xz` archive.
+///
+/// `session` is typically loaded with
+/// [`SessionManager::load_session_snapshot`](crate::session_manager::SessionManager::load_session_snapshot)
+/// so the archive reflects the durable record without applying resume-time
+/// repair. `artifacts_dir` is the session's `artifacts/` directory
+/// (see [`session_artifacts_dir`]); pass `None` (or clear
+/// [`SessionArchiveOptions::include_artifacts`]) to export the transcript
+/// only.
+///
+/// The archive is streamed to a sibling temporary file and renamed into
+/// place, so a failed export never leaves a truncated archive at `output`.
+/// An existing `output` is replaced.
+pub fn write_session_archive(
+    session: &SavedSession,
+    artifacts_dir: Option<&Path>,
+    output: &Path,
+    options: SessionArchiveOptions,
+) -> io::Result<SessionArchiveSummary> {
+    if options.compression_level > 9 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "xz compression level {} is out of range 0-9",
+                options.compression_level
+            ),
+        ));
+    }
+    let session_json = session_json(session)?;
+    let container_json = container_json(session)?;
+    let artifact_files = match (options.include_artifacts, artifacts_dir) {
+        (true, Some(dir)) => collect_artifact_files(dir)?,
+        _ => Vec::new(),
+    };
+
+    let parent = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    fs::create_dir_all(&parent)?;
+    let temp = tempfile::Builder::new()
+        .prefix(".codewhale-session-export-")
+        .tempfile_in(&parent)?;
+    let temp_path = temp.into_temp_path();
+
+    let mut summary = SessionArchiveSummary {
+        output: output.to_path_buf(),
+        session_id: session.metadata.id.clone(),
+        archive_format_version: SESSION_ARCHIVE_FORMAT_VERSION,
+        compression_level: options.compression_level,
+        includes_artifacts: !artifact_files.is_empty(),
+        members: Vec::new(),
+    };
+
+    {
+        let file = fs::File::create(&temp_path)?;
+        let mut tar = Builder::new(XzEncoder::new(file, options.compression_level));
+        append_member(
+            &mut tar,
+            SESSION_RECORD_MEMBER,
+            MemberContents::Bytes(session_json.as_bytes()),
+            &mut summary.members,
+        )?;
+        append_member(
+            &mut tar,
+            SESSION_CONTAINER_MEMBER,
+            MemberContents::Bytes(container_json.as_bytes()),
+            &mut summary.members,
+        )?;
+        for (name, path) in &artifact_files {
+            append_member(
+                &mut tar,
+                name,
+                MemberContents::File(path),
+                &mut summary.members,
+            )?;
+        }
+        let manifest_json = serde_json::to_string_pretty(&ArchiveManifest {
+            archive_format_version: SESSION_ARCHIVE_FORMAT_VERSION,
+            generator: env!("CARGO_PKG_NAME"),
+            generator_version: env!("CARGO_PKG_VERSION"),
+            exported_at: Utc::now().to_rfc3339(),
+            session: session.metadata.clone(),
+            members: summary.members.clone(),
+        })
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        append_member(
+            &mut tar,
+            ARCHIVE_MANIFEST_MEMBER,
+            MemberContents::Bytes(manifest_json.as_bytes()),
+            &mut Vec::new(),
+        )?;
+        let encoder = tar.into_inner()?;
+        let mut file = encoder.finish()?;
+        file.flush()?;
+        file.sync_all()?;
+    }
+    temp_path.persist(output).map_err(|error| error.error)?;
+
+    Ok(summary)
+}
+
+/// Directory holding this session's artifacts, when it exists. `session_id`
+/// is re-checked against path traversal here because this helper is also the
+/// boundary for callers that build the path from user-supplied ids.
+pub fn session_artifacts_dir(sessions_dir: &Path, session_id: &str) -> Option<PathBuf> {
+    if session_id.is_empty()
+        || session_id == "."
+        || session_id == ".."
+        || session_id.contains(['/', '\\'])
+    {
+        return None;
+    }
+    let dir = sessions_dir.join(session_id).join(ARTIFACTS_DIR_NAME);
+    dir.is_dir().then_some(dir)
+}
+
+/// Default archive file name for a session:
+/// `codewhale-session-<short-id>.tar.xz`.
+pub fn default_archive_file_name(metadata: &SessionMetadata) -> String {
+    format!(
+        "codewhale-session-{}.tar.xz",
+        crate::session_manager::truncate_id(&metadata.id)
+    )
+}
+
+fn session_json(session: &SavedSession) -> io::Result<String> {
+    serde_json::to_string_pretty(session)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+fn container_json(session: &SavedSession) -> io::Result<String> {
+    let container: SessionImportContainer = session.export_container("session-archive");
+    serde_json::to_string_pretty(&container)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+/// Collect regular artifact files as `(archive member name, source path)`,
+/// sorted by member name for deterministic archives. Symlinks and other
+/// non-regular entries are skipped so an export cannot reach outside the
+/// session directory through a link.
+fn collect_artifact_files(artifacts_dir: &Path) -> io::Result<Vec<(String, PathBuf)>> {
+    let mut files = Vec::new();
+    collect_artifact_files_recursive(artifacts_dir, "", &mut files)?;
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(files)
+}
+
+fn collect_artifact_files_recursive(
+    dir: &Path,
+    prefix: &str,
+    files: &mut Vec<(String, PathBuf)>,
+) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        let child = entry.file_name().to_string_lossy().into_owned();
+        let member = if prefix.is_empty() {
+            format!("{ARTIFACTS_DIR_NAME}/{child}")
+        } else {
+            format!("{prefix}/{child}")
+        };
+        let path = dir.join(&child);
+        if file_type.is_dir() {
+            collect_artifact_files_recursive(&path, &member, files)?;
+        } else if file_type.is_file() {
+            files.push((member, path));
+        }
+    }
+    Ok(())
+}
+
+fn archive_header(size: u64) -> tar::Header {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(size);
+    header.set_mode(0o644);
+    header.set_mtime(Utc::now().timestamp().max(0) as u64);
+    header.set_cksum();
+    header
+}
+
+/// Payload for one archive member: in-memory bytes or a filesystem file
+/// streamed straight into the tar.
+enum MemberContents<'a> {
+    Bytes(&'a [u8]),
+    File(&'a Path),
+}
+
+/// Append exactly `expected` bytes of `reader` under `name`. The bounded read
+/// keeps the tar header and the member payload consistent when the source
+/// file changes size mid-export: growth is capped at the snapshot size
+/// (valid archive, prefix content), while shrinkage — which would otherwise
+/// silently shift every following header and corrupt the archive — fails the
+/// export instead.
+fn append_sized<W: Write, R: Read>(
+    tar: &mut Builder<W>,
+    header: &mut tar::Header,
+    name: &str,
+    reader: R,
+    expected: u64,
+) -> io::Result<()> {
+    let mut limited = reader.take(expected);
+    tar.append_data(header, name, &mut limited)?;
+    if limited.limit() != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            format!(
+                "member {name} ended before its recorded size of {expected} bytes; the source changed during export"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn append_member(
+    tar: &mut Builder<XzEncoder<fs::File>>,
+    name: &str,
+    contents: MemberContents<'_>,
+    members: &mut Vec<SessionArchiveMember>,
+) -> io::Result<()> {
+    match contents {
+        MemberContents::Bytes(bytes) => {
+            let mut header = archive_header(bytes.len() as u64);
+            tar.append_data(&mut header, name, bytes)?;
+            members.push(SessionArchiveMember {
+                name: name.to_string(),
+                bytes: bytes.len() as u64,
+            });
+        }
+        MemberContents::File(path) => {
+            let mut file = fs::File::open(path)?;
+            let size = file.metadata()?.len();
+            let mut header = archive_header(size);
+            append_sized(tar, &mut header, name, &mut file, size)?;
+            members.push(SessionArchiveMember {
+                name: name.to_string(),
+                bytes: size,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_manager::create_saved_session;
+    use crate::session_tree::SessionJournal;
+    use codewhale_models::{ContentBlock, Message, Role};
+    use std::io::Read;
+
+    fn fixture_session() -> SavedSession {
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: "list the files in src".to_string(),
+                    cache_control: None,
+                }],
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::thinking("I should run ls first"),
+                    ContentBlock::ToolUse {
+                        id: "toolu_01".to_string(),
+                        name: "shell".to_string(),
+                        input: serde_json::json!({ "command": "ls src" }),
+                        caller: None,
+                        thought_signature: None,
+                    },
+                ],
+            },
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "toolu_01".to_string(),
+                    content: "main.rs\nlib.rs".to_string(),
+                    is_error: None,
+                    content_blocks: None,
+                }],
+            },
+        ];
+        let mut session = create_saved_session(
+            &messages,
+            "test-model",
+            Path::new("/tmp/archive-fixture"),
+            128,
+            None,
+        );
+        session.system_prompt = Some("You are a careful coding agent.".to_string());
+        session.journal = Some(SessionJournal::from_messages(messages, 0));
+        session
+    }
+
+    fn read_archive_members(path: &Path) -> Vec<(String, Vec<u8>)> {
+        let file = fs::File::open(path).expect("archive opens");
+        let mut archive = tar::Archive::new(liblzma::read::XzDecoder::new(file));
+        archive
+            .entries()
+            .expect("archive entries")
+            .map(|entry| {
+                let mut entry = entry.expect("entry");
+                let name = entry.path().expect("path").to_string_lossy().into_owned();
+                let mut bytes = Vec::new();
+                entry.read_to_end(&mut bytes).expect("member bytes");
+                (name, bytes)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn forkguard_session_archive_export_roundtrips_full_context() {
+        let session = fixture_session();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = dir.path().join("session.tar.xz");
+
+        let summary =
+            write_session_archive(&session, None, &output, SessionArchiveOptions::default())
+                .expect("archive export");
+
+        assert_eq!(summary.session_id, session.metadata.id);
+        let mut members = read_archive_members(&output);
+        members.sort_by(|left, right| left.0.cmp(&right.0));
+        let names: Vec<&str> = members.iter().map(|(name, _)| name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["container.json", "manifest.json", "session.json"]
+        );
+
+        // The raw session record restores the complete context: system
+        // prompt, thinking, tool call, and tool result.
+        let (_, session_bytes) = members
+            .iter()
+            .find(|(name, _)| name == SESSION_RECORD_MEMBER)
+            .expect("session.json member");
+        let restored: SavedSession =
+            serde_json::from_slice(session_bytes).expect("session.json parses");
+        assert_eq!(
+            restored.system_prompt.as_deref(),
+            Some("You are a careful coding agent.")
+        );
+        let mut saw_tool_use = false;
+        let mut saw_tool_result = false;
+        let mut saw_thinking = false;
+        for message in &restored.messages {
+            for block in &message.content {
+                match block {
+                    ContentBlock::ToolUse { id, .. } => {
+                        saw_tool_use = true;
+                        assert_eq!(id, "toolu_01");
+                    }
+                    ContentBlock::ToolResult { tool_use_id, .. } => {
+                        saw_tool_result = true;
+                        assert_eq!(tool_use_id, "toolu_01");
+                    }
+                    ContentBlock::Thinking { .. } => saw_thinking = true,
+                    _ => {}
+                }
+            }
+        }
+        assert!(saw_tool_use && saw_tool_result && saw_thinking);
+
+        // The portable container feeds the exact import path `/resume` uses
+        // for exported session JSON.
+        let (_, container_bytes) = members
+            .iter()
+            .find(|(name, _)| name == SESSION_CONTAINER_MEMBER)
+            .expect("container.json member");
+        let container = SessionImportContainer::from_json(
+            std::str::from_utf8(container_bytes).expect("container utf8"),
+        )
+        .expect("container parses");
+        let imported = SavedSession::import_foreign(
+            container,
+            PathBuf::from("/tmp/archive-fixture"),
+            "test-model".to_string(),
+        )
+        .expect("container imports");
+        assert!(
+            imported
+                .messages
+                .iter()
+                .any(|message| message.content.iter().any(
+                    |block| matches!(block, ContentBlock::ToolUse { id, .. } if id == "toolu_01")
+                )),
+            "imported session keeps the tool call"
+        );
+        let manifest: serde_json::Value = serde_json::from_slice(
+            &members
+                .iter()
+                .find(|(name, _)| name == ARCHIVE_MANIFEST_MEMBER)
+                .expect("manifest member")
+                .1,
+        )
+        .expect("manifest parses");
+        assert_eq!(
+            manifest["archive_format_version"],
+            SESSION_ARCHIVE_FORMAT_VERSION
+        );
+        assert_eq!(manifest["session"]["id"], session.metadata.id);
+    }
+
+    #[test]
+    fn forkguard_session_archive_includes_artifacts_and_respects_skip() {
+        let session = fixture_session();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = dir.path().join("sessions");
+        let artifacts_dir = sessions_dir
+            .join(&session.metadata.id)
+            .join(ARTIFACTS_DIR_NAME);
+        fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
+        fs::write(artifacts_dir.join("art_call-1.txt"), b"artifact body").expect("artifact");
+        assert!(
+            session_artifacts_dir(&sessions_dir, &session.metadata.id).is_some(),
+            "artifacts dir is discovered for a valid session id"
+        );
+        assert!(
+            session_artifacts_dir(&sessions_dir, "../escape").is_none(),
+            "path traversal ids never resolve to an artifacts dir"
+        );
+
+        let with_artifacts = write_session_archive(
+            &session,
+            Some(&artifacts_dir),
+            &dir.path().join("full.tar.xz"),
+            SessionArchiveOptions::default(),
+        )
+        .expect("archive with artifacts");
+        assert!(with_artifacts.includes_artifacts);
+        let names: Vec<&str> = with_artifacts
+            .members
+            .iter()
+            .map(|member| member.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["session.json", "container.json", "artifacts/art_call-1.txt"]
+        );
+        let members = read_archive_members(&dir.path().join("full.tar.xz"));
+        let (_, artifact_bytes) = members
+            .iter()
+            .find(|(name, _)| name == "artifacts/art_call-1.txt")
+            .expect("artifact member");
+        assert_eq!(artifact_bytes, b"artifact body");
+
+        let transcript_only = write_session_archive(
+            &session,
+            Some(&artifacts_dir),
+            &dir.path().join("lean.tar.xz"),
+            SessionArchiveOptions {
+                include_artifacts: false,
+                ..SessionArchiveOptions::default()
+            },
+        )
+        .expect("archive without artifacts");
+        assert!(!transcript_only.includes_artifacts);
+        assert!(
+            !transcript_only
+                .members
+                .iter()
+                .any(|member| member.name.starts_with(ARTIFACTS_DIR_NAME))
+        );
+    }
+
+    #[test]
+    fn forkguard_session_archive_rejects_artifact_shorter_than_recorded_size() {
+        // A member whose source shrank between stat and copy must fail the
+        // export instead of being zero-padded into a silently shifted
+        // archive (the growth direction is capped to the snapshot size).
+        let mut tar = Builder::new(Vec::new());
+        let mut header = archive_header(16);
+        let error = append_sized(
+            &mut tar,
+            &mut header,
+            "artifacts/shrinking.bin",
+            &b"only-nine"[..],
+            16,
+        )
+        .expect_err("short member must fail the export");
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+
+        let mut tar = Builder::new(Vec::new());
+        let mut header = archive_header(9);
+        append_sized(
+            &mut tar,
+            &mut header,
+            "artifacts/stable.bin",
+            &b"only-nine"[..],
+            9,
+        )
+        .expect("exact-size member succeeds");
+    }
+
+    #[test]
+    fn session_archive_rejects_out_of_range_compression_level() {
+        let session = fixture_session();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let error = write_session_archive(
+            &session,
+            None,
+            &dir.path().join("out.tar.xz"),
+            SessionArchiveOptions {
+                compression_level: 10,
+                ..SessionArchiveOptions::default()
+            },
+        )
+        .expect_err("level 10 must be rejected");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn session_archive_replaces_existing_output_atomically() {
+        let session = fixture_session();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = dir.path().join("out.tar.xz");
+        write_session_archive(&session, None, &output, SessionArchiveOptions::default())
+            .expect("first export");
+        write_session_archive(&session, None, &output, SessionArchiveOptions::default())
+            .expect("second export replaces");
+        let members = read_archive_members(&output);
+        assert_eq!(members.len(), 3);
+        assert!(default_archive_file_name(&session.metadata).ends_with(".tar.xz"));
+    }
+}


### PR DESCRIPTION
## Summary

`/export` markdown is lossy and share-facing; this adds the machine-facing counterpart: one command packs the complete durable session record into a compressed archive, from the CLI or through the library for embedding hosts.

- **`session_export` module**: `write_session_archive` streams the complete `SavedSession` — standalone system prompt, every user/assistant message including thinking, tool_use and tool_result blocks, the branch journal, and hydrated approval receipts — into a tar archive together with the portable `SessionImportContainer` and the session's `artifacts/` tree, compressed with xz. Output goes to a sibling temp file renamed into place, so a failed export never leaves a truncated archive at the destination.
- **Archive layout (format version 1)**: `session.json` (restore with `/load` for full fidelity), `container.json` (version-tolerant `/resume` import of the conversation transcript), `artifacts/**` (regular files only — symlinks are skipped so an export cannot read outside the session directory; members are size-bounded so a file that shrinks mid-export fails the export instead of silently shifting every following header), and `manifest.json` (format version, generator, timestamp, member index) written last.
- **CLI**: `codewhale sessions export <id> [--output <path>] [--compression 0-9] [--skip-artifacts] [--force]`, with unambiguous id-prefix fallback like resume. Bare `codewhale sessions` keeps its listing behavior (optional clap subcommand).
- **Dependency**: `liblzma` (the maintained, API-compatible continuation of `xz2`) with vendored static liblzma — no system xz headers, hermetic on every release target.
- **Not sanitized, on purpose**: this is the session owner's complete log; `/export` remains the redacted, share-facing format. The distinction is documented on the module.

## Tests

- `forkguard_session_archive_export_roundtrips_full_context` — system prompt, thinking, tool call, and tool result all round-trip; `container.json` imports through the exact `SavedSession::import_foreign` path `/resume` uses
- `forkguard_session_archive_includes_artifacts_and_respects_skip` — artifact inclusion with exact bytes, skip behavior, and path-traversal id rejection
- `forkguard_session_archive_rejects_artifact_shorter_than_recorded_size` — mid-export shrink fails instead of zero-padding
- `session_archive_replaces_existing_output_atomically`, `session_archive_rejects_out_of_range_compression_level`

Verified on this branch: 5 module tests pass; `cargo check` clean for lib and bins; `cargo fmt` clean.

Port notes: adapted to current main — the test imports use `codewhale_models` directly, and the CLI wiring merged against the current `Sessions { limit, search }` dispatch without conflicts.

## Credits

Original implementation by @asto18089 (co-authored).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/6056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->