### PR TITLE
fix(tui): follow symlinked user-level context files

### DIFF
--- a/crates/tui/src/project_context.rs
+++ b/crates/tui/src/project_context.rs
@@ -977,7 +977,7 @@ fn load_global_agents_context(workspace: &Path, home_dir: Option<&Path>) -> Opti
         let path = join_relative_components(home, candidate);
 
         if context_candidate_exists(&path) {
-            match load_context_file(&path) {
+            match load_global_context_file(&path) {
                 Ok(content) => {
                     let mut ctx = ProjectContext::empty(workspace.to_path_buf());
                     ctx.instructions = Some(content);
@@ -1014,6 +1014,48 @@ fn generate_ephemeral_context(workspace: &Path) -> Option<String> {
 
 /// Load a context file with size checking
 fn load_context_file(path: &Path) -> Result<String, ProjectContextError> {
+    load_context_file_with_symlink_policy(path, false)
+}
+
+/// Load a user-level context file, following a symlink to its target.
+///
+/// The refusal in [`load_context_file`] protects checkouts: a link planted in
+/// an untrusted repository could point the loader at anything on the machine.
+/// The user-level layer is the operator's own file in `$HOME`, where that
+/// escape does not apply and a symlink is the ordinary way to share one
+/// instruction set between agents (`~/.deepseek/AGENTS.md` -> `~/AGENTS.md`).
+/// Refusing it there failed silently: the refusal is collected as a warning,
+/// so the whole user-level layer was dropped without any visible error.
+fn load_global_context_file(path: &Path) -> Result<String, ProjectContextError> {
+    load_context_file_with_symlink_policy(path, true)
+}
+
+/// Resolve a symlinked context file to its target.
+///
+/// `open_context_file` opens with `O_NOFOLLOW`, so the resolved target is what
+/// must be opened, never the link itself.
+fn resolve_symlinked_context_path(path: &Path) -> Result<PathBuf, ProjectContextError> {
+    let metadata = fs::symlink_metadata(path).map_err(|source| ProjectContextError::Metadata {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.file_type().is_symlink() {
+        return Ok(path.to_path_buf());
+    }
+    fs::canonicalize(path).map_err(|source| ProjectContextError::Metadata {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn load_context_file_with_symlink_policy(
+    path: &Path,
+    follow_symlinks: bool,
+) -> Result<String, ProjectContextError> {
+    let resolved = follow_symlinks
+        .then(|| resolve_symlinked_context_path(path))
+        .transpose()?;
+    let path = resolved.as_deref().unwrap_or(path);
     let metadata = fs::symlink_metadata(path).map_err(|source| ProjectContextError::Metadata {
         path: path.to_path_buf(),
         source,
@@ -1995,6 +2037,61 @@ mod tests {
                 .contains("Vendor-neutral instructions")
         );
         assert_eq!(ctx.source_path, Some(global_agents));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_symlinked_global_agents_is_followed() {
+        let workspace = tempdir().expect("workspace tempdir");
+        let home = tempdir().expect("home tempdir");
+        let shared = home.path().join("AGENTS.md");
+        fs::write(&shared, "Shared global instructions").expect("write shared agents");
+        let global_dir = home.path().join(".deepseek");
+        fs::create_dir(&global_dir).expect("mkdir .deepseek");
+        let link = global_dir.join("AGENTS.md");
+        std::os::unix::fs::symlink(&shared, &link).expect("symlink global agents");
+
+        let ctx = load_project_context_with_parents_and_home(workspace.path(), Some(home.path()));
+
+        assert!(ctx.has_instructions());
+        assert!(
+            ctx.instructions
+                .as_ref()
+                .unwrap()
+                .contains("Shared global instructions"),
+            "a symlinked user-level AGENTS.md must be read: {:?}",
+            ctx.warnings
+        );
+        assert_eq!(ctx.source_path, Some(link));
+        assert!(
+            !ctx.warnings.iter().any(|w| w.contains("symlink")),
+            "following the user-level link must not warn: {:?}",
+            ctx.warnings
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_symlinked_workspace_agents_is_still_refused() {
+        let workspace = tempdir().expect("workspace tempdir");
+        let home = tempdir().expect("home tempdir");
+        let outside = tempdir().expect("outside tempdir");
+        let secret = outside.path().join("secret.md");
+        fs::write(&secret, "outside content").expect("write outside file");
+        std::os::unix::fs::symlink(&secret, workspace.path().join("AGENTS.md"))
+            .expect("symlink workspace agents");
+
+        let ctx = load_project_context_with_parents_and_home(workspace.path(), Some(home.path()));
+
+        assert!(
+            ctx.instructions.is_none()
+                || !ctx
+                    .instructions
+                    .as_ref()
+                    .unwrap()
+                    .contains("outside content"),
+            "a workspace AGENTS.md symlink must not be followed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The user-level instruction layer (`~/.codewhale/AGENTS.md`, `~/.agents/AGENTS.md`, `~/.deepseek/AGENTS.md`) now follows a symlink to its target instead of refusing it. Files inside a checkout keep the existing refusal.

Closes #6115

## Why

`load_context_file` refuses symlinked files, and `load_global_agents_context` collects that refusal as a **warning**, not an error. So a symlinked user-level file dropped the whole layer silently: the model ran without the global instructions and nothing told the user.

The guard itself is right for its original target. It was introduced in `fa5108f54 fix(security): reject symlinked project context`, whose message and tests cover project instruction files and the repo constitution — a link planted inside an untrusted checkout can point the loader at anything on the machine. That threat does not apply to the user-level layer: the file lives in the operator's own `$HOME`, and pointing it at a shared file is the ordinary way to keep one instruction set across several agents (`~/.config/<agent>/AGENTS.md` -> `~/AGENTS.md`). A hardlink only substitutes by accident, and detaches silently whenever the canonical file is rewritten atomically (new inode) — which is the failure mode this replaces.

## Changes

- `crates/tui/src/project_context.rs`: the loader keeps its exact behaviour but is split so the symlink policy is a parameter; `load_global_context_file` resolves the link and continues with the target. `open_context_file` opens with `O_NOFOLLOW`, so the resolved path must be the one handed to it, never the link.
- Two tests: a symlinked user-level `AGENTS.md` is read, and a symlinked workspace `AGENTS.md` is still refused.

## Verification

- `cargo test -p codewhale-tui --lib project_context` — **77 passed, 0 failed** (12432 filtered out).
- **Negative control** (so the new test is a reproducer rather than an ornament): with the following policy flipped back to `false`, `test_symlinked_global_agents_is_followed` fails with

  ```
  a symlinked user-level AGENTS.md must be read: ["Refusing symlinked context file /tmp/.tmp2eogYp/.deepseek/AGENTS.md"]
  ```

  and with the policy on it passes.
- Existing symlink guards are unaffected: `rules_rejects_symlinked_directory`, `rules_rejects_symlinked_files`, `symlinked_foreign_fragment_does_not_claim_importable_instructions` and `signature_does_not_follow_symlinked_foreign_fragment_directories` all still pass, so the workspace escape stays closed.

## Notes

- A broken symlink or a symlink to a directory still produces a load error that is reported as a warning and falls through to the next candidate — the same shape as before this change.
