### PR TITLE
docs(zh_hans): fix relative links that break under docs/zh_hans/

### DIFF
--- a/docs/zh_hans/README.md
+++ b/docs/zh_hans/README.md
@@ -41,7 +41,7 @@
 为 Codewhale 贡献代码或做集成开发。
 
 1. [ARCHITECTURE.md](../ARCHITECTURE.md) —— 架构总览
-2. [CONTRIBUTING.md](CONTRIBUTING.md) —— 贡献指南：如何提交 Issue 与 PR、代码约定与验证门禁
+2. [CONTRIBUTING.md](../../CONTRIBUTING.md) —— 贡献指南：如何提交 Issue 与 PR、代码约定与验证门禁
 3. [CODE_OF_CONDUCT.md](../../CODE_OF_CONDUCT.md) —— 社区行为准则
 4. [RUNTIME_API.md](../RUNTIME_API.md) —— Runtime API 与集成契约（供集成与二次开发）
 5. [PLUGIN_AUTHORING.md](PLUGIN_AUTHORING.md) —— 从最小 Skills 示例开始编写、审查和启用插件

--- a/docs/zh_hans/WINDOWS_BEGINNER.md
+++ b/docs/zh_hans/WINDOWS_BEGINNER.md
@@ -195,7 +195,7 @@ https://github.com/Hmbown/CodeWhale/releases
 
 文件名带 **arm64** 的是给 ARM 架构设备用的，普通电脑不要选。如果你更习惯传统安装方式，也可以下载 **`CodeWhaleSetup.exe`**（Windows 安装器）：它会安装到 `%LOCALAPPDATA%\Programs\CodeWhale\bin` 并自动加入用户 PATH，开始菜单快捷方式指向 `codewhale.bat`，无需手动配置环境变量；因为安装包未签名，双击会弹 Windows SmartScreen 提示，点"更多信息 → 仍要运行"即可。注意：发布页里的 `codewhale-windows-x64.exe` 是**纯命令行程序，不是安装器**，双击只会打开默认 cmd 窗口，请改用 zip 里的 `codewhale.bat` 或安装器的开始菜单项。
 
-![GitHub 发布页，选择 windows-x64 版本](images/github-release-page.png)
+![GitHub 发布页，选择 windows-x64 版本](../images/github-release-page.png)
 
 ### 2.2 第二步：放到固定目录【codewhale-windows-x64-portable.zip】
 
@@ -209,12 +209,12 @@ https://github.com/Hmbown/CodeWhale/releases
 
 1. 打开 Windows【设置】→【系统】→【系统信息】，点击右侧的【高级系统设置】
 
-![打开高级系统设置](images/windows-system-info.png)
+![打开高级系统设置](../images/windows-system-info.png)
 
 2. 在弹出的【系统属性】窗口点【环境变量(N)…】
 3. 在"用户变量"里找到 **Path**，点【编辑(E)…】→【新建(N)】，填入程序所在目录 `D:\codewhale`，一路点【确定】保存
 
-![把 D:\codewhale 加入 Path 环境变量](images/env-path-setting.png)
+![把 D:\codewhale 加入 Path 环境变量](../images/env-path-setting.png)
 
 > 注意：改完环境变量后，**已经打开的终端窗口要关掉重开**才会生效。
 
@@ -225,7 +225,7 @@ https://github.com/Hmbown/CodeWhale/releases
 1. 下载地址：`https://aka.ms/vs/17/release/vc_redist.x64.exe`（64 位系统选 x64，32 位选 x86）
 2. 双击安装，完成后重新启动 `codewhale.exe`
 
-![VCRUNTIME140_1.dll 报错及解决办法](images/vc-runtime-dll-error.png)
+![VCRUNTIME140_1.dll 报错及解决办法](../images/vc-runtime-dll-error.png)
 
 > 离线/内网备选：从其他已装该运行库的电脑复制 `C:\Windows\System32\VCRUNTIME140_1.dll` 到本机同目录，或放到 `codewhale.exe` 同级目录下。
 


### PR DESCRIPTION
## Summary

Two relative links under `docs/zh_hans/` do not resolve from that directory,
so the Simplified-Chinese docs render with broken images and one dead link.
Both were introduced by `97eaf6627` (Tier 1 of #5482), the commit that created
`docs/zh_hans/`:

| File | Link target | Resolves to | Actual location |
|---|---|---|---|
| `docs/zh_hans/WINDOWS_BEGINNER.md` (×4) | `images/<name>.png` | `docs/zh_hans/images/` (does not exist) | `docs/images/<name>.png` |
| `docs/zh_hans/README.md:44` | `CONTRIBUTING.md` | `docs/zh_hans/CONTRIBUTING.md` (does not exist) | `CONTRIBUTING.md` |

**Why the images broke.** `97eaf6627` moved `docs/WINDOWS_BEGINNER.zh-CN.md`
to `docs/zh_hans/WINDOWS_BEGINNER.md` and carried the four
`![...](images/...)` lines over unchanged. Those paths were correct at the old
location — the file sat in `docs/`, beside `docs/images/` — and stopped
resolving once it moved one level deeper. The screenshots themselves were not
moved; they are still at `docs/images/`.

**Why the CONTRIBUTING link is an oversight, not a convention.** There is no
Chinese CONTRIBUTING anywhere in the tree (`git ls-files | grep -i contribut`
returns only `CONTRIBUTING.md`, its Indonesian redirect stub, and unrelated
files), and the very next line of the same list already reaches the repo root
with `../../CODE_OF_CONDUCT.md`. So the entry needs one more `../`, matching
its neighbour.

**Change.** Five link targets, two files, five inserted and five deleted lines
— each one just an added `../` prefix:

- `docs/zh_hans/WINDOWS_BEGINNER.md`: `images/…` → `../images/…` (4 lines)
- `docs/zh_hans/README.md`: `CONTRIBUTING.md` → `../../CONTRIBUTING.md` (1 line)

No prose, wording, heading, or translation content is touched, and no other
file is affected. `docs/zh_hans/README.md:60` also contains a
`[zh_hans/INSTALL.md](zh_hans/INSTALL.md)` string, but that one is inside an
example of the banner an English doc carries at its own location — it is
correct there and is deliberately left untouched.

## Testing

This is a docs-only diff: no Rust source, manifest, or test is modified.

The three cargo gates below were **not** run locally, and I am not claiming
them. This machine has no Rust toolchain installed, and `cargo test
--workspace` on `crates/tui` is a ~750k-line crate that needs ~8 GB for one
rustc — so there is no honest way to run them here. The `changes` job also
classifies `docs/*` and `*.md` as non-heavy, so the lanes that would exercise
them do not run on this diff either.

What was actually run, on this diff:

```console
$ python3 scripts/check-provider-registry.py        # Provider registry drift check passed.
$ python3 scripts/check-readme-translations.py      # pass — only the advisory stale-README stamps main already reports
$ bash scripts/check-readme-locales.sh              # PASS
$ python3 scripts/check-tui-locale-parity.py        # PASS (all locales 2203/2203)
$ sh scripts/check-tui-product-vocabulary.sh        # rc=0
$ git diff --check                                  # no whitespace errors
```

Plus a scripted sweep of every tracked `.md`/`.mdx` for relative links whose
resolved path is neither a tracked file nor a tracked directory. Before this
change it reported the five `docs/zh_hans/` targets above; after it, they are
gone and no new unresolved link appears. The two remaining hits are
`crates/tui/CHANGELOG.md` (left alone on purpose — CONTRIBUTING.md says
changelogs are written on `main` at merge time) and the banner example
described above.

Both staged blobs are LF-only, and the commit carries a `Signed-off-by` trailer.

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` (warning-free under the CI allow list)
- [ ] `cargo test --workspace --all-features --locked`

## Checklist

- [x] This PR adds a new layer/module/abstraction — it names or deletes the layer it replaces *(N/A: no layer is added; five link targets change)*
- [x] Updated docs or comments as needed *(this PR is exactly that)*
- [x] Added or updated tests where relevant *(N/A: no behavior to test; link resolution is verified by the sweep in Testing)*
- [x] Verified TUI behavior manually if UI changes *(N/A: no TUI change)*
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address *(commit author uses `251123242+c020627@users.noreply.github.com`)*

No-Issue: docs-only repair of relative links left behind by the `docs/zh_hans/` restructure in `97eaf6627`; no tracking issue exists for it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/6080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->